### PR TITLE
dashboard(automations): show external (claude.ai routine) source in default view

### DIFF
--- a/dashboard/redesign/sections/automations.js
+++ b/dashboard/redesign/sections/automations.js
@@ -11,7 +11,7 @@
   const esc = (s) => String(s == null ? "" : s).replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
   // Local schedulers the operator runs directly; github-actions (the bulk) is
   // folded away by default so the map opens on what's actually theirs to mind.
-  const LOCAL = ["launchd", "hermes", "codex", "claude"];
+  const LOCAL = ["launchd", "hermes", "codex", "claude", "claude-ai"];
 
   let MODEL = { items: [], summary: {}, stale: false, ageS: null, warnings: [], attn: new Set(), source: "snapshot" };
   let scope = "local"; // "local" (+attention) | "all"


### PR DESCRIPTION
Follow-up to #959.

The automation census now has an **`external`** source for off-box automations the local collectors can't discover — e.g. claude.ai cloud routines. The operator-local census reads a manifest (`~/.local/share/unitares/automation-external.json`) that a process *with* claude.ai access populates, so the cron itself needs no auth (it just reads a file).

This one-liner adds `claude-ai` to the dashboard's default `LOCAL` scope so those rows appear in the operator's default pane instead of only under "show all sources". The github-actions bulk stays folded away as before.

**Verified live:** the *Public-surface freshness sweep* routine renders with an `external` gate badge, `enabled` status, cadence `0 15 * * 1`, and an honest "snapshot, not locally watched" note.

_Scope note:_ the census CLI (`~/.local/bin/unitares-automations`) and its new `collect_external` collector are operator-local like the whole `unitares-automation*` family — intentionally not vendored in this repo. This PR is only the dashboard-render change.