### PR TITLE
docs(ops): correct KG-lineage handoff to the real supersession data source

### DIFF
--- a/docs/operations/kg-lineage-dashboard-handoff.md
+++ b/docs/operations/kg-lineage-dashboard-handoff.md
@@ -1,50 +1,97 @@
 # Handoff: KG supersession / correction lineage on the dashboard
 
 **Goal:** let an operator click a knowledge-graph discovery and see its
-**lineage** — what it supersedes / corrects / extends, and what later
-superseded or corrected *it*. This is the "history" the dashboard currently
-can't show for the KG (dialectic transcripts and agent EISV history already
-ship; this is the missing third).
+**lineage** — what it supersedes, and what later superseded it — plus its
+related (similarity) neighbours. This is the "history" the dashboard can't show
+for the KG yet (dialectic transcripts and agent EISV history already ship).
 
-This is an **exposure** task, not a graph-modeling one. The lineage already
-exists relationally; the read API just doesn't return it.
+This is an **exposure** task, not a graph-modeling one. The links already exist;
+the read API just doesn't return them.
+
+> **Correction note (2026-06-21).** An earlier draft of this handoff specced the
+> wrong columns. It claimed lineage lived in `response_to_id` / `response_type`
+> and that "AGE has no supersession label — use the relational columns." Both are
+> wrong, verified live (see below). `response_to_id` / `response_type` are
+> **NULL on 100% of rows** (that typed-response feature has never been used), and
+> **supersession is stored as a `SUPERSEDES` edge in AGE**, the opposite of what
+> the draft said. This version points at the real data. Read the **Scope reality**
+> section before deciding to build — the authored signal is small.
+
+## Scope reality (verified 2026-06-21, live DB — read this first)
+
+| Signal | Where it lives | Rows (of 1091) |
+|---|---|---|
+| **Supersession** (`A SUPERSEDES B`) | **AGE graph edge** `(:Discovery)-[:SUPERSEDES]->(:Discovery)` + the old row's `status='superseded'` | **18 edges** (~1.6%) |
+| `response_to_id` (typed-response parent) | relational column | **0** — never written |
+| `response_type` (edge label enum) | relational column | **0** — never written |
+| **related** (similarity neighbours) | `related_to text[]` (auto-computed at store time) | **643** (~59%) |
+
+Implications for whoever picks this up:
+- The headline "what does this supersede / correct" view is driven by **18
+  edges across 1091 notes**. Most cards will have no supersession lineage. That
+  may still be worth a small expander — but size the effort to the payoff.
+- **`related_to` is NOT lineage.** It is auto-computed semantic-similarity
+  neighbours written by the store path, not an authored "this corrects that"
+  edge. Surface it as a **separate, clearly-labelled "related" list** — do not
+  fold it into "supersedes/history" or you mislabel similarity as authorship.
+- Ignore `response_to_id` / `response_type` entirely for now (empty). If the
+  typed-response feature ever gets used, revisit.
 
 ## Why it isn't done yet
 
 The redesign discovery cards (`dashboard/redesign/sections/discoveries.js`)
-already surface summary, provenance (agent / originating session / system
-version / created), details, and tags. But the *links between* discoveries are
-invisible because `knowledge(action="search")` strips them from its result
-(the response carries `id, by, summary, session_id_at_write, type, status,
-tags, created_at, details, _agent_id, system_version` — no relation fields).
+surface summary, provenance, details, and tags, but the *links between*
+discoveries are invisible because `knowledge(action="search")` strips relation
+fields from its result.
 
 ## The data model (verified)
 
-`knowledge.discoveries` records lineage relationally:
+`knowledge.discoveries` columns that exist: `id` (text), `status` (text — value
+`superseded` on superseded rows), `related_to` (text[]), `provenance_chain`
+(present but **empty on the superseded rows checked** — do not rely on it),
+`response_to_id` / `response_type` (both 100% NULL — unused).
 
-| Column | Meaning |
-|---|---|
-| `response_to_id` (text) | the discovery this one responds to — the parent link in a chain |
-| `response_type` (text, CHECK enum) | the **edge label**: `extend` / `question` / `disagree` / `support` / `answer` / `follow_up` / `correction` / `elaboration` / **`supersedes`** |
-| `related_to` (text[]) | sibling / related discovery ids |
-| `provenance_chain` (jsonb-ish — *verify shape*) | ancestry chain |
-| `epoch`, `provenance` | additional context |
+Supersession is a **graph edge**, created by `KnowledgeGraphAGE.supersede_discovery`
+(`src/storage/knowledge_graph_age.py:2449`, via `create_supersedes_edge(new_id, old_id)`):
 
