### PR TITLE
fix(identity): close two agent-id leaks (P1.3 signature handle + free-text client_hint)

### DIFF
--- a/src/mcp_handlers/support/agent_auth.py
+++ b/src/mcp_handlers/support/agent_auth.py
@@ -106,10 +106,15 @@ def compute_agent_signature(
             structured_id = getattr(meta, 'structured_id', None)
 
         signature = {"uuid": agent_uuid}
-        # display_name (user-chosen) takes precedence over agent_id (auto-generated)
+        # P1.3 contract: `agent_id` is a STRUCTURED-identifier slot. It must
+        # never carry a bare display label when a structured handle exists —
+        # the cosmetic label belongs in `display_name`. Emitting the label in
+        # a field literally named `agent_id` leaked multiple handles for one
+        # agent (KG 2026-06-13 dogfood P1.3). Prefer the structured handle;
+        # fall back to the label only when no handle is available at all.
         auto_id = public_agent_id or structured_id
         if display_label:
-            signature["agent_id"] = display_label
+            signature["agent_id"] = auto_id or display_label
             if auto_id:
                 signature["structured_agent_id"] = auto_id
             signature["display_name"] = display_label

--- a/src/mcp_handlers/support/naming_helpers.py
+++ b/src/mcp_handlers/support/naming_helpers.py
@@ -139,6 +139,30 @@ def generate_name_suggestions(
     
     return suggestions[:4]  # Return top 4 suggestions
 
+def _safe_interface_hint(client_hint: Optional[str]) -> Optional[str]:
+    """Vet a caller-supplied client_hint for use as the leading interface token.
+
+    Returns the lowercased hint when it is safe to seed a structured id, or
+    ``None`` when it is empty, the literal ``"unknown"``, or would collide with
+    the reserved/privileged namespace. The leading token is followed by ``_``
+    in the structured id, so a hint equal to a reserved-prefix root (``mcp``,
+    ``admin``, ``root``, ``system``, ``governance``, ``auth``) or any reserved
+    name must be rejected — otherwise the mint produces a reserved-prefix
+    agent_id that downstream validation refuses. Caller falls back to the
+    detected interface when this returns ``None``.
+    """
+    if not client_hint or client_hint == "unknown":
+        return None
+    from ..validators import RESERVED_NAMES, RESERVED_PREFIXES
+
+    hint_lower = client_hint.lower()
+    reserved_roots = {prefix.rstrip("_") for prefix in RESERVED_PREFIXES}
+    leading_token = hint_lower.replace("-", "_").split("_", 1)[0]
+    if hint_lower in RESERVED_NAMES or leading_token in reserved_roots:
+        return None
+    return client_hint
+
+
 def generate_structured_id(
     context: Optional[Dict[str, str]] = None,
     existing_ids: Optional[List[str]] = None,
@@ -192,9 +216,17 @@ def generate_structured_id(
     timestamp = datetime.now().strftime("%Y%m%d")
 
     # Use client_hint if provided (takes precedence over auto-detection)
-    # This allows ChatGPT and other HTTP clients to get meaningful names
-    if client_hint and client_hint != "unknown":
-        interface = client_hint
+    # This allows ChatGPT and other HTTP clients to get meaningful names.
+    # client_hint is free text from the caller, so it must NOT be allowed to
+    # seed the leading token of the structured id with a reserved/privileged
+    # word (e.g. "admin", "mcp", "root"): that produces a reserved-prefix
+    # agent_id which is later rejected by validate_agent_id_reserved_names,
+    # leaking free text into the privileged identifier namespace (KG dogfood
+    # 2026-05-09 "client_hint leaks into agent_id namespace"). When the hint
+    # would collide, fall back to the detected interface instead.
+    safe_hint = _safe_interface_hint(client_hint)
+    if safe_hint:
+        interface = safe_hint
     else:
         interface = context.get("interface", "mcp")
 

--- a/src/mcp_handlers/support/naming_helpers.py
+++ b/src/mcp_handlers/support/naming_helpers.py
@@ -139,28 +139,46 @@ def generate_name_suggestions(
     
     return suggestions[:4]  # Return top 4 suggestions
 
-def _safe_interface_hint(client_hint: Optional[str]) -> Optional[str]:
-    """Vet a caller-supplied client_hint for use as the leading interface token.
+_MAX_HINT_LEN = 40
 
-    Returns the lowercased hint when it is safe to seed a structured id, or
-    ``None`` when it is empty, the literal ``"unknown"``, or would collide with
-    the reserved/privileged namespace. The leading token is followed by ``_``
-    in the structured id, so a hint equal to a reserved-prefix root (``mcp``,
-    ``admin``, ``root``, ``system``, ``governance``, ``auth``) or any reserved
-    name must be rejected — otherwise the mint produces a reserved-prefix
-    agent_id that downstream validation refuses. Caller falls back to the
-    detected interface when this returns ``None``.
+
+def _safe_interface_hint(client_hint: Optional[str]) -> Optional[str]:
+    """Vet & sanitize a caller-supplied client_hint for use as the leading
+    interface token of a structured id.
+
+    client_hint is free text from the caller. Two failure modes must be
+    contained before it can seed an id (KG dogfood 2026-05-09 "client_hint
+    leaks into agent_id namespace"; follow-up 2026-06-10):
+
+    1. Shape — a descriptor like ``"Anthropic Claude, mobile app, dogfooding"``
+       must not become an identifier full of spaces and commas. Strip to
+       ``[a-zA-Z0-9_-]`` (mirrors validators.sanitize_agent_name), collapse
+       separators, and length-cap.
+    2. Namespace — the leading token is immediately followed by ``_`` in the
+       id, so a hint equal to a reserved-prefix root (``mcp``, ``admin``,
+       ``root``, ``system``, ``governance``, ``auth``) or any reserved name
+       would mint a reserved-prefix agent_id that downstream validation
+       refuses.
+
+    Returns a sanitized, identifier-shaped token, or ``None`` when the hint is
+    empty/``"unknown"``, sanitizes to nothing, or collides with the reserved
+    namespace. The caller falls back to the detected interface on ``None``.
     """
     if not client_hint or client_hint == "unknown":
         return None
     from ..validators import RESERVED_NAMES, RESERVED_PREFIXES
 
-    hint_lower = client_hint.lower()
-    reserved_roots = {prefix.rstrip("_") for prefix in RESERVED_PREFIXES}
-    leading_token = hint_lower.replace("-", "_").split("_", 1)[0]
-    if hint_lower in RESERVED_NAMES or leading_token in reserved_roots:
+    cleaned = re.sub(r'[^a-zA-Z0-9_-]', '_', client_hint)
+    cleaned = re.sub(r'_+', '_', cleaned).strip('_-')[:_MAX_HINT_LEN].strip('_-')
+    if not cleaned:
         return None
-    return client_hint
+
+    reserved_roots = {prefix.rstrip("_") for prefix in RESERVED_PREFIXES}
+    cleaned_lower = cleaned.lower()
+    leading_token = cleaned_lower.replace("-", "_").split("_", 1)[0]
+    if cleaned_lower in RESERVED_NAMES or leading_token in reserved_roots:
+        return None
+    return cleaned
 
 
 def generate_structured_id(

--- a/src/mcp_handlers/validators.py
+++ b/src/mcp_handlers/validators.py
@@ -133,6 +133,13 @@ def sanitize_agent_name(agent_id: str) -> str:
         sanitized = sanitized + '_agent'
     return sanitized
 
+# Reserved/privileged identifiers, promoted to module scope so the structured-id
+# generator (support/naming_helpers.py) can reuse the exact same set rather than
+# duplicating it — keeps the namespace guard single-sourced.
+RESERVED_NAMES = frozenset({'system', 'admin', 'root', 'superuser', 'administrator', 'sudo', 'null', 'undefined', 'none', 'anonymous', 'guest', 'default', 'mcp', 'server', 'client', 'handler', 'transport', 'governance', 'monitor', 'arbiter', 'validator', 'auditor', 'security', 'auth', 'identity', 'certificate'})
+RESERVED_PREFIXES = ('system_', 'admin_', 'root_', 'mcp_', 'governance_', 'auth_')
+
+
 def validate_agent_id_format(agent_id: str) -> Tuple[Optional[str], Optional[TextContent]]:
     """
     Validate and sanitize agent_id format for safety (filesystem, URLs, etc).
@@ -164,8 +171,6 @@ def validate_agent_id_reserved_names(agent_id: str) -> Tuple[Optional[str], Opti
     if agent_id is None:
         return (None, None)
     agent_id_lower = agent_id.lower()
-    RESERVED_NAMES = {'system', 'admin', 'root', 'superuser', 'administrator', 'sudo', 'null', 'undefined', 'none', 'anonymous', 'guest', 'default', 'mcp', 'server', 'client', 'handler', 'transport', 'governance', 'monitor', 'arbiter', 'validator', 'auditor', 'security', 'auth', 'identity', 'certificate'}
-    RESERVED_PREFIXES = ('system_', 'admin_', 'root_', 'mcp_', 'governance_', 'auth_')
     if agent_id_lower in RESERVED_NAMES:
         return (None, error_response(f"SECURITY: agent_id '{agent_id}' is reserved for system use", details={'error_type': 'reserved_agent_id', 'reason': 'Reserved name blocked to prevent privilege confusion'}, recovery={'action': 'Choose a different agent_id that describes your work', 'example': 'my_agent_work_20251209', 'note': 'Reserved names include: system, admin, root, null, etc.'}))
     if agent_id_lower.startswith(RESERVED_PREFIXES):

--- a/tests/test_mcp_utils.py
+++ b/tests/test_mcp_utils.py
@@ -170,8 +170,9 @@ class TestComputeAgentSignature:
         mock_srv.return_value = _mock_server({"ctx-456": _meta(label="Ctx", structured_id="S1")})
         sig = compute_agent_signature()
         assert sig["uuid"] == "ctx-456"
-        # display_name (label) takes precedence over structured_id
-        assert sig["agent_id"] == "Ctx"
+        # P1.3: agent_id carries the STRUCTURED handle, not the display label;
+        # the label lives in display_name.
+        assert sig["agent_id"] == "S1"
         assert sig["structured_agent_id"] == "S1"
         assert sig["display_name"] == "Ctx"
 
@@ -215,8 +216,28 @@ class TestComputeAgentSignature:
             "uuid-1": _meta(label="hikewa", public_agent_id="Claude_Code_20260417", structured_id="mcp_20260417"),
         })
         sig = compute_agent_signature()
-        assert sig["agent_id"] == "hikewa"
+        # P1.3: the structured handle is surfaced in agent_id; the claimed
+        # label is reported via display_name + label_source, not agent_id.
+        assert sig["agent_id"] == "Claude_Code_20260417"
+        assert sig["display_name"] == "hikewa"
         assert sig["label_source"] == "claimed"
+
+    @patch("src.mcp_handlers.context.get_context_agent_id")
+    @patch("src.mcp_handlers.shared.get_mcp_server")
+    def test_agent_id_carries_structured_handle_not_label(self, mock_srv, mock_ctx):
+        """P1.3 regression: when both a display label and a structured handle
+        exist, agent_id must be the structured handle (never the bare label),
+        and the label must be reachable only via display_name."""
+        mock_ctx.return_value = "uuid-p13"
+        mock_srv.return_value = _mock_server({
+            "uuid-p13": _meta(label="claude-opus48-dogfood",
+                              public_agent_id="Claude_Opus_4_8_20260613"),
+        })
+        sig = compute_agent_signature()
+        assert sig["agent_id"] == "Claude_Opus_4_8_20260613"
+        assert sig["agent_id"] != "claude-opus48-dogfood"
+        assert sig["display_name"] == "claude-opus48-dogfood"
+        assert sig["structured_agent_id"] == "Claude_Opus_4_8_20260613"
 
     @patch("src.mcp_handlers.context.get_context_agent_id")
     @patch("src.mcp_handlers.shared.get_mcp_server")

--- a/tests/test_naming_helpers.py
+++ b/tests/test_naming_helpers.py
@@ -197,6 +197,26 @@ class TestGenerateStructuredId:
         assert generate_structured_id(context=ctx, client_hint="claude_code").startswith("claude_code_")
         assert "vscode" in generate_structured_id(context=ctx, client_hint="vscode")
 
+    def test_freetext_client_hint_is_sanitized_to_identifier(self):
+        """A descriptor-style client_hint with spaces and commas must not become
+        an identifier full of spaces/commas (KG dogfood 2026-05-09: client_hint
+        "Anthropic Claude, mobile app, dogfooding UX review" leaked verbatim
+        into agent_id). It must sanitize to identifier-shaped chars only."""
+        ctx = {"interface": "cursor", "model_hint": None, "environment": None}
+        result = generate_structured_id(
+            context=ctx, client_hint="Anthropic Claude, mobile app, dogfooding UX review"
+        )
+        assert " " not in result and "," not in result
+        # Only identifier-safe characters survive.
+        assert all(c.isalnum() or c == "_" for c in result), result
+        assert result.startswith("Anthropic_Claude")
+
+    def test_empty_after_sanitization_falls_back(self):
+        """A hint that is all punctuation sanitizes to nothing → fall back."""
+        ctx = {"interface": "cursor", "model_hint": None, "environment": None}
+        result = generate_structured_id(context=ctx, client_hint="!!! ,,, ###")
+        assert result.startswith("cursor_")
+
     def test_collision_avoidance_single(self):
         ctx = {"interface": "cursor", "model_hint": None, "environment": None}
         first = generate_structured_id(context=ctx)

--- a/tests/test_naming_helpers.py
+++ b/tests/test_naming_helpers.py
@@ -176,6 +176,27 @@ class TestGenerateStructuredId:
         result = generate_structured_id(context=ctx, client_hint="chatgpt")
         assert "chatgpt" in result
 
+    def test_reserved_client_hint_does_not_leak_reserved_prefix(self):
+        """A free-text client_hint that collides with a reserved prefix root
+        (e.g. "admin") must NOT seed the structured id — otherwise the mint is a
+        reserved-prefix agent_id that downstream validation rejects (KG dogfood
+        2026-05-09 'client_hint leaks into agent_id namespace'). The id falls
+        back to the detected interface instead."""
+        from src.mcp_handlers.validators import validate_agent_id_reserved_names
+        ctx = {"interface": "cursor", "model_hint": None, "environment": None}
+        for reserved in ("admin", "mcp", "root", "system", "governance", "auth", "admin-tools"):
+            result = generate_structured_id(context=ctx, client_hint=reserved)
+            assert result.startswith("cursor_"), f"{reserved!r} leaked: {result}"
+            # The generated id must pass the reserved-name guard.
+            _, err = validate_agent_id_reserved_names(result)
+            assert err is None, f"{reserved!r} produced reserved id: {result}"
+
+    def test_non_reserved_client_hint_still_used(self):
+        """Ordinary client hints are unaffected — they still seed the id."""
+        ctx = {"interface": "cursor", "model_hint": None, "environment": None}
+        assert generate_structured_id(context=ctx, client_hint="claude_code").startswith("claude_code_")
+        assert "vscode" in generate_structured_id(context=ctx, client_hint="vscode")
+
     def test_collision_avoidance_single(self):
         ctx = {"interface": "cursor", "model_hint": None, "environment": None}
         first = generate_structured_id(context=ctx)


### PR DESCRIPTION
Closes two verified-open agent-experience grievances from the KG audit. Both land on the writer-locked identity surface; no in-flight identity PRs on unitares (checked). Draft — operator is the merge gate.

## 1. P1.3 — display label leaked into `agent_signature.agent_id`

`compute_agent_signature` (`support/agent_auth.py`) emitted the cosmetic **display label** in a field literally named `agent_id`, surfacing multiple divergent handles for one agent. **Reproduced live** while auditing — my own `knowledge(search)` returned `agent_id="claude-grievance-check"` (a display name) alongside `structured_agent_id="Claude_20260621"`.

**Fix:** `agent_id` now carries the structured handle (`auto_id or display_label`); the label stays reachable via `display_name` + `label_source`. Falls back to the label only when no structured handle exists. (KG `2026-06-13` P1.3)

## 2. `client_hint` free-text leaked into the agent_id namespace

A caller-supplied `client_hint` flowed straight into `generate_structured_id` as the leading interface token, two failure modes:
- **Shape:** `"Anthropic Claude, mobile app, dogfooding UX review"` → `agent_id="Anthropic Claude, mobile app, dogfooding UX review_20260508"` (spaces + commas in an identifier).
- **Namespace:** a hint like `admin`/`mcp`/`root` minted a reserved-prefix id that `validate_agent_id_reserved_names` then rejects.

**Fix:** new `_safe_interface_hint()` sanitizes to identifier-safe chars (mirrors `sanitize_agent_name`), collapses separators, length-caps at 40, then applies a reserved name/prefix guard; a colliding or empty hint falls back to the detected interface. `RESERVED_NAMES`/`RESERVED_PREFIXES` promoted to module scope in `validators.py` and reused (single source of truth). `model_type` left unchanged (never the leading token). (KG `2026-05-09` + follow-up `2026-06-10`)

## Tests

New regression tests: `test_agent_id_carries_structured_handle_not_label`, `test_reserved_client_hint_does_not_leak_reserved_prefix`, `test_freetext_client_hint_is_sanitized_to_identifier`, `test_empty_after_sanitization_falls_back`. Two tests that encoded the old "label wins in agent_id" contract updated. 636 tests green across the identity/onboard/validators suite (Python 3.12).

## Notes / out of scope

- Updates a contract that was deliberately tested (`agent_id == <label>`) — that was the bug per P1.3, but it changes a public response field's meaning; worth an explicit ack before merge.
- Full `s22.identity_response.v1` "one contract everywhere" propagation across the note/knowledge builders and the **`unitares-governance-plugin`** repo remains open (cross-repo, not touched here).
- The pre-existing `"mcp"` default-interface reserved-prefix case is a separate, already-tracked telemetry concern — intentionally not changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)