### PR TITLE
fix(kg): expose supersession link params on the unified knowledge tool

### DIFF
--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -3054,6 +3054,16 @@ async def handle_supersede_discovery(arguments: Dict[str, Any]) -> Sequence[Text
 
         result = await graph.supersede_discovery(new_id=new_id, old_id=old_id)
         if result.get("success"):
+            # Also flip the old entry to superseded so it's flagged stale in
+            # search — keep all three supersede paths consistent (store/update
+            # both set status + edge; the edge alone doesn't change status).
+            try:
+                await graph.update_discovery(old_id, {
+                    "status": "superseded",
+                    "updated_at": _utc_now_iso(),
+                })
+            except Exception as exc:  # noqa: BLE001 — edge is the primary effect
+                logger.warning(f"[KG] supersede status flip for {old_id[:8]} failed: {exc}")
             return success_response(result, arguments=arguments)
         else:
             return [error_response(result.get("error", "Failed to create SUPERSEDES edge"))]

--- a/src/mcp_handlers/schemas/knowledge.py
+++ b/src/mcp_handlers/schemas/knowledge.py
@@ -318,9 +318,15 @@ class KnowledgeParams(AgentIdentityMixin):
     discovery_type: Optional[str] = Field(None, description="Type: bug_found, insight, pattern, question, note, etc. (for action=store)")
     tags: Optional[List[str]] = Field(None, description="Tags for discovery (for action=store, search, note)")
     severity: Optional[str] = Field(None, description="Severity: low, medium, high, critical (for action=store)")
-    discovery_id: Optional[str] = Field(None, description="Discovery ID (for action=details, update)")
+    discovery_id: Optional[str] = Field(None, description="Discovery ID (for action=details, update; the NEW discovery for action=supersede)")
     status: Optional[str] = Field(None, description="Status filter/update value (open, resolved, archived, superseded)")
     resolution_notes: Optional[str] = Field(None, description="Rationale to append when closing or updating a discovery")
+    # Supersession LINK params. Without these declared here the unified tool's
+    # validator silently strips them, so the directed link is never recorded —
+    # the 2026-06-21 finding (status='superseded' set, but 0 SUPERSEDES edges).
+    supersedes: Optional[str] = Field(None, description="ID of an older discovery this new one replaces (for action=store)")
+    superseded_by: Optional[str] = Field(None, description="ID of the discovery that supersedes this one (for action=update with status=superseded)")
+    supersedes_id: Optional[str] = Field(None, description="ID of the older discovery being replaced (for action=supersede; discovery_id is the newer one)")
     agent_id: Optional[str] = Field(None, description="Filter by agent (for action=get, search)")
     limit: Optional[int] = Field(None, description="Max results")
     include_details: Optional[bool] = Field(None, description="Include full details inline (for action=search/get)")

--- a/tests/test_pydantic_schemas.py
+++ b/tests/test_pydantic_schemas.py
@@ -166,6 +166,29 @@ class TestPydanticSchemas:
         dumped = model.model_dump()
         assert dumped["tags"] is None
 
+    def test_knowledge_exposes_supersession_link_params(self):
+        """Unified knowledge() must pass the supersession LINK params through.
+
+        Regression (2026-06-21): superseded_by / supersedes / supersedes_id were
+        NOT declared on KnowledgeParams, so the validator silently stripped them
+        before they reached the handlers. Result: agents could set
+        status='superseded' but the SUPERSEDES edge was never created (18
+        superseded rows, 0 edges). These fields must survive validation so the
+        directed link is recorded.
+        """
+        from src.mcp_handlers.schemas.knowledge import KnowledgeParams
+
+        upd = KnowledgeParams(action="update", discovery_id="old-1",
+                              status="superseded", superseded_by="new-1")
+        assert upd.superseded_by == "new-1"
+        assert upd.model_dump()["superseded_by"] == "new-1"
+
+        store = KnowledgeParams(action="store", summary="replaces old", supersedes="old-1")
+        assert store.supersedes == "old-1"
+
+        sup = KnowledgeParams(action="supersede", discovery_id="new-1", supersedes_id="old-1")
+        assert sup.supersedes_id == "old-1"
+
     def test_knowledge_cleanup_accepts_string_dry_run_false(self):
         """Unified knowledge(cleanup) must expose and coerce dry_run.
 


### PR DESCRIPTION
The completion of #991. A **live agent-path test** revealed the edge still wasn't being created: the unified `KnowledgeParams` schema never declared the link params, so the validator **silently stripped** `superseded_by` / `supersedes` / `supersedes_id` before they reached the handlers.

That's the true root cause of "18 `status='superseded'` rows, 0 SUPERSEDES edges" — `status` is in the schema; the link params never were. #991's handler fix was correct but unreachable through the real tool. (Unit tests missed it because they call handlers directly, bypassing schema validation — same class as the previously-fixed `dry_run` stripping.)

## Fix
- Declare `supersedes` / `superseded_by` / `supersedes_id` on `KnowledgeParams` so the link survives validation.
- `action='supersede'` now also flips the old entry to `status='superseded'` (consistency: all 3 supersede paths set status **and** edge).
- Regression test asserting the schema preserves the link params.

## Verification
- 268 tests pass.
- Live agent-path **re-verification through the MCP tool** after deploy (the in-process unit path can't catch schema stripping — that's what let this through the first time).

Draft — operator is the merge/deploy gate.

https://claude.ai/code/session_011onoEr3t2JbEEUDQZHwvk8