### PR TITLE
fix(ci): publish glossary via gh-pages branch (token-only); link from README

### DIFF
--- a/.github/workflows/glossary-pages.yml
+++ b/.github/workflows/glossary-pages.yml
@@ -32,11 +32,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # Auto-enable Pages (Actions source) on first run so a fresh repo doesn't
-      # need the manual Settings -> Pages toggle and the deploy job stops 404ing.
-      - uses: actions/configure-pages@v5
-        with:
-          enablement: true
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/.github/workflows/glossary-pages.yml
+++ b/.github/workflows/glossary-pages.yml
@@ -1,11 +1,11 @@
 name: glossary-pages
 
-# Publishes the public glossary site (generated from docs/ontology/glossary.md)
-# to GitHub Pages. Free: public repo + GITHUB_TOKEN only, no model API.
-#
-# One-time setup before this can deploy: repo Settings -> Pages -> Source =
-# "GitHub Actions". To serve from a custom domain, pass --cname below and add the
-# matching DNS record (see docs/operations/glossary-site.md).
+# Publishes the glossary site (generated from docs/ontology/glossary.md) by
+# building it and pushing to the `gh-pages` branch. Token-only by design: this
+# uses `contents: write` to push a branch — it does NOT call the Pages API (the
+# workflow GITHUB_TOKEN cannot create a Pages site, which is why the Actions-source
+# path required a manual enable). Branch-source Pages can auto-serve; if it does
+# not, enabling is a one-click "Deploy from a branch -> gh-pages" with no re-run.
 
 on:
   push:
@@ -18,17 +18,14 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
-# Never cancel an in-flight deploy; let the latest queue.
 concurrency:
   group: glossary-pages
   cancel-in-progress: false
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -39,16 +36,16 @@ jobs:
       - name: Build glossary site
         # To brand the URL, append: --cname glossary.cirwel.org
         run: python3 scripts/dev/build_glossary_site.py --out build/glossary-site
-      - uses: actions/upload-pages-artifact@v3
-        with:
-          path: build/glossary-site
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Publish to gh-pages branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd build/glossary-site
+          touch .nojekyll                 # serve our prebuilt HTML as-is
+          git init -q
+          git checkout -q -b gh-pages
+          git add -A
+          git -c user.name='github-actions[bot]' \
+              -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+              commit -q -m "Publish glossary site (${GITHUB_SHA})"
+          git push -f "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" gh-pages

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ python src/mcp_server.py --port 8767
 | [Reviewer Guide](docs/REVIEWER_GUIDE.md) | Cold-evaluator path + falsifiability harness |
 | [Scope & threat model](docs/SCOPE_AND_THREAT_MODEL.md) | Who it's for, why agents can't game it, what's unproven |
 | [Architecture](docs/UNIFIED_ARCHITECTURE.md) | Pipeline, verdicts, recovery, storage |
