### PR TITLE
feat(kg): expose include_archived / include_cold on the unified knowledge tool

### DIFF
--- a/src/mcp_handlers/schemas/knowledge.py
+++ b/src/mcp_handlers/schemas/knowledge.py
@@ -330,6 +330,12 @@ class KnowledgeParams(AgentIdentityMixin):
     agent_id: Optional[str] = Field(None, description="Filter by agent (for action=get, search)")
     limit: Optional[int] = Field(None, description="Max results")
     include_details: Optional[bool] = Field(None, description="Include full details inline (for action=search/get)")
+    # Recall-recovery levers for action=search. Default search excludes archived
+    # and cold-storage notes; pass these to reach them when an active-tier search
+    # comes up empty. The handler already honors both — they were just never
+    # exposed on the unified tool (see test_knowledge_param_coverage backlog).
+    include_archived: Optional[bool] = Field(None, description="Include archived discoveries in search results (default: excluded)")
+    include_cold: Optional[bool] = Field(None, description="Include cold-storage (long-term) discoveries in search results (default: excluded)")
     dry_run: Union[bool, str, None] = Field(None, description="Dry run mode (for action=cleanup, synthesize)")
     # Synthesis (action=synthesize): roll discoveries up into topic summaries.
     topic: Optional[str] = Field(None, description="Synthesize just this one tag/topic (for action=synthesize). Omit to sweep the densest topics.")

--- a/tests/test_knowledge_param_coverage.py
+++ b/tests/test_knowledge_param_coverage.py
@@ -65,12 +65,15 @@ INTERNAL_KEYS = {
 # not to grow it. Adding a NEW entry must be a deliberate, reviewed act.
 KNOWN_UNEXPOSED = {
     "auto_link_related", "confidence", "epoch_scope", "exclude_agent_labels",
-    "include_archived", "include_cold", "include_provenance",
+    "include_provenance",
     "include_response_chain", "including_cold", "length", "max_chain_depth",
     "min_similarity", "offset", "operator", "related_files", "resolve_question",
     "response_to", "scope", "search_mode", "semantic", "synthesize", "top_n",
     "use_model",
 }
+# include_archived / include_cold were exposed on KnowledgeParams (2026-06-22) as
+# recall-recovery levers — removed from the backlog above. Shrinking this set is
+# the goal; growing it is the smell.
 
 
 def _classify_undeclared() -> set[str]:
@@ -96,6 +99,20 @@ def test_no_new_unexposed_handler_param():
         f"(silent-strip class): {sorted(offenders)}. Declare them on "
         "KnowledgeParams or classify them — see this file's docstring."
     )
+
+
+def test_known_unexposed_has_no_declared_params():
+    """Hygiene: a param that's been declared on the schema must not linger in the
+    KNOWN_UNEXPOSED backlog — otherwise the backlog overstates what's missing."""
+    declared = set(KnowledgeParams.model_fields.keys())
+    stale = declared & KNOWN_UNEXPOSED
+    assert not stale, f"declared params still listed as unexposed: {sorted(stale)}"
+
+
+def test_archived_cold_recall_levers_exposed():
+    """include_archived / include_cold must be agent-sendable (recall recovery)."""
+    declared = set(KnowledgeParams.model_fields.keys())
+    assert {"include_archived", "include_cold"} <= declared
 
 
 def test_supersession_link_params_stay_declared():


### PR DESCRIPTION
First paydown of the unexposed-param backlog #997 surfaced — the two **recall-recovery levers**.

## Why
Default search excludes archived (774) and cold (264) notes. The handler honors `include_archived`/`include_cold` overrides (`handlers.py:1153/1156`), but they were never on `KnowledgeParams`, so the unified tool stripped them upstream — an agent that comes up empty in the active tier **cannot reach archived/cold notes, even deliberately**.

## Honest scope
The recall-miss telemetry (#972) is still empty (hours old), so this is a **capability/safety** call, not demand-evidenced: exposing an existing, handler-honored, default-False, zero-risk control — not new inventory. Held to exactly these two; the other ~21 unexposed params stay baselined in the lint. (Default search behavior is unchanged — both opt-in.)

## Changes
- `KnowledgeParams`: `+ include_archived`, `+ include_cold`.
- `test_knowledge_param_coverage`: removed both from `KNOWN_UNEXPOSED` (backlog shrinks — the stated goal), `+` a hygiene guard that no declared param lingers in the backlog, `+` an assertion these stay agent-sendable.

## Verification
147 tests pass. **Live verification after deploy**: an agent `search` with `include_archived=true` actually returns archived results (the real-surface check this session's bugs taught — declaring ≠ working).

Draft — operator is the merge/deploy gate.

https://claude.ai/code/session_011onoEr3t2JbEEUDQZHwvk8