### PR TITLE
feat(kg): record supersession links + flag superseded results to agents

### DIFF
--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -315,6 +315,66 @@ def _resolve_reader_agent_id(arguments: Dict[str, Any]) -> Optional[str]:
     return get_context_agent_id()
 
 
+async def _annotate_supersession(discovery_list: list, graph) -> None:
+    """Flag superseded rows in a result list so agents don't cite stale notes.
+
+    Agent-facing trust signal (2026-06-21). Default search excludes archived/cold
+    but NOT superseded, so a superseded discovery surfaces in results (only
+    down-ranked). This marks those rows `superseded: True` from the already-loaded
+    `status` (free) and best-effort attaches the replacement id(s) from the AGE
+    SUPERSEDES edge. Mutates `discovery_list` in place; fail-soft (a graph error
+    still leaves the free status-based flag).
+    """
+    superseded_ids = [
+        d["id"] for d in discovery_list
+        if d.get("status") == "superseded" and d.get("id")
+    ]
+    if not superseded_ids:
+        return
+    successors: Dict[str, list] = {}
+    if hasattr(graph, "get_superseded_by"):
+        try:
+            successors = await graph.get_superseded_by(superseded_ids)
+        except Exception as exc:  # noqa: BLE001 — advisory flag, never break search
+            logger.debug(f"[KG_SEARCH] supersession lookup failed (non-fatal): {exc}")
+    for d in discovery_list:
+        if d.get("status") != "superseded":
+            continue
+        d["superseded"] = True
+        newer = successors.get(d.get("id")) or []
+        if newer:
+            d["superseded_by"] = newer
+        d["superseded_warning"] = (
+            "Superseded — a newer discovery replaced this. "
+            + (f"Current version: {newer[0]}. " if newer else "")
+            + "Prefer the newer entry over this one."
+        )
+
+
+async def _record_supersession_edge(graph, *, new_id: str, old_id: str) -> Optional[str]:
+    """Durably record that ``new_id`` supersedes ``old_id`` (AGE SUPERSEDES edge).
+
+    The relational row has no ``superseded_by`` column, so both write paths used
+    to pass ``superseded_by`` into ``update_discovery``, which silently dropped
+    it — the 2026-06-21 finding: 18 ``status='superseded'`` rows but 0 SUPERSEDES
+    edges, i.e. the successor link was lost everywhere. Creating the edge here is
+    what lets a reader/dashboard resolve what replaced a note. Returns an error
+    string on failure (the caller surfaces it), or ``None`` on success.
+    """
+    if not new_id or not old_id or new_id == old_id:
+        return None
+    if not hasattr(graph, "supersede_discovery"):
+        return "supersession link not recorded: requires the AGE graph backend"
+    try:
+        res = await graph.supersede_discovery(new_id=new_id, old_id=old_id)
+    except Exception as exc:  # noqa: BLE001 — link is best-effort, never crash the write
+        logger.warning(f"[KG] supersession edge {new_id[:8]}->{old_id[:8]} failed: {exc}")
+        return f"supersession link not recorded: {exc}"
+    if not (isinstance(res, dict) and res.get("success")):
+        return f"supersession link not recorded: {(res or {}).get('error', 'unknown')}"
+    return None
+
+
 def _compute_staleness_warning(discovery, current_server_version: str) -> Optional[str]:
     """Flag open entries that are likely stale (>60 days old or 2+ minor versions behind)."""
     warning_parts = []
@@ -951,6 +1011,10 @@ async def handle_store_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[Te
                 "superseded_by": discovery_id,
                 "updated_at": _utc_now_iso(),
             })
+            # update_discovery can't persist the successor pointer (no relational
+            # column); record the directed link as a SUPERSEDES edge so it isn't
+            # lost (this new discovery supersedes the predecessor).
+            await _record_supersession_edge(graph, new_id=discovery_id, old_id=supersedes_id)
 
         # v2.5.3: Resolve UUID to display name for human-readable output
         agent_display = arguments.get("_agent_display") or _resolve_agent_display(agent_id)
@@ -1656,7 +1720,11 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
                 if d.provenance_chain:
                     d_dict["provenance_chain"] = d.provenance_chain
             discovery_list.append(d_dict)
