### PR TITLE
docs: add KG subsystem-guide pointer to docs index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,12 @@ This is the documentation tree for the [UNITARES governance MCP server](../READM
 - **[`tonality-metaphor.md`](tonality-metaphor.md)** — a teaching lens: how key signatures and chromaticism map onto EISV, coherence, and drift. Intuition for [`EISV_COMPUTATION.md`](EISV_COMPUTATION.md), not a spec.
 - **[`CHANGELOG.md`](CHANGELOG.md)** — release history.
 
+### Subsystem guides
+
+Operating guidance for individual subsystems lives next to the code as Skills, not in `docs/` (this keeps the guide in sync with its `source_files:` and carries its own freshness budget). The map to those lives here:
+
+- **Knowledge graph (KG)** — agent-facing operating manual: search-before-write discipline, the `knowledge()` actions, discovery types/statuses, tagging, and closing the loop → [`skills/knowledge-graph/SKILL.md`](../skills/knowledge-graph/SKILL.md)
+
 ### `guides/` — getting started
 
 User- and integrator-facing how-tos. Thin by design — most architecture lives in `UNIFIED_ARCHITECTURE.md` and the repo README.


### PR DESCRIPTION
## What

Adds a **"Subsystem guides"** pointer to `docs/README.md` that signposts the existing knowledge-graph operating manual at [`skills/knowledge-graph/SKILL.md`](../skills/knowledge-graph/SKILL.md).

## Why

Came out of a docs-organization review. The question was whether `docs/` needs a comprehensive by-component reference section (KG, dialectic, identity, …). Findings:

- The docs are already well-organized — but **by audience/lifecycle** (`guides/`, `install/`, `operations/`, `ontology/`, `proposals/`), not by component.
- The KG looked like the biggest gap (no front door in `docs/`), but it turns out the KG **already has** a high-quality, AI-facing operating manual at `skills/knowledge-graph/SKILL.md` — search-before-write discipline, the `knowledge()` actions, discovery types/statuses, tagging, loop-closing. That skill carries its own `last_verified` / `freshness_days` / `source_files:` contract.
- The real gap was only **discoverability**: nothing in `docs/` pointed to it.

Rather than author a parallel `docs/kg.md` (which would duplicate the skill and create a drift surface — a second copy to keep in sync), this adds a one-line pointer. Single source of truth, signpost to it, nothing to keep in sync.

## Scope

Documentation only — one additive subsection in `docs/README.md`. No code, no shared-contract (`CLAUDE.md`/`AGENTS.md`) changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V89fLP3DCktgVSdciSRHps)_