-So a discovery's lineage is:
-- **ancestors** — walk `response_to_id` upward (bounded depth);
-- **descendants** — discoveries whose `response_to_id` = this id (reverse lookup, bounded/transitive);
-- **edges** — labelled by each row's `response_type`;
-- **related** — the `related_to` array.
+```
+(newer:Discovery)-[:SUPERSEDES]->(older:Discovery)
+```
 
-AGE graph has **no** supersession label (checked: `ag_label` has nothing
-matching `%supersed%`). Use the relational columns, not AGE.
+The edge points **from the newer discovery to the one it replaces**. The
+connectivity scorer already reads it (`knowledge_graph_age.py:2029`,
+`OPTIONAL MATCH (newer)-[s:SUPERSEDES]->(d) ... count(...) as superseded_by`) —
+copy that read shape.
+
+So a discovery `d`'s lineage is:
+- **ancestors** (what `d` supersedes): `MATCH (d)-[:SUPERSEDES]->(older)`;
+- **descendants** (what superseded `d`): `MATCH (newer)-[:SUPERSEDES]->(d)`;
+- **related** (similarity, separate): the `related_to` array (relational).
+
+### Depth / traversal caveat (don't skip)
+
+AGE 1.7 **cannot reliably filter a variable-length path** (the dual-store verdict
+— `knowledge.discoveries` is relational-authoritative, AGE advisory; see the KG
+dual-store architecture note). So do **not** write `[:SUPERSEDES*1..N]` and trust
+it. Two honest options:
+
+1. **v1 (recommended, matches current scale): bounded 1–2 hop read.** Supersession
+   chains are realistically ≤2–3 deep and there are only 18 edges total. A single
+   1-hop query each direction (optionally iterated a fixed 2–3 times in Python)
+   covers it without variable-length Cypher. Simple, correct, cheap.
+2. **If chains grow or you want relational-authoritative cleanliness:** backfill a
+   relational `superseded_by text` column from the existing AGE edges (one-time)
+   and have `supersede_discovery` maintain it going forward, then walk it with a
+   depth-bounded recursive CTE. Bigger lift; defer until the data warrants it.
 
 ## Backend (recommended)
 
