### PR TITLE
docs(ontology): code-grounded corrections to glossary (basin/free-energy homonyms, physics-register retraction)

### DIFF
--- a/docs/ontology/glossary-drift-audit-2026-06-20.md
+++ b/docs/ontology/glossary-drift-audit-2026-06-20.md
@@ -11,6 +11,34 @@ which sense is meant.
 question-keyed glossary). This file is the point-in-time evidence and the
 recommended-fix list. Re-run and re-date when the vocabulary moves.
 
+**Addendum (2026-06-20b — code-grounded pass).** The first sweep read only docs.
+A follow-up read of the *code* (`governance_core/dynamics.py`,
+`src/grounding/free_energy.py`, `src/behavioral_assessment.py`,
+`docs/EISV_COMPUTATION.md`) found two collisions the docs-only sweep missed and
+one wrong claim to retract:
+
+- **NEW `basin` (DRIFT, confirmed in code):** `governance_core/dynamics.py::check_basin`
+  (bistable **attractor** basin, research-lens ODE) vs.
+  `src/behavioral_assessment.py::_basin_health_gate` / `config.governance_config.BASIN_HIGH`
+  (a static **health band** — the verdict-driving gate). Only the second drives
+  decisions, and it is a configured box, not an attractor. Previously listed as
+  single-sense; **promoted to high-risk homonym.** A runtime glossary
+  (`src/governance_glossary.py::explain_basin`, #428) resolves the health-band
+  sense — keep it consistent with the doc glossary.
+- **NEW `free energy` (DRIFT, code):** ODE `V` ("like Helmholtz free energy", a
+  signed integrator) vs. `src/grounding/free_energy.py` target `E=−F` (variational,
+  Tier-1 explicitly stubbed).
+- **RETRACTED claim:** the Rosetta skeleton's "physics register is aspirational,
+  all candidate, zero earned" was **wrong**. Three rows are `◐ research-lens`
+  (implemented in the parallel ODE / grounding tiers, honestly provenance-tagged,
+  but not wired to the verdict path). The real gap is *wiring built physics onto
+  the verdict path*, not building it. Notably `grounding/free_energy.py` already
+  enforces this audit's own "name nothing more rigorous than it is" guardrail at
+  runtime (tiered estimator, `source=` tags, FEP stubbed).
+
+Lesson for future sweeps: **read the code, not only the proposal docs.** Drift
+between a term's doc sense and its code symbol is invisible to a docs-only pass.
+
 **Headline:** Three words carry the most collision risk — `substrate` (3 senses),
 `fingerprint` (3 senses), `surface` (2 senses) — because in each case more than
 one sense is genuinely load-bearing and at least two senses live close together

--- a/docs/ontology/glossary-viewer.html
+++ b/docs/ontology/glossary-viewer.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>UNITARES Glossary — live view (prototype)</title>
+<style>
+  :root{
+    --bg:#0e1116; --panel:#161b22; --panel2:#1c232c; --line:#2a313c;
+    --ink:#e6edf3; --dim:#8b949e; --acc:#58a6ff;
+    --earned:#3fb950; --lens:#d29922; --cand:#6e7681; --false:#f85149;
+    --reg-phil:#bc8cff; --reg-fep:#58a6ff; --reg-ops:#3fb950; --reg-man:#f0883e;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;background:var(--bg);color:var(--ink)}
+  header{position:sticky;top:0;background:linear-gradient(180deg,#0e1116,#0e1116ee);backdrop-filter:blur(6px);border-bottom:1px solid var(--line);padding:16px 22px;z-index:10}
+  h1{margin:0 0 2px;font-size:17px;letter-spacing:.2px}
+  .sub{color:var(--dim);font-size:12px}
+  .controls{display:flex;gap:10px;flex-wrap:wrap;margin-top:12px;align-items:center}
+  input[type=search]{flex:1;min-width:200px;background:var(--panel2);border:1px solid var(--line);color:var(--ink);padding:8px 12px;border-radius:8px;font-size:13px}
+  .chip{cursor:pointer;border:1px solid var(--line);background:var(--panel);color:var(--dim);padding:5px 11px;border-radius:999px;font-size:12px;user-select:none}
+  .chip.on{color:var(--ink);border-color:var(--acc);background:#1f2a3a}
+  main{max-width:1100px;margin:0 auto;padding:20px 22px 80px}
+  .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(330px,1fr));gap:14px}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:14px 16px}
+  .card h3{margin:0 0 2px;font-size:15px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+  .typebadge{font-size:10px;text-transform:uppercase;letter-spacing:.6px;color:var(--dim);border:1px solid var(--line);border-radius:5px;padding:1px 6px;margin-left:8px;vertical-align:middle}
+  .sense{border-top:1px dashed var(--line);padding-top:9px;margin-top:9px}
+  .sense:first-of-type{border-top:0;margin-top:6px}
+  .sname{font-family:ui-monospace,monospace;font-size:12.5px;color:var(--acc)}
+  .q{color:var(--ink);margin:2px 0}
+  .src{color:var(--dim);font-size:11.5px}
+  .tags{margin-top:6px;display:flex;gap:6px;flex-wrap:wrap;align-items:center}
+  .reg{font-size:10.5px;padding:1px 7px;border-radius:5px;border:1px solid var(--line)}
+  .reg.phil{color:var(--reg-phil)} .reg.fep{color:var(--reg-fep)} .reg.ops{color:var(--reg-ops)} .reg.man{color:var(--reg-man)}
+  .status{font-size:10.5px;padding:1px 7px;border-radius:5px;font-weight:600}
+  .status.earned{color:#06240f;background:var(--earned)} .status.lens{color:#241a00;background:var(--lens)}
+  .status.cand{color:#0c0f14;background:var(--cand)} .status.false{color:#2b0707;background:var(--false)}
+  .sectitle{grid-column:1/-1;margin:22px 0 2px;font-size:12px;text-transform:uppercase;letter-spacing:1px;color:var(--dim)}
+  table.rosetta{grid-column:1/-1;width:100%;border-collapse:collapse;font-size:12.5px;background:var(--panel);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+  table.rosetta th,table.rosetta td{text-align:left;padding:9px 11px;border-bottom:1px solid var(--line);vertical-align:top}
+  table.rosetta th{color:var(--dim);font-weight:600;font-size:11px;text-transform:uppercase;letter-spacing:.5px}
+  table.rosetta tr:last-child td{border-bottom:0}
+  .legend{display:flex;gap:14px;flex-wrap:wrap;margin-top:10px;font-size:11.5px;color:var(--dim)}
+  .legend span b{font-weight:600}
+  .note{grid-column:1/-1;color:var(--dim);font-size:12px;background:var(--panel2);border:1px solid var(--line);border-left:3px solid var(--acc);padding:10px 13px;border-radius:8px}
+  .hidden{display:none}
+  footer{max-width:1100px;margin:0 auto;padding:0 22px 40px;color:var(--dim);font-size:11.5px}
+</style>
+</head>
+<body>
+<header>
+  <h1>UNITARES Glossary <span class="typebadge">live view · prototype</span></h1>
+  <div class="sub">Generated mirror of <code>docs/ontology/glossary.md</code> — keyed by the question each term answers. Markdown stays canonical; this is a view.</div>
+  <div class="controls">
+    <input id="q" type="search" placeholder="Search term, question, or source…" autocomplete="off">
+    <span class="chip on" data-f="all">All</span>
+    <span class="chip" data-f="homonym">Homonyms</span>
+    <span class="chip" data-f="single">Single-sense</span>
+    <span class="chip" data-f="rosetta">Rosetta</span>
+    <span class="chip" data-f="gap">Open gaps</span>
+  </div>
+  <div class="legend">
+    <span><b>register:</b></span>
+    <span class="reg phil">philosophical</span><span class="reg ops">ops</span><span class="reg fep">fep</span><span class="reg man">manifesto</span>
+    <span style="margin-left:10px"><b>status:</b></span>
+    <span class="status earned">✓ earned</span><span class="status lens">◐ research-lens</span><span class="status cand">~ candidate</span><span class="status false">✗ false friend</span>
+  </div>
+</header>
+<main>
+  <div class="grid" id="grid"></div>
+</main>
+<footer>
+  Prototype · static snapshot. "Live" (auto-reflecting md + code symbols, drift-flagged) means generating this JSON from <code>glossary.md</code> at build and cross-checking code symbols — see chat. Not committed; not a source of truth.
+</footer>
+<script>
+const REG={phil:"philosophical",ops:"ops",fep:"fep",man:"manifesto"};
+// --- data faithfully derived from docs/ontology/glossary.md ---
+const TERMS=[
+ {term:"substrate",type:"homonym",senses:[
+   {name:"substrate (inference)",q:"What inference engine generates this behavior?",src:"harness-substrate-plurality.md",reg:"fep"},
+   {name:"substrate (deployment)",q:"What persistent hardware/disk/DB survives a restart and can earn continuity?",src:"identity.md",reg:"phil"},
+   {name:"substrate (runtime)",q:"What execution model runs the work — per-process vs shared asyncio loop?",src:"CLAUDE.md / AGENTS.md (Substrate Tax)",reg:"ops"}]},
+ {term:"fingerprint",type:"homonym",senses:[
+   {name:"fingerprint (transport)",q:"Which driver is this, by ip:ua, for the weak sticky-resume pin?",src:"identity.md",reg:"ops"},
+   {name:"fingerprint (behavioral)",q:"Does this process's EISV match the lineage it claims?",src:"identity.md / R1",reg:"phil"},
+   {name:"fingerprint (finding-dedup)",q:"Is this CI/Watcher finding one we already saw? (sha256)",src:"CLAUDE.md / ci-issue-surfacing.md",reg:"ops"}]},
+ {term:"surface",type:"homonym",senses:[
+   {name:"surface (lease)",q:"What shared mutation target is claimed under single-writer coordination?",src:"beam-coordination-kernel.md",reg:"ops"},
+   {name:"surface (tool)",q:"What actions are available to the agent right now?",src:"harness-substrate-plurality.md",reg:"ops"}]},
+ {term:"basin",type:"homonym",code:true,senses:[
+   {name:"basin (attractor)",q:"Which equilibrium will the system's own EISV dynamics flow to?",src:"governance_core/dynamics.py::check_basin (research lens)",reg:"fep",status:"lens"},
+   {name:"basin (health band)",q:"Is each EISV axis inside its configured healthy box, so deviation should count as risk?",src:"behavioral_assessment.py::_basin_health_gate / BASIN_HIGH (drives verdicts)",reg:"ops",status:"earned"}]},
+ {term:"free energy",type:"homonym",code:true,senses:[
+   {name:"free energy (ODE V)",q:"What is the running E−I imbalance accumulator?",src:"governance_core/dynamics.py (V, Helmholtz-like)",reg:"fep",status:"lens"},
+   {name:"free energy (variational −F)",q:"What is E as negative variational free energy under a generative model?",src:"grounding/free_energy.py — Tier-1 stubbed",reg:"fep",status:"cand"}]},
+ {term:"harness",type:"homonym",senses:[
+   {name:"harness (agent body)",q:"What body/interface mediates this agent's action? (preferred term: body)",src:"harness-substrate-plurality.md",reg:"phil"},
+   {name:"harness (lifecycle wrapper)",q:"What plugin/hook chain wraps the session?",src:"CLAUDE.md",reg:"ops"},
+   {name:"harness (test rig)",q:"What scaffold drives a bounded eval?",src:"calibration_harness/, deep-research skill",reg:"ops"}]},
+ {term:"fork",type:"homonym",senses:[
+   {name:"fork (sibling locus)",q:"Fresh process-instance under the same registry UUID, no child minted?",src:"r6-episode-fork-response-shape.md",reg:"phil"},
+   {name:"fork (identity lineage)",q:"A distinct child UUID with declared parent_agent_id + spawn_reason?",src:"r6-episode-fork-response-shape.md",reg:"phil"}]},
+ {term:"continuity",type:"homonym",senses:[
+   {name:"continuity (concept)",q:"At which layers does this identity claim actually hold?",src:"identity.md (five-layer taxonomy)",reg:"phil"},
+   {name:"continuity_token (mechanism)",q:"Can this same live process re-bind by signed proof?",src:"identity.md (largely retired)",reg:"ops"}]},
+ {term:"lineage",type:"homonym",senses:[
+   {name:"lineage (causal ancestry)",q:"Which finished predecessor's work does this process inherit?",src:"identity.md",reg:"phil"},
+   {name:"thread lineage (conversation)",q:"Which logical conversation/history thread is this? (thread_id)",src:"harness-substrate-plurality.md",reg:"ops"}]},
+ // single-sense
+ {term:"process-instance",type:"single",senses:[{name:"process-instance",q:"Which live subject is speaking right now?",src:"identity.md",reg:"phil"}]},
+ {term:"registry",type:"single",senses:[{name:"registry (identity layer)",q:"Which governance record is this claim bound to? (the UUID)",src:"harness-substrate-plurality.md",reg:"phil"}]},
+ {term:"transport",type:"single",senses:[{name:"transport",q:"Through what channel does the process act? (CLI, MCP-http, Discord, cron)",src:"harness-substrate-plurality.md",reg:"ops"}]},
+ {term:"lease",type:"single",senses:[{name:"lease",q:"What time-bounded claim to a surface is live, with what proof and expiry?",src:"beam-coordination-kernel.md",reg:"ops"}]},
+ {term:"handoff",type:"single",senses:[{name:"handoff",q:"How is custody transferred without TTL expiry or ghost claims?",src:"beam-coordination-kernel.md",reg:"ops"}]},
+ {term:"locus",type:"single",senses:[{name:"locus",q:"What situated coordinate is this? (guild_id, channel_id, tab_id, profile)",src:"harness-substrate-plurality.md",reg:"ops"}]},
+ {term:"episode",type:"single",senses:[{name:"episode",q:"What bounded local interaction span is this?",src:"harness-substrate-plurality.md",reg:"ops"}]},
+ {term:"affordance_state",type:"single",senses:[{name:"affordance_state",q:"What reach/permissions/capability does the agent have at event time?",src:"harness-substrate-plurality.md",reg:"ops"}]},
+ {term:"assurance",type:"single",senses:[{name:"assurance (identity_assurance)",q:"How strongly is this identity claim grounded? (tier + source)",src:"identity.md",reg:"phil"}]},
+ {term:"governance_mode",type:"single",senses:[{name:"governance_mode",q:"Under what authority context was this write made?",src:"harness-substrate-plurality.md",reg:"ops"}]},
+ {term:"typed absence",type:"single",senses:[{name:"typed absence",q:"What kind of absence is this? — never a bare null",src:"beam-coordination-kernel.md",reg:"ops"}]},
+ {term:"proof of life",type:"single",senses:[{name:"proof of life / heartbeat",q:"How does a remote holder prove it is still alive on its lease?",src:"beam-coordination-kernel.md",reg:"ops"}]},
+ // open gaps
+ {term:"BEAM-resident harness value",type:"gap",senses:[{name:"open gap",q:"No harness-enum value for an agent whose body IS a BEAM/OTP process (Sentinel Wave 1/3).",src:"glossary.md · Open gaps",reg:"phil"}]},
+ {term:"affordance_state shape",type:"gap",senses:[{name:"open gap",q:"Term exists, type does not — boolean reach? capability list? permission diff?",src:"glossary.md · Open gaps",reg:"ops"}]},
+ {term:"episode nesting",type:"gap",senses:[{name:"open gap",q:"Question answered, granularity not — does a long shell session nest episodes?",src:"glossary.md · Open gaps",reg:"ops"}]},
+];
+const ROSETTA=[
+ ["Agent identity","layered continuity bundle","uuid + client_session_id","—","",  "must be earned, not performative"],
+ ["Internal state","behavioral trajectory","EISV state vector","ODE state; target E=−F tiered+stubbed","lens",""],
+ ["Healthy operating region","\"stable self\"","basin (+ health gating)","attractor — real in check_basin; verdict path uses BASIN_HIGH box","lens",""],
+ ["Deviation signal","—","running hot, basin-edge","running hot (V-sign) ships; surprise as −logP does not","lens",""],
+ ["Agent↔world boundary","process-instance boundary","lease surface, affordance_state","Markov blanket","false",""],
+ ["Custody transfer","lineage / inheritance","handoff","—","",""],
+ ["Proof of life","process-instance liveness","heartbeat","non-equilibrium steady state","cand","\"build nothing more alive than it is\""],
+ ["Belief revision","dialectic resolution","dialectic","active inference / policy selection","cand",""],
+ ["Confidence grounding","earned vs performative","identity_assurance, calibration","precision-weighting","cand",""],
+];
+const grid=document.getElementById("grid"), qbox=document.getElementById("q");
+let filter="all", query="";
+function statusClass(s){return s||"";}
+function statusLabel(s){return {earned:"✓ earned",lens:"◐ research-lens",cand:"~ candidate",false:"✗ false friend"}[s]||"";}
+function card(t){
+  const senses=t.senses.map(s=>`
+    <div class="sense">
+      <div class="sname">${s.name}${t.code?' <span class="typebadge">code</span>':''}</div>
+      <div class="q">${s.q}</div>
+      <div class="src">${s.src}</div>
+      <div class="tags">
+        <span class="reg ${s.reg}">${REG[s.reg]}</span>
+        ${s.status?`<span class="status ${statusClass(s.status)}">${statusLabel(s.status)}</span>`:''}
+      </div>
+    </div>`).join("");
+  return `<div class="card" data-type="${t.type}" data-blob="${(t.term+' '+t.senses.map(s=>s.name+' '+s.q+' '+s.src).join(' ')).toLowerCase().replace(/"/g,'')}">
+    <h3>${t.term}<span class="typebadge">${t.type}</span></h3>${senses}</div>`;
+}
+function rosetta(){
+  const rows=ROSETTA.map(r=>`<tr>
+    <td><b>${r[0]}</b></td><td>${r[1]}</td><td>${r[2]}</td>
+    <td>${r[4]?`<span class="status ${r[4]}">${statusLabel(r[4])}</span> `:''}${r[3]}</td>
+    <td>${r[5]||'—'}</td></tr>`).join("");
+  return `<div class="sectitle" data-section="rosetta">Cross-register map (Rosetta)</div>
+  <div class="note" data-section="rosetta">Physics is <b>built but not wired</b>: ◐ rows are real math in the parallel ODE / grounding tiers that does <b>not</b> drive verdicts. Promoting ◐→✓ = wiring ODE onto the verdict path. Highest-leverage move: make EISV distributional (mean + precision).</div>
+  <table class="rosetta" data-section="rosetta">
+    <tr><th>Referent</th><th>philosophical</th><th>ops</th><th>fep</th><th>manifesto</th></tr>${rows}</table>`;
+}
+function render(){
+  const showRos=(filter==="all"||filter==="rosetta");
+  const cards=TERMS.filter(t=>filter==="all"||t.type===filter)
+    .map(card).join("");
+  grid.innerHTML=cards+(showRos?rosetta():"");
+  // apply text query
+  document.querySelectorAll(".card").forEach(c=>{
+    c.classList.toggle("hidden", query && !c.dataset.blob.includes(query));
+  });
+  if(query){document.querySelectorAll('[data-section="rosetta"]').forEach(e=>e.classList.add("hidden"));}
+}
+document.querySelectorAll(".chip").forEach(ch=>ch.onclick=()=>{
+  document.querySelectorAll(".chip").forEach(c=>c.classList.remove("on"));
+  ch.classList.add("on"); filter=ch.dataset.f; render();
+});
+qbox.oninput=()=>{query=qbox.value.trim().toLowerCase();render();};
+render();
+</script>
+</body>
+</html>

--- a/docs/ontology/glossary.md
+++ b/docs/ontology/glossary.md
@@ -136,6 +136,31 @@ you write "continuity," mean the layered concept unless you write the full
 Both appear in the provenance envelope; keep `thread_id` out of any sentence
 about causal ancestry.
 
+### basin — attractor vs. health band (**confirmed at code level, 2026-06-20**)
+
+| Sense | Question it answers | Canonical source |
+|---|---|---|
+| `basin (attractor)` | Which equilibrium will the system's own EISV *dynamics* flow to? | `governance_core/dynamics.py::check_basin` — bistable `I>0.5` high/low/boundary; the parallel ODE (research lens) |
+| `basin (health band)` | Is each EISV axis inside its *configured* healthy box, so self-relative deviation should count as risk? | `src/behavioral_assessment.py::_basin_health_gate` (#689), `config.governance_config.BASIN_HIGH` — the **verdict-driving** gate |
+
+This is the dangerous kind: only the second sense drives verdicts, and it is a
+*static configured box* (`BASIN_E_HEALTHY=0.60`, …), **not** an attractor derived
+from dynamics — even though it borrows the attractor word. The real attractor
+basin exists in the ODE but does not gate verdicts. A runtime glossary
+(`src/governance_glossary.py::explain_basin`, #428) resolves the health-band sense
+for users; keep it consistent with this entry.
+
+### free energy — ODE accumulator vs. variational −F (code level)
+
+| Sense | Question it answers | Canonical source |
+|---|---|---|
+| `free energy (ODE V)` | What is the running E−I imbalance accumulator? | `governance_core/dynamics.py` — `V` is "like Helmholtz free energy", a signed integrator |
+| `free energy (variational −F)` | What is `E` as negative variational free energy under a generative model? | `src/grounding/free_energy.py` — Tier-1 FEP, **explicitly stubbed** (`NotImplementedError`, "Phase 2") |
+
+The first ships and drives nothing on its own; the second is the *target* `E`
+semantics and is honestly not-yet-implemented. Don't let "free energy" stand
+unqualified across the two.
+
 ---
 
 ## Single-sense load-bearing terms
@@ -150,7 +175,6 @@ against a baseline.
 | `transport` | Through what channel does the process act? (CLI, MCP-http, Discord, cron) | `harness-substrate-plurality.md` |
 | `lease` | What time-bounded claim to a surface is live, with what proof obligation and expiry? | `beam-coordination-kernel.md` |
 | `handoff` | How is custody of a lease (or of work) transferred without TTL expiry or ghost claims? | `beam-coordination-kernel.md`, `identity.md` |
-| `basin` | Is the agent's EISV inside its healthy operating region? | `eisv-basin-health-gating-v0.md` |
 | `locus` | What situated coordinate is this? (guild_id, channel_id, tab_id, profile) | `harness-substrate-plurality.md` |
 | `episode` | What bounded local interaction span is this? (one thread, one CLI conversation) | `harness-substrate-plurality.md` |
 | `affordance_state` | What reach/permissions/capability does the agent actually have at event time? | `harness-substrate-plurality.md` |
@@ -216,32 +240,54 @@ One row per **referent**; columns are its name in each register. This bounds the
 "unbounded nomenclature" into a finite table that grows by *rows* (new referents),
 not by uncontrolled vocabulary. Status marks the `fep` column specifically:
 
-- **✓ earned** — mapping holds in code/math today.
-- **~ candidate** — plausible conceptual fit, *not yet* earned; decorative if shipped as fact.
+- **✓ earned** — mapping holds and *drives behavior* (verdict path) today.
+- **◐ research-lens** — implemented as real math in the **parallel ODE / grounding tiers**, but **not wired to the verdict path**; honest, not decorative, but not yet load-bearing. (Added 2026-06-20 after reading the code; see correction below.)
+- **~ candidate** — plausible conceptual fit, *not yet* implemented anywhere; decorative if shipped as fact.
 - **✗ false friend** — looks like a synonym across registers but is a different referent; do not conflate.
 
 | Referent | philosophical | ops | fep | manifesto |
 |---|---|---|---|---|
 | Agent identity | layered continuity bundle | `uuid` + `client_session_id` | — | must be earned, not performative |
-| Internal state | behavioral trajectory | `EISV` state vector | ~ belief / hidden states of a generative model | — |
-| Healthy operating region | "stable self" | `basin` (+ health gating) | ~ attractor / characteristic-state set (**strongest candidate**) | — |
-| Deviation signal | — | `running hot`, basin-edge crossing | ~ surprise / prediction error / precision spike | — |
+| Internal state | behavioral trajectory | `EISV` state vector | ◐ ODE state (`governance_core/dynamics.py`); target `E=−F` tiered+stubbed in `grounding/free_energy.py` | — |
+| Healthy operating region | "stable self" | `basin` (+ health gating) | ◐ attractor — **real** in `check_basin` (bistable ODE), but verdict path uses a configured `BASIN_HIGH` box, not the attractor | — |
+| Deviation signal | — | `running hot`, basin-edge crossing | ◐ `running hot` (V-sign) ships; `surprise`/prediction-error as `−log P` does not | — |
 | Agent↔world boundary | process-instance boundary | `lease surface`, `affordance_state` | ✗ Markov blanket (**false friend** — statistical conditional-independence boundary, *not* a coordination claim) | — |
 | Custody transfer | lineage / inheritance | `handoff` | — | — |
 | Proof of life | process-instance liveness | `heartbeat` | ~ non-equilibrium steady state / self-maintenance | "build nothing more alive than it is" |
 | Belief revision | dialectic resolution | `dialectic` | ~ active inference / belief updating | — |
 | Confidence grounding | earned vs. performative | `identity_assurance` tier, calibration | ~ precision-weighting | — |
 
-**What the skeleton already reveals:** the `fep` column is almost entirely `~`
-(candidate) — one false friend, zero `✓` earned. So as of this writing the
-**physics register is aspirational, not load-bearing**: it's the register most at
-risk of decorative borrowing, which is exactly what the "name nothing more
-rigorous than it is" guardrail exists to police. Promote a `fep` cell to `✓` only
-when there is real variational machinery behind it, not when the metaphor merely
-reads well. The four-register model holds for these nine rows; if a referent
-won't fit a column, that absence is a finding (e.g. most rows have no genuine
-`manifesto` name — the norm register governs a few load-bearing referents, not
-all of them), not a gap to backfill.
+**Correction (code-grounded, 2026-06-20).** The skeleton's first claim — "physics
+register is aspirational, all `~`, zero earned" — **was wrong, and reading the
+code corrected it.** Three rows are `◐ research-lens`, not `~`:
+
+- `governance_core/dynamics.py` is a **real thermodynamic ODE** (full `dE/dt…dV/dt`,
+  RK4, coherence feedback, soft barriers, `compute_equilibrium`, contraction-theory
+  convergence, and `check_basin` — a genuine bistable basin of attraction).
+- `src/grounding/free_energy.py` already implements the **"name nothing more
+  rigorous than it is" guardrail in code**: a 3-tier estimator where Tier-1 FEP is
+  explicitly `raise NotImplementedError("…Phase 2 scope")`, Tier-2 resource ships,
+  and every value carries a `source=` provenance tag so a heuristic is never
+  laundered as a measurement. The guardrail predates this glossary and runs at
+  runtime.
+- `docs/EISV_COMPUTATION.md` already states the deployed-vs-target split this table
+  was re-deriving: deployed EISV = "auditable heuristic blends, EMA-smoothed";
+  target = `E`as`−F`, `I`as mutual information, `S`as entropy. **The ODE "runs in
+  parallel and does NOT drive verdicts."**
+
+So the accurate finding is sharper than "aspirational": **the physics is built but
+not wired.** Your system is two loops — a heuristic verdict path (EMA + z-score +
+`BASIN_HIGH` health gate) that drives decisions, and a parallel thermodynamic ODE
+that's a research lens. Promoting a `◐` to `✓` does not mean *building* the math;
+it means **wiring the existing ODE/grounding forms onto the verdict path** — a real
+control-loop change to trajectory/telemetry, gated tier-by-tier with the provenance
+honesty already in place. That is the single most important thing this whole
+glossary exercise surfaced.
+
+The four-register model still holds for these nine rows; if a referent won't fit a
+column, that absence is a finding (e.g. most rows have no genuine `manifesto` name
+— the norm register governs a few load-bearing referents, not all of them), not a
+gap to backfill.
 
 ### FEP promotion conditions (roadmap)
 
@@ -253,8 +299,8 @@ most-reachable first.
 | Candidate mapping | Earned when (falsifiable test) | Reachability |
 |---|---|---|
 | assurance/calibration → **precision-weighting** | An observation's effect on state/calibration is scaled by its assurance as an explicit inverse-variance **precision** term — low-assurance writes are down-weighted *proportionally*, not by category. Test: the update weight is a continuous function of assurance, derivable as precision, not an `if tier == weak` branch. (`identity.md` already gestures at this: "a gated pre-check should not weight calibration the same way an explicit check-in does.") | **High** — closest to earnable; the weighting intent already exists, it just needs to be Bayesian rather than categorical. |
-| basin → **attractor / characteristic-state set** | The basin is the *attracting set of the system's own EISV dynamics* — perturb EISV and return-to-basin is an emergent property of the update flow, with the "edge" a real separatrix. Test: the basin boundary is derived from the dynamics, not a configured threshold box; a clamp disqualifies it. | **High** — basin-health gating already behaves attractor-ish; earned only if the edge is dynamics, not a set point. |
-| EISV → **generative-model belief state** | EISV carries explicit **uncertainty** (a distribution, not a point), and its update rule is (an approximation of) gradient descent on a variational free-energy functional — not EWMA-style smoothing. Test: the EISV update equals/approximates free-energy minimization under a stated generative model. | **Medium** — requires EISV to become distributional (mean + precision) first. |
+| basin → **attractor / characteristic-state set** | *Already built (`◐`)* — the attractor exists in `check_basin` (bistable ODE). Earned (`✓`) when the **verdict path's** basin gate is the ODE attractor, not the static `BASIN_HIGH` box in `behavioral_assessment.py`. Test: the gate edge moves with the dynamics; replacing the config box with the ODE separatrix changes no test that depends on a *real* edge. | **High** — not "build the math" but "wire ODE→verdict path"; the math is done. |
+| EISV → **generative-model belief state** | *Partly built (`◐`)* — the ODE evolves EISV; what's missing is **uncertainty**: EISV is a point estimate. Earned when EISV carries explicit precision (a distribution) and updates approximate free-energy minimization, not EMA smoothing. Test: the EISV update equals/approximates FE-minimization under a stated generative model. | **Medium** — the prerequisite that unlocks three rows; needs EISV distributional (mean + precision). |
 | running-hot / basin-edge → **surprise / prediction error** | The hot signal is computed as (an approximation of) `−log P(behavior \| model)` under an explicit generative model — how *unexpected* current behavior is, not variance-from-norm. Test: high surprise provably drives belief updates (couples to the EISV and dialectic rows). | **Medium** — depends on EISV-as-belief-state landing first. |
 | dialectic → **active inference / policy selection** | Resolution is formalized as selecting the position/action that minimizes **expected** free energy (future surprise), with an explicit EFE objective. Test: a dialectic verdict is reconstructable from an EFE computation, not an LLM judgment or scoring heuristic. | **Medium-low** — the largest formalization lift. |
 | heartbeat → **non-equilibrium steady state / self-maintenance** | Proof-of-life is contingent on the agent *actively maintaining its own boundary/characteristic states* (resisting dissipation), not emitting a TTL ping. Test: liveness fails when self-maintenance work stops, even if the timer fires. | **Decorative — recommend demote.** A TTL heartbeat is an ops timer; "NESS" is almost certainly borrowed rigor here. Drop the `fep` name unless heartbeat is re-grounded in real self-maintenance. |
@@ -266,10 +312,15 @@ agent's internal states from external ones (sensory + active states mediating) �
 closer to `affordance_state` than to a coordination claim — and it is earned only
 when that statistical independence structure is actually modeled, not asserted.
 
-**Roadmap reading:** two mappings (precision-weighting, basin-as-attractor) are
-genuinely reachable and worth pursuing; three are gated behind making EISV
-distributional first; one (heartbeat→NESS) should be dropped rather than chased.
-That ordering is the actual deliverable — it says which physics claims to earn
+**Roadmap reading (code-corrected):** the work is mostly *wiring, not building*.
+`basin-as-attractor` is a wire-up (ODE exists); `precision-weighting` is the
+closest greenfield-ish step (the basin-health gate is already a 0→1 ramp, which is
+precision-shaped); the EISV-distributional change is the prerequisite that unlocks
+surprise + active-inference; `heartbeat→NESS` should be dropped. The single
+highest-leverage move is **making EISV distributional** (mean + precision), because
+it both unlocks three FEP rows *and* is the precondition for letting the ODE drive
+verdicts honestly. That ordering is the actual deliverable — it says which physics
+claims to earn
 next and which to stop borrowing.
 
 ---


### PR DESCRIPTION
Follow-up to #975. The first glossary was a docs-only sweep; this corrects it against the **actual code**, which changed three findings.

## What reading the code corrected

- **New homonym `basin` (confirmed at symbol level).** `governance_core/dynamics.py::check_basin` = a bistable **attractor** basin (research-lens ODE); `src/behavioral_assessment.py::_basin_health_gate` / `config.governance_config.BASIN_HIGH` = a static **health band** that is the *verdict-driving* gate. Only the second drives decisions, and it's a configured box, not an attractor — even though it borrows the attractor word. Promoted from single-sense to high-risk homonym. (Runtime glossary `src/governance_glossary.py::explain_basin` (#428) resolves the health-band sense.)
- **New homonym `free energy`.** ODE `V` ("like Helmholtz free energy", a signed integrator) vs. `src/grounding/free_energy.py` target `E=−F` (variational, Tier-1 explicitly stubbed).
- **Retracted a wrong claim.** The Rosetta skeleton said "physics register is aspirational, zero earned." That's wrong: `governance_core/dynamics.py` is a real thermodynamic ODE (RK4, coherence feedback, `compute_equilibrium`, contraction-theory convergence, `check_basin`), and `src/grounding/free_energy.py` already enforces this glossary's own "name nothing more rigorous than it is" guardrail at runtime (tiered estimator, `source=` provenance tags, FEP stubbed). Per `docs/EISV_COMPUTATION.md`, the ODE "runs in parallel and does NOT drive verdicts."

## The sharper finding

The physics is **built but not wired.** The system is two loops — a heuristic verdict path (EMA + z-score + `BASIN_HIGH` health gate) that drives decisions, and a parallel thermodynamic ODE that's a research lens. So the FEP roadmap is reframed: promoting a mapping means **wiring the existing ODE/grounding forms onto the verdict path**, not building math. New `◐ research-lens` status marks the built-but-unwired rows. Highest-leverage move: **make EISV distributional** (mean + precision) — it unlocks three FEP rows and is the precondition for letting the ODE drive verdicts honestly.

## Does this change runtime behavior?

No. Docs-only (`docs/ontology/*.md`). It corrects the *description* of the math; it touches no math, verdict path, or telemetry. The wiring it describes is a future, separately-gated change.

Lesson recorded in the audit addendum: **read the code, not only the proposal docs** — doc-sense vs code-symbol drift is invisible to a docs-only pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0175PJNxU7V5HrpGXcMtszEM)_