### PR TITLE
fix(ci): auto-enable GitHub Pages in glossary-pages workflow

### DIFF
--- a/.github/workflows/glossary-pages.yml
+++ b/.github/workflows/glossary-pages.yml
@@ -32,6 +32,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # Auto-enable Pages (Actions source) on first run so a fresh repo doesn't
+      # need the manual Settings -> Pages toggle and the deploy job stops 404ing.
+      - uses: actions/configure-pages@v5
+        with:
+          enablement: true
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/docs/operations/glossary-site.md
+++ b/docs/operations/glossary-site.md
@@ -23,13 +23,17 @@ python3 scripts/dev/build_glossary_site.py --out build/glossary-site
 # open build/glossary-site/index.html
 ```
 
-## One-time enablement (operator, admin)
+## Enablement
 
-Pages is not enabled yet (`has_pages: false`). Once:
+The workflow **auto-enables Pages on its first run** via
+`actions/configure-pages@v5` with `enablement: true` (it holds `pages: write`), so
+no manual toggle is normally needed — push to `master` (or run the workflow
+manually) and the site publishes at **https://cirwel.github.io/unitares/**.
 
-1. Repo **Settings → Pages → Build and deployment → Source = "GitHub Actions"**.
-2. Push to `master` (or run the workflow manually). The site publishes at
-   **https://cirwel.github.io/unitares/**.
+Fallback (if an org/account policy blocks API enablement and the deploy job 404s
+with "Ensure GitHub Pages has been enabled"): set it by hand once —
+repo **Settings → Pages → Build and deployment → Source = "GitHub Actions"** — then
+re-run the workflow.
 
 ## Custom domain (optional, branded URL)
 


### PR DESCRIPTION
Fixes the post-merge failure of `glossary-pages` from #985.

## What happened

The `glossary-pages` workflow only runs `on: push` to `master`, so it never executed during #985's PR checks (which were green) — its **first run was post-merge, and it failed**. The logs show the `build` job succeeded (artifact built + uploaded); the `deploy` job 404'd:

```
Error: Failed to create deployment (status: 404) ... Ensure GitHub Pages has been enabled
```

Not a code bug — Pages simply isn't enabled on the repo yet (`has_pages: false`). But a workflow that red-X's on every glossary push until someone flips a settings toggle is poor hygiene.

## Fix

Add `actions/configure-pages@v5` with `enablement: true` to the build job. The workflow already holds `pages: write`, so it now **enables Pages (Actions source) itself on first run** — removing both the recurring failure *and* the manual Settings step. The runbook is updated to match, keeping the manual toggle documented as a fallback for the case where an org/account policy blocks API enablement.

After this merges, the next `glossary-pages` run should enable Pages and publish to **https://cirwel.github.io/unitares/** with no manual action.

Workflow-only change; YAML validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0175PJNxU7V5HrpGXcMtszEM)_