-Add a read-only endpoint mirroring the agent-history one already in the repo —
-`http_agent_history` in `src/http_api.py` (route `/v1/agents/{agent_id}/history`,
-added in PR #935) is the exact template: bearer-auth via `_check_http_auth`,
-`JSONResponse`, graceful-empty, registered in `register_http_routes`.
+Mirror the agent-history endpoint already in the repo — `http_agent_history`
+(`src/http_api.py:1025`, route `/v1/agents/{agent_id}/history`, PR #935) is the
+exact template: bearer-auth via `_check_http_auth` / `_http_unauthorized`,
+`db.acquire()`, `JSONResponse`, graceful-empty, registered with
+`app.routes.append(Route(..., methods=["GET"]))` in `register_http_routes`
+(`http_api.py:3101`).
 
 ```
 GET /v1/discoveries/{id}/lineage
@@ -55,38 +102,29 @@ returns:
 ```json
 {
   "id": "<id>",
-  "ancestors":   [{"id","summary","type","response_type","created_at","by"}],
-  "descendants": [{"id","summary","type","response_type","created_at","by"}],
-  "related":     [{"id","summary","type"}]
+  "status": "superseded | open | ...",
+  "supersedes":    [{"id","summary","type","created_at","by"}],
+  "superseded_by": [{"id","summary","type","created_at","by"}],
+  "related":       [{"id","summary","type"}]
 }
 ```
 
-SQL sketch (recursive CTE up for ancestors; one join down for descendants):
+- `supersedes` = ancestors `(d)-[:SUPERSEDES]->older`; `superseded_by` =
+  descendants `newer-[:SUPERSEDES]->(d)`. Run the bounded SUPERSEDES read against
+  AGE (copy the `knowledge_graph_age.py:2029` cypher shape via the same
+  graph_query path it uses; the wrapper was hardened in #794). Hydrate ids →
+  summaries from `knowledge.discoveries` in one relational `WHERE id = ANY(...)`
+  (avoid N+1).
+- `related`: `SELECT ... FROM knowledge.discoveries WHERE id = ANY((SELECT related_to FROM knowledge.discoveries WHERE id = $1))`.
+- Empty arrays when there's nothing — never error on a discovery with no lineage.
 
-```sql
-WITH RECURSIVE up AS (
-  SELECT d.id, d.summary, d.type, d.response_type, d.created_at, d.agent_id, 1 AS depth
-  FROM knowledge.discoveries d
-  WHERE d.id = (SELECT response_to_id FROM knowledge.discoveries WHERE id = $1)
-  UNION ALL
-  SELECT p.id, p.summary, p.type, p.response_type, p.created_at, p.agent_id, up.depth + 1
-  FROM knowledge.discoveries p
-  JOIN up ON p.id = (SELECT response_to_id FROM knowledge.discoveries WHERE id = up.id)
-  WHERE up.depth < 20
-)
-SELECT * FROM up;
--- descendants: SELECT ... FROM knowledge.discoveries WHERE response_to_id = $1 (+ recurse, bounded)
--- related:     SELECT ... WHERE id = ANY((SELECT related_to FROM knowledge.discoveries WHERE id = $1))
-```
-
-(Alternative: expose `response_to_id` / `response_type` / `related_to` in the
-existing `knowledge` search result and resolve client-side. Simpler to wire but
-N+1 for summaries and no transitive walk — the dedicated endpoint is cleaner.)
+(Alternative: expose `related_to` + a `has_supersession` flag in the existing
+`knowledge` search result and resolve client-side. Simpler to wire, but no graph
+read and N+1 for summaries — the dedicated endpoint is cleaner.)
 
 ## Frontend
 
-Reuse the **dialectic-transcript lazy-load** pattern shipped in PR #981 — it is
-the model to copy:
+Reuse the **dialectic-transcript lazy-load** pattern (PR #981) — the model to copy:
 - `dashboard/redesign/sections/dialectic.js` → `renderTranscript()` + the
   `<details class="dlc-transcript">` toggle that lazy-fetches on first expand.
 - `dashboard/redesign/data.js` → `dialecticSession(id)` accessor.
@@ -94,43 +132,48 @@ the model to copy:
 Do the same here:
 - `data.js`: add `discoveryLineage(id)` → calls the new endpoint, `withFallback`.
 - `discoveries.js`: add a lazy-loaded **"lineage"** `<details>` per card, but
-  **only render it when the discovery actually has a relation** (it has a
-  `response_to_id`, OR it is some row's `response_to_id`, OR `related_to` is
-  non-empty). Render the chain as directed edges: `supersedes → <summary>`,
-  `superseded by ← <summary> (correction)`, plus a related list. Colour the
-  `supersedes` edge stronger than the soft ones.
+  **only render it when the discovery actually has a relation** — i.e. it
+  participates in a SUPERSEDES edge (either direction) OR `related_to` is
+  non-empty. Render `supersedes` and `superseded_by` as directed edges and put
+  `related` in its own labelled sub-list. Colour the supersession edges stronger
+  than the related list.
 
-You'll need the discovery's relation flags in the list to decide whether to show
-the expander — thread `response_to_id` / `has_responses` / `related_to` through
-the `discoveries()` accessor (currently dropped), or have the lineage endpoint
-return `{empty:true}` and hide the expander after a probe (worse UX).
+To decide whether to show the expander without a probe, thread a lightweight
+flag through the `discoveries()` accessor (currently dropped): `related_to`
+non-empty is already known relationally; for supersession, expose a boolean
+`has_supersession` (cheap: `status='superseded'` OR the id appears as a
+SUPERSEDES endpoint). Otherwise the endpoint can return `{empty:true}` and the
+expander hides after a probe (worse UX).
 
 ## Checks
 
-- Focused endpoint test (temp `knowledge.discoveries` rows with a
-  `response_to_id` chain + a `supersedes` edge; assert ancestors/descendants/
-  related resolve, depth-bounded).
+- Focused endpoint test: insert temp `knowledge.discoveries` rows, create a
+  `SUPERSEDES` edge (use `supersede_discovery`, the real path), assert
+  `supersedes` / `superseded_by` / `related` resolve and are depth-bounded. Add a
+  cycle / depth-cap case so a bad chain can't hang the read.
 - `pytest tests/test_dashboard_redesign_route.py tests/test_dashboard.py`
-- `cd dashboard && npm test` and `npm run lint` + `npm run format:check`
-  (the `format:check` gate bit the automation PR — prettier the JS).
-- Verify in a **real browser** on a discovery with a known supersedes chain.
+- `cd dashboard && npm test && npm run lint && npm run format:check`
+  (the `format:check` gate bit a prior dashboard PR — prettier the JS).
+- Verify in a **real browser** on a discovery with a known supersedes chain
+  (there are 18 — query `status='superseded'` for one).
 
 ## Caveats (don't paper over these)
 
-- `supersedes` is the strong edge; `correction` / `extend` / `disagree` etc. are
-  *softer* relations. Show the edge label — do **not** collapse everything to
-  "history."
-- Bound the recursive walk (chains can be long; guard against cycles — a bad
-  `response_to_id` loop will hang the CTE without the depth cap).
-- **Most discoveries have no lineage** (`response_to_id` null, never referenced).
-  The expander must simply *not appear* — not show "no lineage." (Same honesty
-  rule as the rest of the dashboard: absence is silent, not a false row.)
-- `provenance_chain` shape is unverified — inspect a populated row before relying
-  on it; `response_to_id` + `response_type` are the load-bearing fields.
+- **Supersession is the only authored edge; `related_to` is similarity.** Keep
+  them visually and semantically distinct. Show the edge meaning, don't collapse
+  everything to "history."
+- **Most discoveries have no lineage.** The expander must simply *not appear* —
+  not show a "no lineage" row. Absence is silent (same rule as the rest of the
+  dashboard).
+- **Bound the walk.** AGE can't do safe variable-length paths; iterate a fixed
+  small depth in code and guard against cycles.
+- **Don't trust `response_to_id` / `response_type` / `provenance_chain`** — the
+  first two are empty, the third was empty on every superseded row checked.
 
 ## Surfaces
 
-- backend: `src/http_api.py` (endpoint + `register_http_routes`), `tests/`
+- backend: `src/http_api.py` (endpoint + `register_http_routes`),
+  `src/storage/knowledge_graph_age.py` (SUPERSEDES read shape at :2029), `tests/`
 - frontend: `dashboard/redesign/sections/discoveries.js`, `dashboard/redesign/data.js`
-- patterns to copy: agent-history endpoint (#935, `/v1/agents/{id}/history`),
+- patterns to copy: agent-history endpoint (#935, `http_api.py:1025`),
   dialectic transcript lazy-load (#981)


### PR DESCRIPTION
Corrects `docs/operations/kg-lineage-dashboard-handoff.md`. The prior version's data premise was verifiably wrong, so an agent handed it would faithfully build an **empty** feature.

## Verified live (2026-06-21)
| Spec claimed | Reality |
|---|---|
| lineage in `response_to_id` / `response_type` | both **NULL on 100%** of 1091 rows — typed-response feature unused |
| "AGE has no supersession label, use relational" | **backwards** — supersession is an AGE `(newer)-[:SUPERSEDES]->(old)` edge (`supersede_discovery`, `knowledge_graph_age.py:2449`), 18 edges = the 18 `status='superseded'` rows |
| `related_to` as lineage | it's **auto-computed similarity** (643 rows), not authored lineage |

## What the corrected version does
- Sources supersession from the **AGE SUPERSEDES edges** (copying the read shape already at `knowledge_graph_age.py:2029`), with a **bounded read** — AGE 1.7 can't safely filter variable-length paths (dual-store verdict), and chains are short, so 1–2 hop iterated covers it.
- Keeps `related_to` as a **separate, correctly-labelled** similarity list — not folded into "supersedes/history".
- Adds a **Scope reality** section up front: the authored signal is 18 edges (~1.6%); size the effort accordingly.
- Preserves the parts that checked out: the #935 endpoint template (`http_api.py:1025`), the #981 lazy-load frontend pattern, and the absence-is-silent / show-the-edge-label UX caveats.

Docs-only. Operator is the merge gate.

https://claude.ai/code/session_011onoEr3t2JbEEUDQZHwvk8