### PR TITLE
EISV distributional signal probe — spec + Probe A implementation

### DIFF
--- a/docs/proposals/eisv-distributional-signal-probe-v0.md
+++ b/docs/proposals/eisv-distributional-signal-probe-v0.md
@@ -1,8 +1,18 @@
 # EISV Distributional Signal Probe — v0
 
 **Created:** 2026-06-20
-**Status:** Sketch for review. Cheap, falsifiable probe that must greenlight (or kill) the larger "make EISV distributional" work **before** any dynamics change.
+**Status:** **Probe A implemented** in `scripts/analysis/eisv_skeptic_report.py` (tested; awaiting a run against a deployment DB). Probe B still a sketch. Cheap, falsifiable probe that must greenlight (or kill) the larger "make EISV distributional" work **before** any dynamics change.
 **Companion to:** `docs/REVIEWER_GUIDE.md` (§ Falsifiability), `scripts/analysis/eisv_skeptic_report.py`, `docs/EISV_COMPUTATION.md`, `docs/ontology/glossary.md` (FEP roadmap).
+
+> **Implementation note (2026-06-20).** Probe A landed in the harness: the
+> dispersion-window `LATERAL` join, the `prior_*_disp` fields on `OutcomeRow`, the
+> `prior_eisv_dispersion_binned` + `previous_bad_plus_dispersion` models, the
+> `--dispersion-window-minutes` flag, and a "By recent-state dispersion quartile"
+> bad-rate table. Tunables are module constants: `DISPERSION_WINDOW_MINUTES=90`,
+> `MIN_DISPERSION_SNAPSHOTS=5`, `DISPERSION_FEATURE="prior_s_disp"` (one-line swap
+> to another axis). Unit-tested; the A1–A5 sections below are the design of record,
+> now realized. **Next action is a single run against real outcomes** — there is no
+> deployment DB in this environment, so the greenlight/kill decision is pending data.
 
 ---
 

