### PR TITLE
Dashboard: expose dialectic transcripts + discovery provenance; honest card affordance

### DIFF
--- a/dashboard/redesign/data.js
+++ b/dashboard/redesign/data.js
@@ -184,6 +184,8 @@
           status: d.status || "open", by: d.by || d.agent_id || d._agent_id, tags: d.tags || [],
           summary: d.summary || "Untitled", details: d.details || d.content || d.discovery || "",
           stale: !!d.staleness_warning,
+          // provenance the card now exposes
+          agentId: d._agent_id, session: d.session_id_at_write, version: d.system_version, created: d.created_at,
         }));
         const st = statsR ? (statsR.stats || statsR) : null;
         return {
@@ -212,6 +214,16 @@
         sessions.forEach((s) => { if (["resolved"].includes(s.phase)) c.resolved++; else if (["failed", "escalated"].includes(s.phase)) c.failed++; else c.active++; });
         return { sessions, counts: c };
       }, () => ({ sessions: S().dialectic.sessions, counts: S().dialectic.counts }));
+    },
+
+    async dialecticSession(id) {
+      // Full transcript (thesis → antithesis → synthesis) + resolution for one
+      // session — the history the list view hides behind message_count.
+      return withFallback(async () => {
+        const r = await callTool("dialectic", { action: "get", session_id: id });
+        if (!r || !Array.isArray(r.transcript)) return null;
+        return { transcript: r.transcript, resolution: r.resolution, reason: r.reason, recommended: r.recommended_action };
+      }, () => null);
     },
 
     async activity() {

--- a/dashboard/redesign/kit.css
+++ b/dashboard/redesign/kit.css
@@ -121,6 +121,10 @@ body {
   transition: border-color var(--dur) var(--ease);
 }
 .card:hover { border-color: var(--line-2); }
+/* Cards that are links (map to a section) get a clearer clickable cue than the
+   plain stat cards, so the affordance is honest. */
+a.card { cursor: pointer; }
+a.card:hover { border-color: color-mix(in srgb, var(--accent) 55%, var(--line-2)); }
 .card h3 { font-size: var(--text-xs); letter-spacing: var(--tracking-label);
   text-transform: uppercase; color: var(--muted); font-weight: 600; }
 .card .num { font-family: var(--font-mono); font-size: var(--text-2xl); font-weight: 500;

--- a/dashboard/redesign/sections/dialectic.js
+++ b/dashboard/redesign/sections/dialectic.js
@@ -60,7 +60,26 @@
           ${res.reasoning ? `<div style="margin-bottom:var(--space-2)">${esc(res.reasoning)}</div>` : ""}
           ${res.rootCause ? `<div style="color:var(--muted)"><b style="color:var(--ink-2)">root cause:</b> ${esc(res.rootCause)}</div>` : ""}
         </div></details>` : ""}
+      ${s.msgs ? `<details class="dlc-transcript" data-sid="${esc(s.id)}" style="margin-top:var(--space-2)"><summary style="cursor:pointer;color:var(--muted);font-size:var(--text-sm)">transcript · ${s.msgs} message${s.msgs === 1 ? "" : "s"}</summary>
+        <div class="dlc-tbody" style="margin-top:var(--space-3)"><span class="fresh">loading…</span></div></details>` : ""}
     </div>`;
+  }
+
+  // Render a session's transcript: the thesis → antithesis → synthesis exchange,
+  // each turn coloured by phase, with reasoning + content + root cause.
+  function renderTranscript(msgs) {
+    if (!msgs || !msgs.length) return `<span class="fresh">no transcript recorded</span>`;
+    return msgs.map((m) => {
+      const ph = PHASE[m.phase || m.role] || { color: "var(--muted)", label: m.role || m.phase || "—" };
+      return `<div style="border-left:2px solid ${ph.color};padding-left:var(--space-3);margin-bottom:var(--space-3)">
+        <div style="display:flex;gap:6px;align-items:center;margin-bottom:2px">
+          <span class="tag" style="color:${ph.color};border-color:color-mix(in srgb, ${ph.color} 40%, var(--line-2))">${ph.label}</span>
+          <span class="fresh">${esc((m.agent_id || "").slice(0, 8))}${m.timestamp ? " · " + relTime(m.timestamp) : ""}</span></div>
+        ${m.content ? `<div style="color:var(--ink-2);font-size:var(--text-sm);line-height:var(--leading-body);white-space:pre-wrap">${esc(m.content)}</div>` : ""}
+        ${m.reasoning && m.reasoning !== m.content ? `<div style="color:var(--muted);font-size:var(--text-sm);margin-top:2px">${esc(m.reasoning)}</div>` : ""}
+        ${m.root_cause ? `<div style="color:var(--muted);font-size:var(--text-xs);margin-top:2px"><b style="color:var(--ink-2)">root cause:</b> ${esc(m.root_cause)}</div>` : ""}
+      </div>`;
+    }).join("");
   }
 
   function render() {
@@ -79,6 +98,16 @@
        ${rows.length ? `<div style="display:flex;flex-direction:column;gap:var(--space-3)">${rows.map(card).join("")}</div>`
          : `<div class="empty">🔄 No dialectic sessions in this view. Sessions open when an agent's circuit-breaker trips or review is requested.</div>`}`;
     document.querySelectorAll(".dlc-f").forEach((b) => b.onclick = () => { phaseFilter = b.dataset.f; render(); });
+    // Lazy-load each transcript on first expand (the list doesn't carry messages).
+    document.querySelectorAll(".dlc-transcript").forEach((d) => {
+      d.addEventListener("toggle", async () => {
+        if (!d.open || d.dataset.loaded) return;
+        d.dataset.loaded = "1";
+        const body = d.querySelector(".dlc-tbody");
+        const r = await DATA.dialecticSession(d.dataset.sid);
+        body.innerHTML = renderTranscript(r.data && r.data.transcript);
+      });
+    });
   }
 
   async function load() {

--- a/dashboard/redesign/sections/discoveries.js
+++ b/dashboard/redesign/sections/discoveries.js
@@ -52,8 +52,14 @@
       </div>
       <div style="color:var(--ink);font-size:var(--text-base);line-height:var(--leading-body);margin-bottom:${details || tags ? "var(--space-3)" : "0"}">${highlight(d.summary, q)}</div>
       ${tags ? `<div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:${details ? "var(--space-3)" : "0"}">${tags}</div>` : ""}
-      ${details ? `<details><summary style="cursor:pointer;color:var(--muted);font-size:var(--text-sm)">details</summary>
-        <div style="margin-top:var(--space-2);color:var(--ink-2);font-size:var(--text-sm);white-space:pre-wrap">${esc(details)}</div></details>` : ""}
+      ${details || d.session || d.version || d.agentId ? `<details><summary style="cursor:pointer;color:var(--muted);font-size:var(--text-sm)">${details ? "details" : "provenance"}</summary>
+        ${details ? `<div style="margin-top:var(--space-2);color:var(--ink-2);font-size:var(--text-sm);white-space:pre-wrap">${esc(details)}</div>` : ""}
+        <div style="margin-top:var(--space-3);display:flex;gap:var(--space-4);flex-wrap:wrap;font-size:var(--text-xs);color:var(--faint)">
+          ${d.agentId ? `<span title="${esc(d.agentId)}">agent ${esc((d.agentId || "").slice(0, 8))}</span>` : ""}
+          ${d.session ? `<span title="${esc(d.session)}">session ${esc((d.session || "").slice(0, 8))}</span>` : ""}
+          ${d.version ? `<span>v${esc(d.version)}</span>` : ""}
+          ${d.created ? `<span title="${esc(d.created)}">created ${esc((d.created || "").slice(0, 10))}</span>` : ""}
+        </div></details>` : ""}
     </div>`;
   }
 

--- a/dashboard/redesign/sections/landing.js
+++ b/dashboard/redesign/sections/landing.js
@@ -79,14 +79,17 @@
     // A null metric = its live source didn't answer this cycle. Show "—"
     // (unavailable), never a stale snapshot value passed off as current.
     const un = (v) => v == null;
+    // Cards that map to a section are links (href); the rest (Calibration,
+    // Anomalies — pure stats with no detail view) stay plain, so the clickable
+    // affordance is honest rather than implied on everything.
     const cards = [
-      { h: "Fleet Coherence", num: num(fleetCoh), sub: `${live.length} of ${residents.length} residents reporting`, cls: "up", rule: true },
-      { h: "Agents", num: un(stats.agentsActive) ? "—" : stats.agentsActive, of: un(stats.agentsTotal) ? "" : "/ " + stats.agentsTotal, sub: un(stats.agentsActive) ? "unavailable" : "active / total" },
-      { h: "Stuck", num: un(stats.stuck) ? "—" : stats.stuck, sub: un(stats.stuck) ? "unavailable" : (stats.stuck ? "needs attention" : "none flagged"), cls: un(stats.stuck) ? "" : (stats.stuck ? "down" : "up") },
+      { h: "Fleet Coherence", num: num(fleetCoh), sub: `${live.length} of ${residents.length} residents reporting`, cls: "up", rule: true, href: "#residents" },
+      { h: "Agents", num: un(stats.agentsActive) ? "—" : stats.agentsActive, of: un(stats.agentsTotal) ? "" : "/ " + stats.agentsTotal, sub: un(stats.agentsActive) ? "unavailable" : "active / total", href: "#agents" },
+      { h: "Stuck", num: un(stats.stuck) ? "—" : stats.stuck, sub: un(stats.stuck) ? "unavailable" : (stats.stuck ? "needs attention" : "none flagged"), cls: un(stats.stuck) ? "" : (stats.stuck ? "down" : "up"), href: "#agents" },
       { h: "Automations", num: asum.total || 0, sub: autoSub, cls: aWarn ? "down" : "up", href: "#automations" },
-      { h: "Discoveries", num: un(stats.discoveries) ? "—" : stats.discoveries.toLocaleString(), sub: un(stats.discoveries) ? "unavailable" : (typeof stats.discoveriesToday === "number" ? "+" + stats.discoveriesToday + " today" : "knowledge graph") },
-      { h: "Dialectic", num: un(stats.dialectic) ? "—" : stats.dialectic, sub: un(stats.dialectic) ? "unavailable" : (stats.dialectic ? "open sessions" : "no open sessions") },
-      { h: "System Health", num: un(stats.systemHealth) ? "—" : stats.systemHealth, sub: un(stats.systemHealth) ? "unavailable" : (stats.systemHealthDetail || "db · ws · reaper"), cls: un(stats.systemHealth) ? "" : (stats.systemHealth === "OK" ? "up" : "down") },
+      { h: "Discoveries", num: un(stats.discoveries) ? "—" : stats.discoveries.toLocaleString(), sub: un(stats.discoveries) ? "unavailable" : (typeof stats.discoveriesToday === "number" ? "+" + stats.discoveriesToday + " today" : "knowledge graph"), href: "#discoveries" },
+      { h: "Dialectic", num: un(stats.dialectic) ? "—" : stats.dialectic, sub: un(stats.dialectic) ? "unavailable" : (stats.dialectic ? "open sessions" : "no open sessions"), href: "#dialectic" },
+      { h: "System Health", num: un(stats.systemHealth) ? "—" : stats.systemHealth, sub: un(stats.systemHealth) ? "unavailable" : (stats.systemHealthDetail || "db · ws · reaper"), cls: un(stats.systemHealth) ? "" : (stats.systemHealth === "OK" ? "up" : "down"), href: "#residents" },
       { h: "Calibration", num: num(stats.calibration), sub: un(stats.calibration) ? "unavailable" : "trajectory health", cls: stats.calibration >= 0.8 ? "up" : "" },
       { h: "Anomalies", num: un(stats.anomalies) ? "—" : stats.anomalies, sub: un(stats.anomalies) ? "unavailable" : (stats.anomalies ? stats.anomalies + " active" : "clear"), cls: un(stats.anomalies) ? "" : (stats.anomalies ? "down" : "up") },
     ];


### PR DESCRIPTION
Surfaces hidden info and fixes inconsistent affordance.
- **Dialectic transcripts** — sessions showed only `message_count`; each now has a lazy-loaded transcript expander (fetches `dialectic(get)`) rendering thesis→antithesis→synthesis turns with reasoning/content/root-cause.
- **Discovery provenance** — agent / originating session / system version / created date now shown in the details expander.
- **Card affordance** — every `.card` had a clickable-looking hover but only Automations was a link; section-mapped cards are now links (accent hover), pure stats stay plain.
- KG supersession lineage isn't exposed (no relation field in the current tools — flagged, not faked). Frontend-only, eslint clean.

https://claude.ai/code/session_013QDsbjQ1DSQNTf7dpMCXDm