-        
+
+        # Agent-facing trust flag: mark superseded results so they aren't cited
+        # as current (superseded rows are down-ranked but still returned).
+        await _annotate_supersession(discovery_list, graph)
+
         # Include similarity scores for semantic search
         response_data = {
             "search_mode_used": search_mode,
@@ -1930,6 +1998,9 @@ async def handle_get_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[Text
             d_dict["_agent_id"] = d.agent_id
             discovery_list.append(d_dict)
 
+        # Agent-facing trust flag (same as search): mark superseded rows.
+        await _annotate_supersession(discovery_list, graph)
+
         response_data = {
             "agent": agent_display,
             "discoveries": discovery_list,
@@ -2047,6 +2118,9 @@ async def handle_update_discovery_status_graph(arguments: Dict[str, Any]) -> Seq
     severity = arguments.get("severity")
     discovery_type = arguments.get("discovery_type")
     tags = arguments.get("tags")
+    # The discovery that supersedes this one (records the directed link, not just
+    # the status). Previously read nowhere, so it was silently dropped.
+    superseded_by = arguments.get("superseded_by")
 
     # Foolproofing (KG 2026-06-13 footgun): same guard as the store path —
     # reject an edit whose text fields absorbed tool-call markup rather than
@@ -2060,9 +2134,9 @@ async def handle_update_discovery_status_graph(arguments: Dict[str, Any]) -> Seq
         )
         return [_degenerate_write_response(leaked_marker, field)]
 
-    if not any(value is not None for value in (status, raw_details, resolution_note_text, summary, severity, discovery_type, tags)):
+    if not any(value is not None for value in (status, raw_details, resolution_note_text, summary, severity, discovery_type, tags, superseded_by)):
         return [error_response(
-            "At least one updatable field is required. Provide status, details/content, resolution_notes, summary, severity, discovery_type, or tags."
+            "At least one updatable field is required. Provide status, details/content, resolution_notes, summary, severity, discovery_type, tags, or superseded_by."
         )]
     
     try:
@@ -2187,17 +2261,31 @@ async def handle_update_discovery_status_graph(arguments: Dict[str, Any]) -> Seq
         
         if not success:
             return [error_response(f"Discovery '{discovery_id}' not found")]
-        
+
+        # Record the supersession LINK, not just the status. Without this the
+        # successor pointer is lost (no relational column); the AGE SUPERSEDES
+        # edge is what a reader/dashboard resolves. superseded_by SUPERSEDES this.
+        supersession_warning = None
+        if superseded_by:
+            supersession_warning = await _record_supersession_edge(
+                graph, new_id=str(superseded_by), old_id=discovery_id
+            )
+
         discovery = await graph.get_discovery(discovery_id)
-        
+
         message = f"Discovery '{discovery_id}' updated"
         if status is not None:
             message = f"Discovery '{discovery_id}' status updated to '{status}'"
 
-        return success_response({
+        payload = {
             "message": message,
             "discovery": discovery.to_dict(include_details=False) if discovery else None
-        }, arguments=arguments)
+        }
+        if superseded_by:
+            payload["superseded_by"] = str(superseded_by)
+            if supersession_warning:
+                payload["supersession_warning"] = supersession_warning
+        return success_response(payload, arguments=arguments)
         
     except Exception as e:
         return [error_response(f"Failed to update discovery: {str(e)}")]

--- a/src/storage/knowledge_graph_age.py
+++ b/src/storage/knowledge_graph_age.py
@@ -2487,6 +2487,44 @@ class KnowledgeGraphAGE:
         except Exception as e:
             return {"success": False, "error": f"Failed to create SUPERSEDES edge: {e}"}
 
+    async def get_superseded_by(
+        self,
+        discovery_ids: List[str],
+    ) -> Dict[str, List[str]]:
+        """Map each id to the discoveries that SUPERSEDE it (its replacements).
+
+        Reads the AGE ``(newer)-[:SUPERSEDES]->(old)`` edge — the only place the
+        directed supersession link lives (the relational response columns are
+        unused). 1-hop only: AGE 1.7 cannot reliably filter variable-length
+        paths, and supersession chains are short. Used to flag stale rows in
+        search results so an agent does not cite a superseded note. Fail-soft:
+        returns ``{}`` on missing graph or any read error.
+        """
+        if not discovery_ids:
+            return {}
+        db = await self._get_db()
+        if not await db.graph_available():
+            return {}
+        cypher = """
+            UNWIND ${ids} as disc_id
+            MATCH (newer:Discovery)-[s:SUPERSEDES]->(d:Discovery {id: disc_id})
+            RETURN {id: disc_id, newer: newer.id}
+        """
+        try:
+            results = await db.graph_query(cypher, {"ids": discovery_ids})
+        except Exception as e:
+            logger.debug(f"get_superseded_by graph read failed (non-fatal): {e}")
+            return {}
+        out: Dict[str, List[str]] = {}
+        for r in results or []:
+            if not isinstance(r, dict) or "error" in r:
+                continue
+            old = str(r.get("id", "")).strip('"')
+            newer = str(r.get("newer", "")).strip('"')
+            if old and newer:
+                out.setdefault(old, []).append(newer)
+        return out
+
     # =========================================================================
     # LIFECYCLE MANAGEMENT
     # =========================================================================

--- a/tests/test_kg_search.py
+++ b/tests/test_kg_search.py
@@ -161,6 +161,89 @@ class TestSearchKnowledgeGraph:
         assert data["search_mode_used"] == "indexed_filters"
 
     @pytest.mark.asyncio
+    async def test_superseded_result_is_flagged(self, patch_common):
+        """Agent-facing trust flag (2026-06-21): a superseded result is marked
+        superseded + carries the replacement id, so an agent doesn't cite stale
+        knowledge. Default search returns superseded rows (only down-ranked)."""
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+        old = make_discovery(id="old-1", summary="stale finding", status="superseded")
+        mock_graph.full_text_search = AsyncMock(return_value=[old])
+        if hasattr(mock_graph, "semantic_search"):
+            del mock_graph.semantic_search  # force FTS path
+        mock_graph.get_superseded_by = AsyncMock(return_value={"old-1": ["new-1"]})
+
+        result = await handle_search_knowledge_graph({"query": "stale"})
+        data = parse_result(result)
+        disc = next(d for d in data["discoveries"] if d["id"] == "old-1")
+        assert disc["superseded"] is True
+        assert disc["superseded_by"] == ["new-1"]
+        assert "superseded_warning" in disc
+        assert "new-1" in disc["superseded_warning"]
+
+    @pytest.mark.asyncio
+    async def test_superseded_flag_failsoft_without_successor(self, patch_common):
+        """If the AGE successor lookup fails, the row is still flagged superseded
+        from status (free) — just without superseded_by. Never breaks search."""
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+        old = make_discovery(id="old-2", summary="stale", status="superseded")
+        mock_graph.full_text_search = AsyncMock(return_value=[old])
+        if hasattr(mock_graph, "semantic_search"):
+            del mock_graph.semantic_search
+        mock_graph.get_superseded_by = AsyncMock(side_effect=RuntimeError("AGE down"))
+
+        result = await handle_search_knowledge_graph({"query": "stale"})
+        data = parse_result(result)
+        disc = next(d for d in data["discoveries"] if d["id"] == "old-2")
+        assert disc["superseded"] is True
+        assert "superseded_by" not in disc
+        assert "superseded_warning" in disc
+
+    @pytest.mark.asyncio
+    async def test_non_superseded_result_not_flagged(self, patch_common):
+        """An open result carries no supersession fields and triggers no lookup."""
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+        fresh = make_discovery(id="ok-1", summary="current", status="open")
+        mock_graph.full_text_search = AsyncMock(return_value=[fresh])
+        if hasattr(mock_graph, "semantic_search"):
+            del mock_graph.semantic_search
+        mock_graph.get_superseded_by = AsyncMock(return_value={})
+
+        result = await handle_search_knowledge_graph({"query": "current"})
+        data = parse_result(result)
+        disc = next(d for d in data["discoveries"] if d["id"] == "ok-1")
+        assert "superseded" not in disc
+        mock_graph.get_superseded_by.assert_not_awaited()  # no superseded ids -> no AGE read
+
+    @pytest.mark.asyncio
+    async def test_update_superseded_by_records_edge(self, patch_common, registered_agent):
+        """Write-path fix (2026-06-21): update with superseded_by creates the
+        SUPERSEDES edge, not just status. Previously superseded_by was read
+        nowhere, so the successor link was silently dropped (18 rows, 0 edges)."""
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_update_discovery_status_graph
+
+        mock_graph.get_discovery = AsyncMock(return_value=make_discovery(id="old-1", severity="low"))
+        mock_graph.update_discovery = AsyncMock(return_value=True)
+        mock_graph.supersede_discovery = AsyncMock(return_value={"success": True})
+
+        result = await handle_update_discovery_status_graph({
+            "agent_id": registered_agent,
+            "discovery_id": "old-1",
+            "status": "superseded",
+            "superseded_by": "new-1",
+        })
+        data = parse_result(result)
+        assert data["success"] is True
+        mock_graph.supersede_discovery.assert_awaited_once_with(new_id="new-1", old_id="old-1")
+        assert data["superseded_by"] == "new-1"
+
+    @pytest.mark.asyncio
     async def test_search_with_query_text_fts(self, patch_common):
         """Search with query text uses FTS when available."""
         mock_mcp_server, mock_graph = patch_common

--- a/tests/test_kg_store.py
+++ b/tests/test_kg_store.py
@@ -1764,6 +1764,7 @@ class TestSupersedes:
             tags=["routine"],
         )
         mock_graph.get_discovery = AsyncMock(return_value=predecessor)
+        mock_graph.supersede_discovery = AsyncMock(return_value={"success": True})
 
         result = await handle_store_knowledge_graph({
             "agent_id": registered_agent,
@@ -1782,6 +1783,12 @@ class TestSupersedes:
         updates = call_args[0][1]
         assert updates["status"] == "superseded"
         assert updates["superseded_by"] == new_id
+
+        # Write-path fix (2026-06-21): the directed SUPERSEDES edge is recorded,
+        # not just the status — new supersedes old.
+        mock_graph.supersede_discovery.assert_awaited_once_with(
+            new_id=new_id, old_id="old-disc-1"
+        )
 
         # Response surfaces the supersession
         assert data.get("superseded") == "old-disc-1"


### PR DESCRIPTION
Makes supersession actually work end-to-end. Agent-facing trust flag (high-leverage) + the write-path fix that lets lineage data accumulate. Per the 2026-06-21 finding that the directed supersession link existed **nowhere** in the data.

## The bug (verified live)
18 rows `status='superseded'`, but **0 SUPERSEDES edges**, **0 `response_to_id`**, empty `provenance_chain`. Superseding recorded the *status* but lost the *successor link*, because both write paths passed `superseded_by` into `update_discovery` (which has no column for it) and the update handler never read the param.

## Write path — record the link
- `_record_supersession_edge` creates the AGE `(new)-[:SUPERSEDES]->(old)` edge in **both** the store path (`supersedes=`) and the update path.
- Update handler now **reads `superseded_by`**, counts it as an updatable field, surfaces it (+ a `supersession_warning` if the edge write fails). Best-effort: never crashes the write.

## Read path — agent-facing stale flag
- Default search excludes archived/cold but **not** superseded, so stale notes surfaced unflagged. `_annotate_supersession` marks them `superseded: true` + a "prefer the newer entry" warning, and attaches the replacement id from the new `KnowledgeGraphAGE.get_superseded_by` (1-hop AGE read; fail-soft to status-only). Wired into search **and** get-by-agent.

## Verification
- **Live end-to-end on the AGE backend**: `supersede_discovery` creates an edge that `get_superseded_by` reads back (`{old: [new]}`); round-trip OK; test notes cleaned up (archived).
- 181 tests pass (search + store), incl. new tests for the flag (happy / fail-soft / not-flagged) and the write-path edge creation.

## Deliberately not here
The operator **dashboard lineage expander** — deferred until supersession data accumulates (it would render empty today). This PR is what makes that data start existing. Supersedes the premise of docs PR #988 (which assumed 18 edges existed — they don't).

Draft — operator is the merge/deploy gate.

https://claude.ai/code/session_011onoEr3t2JbEEUDQZHwvk8