### PR TITLE
[codex] Clear operations doc health warnings

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -60,15 +60,18 @@ How to run this in production. Most readers can skip these.
 - [`github-workflow-conventions.md`](operations/github-workflow-conventions.md) — canonical delivery contract (branch naming, draft PRs) shared by Codex and Claude; `AGENTS.md`/`CLAUDE.md` carry the short form
 - [`merge-automation-plan.md`](operations/merge-automation-plan.md) — branch-protection + operator-armed auto-merge plan (not yet applied)
 - [`ci-issue-surfacing.md`](operations/ci-issue-surfacing.md) — experiment wiring the surfacing instinct into GitHub CI (deduped issues from new findings)
+- [`automation-overrides.md`](operations/automation-overrides.md) — operator-authored metadata layered onto the automation census for accountability/gate classification
 - [`resident-roster.md`](operations/resident-roster.md) — `UNITARES_RESIDENTS` configuration; the named resident set is config, not a hardcoded fleet
 - [`ablation-negative-controls.md`](operations/ablation-negative-controls.md) — synthetic bad-outcome fixtures for red-team ablation plumbing
 - [`DEFINITIVE_PORTS.md`](operations/DEFINITIVE_PORTS.md) — port assignments across services
 - [`database_architecture.md`](operations/database_architecture.md) — single-Postgres / schema-isolation model
+- [`glossary-site.md`](operations/glossary-site.md) — GitHub Pages publishing path for the ontology glossary site
 - [`lease-plane-operator-runbook.md`](operations/lease-plane-operator-runbook.md) — Elixir lease-plane operations
 - [`branch-hygiene-runbook.md`](operations/branch-hygiene-runbook.md) — resident branch-hygiene sweep (`agents/vigil_hygiene`)
 - [`resident-validation-cohort.md`](operations/resident-validation-cohort.md) — experimental long-running resident validation tick contract
 - [`resident-validation-supervised-invocation.md`](operations/resident-validation-supervised-invocation.md) — local-only supervised canary invocation wrapper
 - [`dormant-capability-registry.md`](operations/dormant-capability-registry.md) — distinguishes built-but-unwired capability from genuine cruft, so cleanup is deliberate
+- [`kg-lineage-dashboard-handoff.md`](operations/kg-lineage-dashboard-handoff.md) — deferred implementation handoff for KG supersession/related-lineage dashboard exposure
 - [`test-suite-triage.md`](operations/test-suite-triage.md) — current state of the test gate and known-triaged suites
 - [`DATA_NOTES.md`](operations/DATA_NOTES.md) — operational data dictionary for the production governance database
 - [`DEPLOYMENT_DATA_CAVEAT.md`](operations/DEPLOYMENT_DATA_CAVEAT.md) — what the cited deployment numbers do and don't mean

--- a/docs/operations/kg-lineage-dashboard-handoff.md
+++ b/docs/operations/kg-lineage-dashboard-handoff.md
@@ -138,7 +138,7 @@ read and N+1 for summaries — the dedicated endpoint is cleaner.)
 ## Frontend
 
 Reuse the **dialectic-transcript lazy-load** pattern (PR #981) — the model to copy:
-- `dashboard/redesign/sections/dialectic.js` → `renderTranscript()` + the
+- `dashboard/redesign/sections/dialectic.js` → the `renderTranscript` helper + the
   `<details class="dlc-transcript">` toggle that lazy-fetches on first expand.
 - `dashboard/redesign/data.js` → `dialecticSession(id)` accessor.
 
@@ -152,7 +152,7 @@ Do the same here:
   than the related list.
 
 To decide whether to show the expander without a probe, thread a lightweight
-flag through the `discoveries()` accessor (currently dropped): `related_to`
+flag through the `discoveries` accessor (currently dropped): `related_to`
 non-empty is already known relationally; for supersession, expose a boolean
 `has_supersession` (cheap: `status='superseded'` OR the id appears as a
 SUPERSEDES endpoint). Otherwise the endpoint can return `{empty:true}` and the


### PR DESCRIPTION
## Summary

Clears the doc-health warnings that surfaced during the identity-contract push hook.

- Links `automation-overrides.md`, `glossary-site.md`, and `kg-lineage-dashboard-handoff.md` from the main docs operations index.
- Rewords two internal dashboard helper references in the KG lineage handoff so the ghost-tool checker does not mistake them for MCP tool calls.

## Investigation

The orphan warnings were real under `scripts/diagnostics/check_doc_health.py`: each file existed under `docs/operations/` but no other markdown/code file referenced its basename. The ghost-tool warnings were false positives from implementation handoff prose using backticked JS helper names with `()`.

## Validation

- `python3 scripts/diagnostics/check_doc_health.py` -> `Doc health: all clear`
- `git diff --check`
- Push hook smoke: `138 passed, 9854 deselected, 1 warning`; doc health all clear
- `git prepr --no-processes --scope "doc-health operations warnings"`