### PR TITLE
feat(adoption-kpi): surface recall-miss telemetry in the daily KPI

### DIFF
--- a/scripts/dev/adoption_kpi.py
+++ b/scripts/dev/adoption_kpi.py
@@ -111,6 +111,22 @@ def snapshot(days: int) -> dict:
     oc["conversion_pct"] = round(100 * oc["converted"] / oc["minted"], 1) if oc["minted"] else None
     op = out["outcome_pipe_health"]
     op["success_pct"] = round(100 * op["ok"] / op["total"], 1) if op["total"] else None
+
+    # Recall-miss telemetry (#972): a zero-result / low-confidence search is a
+    # no-value interaction — an adoption signal, so it belongs in this snapshot.
+    # File-based, written by the live search path; summarize() reads it relative
+    # to whatever checkout runs (the daily cron runs from the deploy worktree →
+    # the live telemetry file). Fail-open: telemetry must never break the KPI.
+    try:
+        import sys as _sys
+        from pathlib import Path as _Path
+        _root = str(_Path(__file__).resolve().parent.parent.parent)
+        if _root not in _sys.path:
+            _sys.path.insert(0, _root)
+        from src.recall_telemetry import summarize as _recall_summarize
+        out["recall_misses"] = _recall_summarize()
+    except Exception as exc:  # noqa: BLE001
+        out["recall_misses"] = {"error": str(exc)}
     return out
 
 
@@ -138,6 +154,9 @@ def main() -> int:
     pk = snap["proactive_kg_surface"]
     print(f"  proactive KG surface: {pk['surfaced']} seen / {pk['fired']} fired "
           f"by {pk['agents']} agents")
+    rm = snap.get("recall_misses") or {}
+    print(f"  recall misses (search no-value, #972): {rm.get('total', 0)} total "
+          f"{rm.get('by_class', {})}")
     return 0
 
 


### PR DESCRIPTION
Closes the "report with no reader" gap on the recall-miss telemetry (#972) — it was writing JSONL nobody consumed.

## What
Wires `recall_telemetry.summarize()` into the daily adoption-KPI snapshot (existing launchd cron, runs from the deploy worktree). A zero-result / low-confidence search is a no-value interaction → an adoption signal, so it belongs here. **No new cron/infra.**

## Why this path is correct
The cron runs `unitares-deploy/scripts/dev/adoption_kpi.py`, and `summarize()` resolves the telemetry file relative to that checkout → the **live** `unitares-deploy/data/telemetry/recall_misses.jsonl` the server writes. Fail-open (telemetry never breaks the KPI).

## Verified
The live file the cron will read holds **13 events (12 low_confidence, 1 zero_result)** — real signal accumulating. (An earlier `summarize()` returned 0 because it read the *dev* checkout's empty copy — the wrong-path trap that motivated this whole "how do reports get surfaced" thread. Now read where the data actually is.)

Rides the next deploy (cron picks up the updated script when the deploy worktree advances). Draft — operator merge gate.

https://claude.ai/code/session_011onoEr3t2JbEEUDQZHwvk8