+| [Glossary](docs/ontology/glossary.md) | Terms keyed by the question they answer — published at [cirwel.github.io/unitares](https://cirwel.github.io/unitares/) |
 | [Production snapshot](docs/PRODUCTION_SNAPSHOT.md) | Live metrics + dashboard views |
 | [MCP Clients](docs/integration/MCP_CLIENTS.md) | Cursor / Claude Code / Claude Desktop config |
 | [Troubleshooting](docs/guides/TROUBLESHOOTING.md) | Common issues |

--- a/docs/operations/glossary-site.md
+++ b/docs/operations/glossary-site.md
@@ -23,17 +23,20 @@ python3 scripts/dev/build_glossary_site.py --out build/glossary-site
 # open build/glossary-site/index.html
 ```
 
-## Enablement
+## One-time enablement (required, admin)
 
-The workflow **auto-enables Pages on its first run** via
-`actions/configure-pages@v5` with `enablement: true` (it holds `pages: write`), so
-no manual toggle is normally needed — push to `master` (or run the workflow
-manually) and the site publishes at **https://cirwel.github.io/unitares/**.
+Pages must be enabled **by hand once** — the workflow `GITHUB_TOKEN` cannot create
+the Pages site itself (the `actions/configure-pages` `enablement: true` path was
+tried and fails with `Resource not accessible by integration`; see PRs #986/#987).
+So:
 
-Fallback (if an org/account policy blocks API enablement and the deploy job 404s
-with "Ensure GitHub Pages has been enabled"): set it by hand once —
-repo **Settings → Pages → Build and deployment → Source = "GitHub Actions"** — then
-re-run the workflow.
+1. Repo **Settings → Pages → Build and deployment → Source = "GitHub Actions"**.
+2. Re-run **Actions → glossary-pages** (or push a glossary change). The site then
+   publishes at **https://cirwel.github.io/unitares/** and re-deploys automatically
+   on every future glossary change.
+
+Until step 1 is done, the `deploy` job 404s with "Ensure GitHub Pages has been
+enabled" — that is expected, not a code bug.
 
 ## Custom domain (optional, branded URL)
 

--- a/docs/operations/glossary-site.md
+++ b/docs/operations/glossary-site.md
@@ -23,20 +23,27 @@ python3 scripts/dev/build_glossary_site.py --out build/glossary-site
 # open build/glossary-site/index.html
 ```
 
-## One-time enablement (required, admin)
+## How publishing works (branch-source, token-only)
 
-Pages must be enabled **by hand once** — the workflow `GITHUB_TOKEN` cannot create
-the Pages site itself (the `actions/configure-pages` `enablement: true` path was
-tried and fails with `Resource not accessible by integration`; see PRs #986/#987).
-So:
+The workflow builds the site and **pushes it to the `gh-pages` branch** with
+`contents: write`. It deliberately does *not* use the Pages API or the
+Actions-source deploy: the workflow `GITHUB_TOKEN` cannot create a Pages site
+(`Resource not accessible by integration` — tried in #986), so an API/Actions path
+needs a human to enable Pages first. Pushing a branch needs no such permission, so
+**the workflow always succeeds** and the published HTML lands on `gh-pages`.
 
-1. Repo **Settings → Pages → Build and deployment → Source = "GitHub Actions"**.
-2. Re-run **Actions → glossary-pages** (or push a glossary change). The site then
-   publishes at **https://cirwel.github.io/unitares/** and re-deploys automatically
-   on every future glossary change.
+Going live then depends on GitHub's branch-source behavior:
 
-Until step 1 is done, the `deploy` job 404s with "Ensure GitHub Pages has been
-enabled" — that is expected, not a code bug.
+- If Pages auto-serves `gh-pages`, the site is live at
+  **https://cirwel.github.io/unitares/** with no manual step.
+- If it does not, enable it **once** (no re-run needed):
+  **Settings → Pages → Build and deployment → Source = "Deploy from a branch" →
+  Branch = `gh-pages` / `/ (root)`**.
+
+History note: the Actions-source + `configure-pages enablement: true` paths were
+tried first (#985, #986) and both hit the token's inability to create the Pages
+site. Branch-source is the token-only route (#987) and at worst reduces the manual
+step to a one-click branch selection.
 
 ## Custom domain (optional, branded URL)
 


### PR DESCRIPTION
Gets the glossary site live with **no laptop required**, and links it from the README.

## Why the approach changed (3rd time)

Two prior paths both hit the same wall — the workflow `GITHUB_TOKEN` **cannot create a Pages site**:
- #985 Actions-source deploy → `deploy` job 404'd ("Ensure GitHub Pages has been enabled").
- #986 `configure-pages enablement: true` → `Create Pages site failed: Resource not accessible by integration`.

That's GitHub deliberately blocking automated first-time Pages enablement. The one token-only route left is **branch-source**: the token *can* push a branch even though it can't call the Pages API.

## What this does

Builds the site and **pushes it to a `gh-pages` branch** (`contents: write`, plain `git`, no Pages API, no third-party action). `.nojekyll` added so the prebuilt HTML serves as-is.

Two outcomes, both better than the current red-failing state:
- **Best case:** GitHub auto-serves `gh-pages` → live at `https://cirwel.github.io/unitares/`, zero clicks.
- **Worst case:** not auto-served, but the **workflow now succeeds (green)** instead of failing, and going live shrinks to a one-click **Settings → Pages → Deploy from a branch → `gh-pages`** whenever you're back at a laptop — no workflow re-run needed.

## Also

Adds a **Glossary** row to the README Documentation table (it was linked nowhere) → canonical markdown + the `cirwel.github.io/unitares/` URL. Runbook rewritten to document the branch-source mechanism and the prior dead-ends.

The `glossary-pages` workflow is push-to-master-triggered, so it won't run on this PR — the real test is the post-merge run. Build script + YAML validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)