--- a/docs/proposals/eisv-distributional-signal-probe-v0.md
+++ b/docs/proposals/eisv-distributional-signal-probe-v0.md
@@ -1,0 +1,154 @@
+# EISV Distributional Signal Probe — v0
+
+**Created:** 2026-06-20
+**Status:** Sketch for review. Cheap, falsifiable probe that must greenlight (or kill) the larger "make EISV distributional" work **before** any dynamics change.
+**Companion to:** `docs/REVIEWER_GUIDE.md` (§ Falsifiability), `scripts/analysis/eisv_skeptic_report.py`, `docs/EISV_COMPUTATION.md`, `docs/ontology/glossary.md` (FEP roadmap).
+
+---
+
+## The question, sharpened
+
+The glossary's FEP roadmap names "make EISV distributional (mean + precision)" as the
+highest-leverage move. But "would it improve signal?" is an **empirical** question, and
+distributional dressing can fit noise as easily as it can earn signal (same trap as the
+dropped 128-parameter idea). So before touching `governance_core/dynamics.py` or the
+observation blend, we test the cheap proxy:
+
+> **Does the *uncertainty* in recent EISV carry predictive lift over the boring
+> `previous_outcome_bad` baseline — and over the current best feature `prior_risk`?**
+
+If yes → distributional EISV is worth building, with evidence in hand. If no → the
+bottleneck is upstream in the *observations*, not the *representation*, and effort should
+redirect there. Either answer is a win; only "build it and hope" is a loss.
+
+## Why this is testable today (no new instrumentation)
+
+The skeptic harness scores features that already live in the DB:
+`audit.outcome_events` joined (`fetch_rows`, LATERAL) to the agent's prior
+`core.agent_state` snapshot at a lead time before the outcome. Each "model" in
+`build_model_scores` is just: quartile-bin a feature on train, fit a smoothed bad-rate
+per bin, predict on test, score AUC (ranking) + Brier (calibration) **paired against the
+baseline** (`score_deltas_vs_baseline`), and self-label
+INCONCLUSIVE / SKEPTICAL / WEAK SIGNAL / KEEP TESTING (`summarize_conclusion`).
+
+A point estimate hides its own uncertainty — but the **dispersion of recent state
+snapshots** is a stored proxy for that uncertainty. The harness currently joins exactly
+one prior snapshot (`LIMIT 1`). Widen that to a window and aggregate, and you recover a
+historical proxy variance for free. That is the whole probe.
+
+## Probe A — dispersion-as-feature (cheap; ~½ day)
+
+Tests the **uncertainty-as-feature** leg: is the spread of recent EISV predictive on its
+own and additively over `prior_risk`?
+
+### A1. Widen the prior-state join to a dispersion window
+
+In `fetch_rows`, add a second LATERAL that aggregates over the last *N* non-synthetic
+snapshots strictly **before the lead cutoff** (reusing the existing leak-safe
+`recorded_at <= o.ts - lead` guard):
+
+```sql
+LEFT JOIN LATERAL (
+    SELECT
+        count(*)                                               AS n_prior_snapshots,
+        stddev_samp((s.state_json->>'S')::float)               AS prior_s_disp,
+        stddev_samp((s.state_json->>'E')::float)               AS prior_e_disp,
+        stddev_samp((s.state_json->>'I')::float)               AS prior_i_disp,
+        stddev_samp((s.state_json->>'V')::float)               AS prior_v_disp,
+        stddev_samp(s.risk_score)                              AS prior_risk_disp
+    FROM core.identities i
+    JOIN core.agent_state s ON s.identity_id = i.identity_id
+    WHERE i.agent_id = o.agent_id
+      AND s.synthetic IS NOT TRUE
+      AND s.recorded_at <= o.ts - ($2::double precision * INTERVAL '1 minute')
+      AND s.recorded_at >  o.ts - ($2::double precision * INTERVAL '1 minute')
+                              - (INTERVAL '90 minutes')         -- dispersion window
+) disp ON TRUE
+```
+
+Tunable: the window length and a minimum `n_prior_snapshots` (suggest ≥ 5) below which
+dispersion is null — a stddev over 1–2 points is noise, not a signal.
+
+### A2. Carry the fields on `OutcomeRow`
+
+Add `n_prior_snapshots`, `prior_s_disp`, `prior_e_disp`, `prior_i_disp`, `prior_v_disp`,
+`prior_risk_disp` to the `OutcomeRow` dataclass and `_row_from_record`, gated on
+`n_prior_snapshots >= 5` (else null, so sparse agents don't pollute the bins).
+
+### A3. Add the models (mirror `prior_s_binned` / `previous_bad_plus_prior_risk`)
+
+In `build_model_scores`, add — using the existing `quantile_cuts` + `_fit_group_rates`
+machinery, no new scoring code:
+
+- **`prior_eisv_dispersion_binned`** — bin a single composite dispersion (suggest
+  `prior_s_disp`, since S already *is* the entropy/uncertainty axis; or the L2 of the
+  four axis dispersions). Raw AUC score = the dispersion value (higher disp ⇒ higher
+  predicted bad).
+- **`previous_bad_plus_dispersion`** — the additive test that actually matters: group by
+  `(previous_bad, dispersion_quartile)`, exactly as `previous_bad_plus_prior_risk` groups
+  by `(previous_bad, risk_quartile)`.
+
+Then add both names to `EISV_PRIOR_STATE_MODELS` so they enter
+`score_deltas_vs_baseline` and the conclusion.
+
+### A4. Run it
+
+```bash
+export GOVERNANCE_DATABASE_URL=postgresql://...   # real outcomes
+python3 scripts/analysis/eisv_skeptic_report.py --scope task --window-days 90 \
+  --output data/analysis/eisv_dispersion_probe.md
+# repeat --lead-minutes 0 and 5 (the lead band where current signal exists)
+```
+
+Also eyeball the new "By dispersion quartile" bad-rate table for **monotonicity** — a real
+signal shows rising bad-rate across dispersion quartiles, not a flat or U-shaped smear.
+
+### A5. Decision rule (uses the harness's own thresholds)
+
+| Result | Read | Action |
+|---|---|---|
+| `previous_bad_plus_dispersion` **beats baseline** (AUC Δ ≥ 0.03 **and** Brier improvement ≥ 0.001 → "KEEP TESTING") **and** beats `previous_bad_plus_prior_risk` on the paired delta | Uncertainty carries lift the point estimate was hiding | **Greenlight** the distributional build (Probe B, then dynamics) |
+| Dispersion model present but `SKEPTICAL` / non-monotonic quartiles | Spread doesn't rank outcomes | **Kill** distributional-for-signal; redirect to the observation layer |
+| `INCONCLUSIVE` (the 90d task scope has only ~80 bad outcomes; adding a ≥5-snapshot filter shrinks coverage further) | Underpowered, not negative | **Hold**; the modeling/honesty case for distributional EISV still stands, but it can't be justified on *signal* yet |
+
+## Probe B — precision-reweighted state (follow-up; heavier)
+
+Probe A tests uncertainty as a *feature*. The other leg of "distributional" is
+**precision-weighted updates** — the EMA today uses a schedule-based α
+(`behavioral_state.py`, ramps ~0.5 → configured), so a noisy observation moves state as
+much as a clean one. Probe B tests the *update rule*, offline, without shipping it:
+
+1. From stored observation history, recompute an alternative EISV where the per-step α is
+   scaled by inverse dispersion (confident observations move state more).
+2. Expose the reweighted `risk`/`S` as new harness features
+   (`prior_risk_precisionweighted_binned`).
+3. If the reweighted feature out-predicts the as-stored one on the same paired delta,
+   precision-weighting earns its place — that's the strongest single signal argument for
+   the distributional build, and it's the cheapest *real* slice of it.
+
+Probe B is only worth running if Probe A greenlights or is inconclusive-but-suggestive.
+
+## Honesty caveats (state these in any result write-up)
+
+- **Power.** ~80 bad task-outcomes over 90d; the harness gates `<10 bad` and `<100
+  trusted` as INCONCLUSIVE. The ≥5-snapshot dispersion filter reduces coverage. A null
+  here is weak evidence, not proof of absence.
+- **Proxy ≠ the thing.** Static dispersion of stored snapshots is a *proxy* for the
+  uncertainty an explicit precision term would carry. A positive result greenlights;
+  a null leaves Probe B (the update-rule leg) still open, since precision-weighting can
+  improve *calibration* even when a static dispersion feature doesn't improve *ranking*.
+- **Leakage.** All dispersion must come from snapshots strictly before `o.ts - lead`. The
+  existing query already enforces this; the window addition must keep both bounds.
+- **What it does not prove.** This checks for measurable predictive lift over dumb
+  baselines — not that EISV is the right ontology, and not that distributional EISV would
+  let the ODE drive verdicts safely. It only decides whether the *signal* case for the
+  build is earned.
+
+## Why bother (the connecting thread)
+
+This is the disciplined version of the whole glossary thread applied to code: a physics-
+shaped upgrade (distributional state) gets a falsifiable test against the system's own
+skeptic harness **before** it ships, so "more rigorous-looking" has to become "measurably
+better" first. Greenlight buys the distributional build with evidence; a kill saves the
+build and redirects to the real bottleneck. The probe is pure SQL + deterministic stats —
+no model API, no new instrumentation — so it costs a day, not a quarter.

--- a/scripts/analysis/eisv_skeptic_report.py
+++ b/scripts/analysis/eisv_skeptic_report.py
@@ -52,12 +52,26 @@ TASK_OUTCOMES = (
 
 SMOOTHING_ALPHA = 1.0
 
+# Probe A — dispersion-as-feature (docs/proposals/eisv-distributional-signal-probe-v0.md).
+# A point-estimate EISV hides its own uncertainty; the dispersion of recent state
+# snapshots is a stored proxy for it. We aggregate stddev over the snapshots in a
+# window strictly before the lead cutoff (leak-safe), and require a minimum count
+# because a stddev over 1-2 points is noise, not a signal.
+DISPERSION_WINDOW_MINUTES = 90.0
+MIN_DISPERSION_SNAPSHOTS = 5
+# Headline dispersion axis: S is the entropy/uncertainty axis, so its volatility is
+# the most on-thesis proxy. One-line swap to prior_risk_disp / another axis if a
+# bad-rate table below shows a cleaner monotonic separation.
+DISPERSION_FEATURE = "prior_s_disp"
+
 EISV_PRIOR_STATE_MODELS = (
     "previous_bad_plus_prior_risk",
     "prior_risk_binned",
     "prior_phi_binned",
     "prior_s_binned",
     "prior_verdict",
+    "prior_eisv_dispersion_binned",
+    "previous_bad_plus_dispersion",
 )
 
 
@@ -90,6 +104,15 @@ class OutcomeRow:
     snapshot_coherence: float | None
     row_key: str | None = None
     previous_bad: bool | None = None
+    # Probe A — dispersion over recent prior snapshots (None unless
+    # n_prior_snapshots >= MIN_DISPERSION_SNAPSHOTS so sparse agents do not
+    # pollute the quantile bins).
+    n_prior_snapshots: int | None = None
+    prior_s_disp: float | None = None
+    prior_e_disp: float | None = None
+    prior_i_disp: float | None = None
+    prior_v_disp: float | None = None
+    prior_risk_disp: float | None = None
 
 
 @dataclass(frozen=True)
@@ -496,6 +519,59 @@ def build_model_scores(
             )
         )
 
+    # --- Probe A: dispersion-as-feature -------------------------------------
+    # Mirrors prior_risk_binned / previous_bad_plus_prior_risk exactly, on the
+    # dispersion of recent state instead of the prior risk level.
+    def _disp(row: OutcomeRow) -> float | None:
+        return getattr(row, DISPERSION_FEATURE)
+
+    disp_train = [r for r in train_rows if _disp(r) is not None]
+    disp_test = [r for r in test_rows if _disp(r) is not None]
+    disp_cuts = quantile_cuts([
+        float(_disp(r)) for r in disp_train if _disp(r) is not None
+    ])
+    if len(disp_train) >= min_feature_rows and disp_cuts:
+        disp_rates = _fit_group_rates(
+            disp_train,
+            lambda row: bucket_index(_disp(row), disp_cuts),
+            global_probability,
+        )
+        scores.append(
+            _score_predictions(
+                "prior_eisv_dispersion_binned",
+                disp_train,
+                disp_test,
+                lambda row: disp_rates.get(
+                    bucket_index(_disp(row), disp_cuts),
+                    disp_rates["__default__"],
+                ),
+                raw_score_fn=_disp,
+                note=(
+                    f"{DISPERSION_FEATURE} quartile cuts="
+                    f"{', '.join(f'{cut:.3f}' for cut in disp_cuts)}"
+                ),
+            )
+        )
+
+        disp_combined_rates = _fit_group_rates(
+            disp_train,
+            lambda row: (row.previous_bad, bucket_index(_disp(row), disp_cuts)),
+            global_probability,
+        )
+        scores.append(
+            _score_predictions(
+                "previous_bad_plus_dispersion",
+                disp_train,
+                disp_test,
+                lambda row: disp_combined_rates.get(
+                    (row.previous_bad, bucket_index(_disp(row), disp_cuts)),
+                    disp_rates.get(bucket_index(_disp(row), disp_cuts), global_probability),
+                ),
+                raw_score_fn=_disp,
+                note="smoothed rate grouped by previous_bad and dispersion quartile",
+            )
+        )
+
     phi_train = [r for r in train_rows if r.prior_phi is not None]
     phi_test = [r for r in test_rows if r.prior_phi is not None]
     phi_cuts = quantile_cuts([
@@ -681,6 +757,7 @@ def _coverage(rows: Sequence[OutcomeRow]) -> dict[str, Any]:
     prior_risk = [r for r in rows if r.prior_risk is not None]
     confidence = [r for r in rows if r.reported_confidence is not None]
     complexity = [r for r in rows if r.reported_complexity is not None]
+    dispersion = [r for r in rows if getattr(r, DISPERSION_FEATURE) is not None]
     ages = [r.prior_state_age_seconds for r in prior_state if r.prior_state_age_seconds is not None]
     return {
         "total": total,
@@ -688,6 +765,7 @@ def _coverage(rows: Sequence[OutcomeRow]) -> dict[str, Any]:
         "prior_risk": len(prior_risk),
         "confidence": len(confidence),
         "complexity": len(complexity),
+        "dispersion": len(dispersion),
         "median_prior_age_seconds": statistics.median(ages) if ages else None,
         "max_prior_age_seconds": max(ages) if ages else None,
     }
@@ -796,6 +874,11 @@ def build_report(
         f"| Rows with reported complexity | {coverage['complexity']} "
         f"| {_fmt_pct(coverage['complexity'] / total if total else None)} |"
     )
+    a(
+        f"| Rows with state dispersion (>= {MIN_DISPERSION_SNAPSHOTS} snapshots) "
+        f"| {coverage['dispersion']} "
+        f"| {_fmt_pct(coverage['dispersion'] / total if total else None)} |"
+    )
     a("")
     if coverage["median_prior_age_seconds"] is not None:
         a(
@@ -891,6 +974,28 @@ def build_report(
         a("| (insufficient prior S coverage) | 0 | 0 | - |")
     a("")
 
+    disp_cuts, disp_bucket_rows = metric_bucket_rates(
+        rows,
+        metric_name=DISPERSION_FEATURE,
+        metric_fn=lambda row: getattr(row, DISPERSION_FEATURE),
+        reverse_labels=False,
+    )
+    a(f"By recent-state dispersion quartile (`{DISPERSION_FEATURE}`):")
+    a("")
+    a("Probe A: a rising bad-rate across dispersion quartiles is the uncertainty-as-signal read.")
+    a("")
+    if disp_cuts:
+        a(f"Dispersion cuts: {', '.join(f'{cut:.4f}' for cut in disp_cuts)}")
+        a("")
+    a("| Dispersion bucket | N | Bad | Bad rate |")
+    a("|---|---:|---:|---:|")
+    if disp_bucket_rows:
+        for key, total, bad_count, rate in disp_bucket_rows:
+            a(f"| `{key}` | {total} | {bad_count} | {_fmt_pct(rate)} |")
+    else:
+        a("| (insufficient dispersion coverage) | 0 | 0 | - |")
+    a("")
+
     a("## Model Comparison")
     a("")
     a("Lower Brier is better. AUC above 0.5 means ranking is better than chance.")
@@ -951,6 +1056,15 @@ def _parse_detail(raw: Any) -> dict[str, Any]:
 
 def _row_from_record(record: Any) -> OutcomeRow:
     detail = _parse_detail(record.get("detail"))
+    n_prior = record.get("n_prior_snapshots")
+    n_prior = int(n_prior) if n_prior is not None else None
+    # Gate dispersion on a minimum snapshot count: a stddev over 1-2 points is
+    # noise. Below the floor, leave all dispersion fields None.
+    sufficient = n_prior is not None and n_prior >= MIN_DISPERSION_SNAPSHOTS
+
+    def _disp_field(key: str) -> float | None:
+        return _to_float(record.get(key)) if sufficient else None
+
     return OutcomeRow(
         ts=record["ts"],
         row_key=str(record["outcome_id"]) if record.get("outcome_id") is not None else None,
@@ -978,6 +1092,12 @@ def _row_from_record(record: Any) -> OutcomeRow:
         snapshot_v=_to_float(record.get("eisv_v")),
         snapshot_phi=_to_float(record.get("eisv_phi")),
         snapshot_coherence=_to_float(record.get("eisv_coherence")),
+        n_prior_snapshots=n_prior,
+        prior_s_disp=_disp_field("prior_s_disp"),
+        prior_e_disp=_disp_field("prior_e_disp"),
+        prior_i_disp=_disp_field("prior_i_disp"),
+        prior_v_disp=_disp_field("prior_v_disp"),
+        prior_risk_disp=_disp_field("prior_risk_disp"),
     )
 
 
@@ -987,6 +1107,7 @@ async def fetch_rows(
     window_days: int,
     lead_minutes: float,
     outcome_types: Sequence[str],
+    dispersion_window_minutes: float = DISPERSION_WINDOW_MINUTES,
 ) -> list[OutcomeRow]:
     try:
         import asyncpg
@@ -1038,7 +1159,13 @@ async def fetch_rows(
                     ps.state_json->'primary_eisv'->>'V',
                     ps.state_json->'ode_eisv'->>'V',
                     ps.volatility::text
-                ) AS prior_v
+                ) AS prior_v,
+                disp.n_prior_snapshots,
+                disp.prior_s_disp,
+                disp.prior_e_disp,
+                disp.prior_i_disp,
+                disp.prior_v_disp,
+                disp.prior_risk_disp
             FROM audit.outcome_events o
             LEFT JOIN LATERAL (
                 SELECT
@@ -1057,6 +1184,40 @@ async def fetch_rows(
                 ORDER BY s.recorded_at DESC
                 LIMIT 1
             ) ps ON TRUE
+            LEFT JOIN LATERAL (
+                -- Probe A dispersion window: stddev of recent state over the
+                -- snapshots strictly before the lead cutoff (same leak-safe
+                -- upper bound as ps) and within DISPERSION_WINDOW_MINUTES.
+                SELECT
+                    count(*) AS n_prior_snapshots,
+                    stddev_samp(COALESCE(
+                        (s.state_json->'primary_eisv'->>'S')::float,
+                        (s.state_json->'ode_eisv'->>'S')::float,
+                        s.entropy
+                    )) AS prior_s_disp,
+                    stddev_samp(COALESCE(
+                        (s.state_json->'primary_eisv'->>'E')::float,
+                        (s.state_json->'ode_eisv'->>'E')::float,
+                        NULL
+                    )) AS prior_e_disp,
+                    stddev_samp(COALESCE(
+                        (s.state_json->'primary_eisv'->>'I')::float,
+                        (s.state_json->'ode_eisv'->>'I')::float,
+                        s.integrity
+                    )) AS prior_i_disp,
+                    stddev_samp(COALESCE(
+                        (s.state_json->'primary_eisv'->>'V')::float,
+                        (s.state_json->'ode_eisv'->>'V')::float,
+                        s.volatility
+                    )) AS prior_v_disp,
+                    stddev_samp(s.risk_score) AS prior_risk_disp
+                FROM core.identities i
+                JOIN core.agent_state s ON s.identity_id = i.identity_id
+                WHERE i.agent_id = o.agent_id
+                  AND s.synthetic IS NOT TRUE
+                  AND s.recorded_at <= o.ts - ($2::double precision * INTERVAL '1 minute')
+                  AND s.recorded_at >  o.ts - (($2 + $4)::double precision * INTERVAL '1 minute')
+            ) disp ON TRUE
             WHERE o.ts >= now() - ($1::int * INTERVAL '1 day')
               AND o.outcome_type = ANY($3::text[])
             ORDER BY o.ts ASC
@@ -1064,6 +1225,7 @@ async def fetch_rows(
             window_days,
             lead_minutes,
             list(outcome_types),
+            dispersion_window_minutes,
         )
     finally:
         await conn.close()
@@ -1080,6 +1242,12 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--window-days", type=int, default=365)
     parser.add_argument("--lead-minutes", type=float, default=0.0)
+    parser.add_argument(
+        "--dispersion-window-minutes",
+        type=float,
+        default=DISPERSION_WINDOW_MINUTES,
+        help="Window before the lead cutoff over which recent-state dispersion is measured (Probe A).",
+    )
     parser.add_argument("--train-fraction", type=float, default=0.7)
     parser.add_argument("--db-url", default=DEFAULT_DB_URL)
     parser.add_argument(
@@ -1105,6 +1273,7 @@ async def main_async(args: argparse.Namespace) -> int:
         window_days=args.window_days,
         lead_minutes=args.lead_minutes,
         outcome_types=outcome_types,
+        dispersion_window_minutes=args.dispersion_window_minutes,
     )
     report = build_report(
         rows,

--- a/tests/test_eisv_skeptic_report.py
+++ b/tests/test_eisv_skeptic_report.py
@@ -1,6 +1,8 @@
+import dataclasses
 from datetime import datetime, timedelta, timezone
 
 from scripts.analysis.eisv_skeptic_report import (
+    MIN_DISPERSION_SNAPSHOTS,
     ModelScore,
     OutcomeRow,
     auc_score,
@@ -156,6 +158,36 @@ def test_summarize_conclusion_prefers_candidates_that_beat_both_metrics():
 
     assert "prior_risk_binned" in conclusion
     assert "do not beat" not in conclusion
+
+
+def _with_dispersion(row: OutcomeRow, disp: float | None, n: int) -> OutcomeRow:
+    return dataclasses.replace(row, prior_s_disp=disp, n_prior_snapshots=n)
+
+
+def test_build_model_scores_includes_dispersion_when_covered():
+    rows = []
+    for idx in range(100):
+        bad = idx >= 80
+        # high dispersion separates bad outcomes; low dispersion for trusted ones
+        disp = 0.9 if bad else 0.1
+        row = _row(idx, bad=bad, risk=0.5, agent=f"agent-{idx % 5}")
+        rows.append(_with_dispersion(row, disp, n=MIN_DISPERSION_SNAPSHOTS + 2))
+    scores = build_model_scores(rows, train_fraction=0.7, min_feature_rows=10)
+    names = {score.name for score in scores}
+    assert "prior_eisv_dispersion_binned" in names
+    assert "previous_bad_plus_dispersion" in names
+
+
+def test_dispersion_models_absent_without_coverage():
+    # prior_s_disp left None (default) -> no dispersion models built
+    rows = [
+        _row(idx, bad=idx >= 80, risk=0.5, agent=f"agent-{idx % 5}")
+        for idx in range(100)
+    ]
+    scores = build_model_scores(rows, train_fraction=0.7, min_feature_rows=10)
+    names = {score.name for score in scores}
+    assert "prior_eisv_dispersion_binned" not in names
+    assert "previous_bad_plus_dispersion" not in names
 
 
 def test_build_report_includes_ablation_delta_section():


### PR DESCRIPTION
Spec **and** working implementation of the cheap, falsifiable probe that gates the "make EISV distributional" work — the highest-leverage item from the glossary FEP roadmap (#975) and code-grounded corrections (#978).

## The idea

Before touching `governance_core/dynamics.py` or the observation blend, test the proxy question against the system's own skeptic harness:

> Does the **uncertainty** in recent EISV carry predictive lift over the `previous_outcome_bad` baseline — and over the current best feature `prior_risk`?

Greenlight → build distributional EISV with evidence. Null → the bottleneck is the *observations*, not the *representation*; redirect there. Inconclusive (live possibility, ~80 bad task-outcomes) → hold. Only "build it and hope" is a loss.

## What's in this PR

- **Spec:** `docs/proposals/eisv-distributional-signal-probe-v0.md` (Probe A + the heavier Probe B follow-up + decision table + honesty caveats).
- **Probe A, implemented** in `scripts/analysis/eisv_skeptic_report.py`:
  - second leak-safe `LATERAL` aggregating `stddev_samp` of E/I/S/V + `risk_score` over snapshots within `DISPERSION_WINDOW_MINUTES` (=90) before the lead cutoff, plus `n_prior_snapshots`;
  - `prior_{s,e,i,v}_disp` / `prior_risk_disp` on `OutcomeRow`, gated to None below `MIN_DISPERSION_SNAPSHOTS` (=5) so sparse agents don't pollute bins;
  - `prior_eisv_dispersion_binned` + `previous_bad_plus_dispersion` models, mirroring the `prior_risk` pair, added to the ablation deltas + conclusion;
  - `--dispersion-window-minutes` flag; `DISPERSION_FEATURE` (=`prior_s_disp`) selects the binned axis (one-line swap);
  - "By recent-state dispersion quartile" bad-rate table — a monotonic rise is the uncertainty-as-signal read.
- **Tests:** two new (`tests/test_eisv_skeptic_report.py`); 13/13 pass locally (pytest absent in env, run via direct invocation).

Pure SQL + deterministic stats — no model API (fits the no-paid-API constraint).

## Decision is pending data

There's **no deployment DB in this environment**, so I can't run the greenlight/kill step. Next action is one command against real outcomes:

```bash
export GOVERNANCE_DATABASE_URL=postgresql://...
python3 scripts/analysis/eisv_skeptic_report.py --scope task --window-days 90 \
  --output data/analysis/eisv_dispersion_probe.md   # also --lead-minutes 5
```

Then read the harness's own AUC/Brier-vs-baseline label and the dispersion-quartile monotonicity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)