### PR TITLE
fix(ci): switch glossary-pages to Actions-source deploy (Pages now enabled)

### DIFF
--- a/.github/workflows/glossary-pages.yml
+++ b/.github/workflows/glossary-pages.yml
@@ -1,11 +1,10 @@
 name: glossary-pages
 
-# Publishes the glossary site (generated from docs/ontology/glossary.md) by
-# building it and pushing to the `gh-pages` branch. Token-only by design: this
-# uses `contents: write` to push a branch — it does NOT call the Pages API (the
-# workflow GITHUB_TOKEN cannot create a Pages site, which is why the Actions-source
-# path required a manual enable). Branch-source Pages can auto-serve; if it does
-# not, enabling is a one-click "Deploy from a branch -> gh-pages" with no re-run.
+# Publishes the glossary site (generated from docs/ontology/glossary.md) to
+# GitHub Pages via the Actions deployment (Pages source = "GitHub Actions").
+# Requires Pages to be enabled once (Settings -> Pages -> Source = GitHub Actions),
+# which it now is — the workflow GITHUB_TOKEN cannot create the Pages site itself
+# but can deploy to it once it exists.
 
 on:
   push:
@@ -18,14 +17,16 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 
 concurrency:
   group: glossary-pages
   cancel-in-progress: false
 
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,16 +37,16 @@ jobs:
       - name: Build glossary site
         # To brand the URL, append: --cname glossary.cirwel.org
         run: python3 scripts/dev/build_glossary_site.py --out build/glossary-site
-      - name: Publish to gh-pages branch
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          cd build/glossary-site
-          touch .nojekyll                 # serve our prebuilt HTML as-is
-          git init -q
-          git checkout -q -b gh-pages
-          git add -A
-          git -c user.name='github-actions[bot]' \
-              -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
-              commit -q -m "Publish glossary site (${GITHUB_SHA})"
-          git push -f "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" gh-pages
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/glossary-site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/operations/glossary-site.md
+++ b/docs/operations/glossary-site.md
@@ -23,27 +23,28 @@ python3 scripts/dev/build_glossary_site.py --out build/glossary-site
 # open build/glossary-site/index.html
 ```
 
-## How publishing works (branch-source, token-only)
+## How publishing works (Actions source)
 
-The workflow builds the site and **pushes it to the `gh-pages` branch** with
-`contents: write`. It deliberately does *not* use the Pages API or the
-Actions-source deploy: the workflow `GITHUB_TOKEN` cannot create a Pages site
-(`Resource not accessible by integration` — tried in #986), so an API/Actions path
-needs a human to enable Pages first. Pushing a branch needs no such permission, so
-**the workflow always succeeds** and the published HTML lands on `gh-pages`.
+The workflow builds the site and deploys it to GitHub Pages via
+`actions/upload-pages-artifact` + `actions/deploy-pages` (Pages **Source =
+"GitHub Actions"**). On every push to `master` touching the glossary, audit, build
+script, or workflow, the site re-publishes to **https://cirwel.github.io/unitares/**.
 
-Going live then depends on GitHub's branch-source behavior:
+### Enablement history (why it took a few tries)
 
-- If Pages auto-serves `gh-pages`, the site is live at
-  **https://cirwel.github.io/unitares/** with no manual step.
-- If it does not, enable it **once** (no re-run needed):
-  **Settings → Pages → Build and deployment → Source = "Deploy from a branch" →
-  Branch = `gh-pages` / `/ (root)`**.
+The workflow `GITHUB_TOKEN` cannot *create* a Pages site — only deploy to one that
+exists. So enabling Pages was a one-time human step:
 
-History note: the Actions-source + `configure-pages enablement: true` paths were
-tried first (#985, #986) and both hit the token's inability to create the Pages
-site. Branch-source is the token-only route (#987) and at worst reduces the manual
-step to a one-click branch selection.
+- #985 (Actions deploy) and #986 (`configure-pages enablement: true`) both failed
+  with `Resource not accessible by integration` / a deploy 404, because Pages was
+  not yet enabled and the token may not enable it.
+- #987 published to a `gh-pages` branch as a token-only fallback (that branch now
+  exists but is unused under Actions source — safe to delete).
+- Once Pages was enabled by hand (**Settings → Pages → Source = "GitHub
+  Actions"**), this Actions-deploy path works and is the maintained one.
+
+If you ever see the deploy job 404 again, confirm **Settings → Pages → Source**
+is still "GitHub Actions".
 
 ## Custom domain (optional, branded URL)
 


### PR DESCRIPTION
You enabled Pages with **Source = "GitHub Actions"**, but the merged workflow (#987) publishes to a `gh-pages` branch — Actions-source ignores that branch. This switches the workflow back to the **Actions deploy** path (`upload-pages-artifact` + `deploy-pages`) so it matches the source you set.

## Why it works now

The earlier Actions-source attempts (#985/#986) failed only because **the Pages site didn't exist** (`Resource not accessible by integration` — the token can't *create* it). You've now created it by hand, so `deploy-pages` can deploy to it. The token never needed create rights — only deploy rights, which it has.

## Result after merge

The post-merge `glossary-pages` run builds the site and deploys it via Actions → live at **https://cirwel.github.io/unitares/**, and auto-redeploys on every future glossary edit. No more branch, no more manual steps.

The `gh-pages` branch from #987 is now unused under Actions source — safe to delete whenever (noted in the runbook).

Workflow YAML validated locally. (The `glossary-pages` workflow is push-to-master-triggered, so the real run is post-merge — I'll verify it deploys and the page resolves.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0175PJNxU7V5HrpGXcMtszEM)_