### PR TITLE
docs: add end-to-end user manual under docs/manual/

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 This is the documentation tree for the [UNITARES governance MCP server](../README.md). If you're new to the project, **start with the [repo README](../README.md)** — it has the core idea, the `make demo` walkthrough, and the integration loop. The deeper [scope & threat model](SCOPE_AND_THREAT_MODEL.md) and [production snapshot](PRODUCTION_SNAPSHOT.md) now live here under `docs/`. This page is the map for everything under `docs/`.
 
+For a single, task-ordered walkthrough that stitches the docs below into one guide — install → run → integrate → read the signals → operate → troubleshoot — see the **[User Manual](manual/README.md)**.
+
 ## Reader's path
 
 | You are… | Read in this order |
@@ -12,6 +14,12 @@ This is the documentation tree for the [UNITARES governance MCP server](../READM
 | **Working on the identity layer** | [`../AGENTS.md`](../AGENTS.md) → [`ontology/README.md`](ontology/README.md) → [`ontology/identity.md`](ontology/identity.md) → [`ontology/plan.md`](ontology/plan.md) |
 
 ## Layout
+
+### `manual/` — the user manual
+
+A cohesive, multi-chapter front door for operators and integrators. Thin chapters that stitch the canonical docs below into one walkthrough; the deep references stay canonical.
+
+→ Start at **[`manual/README.md`](manual/README.md)** (overview · install · running · integrating · reading the signals · operating · troubleshooting).
 
 ### Canonical reference
 

--- a/docs/manual/01-overview.md
+++ b/docs/manual/01-overview.md
@@ -1,0 +1,86 @@
+# 1 · Overview & concepts
+
+[← Manual index](README.md) · [Next: Installation →](02-install.md)
+
+This chapter gives you the mental model and the vocabulary. Read it once; the rest of the manual assumes these terms.
+
+## 1.1 The problem it solves
+
+Autonomous and semi-autonomous agents fail *gradually*. By the time output visibly breaks, the agent has usually been drifting for a while — looping, getting overconfident, wandering off its own normal behavior. Pre-deploy evals can't see this (they run before the work), and per-action guardrails can't either (they only see one action at a time).
+
+UNITARES watches each agent **mid-run** and reports degradation as it happens — to you *and to the agent itself* — while it's still just numbers moving and not yet broken output.
+
+## 1.2 Where it fits
+
+UNITARES runs **alongside** your evals and guardrails. It does not replace either.
+
+| Layer | Question it answers | When it acts |
+|---|---|---|
+| **Evals** | Is this model good enough to ship? | before deploy |
+| **Guardrails** | Is this *action* allowed right now? | per action |
+| **UNITARES** | Is this agent *still healthy* as it works? | continuously, mid-run |
+
+It is **not** an output validator, a sandbox, or a hosted agent platform. It is the runtime *state layer* between evals and guardrails. (Full scope: [`../SCOPE_AND_THREAT_MODEL.md`](../SCOPE_AND_THREAT_MODEL.md).)
+
+**Use UNITARES if** you run autonomous coding/research/ops/resident agents, you want mid-run health signals rather than only pre-deploy evals or post-hoc logs, you want agents to check their own state before continuing, and you want an audit trail of confidence, evidence, drift, and recovery.
+
+## 1.3 The core loop
+
+The entire contract is two calls inside the agent's loop:
+
+```python
+# After a unit of work:
+result = sync_state(response_text=output, complexity=0.6, confidence=0.8)
+verdict = result.get("verdict", {}).get("value")   # proceed / guide / pause / reject
+
+if verdict in ("pause", "reject"):
+    agent.require_human_review(result["verdict"]["next_action"])
+```
+
+The agent reports **what it did** plus its self-reported `complexity` and `confidence`, and gets back a verdict it can act on *before* an external guardrail has to fire. That's it — no new vocabulary required to *use* it. The vocabulary below is for when you want to act on *why*, not just the verdict.
+
+## 1.4 The four numbers: EISV
+
+Each check-in returns four scores per agent, each graded against that agent's **own** ~30-check-in baseline (so slow drift surfaces even while output still looks fine):
+
+| | Name | Reads | Goes wrong when… |
+|---|---|---|---|
+| **E** | Energy | Is the work advancing? | thrashing, retries, no progress |
+| **I** | Integrity | Do claims match results? | high confidence, low actual success |
+| **S** | Entropy | Drifting from its own normal? | erratic, divergent behavior |
+| **V** | Valence | Derived: energy vs integrity | motion without coherence (or vice-versa) |
+
+Two honesty notes that matter for interpretation (full detail in [chapter 5](05-reading-the-signals.md) and [`../EISV_COMPUTATION.md`](../EISV_COMPUTATION.md)):
+
+- **V is derived, not independent.** It is the smoothed `E − I` imbalance. Its *sign* is what's actionable: positive = running hot (energetic but claims outrun results); negative = running careful (coherent but low progress).
+- **The deployed numbers are auditable heuristics, not information theory.** The thermodynamic / information-theoretic language (free energy, mutual information, entropy) is the *target* the paper works toward and tests honestly — it is **not** what the running code computes today. The live verdict path is a transparent weighted-threshold model over observable behavior ([`src/behavioral_assessment.py`](../../src/behavioral_assessment.py)).
+
+## 1.5 The verdict
+
+Every check-in resolves to one of four verdicts:
+
+| Verdict | Meaning | What the agent should do |
+|---|---|---|
+| `proceed` | State is healthy | Continue working normally |
+| `guide` | Slightly off track | Read the guidance text and adjust approach |
+| `pause` | Needs attention | Stop, reflect, consider a dialectic review |
+| `reject` | Significant concern | Open a dialectic review to resolve/contest, or bring in a human |
+
+Verdicts also carry a **margin** (`comfortable` / `tight` / `critical`) indicating proximity to the basin boundary. Definitions live in [`src/governance_glossary.py`](../../src/governance_glossary.py).
+
+## 1.6 Supporting concepts
+
+- **Coherence** — a scalar summary of how internally consistent the agent's state is; it modulates risk and is one input to the E/I observations.
+- **Ethical drift** — a four-signal vector (calibration deviation, complexity divergence, coherence deviation, stability deviation) that feeds entropy. No human oracle is needed for runtime drift estimation.
+- **Calibration** — the system tracks whether stated `confidence` matches *real* outcomes (test pass/fail, exit codes, lint). Persistent overconfidence costs Integrity. This is why an agent can inflate its `confidence` number but not its success rate.
+- **Knowledge graph (KG)** — a shared discovery store across all agents and sessions, so agents build on each other's findings instead of re-discovering known issues. Agent-facing discipline: [`../../skills/knowledge-graph/SKILL.md`](../../skills/knowledge-graph/SKILL.md).
+- **Dialectic** — the structured recovery/peer-review protocol (thesis → antithesis → synthesis) an agent enters after a `pause`/`reject`.
+- **Identity** — a fresh process mints a fresh agent UUID; cross-process continuity is *declared* and verified, never silently inherited. See [chapter 4](04-integrating-agents.md#43-identity-the-one-rule-that-matters) and [`../ontology/identity.md`](../ontology/identity.md).
+
+## 1.7 Don't trust the prose — verify it
+
+A central design stance: the project does not ask you to believe the numbers predict anything. On a fresh clone, the [falsifiability harness](../REVIEWER_GUIDE.md#falsifiability-grade-eisv-yourself-dont-trust-this-doc) scores EISV against a deliberately dumb baseline (AUC, Brier) and self-labels each slice `INCONCLUSIVE` / `SKEPTICAL` / `WEAK SIGNAL` / `KEEP TESTING` rather than asserting. The current honest read is a *weak early signal* at short lead, with no demonstrated prevention — run it yourself before relying on it for anything load-bearing.
+
+---
+
+[← Manual index](README.md) · [Next: Installation →](02-install.md)

--- a/docs/manual/02-install.md
+++ b/docs/manual/02-install.md
@@ -1,0 +1,98 @@
+# 2 · Installation
+
+[← Overview](01-overview.md) · [Manual index](README.md) · [Next: Running the server →](03-running-the-server.md)
+
+There are two supported paths. Pick one:
+
+- **Docker** — fastest, one command, brings up Postgres + Redis + the server together. Best for trying it out and for most deployments.
+- **Bare-metal** — lower overhead, what the maintainer runs in production. You install PostgreSQL + Apache AGE + pgvector yourself.
+
+**Requirements either way:** Python 3.12+, PostgreSQL with Apache AGE and pgvector. Redis is optional (session cache; the server degrades gracefully without it).
+
+## 2.1 Docker (recommended quickstart)
+
+```bash
+git clone https://github.com/cirwel/unitares.git && cd unitares
+docker compose up -d --wait && make demo
+```
+
+`make demo` drives a synthetic agent through seven check-ins — clean work, then confidence drifting from results, then confusion — and prints the verdict at each step. When it finishes, the server is live: point any MCP client at `http://localhost:8767/mcp/` and open the dashboard at `http://localhost:8767/dashboard`.
+
+### Port conflicts
+
+If `5432` (Postgres), `6379` (Redis), or `8767` (server) is already taken, pick alternate **host** ports — the container-internal ports don't change:
+
+```bash
+POSTGRES_HOST_PORT=15432 REDIS_HOST_PORT=16379 GOVERNANCE_HOST_PORT=18767 \
+  docker compose up -d --wait
+UNITARES_DEMO_PORT=18767 make demo
+```
+
+## 2.2 Bare-metal
+
+The condensed version is below. For a **zero-assumption, step-by-step macOS playbook** with expected output and a troubleshooting table at every step, follow [`../install/PLAYBOOK.md`](../install/PLAYBOOK.md) instead — this section is the summary.
+
+### 2.2.1 Dependencies
+
+You need PostgreSQL 16+ (examples use 17) with **Apache AGE** and **pgvector** compiled and installed, plus Python 3.12+. AGE is not in most package managers — you build it from source against your exact `pg_config`. On macOS/Homebrew:
+
+```bash
+brew install postgresql@17 pgvector python@3.12 git
+brew services start postgresql@17
+pg_isready -h localhost -p 5432           # → accepting connections
+
+# Build Apache AGE 1.7.0 against your PG 17
+export PG_CONFIG="$(brew --prefix postgresql@17)/bin/pg_config"
+git clone --depth 1 --branch PG17/v1.7.0-rc0 https://github.com/apache/age.git /tmp/age-build
+cd /tmp/age-build && make PG_CONFIG="$PG_CONFIG" && make install PG_CONFIG="$PG_CONFIG" && cd -
+```
+
+### 2.2.2 Create the database and apply schema
+
+```bash
+createdb -h localhost -p 5432 governance
+export DB_POSTGRES_URL="postgresql://localhost:5432/governance"
+export DB_AGE_GRAPH=governance_graph
+
+psql "$DB_POSTGRES_URL" -f db/postgres/init-extensions.sql
+psql "$DB_POSTGRES_URL" -f db/postgres/schema.sql
+psql "$DB_POSTGRES_URL" -f db/postgres/partitions.sql
+psql "$DB_POSTGRES_URL" -f db/postgres/knowledge_schema.sql
+psql "$DB_POSTGRES_URL" -f db/postgres/embeddings_schema.sql
+psql "$DB_POSTGRES_URL" -f db/postgres/graph_schema.sql
+```
+
+> On Homebrew Postgres the `postgres` superuser doesn't exist — your macOS username is the superuser and the URL above uses local trust auth. If you see `role "postgres" does not exist`, that's why; the DSN omits the user on purpose. DB bring-up detail: [`db/postgres/README.md`](../../db/postgres/README.md).
+
+### 2.2.3 Python environment
+
+```bash
+python3.12 -m venv .venv && source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements-full.txt
+```
+
+`requirements-full.txt` is the default (server, tests, handler dev). `requirements-core.txt` is a 2-package subset (`mcp` + `numpy`) for thin stdio/proxy clients only. The EISV ODE engine (`governance_core/`) lives directly in this repo — no separate install step.
+
+**Signal-only mode (skip the ODE math model):** `export UNITARES_DISABLE_ODE=1`. Verdicts then come from the behavioral-EISV path alone; the dashboard shows a reduced-diagnostic banner. Useful on CI runners without numpy build deps.
+
+## 2.3 Verify the install
+
+```bash
+curl -s http://127.0.0.1:8767/health/live          # → {"status":"alive"}
+
+curl -s -X POST http://127.0.0.1:8767/v1/tools/call \
+  -H 'Content-Type: application/json' \
+  -d '{"tool":"onboard","arguments":{"purpose":"install verification"}}' \
+  | python3 -m json.tool                            # → JSON containing "agent_uuid" + EISV
+```
+
+You're done when `/health/live` returns alive, `onboard` returns an `agent_uuid`, the dashboard at `/dashboard` loads (fleet metrics, even if zeroed), and there are no error log lines from the server.
+
+## 2.4 What install does *not* cover here
+
+The bare-metal playbook deliberately excludes the Pi/Lumen side ([anima-mcp](https://github.com/cirwel/anima-mcp)), multi-host fleet deployments, custom AGE/pgvector versions, and production hardening (TLS, bearer rotation, multi-tenant isolation). Production hardening is [chapter 6](06-operating.md) and the [operator runbook](../operations/OPERATOR_RUNBOOK.md).
+
+---
+
+[← Overview](01-overview.md) · [Manual index](README.md) · [Next: Running the server →](03-running-the-server.md)

--- a/docs/manual/03-running-the-server.md
+++ b/docs/manual/03-running-the-server.md
@@ -1,0 +1,136 @@
+# 3 · Running the server
+
+[← Installation](02-install.md) · [Manual index](README.md) · [Next: Integrating agents →](04-integrating-agents.md)
+
+## 3.1 Starting it
+
+```bash
+python src/mcp_server.py --port 8767
+```
+
+Within a few seconds you should see a log line ending like `Uvicorn running on http://127.0.0.1:8767`. Under Docker, `docker compose up -d --wait` starts it for you.
+
+**The server binds to `127.0.0.1` only by default** — it is not reachable from your LAN until you opt in (see [§3.5](#35-exposing-beyond-loopback)). That default is intentional: the threat model is internal fleet hygiene, not hostile external clients.
+
+## 3.2 Ports and services
+
+A full UNITARES deployment is several bound services. All bind loopback by default.
+
+| Service | Port | Endpoint(s) | Purpose |
+|---|---|---|---|
+| Governance MCP | `8767` | `/mcp/` (Streamable HTTP), `/v1/tools/call` (REST), `/dashboard`, `/health` | Primary agent surface — check-ins, queries, verdicts |
+| Gateway MCP | `8768` | `/mcp/` | Reduced surface for weak external clients |
+| Lease plane | `8788` | `/v1/lease/*` (bearer-auth, fail-closed) | Elixir/OTP coordination for single-writer surfaces |
+| PostgreSQL + AGE | `5432` | `postgresql://…/governance` | Single source of truth |
+| Redis | `6379` | `redis://…/0` | Session cache (optional) |
+
+Full port map: [`../operations/DEFINITIVE_PORTS.md`](../operations/DEFINITIVE_PORTS.md).
+
+## 3.3 Transports — three ways to call it
+
+| Endpoint | Transport | Use case |
+|---|---|---|
+| `/mcp/` | Streamable HTTP | MCP clients (Cursor, Claude Code, Claude Desktop via bridge) |
+| `/v1/tools/call` | REST POST | CLI, scripts, non-MCP clients |
+| `/dashboard` | HTTP | The web dashboard |
+| `/health`, `/health/live` | HTTP | Health checks |
+
+REST call shape (any tool):
+
+```bash
+curl -s -X POST http://127.0.0.1:8767/v1/tools/call \
+  -H 'Content-Type: application/json' \
+  -d '{"tool":"<tool_name>","arguments":{ ... }}'
+```
+
+Client-specific MCP JSON (Cursor, Claude Code, Claude Desktop) is in [chapter 4](04-integrating-agents.md#42-pointing-a-client-at-the-server) and canonically in [`../integration/MCP_CLIENTS.md`](../integration/MCP_CLIENTS.md).
+
+## 3.4 The dashboard
+
+Open `http://127.0.0.1:8767/dashboard` (or `/` ). It reads PostgreSQL directly with the same auth model as MCP and gives operators a human view of the fleet:
+
+- **Stats** — fleet coherence, active/total agents, stuck agents, discoveries, dialectic sessions, system health, calibration, anomalies, trust-tier distribution.
+- **Pulse** — latest decision and risk/confidence/complexity vitals, event sparkline.
+- **EISV** — fleet and per-agent time-series charts.
+- **Agents** — searchable/filterable table with status, metrics, trust tiers, lineage/supersession badges, and operator actions.
+- **Discoveries / Dialectic / Activity** — knowledge-graph entries, peer-review sessions, and a live timeline of check-ins, verdicts, and lifecycle events.
+- **Residents** and per-resident panels (Chronicler, Watcher, Sentinel, Vigil).
+- **Phase space** at `/phase` — E/I particles, basin contours, flow field, live updates.
+
+Live updates stream over a WebSocket at `/ws/eisv`, falling back to 30-second polling. If `UNITARES_HTTP_API_TOKEN` is configured, append `?token=<token>` (or set `localStorage.unitares_api_token`); write actions under strict-identity mode additionally need an operator token. Implementation detail: [`dashboard/README.md`](../../dashboard/README.md). Public deployment screenshots: [`../PRODUCTION_SNAPSHOT.md`](../PRODUCTION_SNAPSHOT.md).
+
+## 3.5 Exposing beyond loopback
+
+Anything past `127.0.0.1` is an explicit operator decision. Two gates must be set or the connection fails before any tool runs.
+
+### LAN
+
+```bash
+export UNITARES_BIND_ALL_INTERFACES=1
+export UNITARES_MCP_ALLOWED_HOSTS="<your-lan-ip>:*,<your-hostname>.local"
+export UNITARES_MCP_ALLOWED_ORIGINS="http://<your-lan-ip>:*"
+python src/mcp_server.py --port 8767
+```
+
+### Public host / remote connector (Claude.ai, Perplexity, …)
+
+1. **Host/Origin allowlist (DNS-rebinding protection, on by default).** A request with an un-allowlisted `Host` is rejected with **HTTP 403** *before* auth — which surfaces in clients as a generic auth/"API key" error. List both the bare host and the `:*` form:
+
+   ```bash
+   export UNITARES_BIND_ALL_INTERFACES=1
+   export UNITARES_MCP_ALLOWED_HOSTS="gov.example.org,gov.example.org:*"
+   export UNITARES_MCP_ALLOWED_ORIGINS="https://gov.example.org"
+   ```
+
+2. **Authentication** — a public endpoint must not run the connector's "none" option:
+
+   ```bash
+   # Simplest: a bearer token you mint yourself, then paste into the client's API-key field
+   export UNITARES_MCP_BEARER_TOKENS="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+   ```
+
+   Comma-separated values rotate without a restart. For OAuth 2.1 with Dynamic Client Registration, set `UNITARES_OAUTH_ISSUER_URL` instead (see [`../integration/MCP_CLIENTS.md`](../integration/MCP_CLIENTS.md#remote-connectors-claudeai-perplexity-etc) and `src/oauth_provider.py`).
+
+After changing any of these, restart and sanity-check from outside:
+
+```bash
+curl -i https://gov.example.org/mcp/ -H 'Accept: text/event-stream'
+# 403 gone → Host gate open. 401 → bearer gate on (expected once a key is set).
+```
+
+## 3.6 Key environment variables
+
+| Variable | Effect |
+|---|---|
+| `DB_BACKEND` / `DB_POSTGRES_URL` | Database backend and DSN |
+| `DB_AGE_GRAPH` | AGE graph name (e.g. `governance_graph`) |
+| `UNITARES_KNOWLEDGE_BACKEND` | `postgres` (default, FTS) or `age` (cypher-style traversal) |
+| `UNITARES_DISABLE_ODE=1` | Behavioral-EISV verdict path only; skip the ODE math model |
+| `UNITARES_BIND_ALL_INTERFACES` / `UNITARES_MCP_HOST` | Bind beyond loopback |
+| `UNITARES_MCP_ALLOWED_HOSTS` / `UNITARES_MCP_ALLOWED_ORIGINS` | Host/Origin allowlists |
+| `UNITARES_MCP_BEARER_TOKENS` | Bearer auth (comma-separated, hot-rotatable) |
+| `UNITARES_OAUTH_ISSUER_URL` | Enable OAuth 2.1 / DCR |
+| `UNITARES_HTTP_API_TOKEN` / `UNITARES_OPERATOR_TOKENS` | Dashboard read / operator-write tokens |
+| `UNITARES_RESIDENTS` | The named resident agent set (config, not hardcoded) |
+
+## 3.7 Run at login (macOS LaunchAgent)
+
+The repo ships a plist template that renders with your paths and generated secrets:
+
+```bash
+sed -e "s|/PATH/TO/UNITARES|$PWD|g" \
+    -e "s|/PATH/TO/PYTHON3|$PWD/.venv/bin/python|g" \
+    -e "s|/YOUR/HOME|$HOME|g" \
+    -e "s|GENERATE_YOUR_OWN_TOKEN|$(openssl rand -hex 32)|g" \
+    -e "s|GENERATE_YOUR_OWN_SECRET|$(openssl rand -hex 32)|g" \
+    scripts/ops/com.unitares.governance-mcp.plist \
+    > ~/Library/LaunchAgents/com.unitares.governance-mcp.plist
+launchctl load ~/Library/LaunchAgents/com.unitares.governance-mcp.plist
+launchctl list | grep unitares
+```
+
+Defaults bind loopback-only and use the trust-auth Postgres connection. Other tunables are inline at the top of the rendered plist.
+
+---
+
+[← Installation](02-install.md) · [Manual index](README.md) · [Next: Integrating agents →](04-integrating-agents.md)

--- a/docs/manual/04-integrating-agents.md
+++ b/docs/manual/04-integrating-agents.md
@@ -1,0 +1,149 @@
+# 4 · Integrating agents
+
+[← Running the server](03-running-the-server.md) · [Manual index](README.md) · [Next: Reading the signals →](05-reading-the-signals.md)
+
+This chapter is for the **integrator** — you have a running server and you want an agent (or an MCP client) governed by it.
+
+## 4.1 The default workflow
+
+Use this unless you have a specific reason not to ([`../guides/START_HERE.md`](../guides/START_HERE.md)):
+
+1. **First run / fresh process:** call `start_session(force_new=true)`; save `agent_uuid` and `client_session_id` from the response.
+2. **Same running process:** pass `client_session_id` on later check-ins and writes.
+3. **Fresh process continuing prior work:** `start_session(force_new=true, parent_agent_id=<saved uuid>, spawn_reason="new_session")` — only for a real handoff from a *finished* predecessor.
+4. Call `sync_state(...)` after each meaningful unit of work.
+5. Call `check_working_state()` to read current state without updating it.
+
+```python
+# First run:
+result = start_session(force_new=True)
+agent_uuid = result["agent_uuid"]
+session_id = result["client_session_id"]
+
+# After work:
+sync_state(response_text="What you did", complexity=0.5, confidence=0.8,
+           client_session_id=session_id)
+```
+
+## 4.2 Pointing a client at the server
+
+**Cursor / Claude Code** (native `type: http`):
+
+```json
+{ "mcpServers": { "unitares": { "type": "http", "url": "http://localhost:8767/mcp/" } } }
+```
+
+**Claude Desktop** (no native HTTP; bridge via `mcp-remote`):
+
+```json
+{ "mcpServers": { "unitares": { "command": "npx", "args": ["mcp-remote", "http://localhost:8767/mcp/"] } } }
+```
+
+Full client matrix and remote-connector auth: [`../integration/MCP_CLIENTS.md`](../integration/MCP_CLIENTS.md).
+
+## 4.3 Identity: the one rule that matters
+
+> **UUID is a server record, not proof that the current process owns that identity.** Use `client_session_id` for writes in the same running process. Use `parent_agent_id` only to declare a real handoff into a fresh process.
+
+Identity is a **write gate**: reads may work without a bound caller, but writes must be accountable. A fresh process mints a fresh UUID; cross-process continuity is *declared and verified*, never silently inherited.
+
+**Do not** do these in normal agent code:
+
+- Bare `onboard()` / `identity()` as a way to *guess* identity.
+- Passing `continuity_token` on every call (it's an advanced same-live-process rebind proof, not part of the normal loop).
+- Treating a display name as identity.
+- Declaring `parent_agent_id` just because another session shares the workspace.
+
+Short dispatched subagents usually should **not** onboard. If one genuinely needs its own identity, use `spawn_reason="subagent"`, set `parent_agent_id=<driver_uuid>`, and land at least one real `sync_state()` before exit. Full model: [`../ontology/identity.md`](../ontology/identity.md).
+
+## 4.4 Primary tools vs. raw implementation tools
+
+Friendly workflow aliases wrap the raw tools and return an agent-experience envelope (with the full raw payload preserved under `raw_governance`). Either name works; prefer the primary.
+
+| Job | Primary workflow tool | Raw implementation tool |
+|---|---|---|
+| Start working | `start_session(force_new=true, ...)` | `onboard` |
+| Check in after work | `sync_state(response_text=..., complexity=...)` | `process_agent_update` |
+| Check current state | `check_working_state()` | `get_governance_metrics` |
+| Search shared memory | `search_shared_memory(query=...)` | `knowledge(action="search")` |
+| Record a real outcome | `record_result(...)` | `outcome_event` |
+| Ask for review | `request_review(issue_description=...)` | `dialectic(action="request")` |
+
+## 4.5 The full agent-facing tool surface
+
+The server exposes ~50 tools; most are consolidated behind an `action` parameter. The ones you'll actually use:
+
+### Session & identity
+- **`onboard`** / `start_session` — register a fresh process-instance. Key params: `name`, `model_type`, `force_new`, `parent_agent_id`, `spawn_reason`, `initial_state`. Returns `agent_uuid` + `client_session_id`.
+- **`identity`** — "who am I?" Check the current binding or set a display name. Same-owner rebind: `identity(agent_uuid=..., continuity_token=..., resume=true)` — never bare `identity(agent_uuid=..., resume=true)` (UUID alone is an unsigned claim).
+- **`bind_session`** — bind a session to an existing identity (cross-process anti-hijack gate).
+
+### Check-in & metrics
+- **`process_agent_update`** / `sync_state` — the main check-in. Key params: `response_text`, `complexity` [0–1], `confidence` [0–1], `ethical_drift` ([float,float,float]), `recent_tool_results` (array of `{tool, summary, is_bad}`), `response_mode` (`minimal`/`compact`/`standard`/`full`/`mirror`/`auto`). Returns the verdict + EISV state, risk, coherence, margin.
+- **`get_governance_metrics`** / `check_working_state` — read-only snapshot, no state update. Fleet-scoped read when unbound.
+
+### Knowledge graph
+- **`knowledge`** — unified KG tool. `action` ∈ `store` / `search` / `get` / `list` / `update` / `details` / `note` / `cleanup` / `synthesize` / `stats` / `supersede` / `audit`.
+- **`leave_note`** — shorthand for `knowledge(action="note")`. Param: `summary` (required), `content`, `discovery_id`.
+
+### Outcomes, review, recovery
+- **`outcome_event`** / `record_result` — record a bounded outcome to improve calibration and verify a prior check-in's prediction. Key params: `outcome_type`, `decision_action`, `verification_source` (`agent_reported_tool_result` / `server_observation` / `external_signal`).
+- **`dialectic`** / `request_review` — unified peer-review/recovery. `action` ∈ `get` / `list` / `quick` / `request` / `thesis` / `antithesis` / `synthesis` / `reassign`.
+- **`self_recovery`** — self-diagnosed recovery after a pause. Params: `reflection` (required), `mode` (`quick_resume` / `self_recovery_review`).
+
+### Observability, admin, lifecycle (mostly operator/diagnostic)
+- **`observe`** — `action` ∈ `agent` / `compare` / `similar` / `anomalies` / `aggregate` / `telemetry` / `audit_events` / `outcome_evidence`.
+- **`health_check`** — quick system health (status, version, component checks).
+- **`calibration`** — `action` ∈ `check` / `update` / `backfill` / `rebuild`.
+- **`config`** — get/set governance thresholds (reads unbound; writes identity-gated).
+- **`agent`** — lifecycle: `list` / `get` / `update` / `archive` / `resume` / `delete`.
+- **`export`** — `history` or `file`.
+- **`list_tools`** / **`describe_tool`** — discover the surface (accessible pre-onboard).
+
+Definitive schemas live in [`src/tool_schemas.py`](../../src/tool_schemas.py) and `src/mcp_handlers/schemas/`. At runtime, call `list_tools()` / `describe_tool(tool_name=...)`.
+
+## 4.6 Handling the verdict
+
+The minimal contract: read `verdict` and course-correct.
+
+```python
+result = sync_state(response_text=output, complexity=0.6, confidence=0.8,
+                    client_session_id=session_id)
+verdict = result.get("verdict", {}).get("value")
+
+if verdict in ("pause", "reject"):
+    agent.require_human_review(result["verdict"]["next_action"])
+```
+
+For per-dimension policies, branch on the EISV components instead of the single verdict:
+
+```python
+eisv = result.get("raw_governance", result).get("primary_eisv", {})
+if eisv.get("I", 1) < 0.4:
+    agent.require_human_review("integrity low — pausing autonomous actions")
+elif eisv.get("S", 0) > 0.7:
+    agent.narrow_scope()         # fewer tools, tighter search
+elif eisv.get("E", 1) < 0.2:
+    agent.stop_and_summarize()   # avoid thrashing
+```
+
+What each verdict and dimension *means* is [chapter 5](05-reading-the-signals.md).
+
+## 4.7 Long-running / scheduled agents — the SDK
+
+For daemons and cron-style agents, the **`unitares-sdk`** ([`../../agents/sdk/README.md`](../../agents/sdk/README.md)) handles connection, identity resolution, check-ins, heartbeats, log rotation, and state persistence so you don't re-implement the loop.
+
+- Subclass **`GovernanceAgent`** and override `run_cycle(client)` (required). Optional hooks: `on_after_checkin(...)`, `on_verdict_pause(...)` (return `True` to retry the check-in after self-recovery).
+- **Daemon:** `agent.run_forever(interval=60)` loops with idle heartbeats. **Scheduled:** `agent.run_once()` for one cycle under launchd/systemd/cron.
+- Identity anchors persist at `~/.unitares/anchors/<name>.json`; agent state via `save_state(dict)` / `load_state()`.
+- Constructor knobs: `name`, `mcp_url` (default `http://127.0.0.1:8767/mcp/`), `persistent`, `refuse_fresh_onboard`, `cycle_timeout_seconds`, `parent_agent_id`, `spawn_reason`.
+
+The resident agents (Vigil, Sentinel, Chronicler) in [`../../agents/`](../../agents/) are reference implementations of these patterns.
+
+## 4.8 Mounting an existing agent without code changes
+
+If you don't want to edit the agent's loop at all, the [governance plugin](https://github.com/cirwel/unitares-governance-plugin) wires check-ins, dialectic review, and verdicts into Claude Code / Codex via hooks, and the [host adapter](https://github.com/cirwel/unitares-host-adapter) provides thin bindings for Hermes, Goose, and arbitrary OpenAI-compatible clients.
+
+---
+
+[← Running the server](03-running-the-server.md) · [Manual index](README.md) · [Next: Reading the signals →](05-reading-the-signals.md)

--- a/docs/manual/05-reading-the-signals.md
+++ b/docs/manual/05-reading-the-signals.md
@@ -1,0 +1,80 @@
+# 5 · Reading the signals
+
+[← Integrating agents](04-integrating-agents.md) · [Manual index](README.md) · [Next: Operating →](06-operating.md)
+
+This chapter is the interpretation guide: what the numbers mean, how they're produced, and how much to trust them. The exact formulas with source references are in [`../EISV_COMPUTATION.md`](../EISV_COMPUTATION.md); this is the readable companion.
+
+## 5.1 The pipeline at a glance
+
+```
+observables ──► observation blend ──► EMA smoothing ──► component risk ──► verdict
+(decisions,     (behavioral_         (behavioral_       (behavioral_       proceed/
+ calibration,    sensor.py)           state.py)          assessment.py)     guide/
+ drift, tools)                                                              pause/reject
+```
+
+The **behavioral EISV** path (EMA observations from grounded signals) is primary and drives verdicts. The **ODE / thermodynamic model** (`governance_core/`) runs in parallel as a research lens and does **not** drive verdicts by default.
+
+After ~30 check-ins the system builds per-agent **Welford baselines** and assesses by z-score deviation from the agent's *own* operating point, rather than universal thresholds. Before that ("warmup"), it uses fixed universal thresholds.
+
+## 5.2 The four dimensions
+
+| Coord | What it reads | Deployed computation (heuristic) |
+|---|---|---|
+| **E** · Energy | Is work advancing? | weighted blend of recent decision-success, coherence, complexity-calibration (and outcomes when present) |
+| **I** · Integrity | Do claims match results? | calibration accuracy + coherence trend (+ outcome consistency) |
+| **S** · Entropy | Drifting from own normal? | drift-norm + regime instability + complexity divergence |
+| **V** · Valence | Energy-vs-integrity imbalance | EMA-smoothed `E − I` (derived) |
+
+Three things to internalize:
+
+1. **Each score is self-relative after warmup.** A "low" number is low *for this agent*, not against a global scale. An ultra-stable agent and a noisy one are graded against different baselines.
+2. **V is a readout, not a fifth fact.** It's `E − I` smoothed. Its **sign** is the actionable part: `V > 0` = running hot (energetic, claims outrun results); `V < 0` = running careful (coherent but low progress).
+3. **The weights are hand-set, not learned.** That's the honest status of the current estimator — see §5.6.
+
+## 5.3 Verdict and margin
+
+The assessment emits an internal `safe` / `caution` / `high-risk` label, which becomes the action the agent reads back:
+
+| Verdict | Internal sense | Agent action | Recovery path |
+|---|---|---|---|
+| `proceed` | safe | Continue | — |
+| `guide` | slightly off | Read guidance, adjust | — |
+| `pause` | needs attention | Stop, reflect | self-recovery or dialectic ([§5.5](#55-recovery-self-recovery--dialectic)) |
+| `reject` | significant concern | Human input or dialectic | dialectic |
+
+Total risk is the **sum of named components** (`low_E`, `low_I`, high-`S`, `|V|`, …), each with an explicit weight — no sigmoid/phi black box, so you can trace exactly why a verdict fired ([`src/behavioral_assessment.py`](../../src/behavioral_assessment.py)). **Absolute safety floors always apply**, overriding the self-relative baseline; and self-relative deviation risk is *gated by absolute basin health* — inside the healthy basin, deviation from your own norm is treated as information, not danger.
+
+**Margin** (`comfortable` / `tight` / `critical`) rides along with the verdict, telling you how close the agent is to a basin boundary even while the verdict is still `proceed`.
+
+## 5.4 Calibration: why the signal resists gaming
+
+The system tracks whether stated `confidence` matches **objective** outcomes — test pass/fail, command exit codes, lint results — fed back via `record_result` / `outcome_event`. Over time this builds a calibration curve, and persistent overconfidence penalizes **Integrity** through entropy coupling.
+
+The practical consequence: an agent can inflate the `confidence` number it reports, but it cannot inflate its actual success rate. Reported confidence is checked *against results*, so dishonest self-assessment shows up as falling Integrity rather than as a passing grade. Feed real outcomes back (`record_result`) to make the calibration meaningful.
+
+## 5.5 Recovery: self-recovery → dialectic
+
+When an agent is paused, recovery is a structured escalation:
+
+1. **Self-recovery** — `self_recovery(reflection=..., mode="quick_resume")` when coherence is high and risk is low; the agent reflects and resumes.
+2. **LLM-assisted dialectic** — a local LLM supplies an antithesis for single-agent reflection (no paid API — the operator constraint rules those out).
+3. **Peer dialectic** — another agent reviews via `dialectic`: thesis → antithesis → synthesis.
+
+Full protocol: [`../dev/CIRCUIT_BREAKER_DIALECTIC.md`](../dev/CIRCUIT_BREAKER_DIALECTIC.md).
+
+## 5.6 The knowledge graph as a signal source
+
+The KG isn't just storage — searching it *before* acting is how agents avoid re-discovering known failures, and it's where closed mysteries and corrected conclusions live. Discipline (agent-facing): **search before writing**; prefer a linked correction or `supersede` over a fresh note; store something only when a future agent would search for it and not already find it. Operational runbooks belong in `docs/`, not KG notes. Full operating manual: [`../../skills/knowledge-graph/SKILL.md`](../../skills/knowledge-graph/SKILL.md).
+
+## 5.7 Don't trust these numbers blindly
+
+The most important interpretation rule. The deployed EISV is **auditable heuristics over observable behavior**, not the information-theoretic quantities (free energy, mutual information, entropy) the paper targets — those become instrumentable only when the inference layer exposes things like token-level logprobs. Every coordinate carries a provenance tier (`e_source`, `s_source`, …) so a heuristic is never laundered as a measurement.
+
+Whether the numbers predict anything beyond a dumb baseline is an **open, measured question.** The [falsifiability harness](../REVIEWER_GUIDE.md#falsifiability-grade-eisv-yourself-dont-trust-this-doc) scores EISV against a deliberately dumb `previous_outcome_bad` baseline on ranking (AUC) and calibration (Brier), self-labeling each slice `INCONCLUSIVE` / `SKEPTICAL` / `WEAK SIGNAL` / `KEEP TESTING`. Current read: a **weak early signal** at short lead, **no demonstrated prevention**, and a caveat that the lift may be carried by a single `prior_risk` feature rather than the full decomposition. Run it yourself before treating EISV as load-bearing.
+
+For intuition (not a spec), [`../tonality-metaphor.md`](../tonality-metaphor.md) maps key signatures and chromaticism onto EISV, coherence, and drift.
+
+---
+
+[← Integrating agents](04-integrating-agents.md) · [Manual index](README.md) · [Next: Operating →](06-operating.md)

--- a/docs/manual/06-operating.md
+++ b/docs/manual/06-operating.md
@@ -1,0 +1,79 @@
+# 6 · Operating
+
+[← Reading the signals](05-reading-the-signals.md) · [Manual index](README.md) · [Next: Troubleshooting →](07-troubleshooting.md)
+
+This chapter is the operator's orientation. The deep, living runbook is [`../operations/OPERATOR_RUNBOOK.md`](../operations/OPERATOR_RUNBOOK.md) — this is the map and the parts most readers actually need.
+
+## 6.1 Database ownership
+
+**PostgreSQL + AGE is the single source of truth for all governance data** — identities, agent state, audit events, discoveries, dialectic, calibration, tool usage. There is no SQLite. Redis is a session cache only and the server degrades gracefully without it.
+
+```
+PostgreSQL+AGE (5432)            Redis (6379)
+  core.identities                  session cache only
+  core.agent_state                 (optional; graceful fallback)
+  audit.events
+  core.discoveries (AGE)
+  dialectic.*
+  core.calibration
+  core.tool_usage
+```
+
+Operational guidance: do **not** create additional PostgreSQL instances, databases, or migration layers — it's a single-Postgres / schema-isolation model ([`../operations/database_architecture.md`](../operations/database_architecture.md)). The production data dictionary is [`../operations/DATA_NOTES.md`](../operations/DATA_NOTES.md).
+
+## 6.2 Resident agents
+
+Several long-lived agents run alongside the server. They consume the **same public contract** as any external agent (the [`unitares-sdk`](../../agents/sdk/)) and double as reference implementations and operational hygiene. They are *not* load-bearing governance internals — the public contract is the SDK, not the residents.
+
+| Resident | Cadence | Role |
+|---|---|---|
+| **Vigil** | scheduled (~30 min) | Janitorial — health checks, KG groundskeeping, test triggers |
+| **Sentinel** | continuous (WebSocket) | Fleet monitor — anomaly detection on the live event stream |
+| **Watcher** | event-driven | Code-watcher — local-LLM pattern match, wired into Claude Code's PostToolUse hook |
+| **Chronicler** | daily | Longitudinal codebase metrics → `metrics.series` |
+| **Steward** | in-process | EISV sync across substrates |
+
+The named set is configured via `UNITARES_RESIDENTS` ([`../operations/resident-roster.md`](../operations/resident-roster.md)), not hardcoded. Reference implementations: [`../../agents/README.md`](../../agents/README.md).
+
+## 6.3 Security posture
+
+UNITARES has run continuously in production since November 2025 on a **single-operator fleet**. The threat model is "internal fleet hygiene + honest agent identity," **not** "hostile external clients."
+
+- All services bind `127.0.0.1` by default; public exposure is an env-var-gated operator decision ([§3.5](03-running-the-server.md#35-exposing-beyond-loopback)).
+- The lease plane **fails closed** if `LEASE_PLANE_BEARER_TOKEN` is unset.
+- Agent identity is bearer-token-based (symmetric stack retained intentionally).
+- The dashboard reads PostgreSQL directly with the same auth model as MCP.
+
+**Multi-tenant or public-facing deployment needs a harder auth posture than the defaults.** Set bearer/OAuth gates and host allowlists before exposing anything. Vulnerability reports: [`../../SECURITY.md`](../../SECURITY.md). Full scope and threat model: [`../SCOPE_AND_THREAT_MODEL.md`](../SCOPE_AND_THREAT_MODEL.md).
+
+## 6.4 Tuning governance thresholds
+
+Read thresholds with `config(action="get")`; change them with `config(action="set", thresholds={...})` (writes are identity-gated). Defaults and margin computation live in [`config/governance_config.py`](../../config/governance_config.py). Prefer leaving defaults in place until the falsifiability harness ([chapter 5](05-reading-the-signals.md#57-dont-trust-these-numbers-blindly)) tells you a change helps on *your* fleet.
+
+## 6.5 Operator constraint: no paid LLM API budget
+
+A standing project constraint worth knowing as an operator: **do not adopt features that require a paid model API** (`ANTHROPIC_API_KEY` etc.). The supported automation paths are free/self-hosted — the local Ollama detector for Watcher, `GITHUB_TOKEN`-only CI, and deterministic CLI tools. Dialectic's "LLM-assisted antithesis" uses a *local* LLM for this reason.
+
+## 6.6 The operations doc map
+
+Most readers can skip these; reach for them when the need is specific.
+
+| Doc | When you need it |
+|---|---|
+| [`OPERATOR_RUNBOOK.md`](../operations/OPERATOR_RUNBOOK.md) | The primary production runbook |
+| [`DEFINITIVE_PORTS.md`](../operations/DEFINITIVE_PORTS.md) | Port assignments across services |
+| [`database_architecture.md`](../operations/database_architecture.md) | Single-Postgres / schema-isolation model |
+| [`DATA_NOTES.md`](../operations/DATA_NOTES.md) | Production data dictionary |
+| [`DEPLOYMENT_DATA_CAVEAT.md`](../operations/DEPLOYMENT_DATA_CAVEAT.md) | What the cited deployment numbers do and don't mean |
+| [`resident-roster.md`](../operations/resident-roster.md) | Configuring the resident set |
+| [`branch-hygiene-runbook.md`](../operations/branch-hygiene-runbook.md) | Resident branch-hygiene sweep |
+| [`lease-plane-operator-runbook.md`](../operations/lease-plane-operator-runbook.md) | Elixir lease-plane operations |
+| [`github-workflow-conventions.md`](../operations/github-workflow-conventions.md) | Branch naming + draft-PR delivery contract |
+
+## 6.7 Multi-agent coordination (advanced)
+
+For fleets that coordinate, the **CIRS protocol** ([`../guides/CIRS_PROTOCOL.md`](../guides/CIRS_PROTOCOL.md)) defines the message types agents use to hand off and synchronize. The **lease plane** (port `8788`) is the Elixir/OTP coordination layer for single-writer surfaces. Both are specialized — you don't need them for a basic governed fleet.
+
+---
+
+[← Reading the signals](05-reading-the-signals.md) · [Manual index](README.md) · [Next: Troubleshooting →](07-troubleshooting.md)

--- a/docs/manual/07-troubleshooting.md
+++ b/docs/manual/07-troubleshooting.md
@@ -1,0 +1,79 @@
+# 7 · Troubleshooting & FAQ
+
+[← Operating](06-operating.md) · [Manual index](README.md)
+
+The fuller, symptom-indexed guide is [`../guides/TROUBLESHOOTING.md`](../guides/TROUBLESHOOTING.md); install-specific failures are in the [playbook's troubleshooting table](../install/PLAYBOOK.md#troubleshooting). This chapter covers the failures and questions new users actually hit.
+
+## 7.1 Quick diagnostics
+
+```bash
+# Is the server alive?
+curl -s http://127.0.0.1:8767/health/live          # → {"status":"alive"}
+
+# What's bound to the port?
+lsof -i :8767
+
+# A full health snapshot via the tool surface
+curl -s -X POST http://127.0.0.1:8767/v1/tools/call \
+  -H 'Content-Type: application/json' \
+  -d '{"tool":"health_check","arguments":{}}' | python3 -m json.tool
+```
+
+## 7.2 Common failures
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `Address already in use` on `8767` | Server already running | `lsof -i :8767` → kill it, or start with `--port 8768` (and the matching Docker host-port vars) |
+| `pg_isready: no response` | Postgres not started | `brew services restart postgresql@17`, wait, retry |
+| `role "postgres" does not exist` | Homebrew Postgres uses *your* username as superuser | Drop `postgres:postgres@` from the DSN, or create the role explicitly |
+| `relation "agents" does not exist` on first call | Schema not applied | Re-run the schema `psql` steps ([§2.2.2](02-install.md#222-create-the-database-and-apply-schema)) |
+| `extension "age" is not available` | AGE built against the wrong `pg_config` | Verify `$PG_CONFIG` points at your PG 17 and rebuild AGE |
+| `make` fails on AGE with `bison` errors | Apple's old bison shadows Homebrew's | `brew install bison && export PATH="$(brew --prefix bison)/bin:$PATH"` |
+| Dashboard loads but is empty | Expected — no agents yet | Run one `onboard` / `start_session` call |
+| Remote client reports a generic auth / "API key" error | **HTTP 403 from the Host allowlist**, which runs *before* auth | Add the host to `UNITARES_MCP_ALLOWED_HOSTS` (bare *and* `:*` forms) and restart ([§3.5](03-running-the-server.md#35-exposing-beyond-loopback)) |
+| Remote client gets `401` | Bearer gate is on (expected once a key is set) | Paste the same `UNITARES_MCP_BEARER_TOKENS` value into the client's API-key field |
+| Server starts but verdicts lack ODE diagnostics | `UNITARES_DISABLE_ODE=1` is set | Intentional in signal-only mode; unset it to restore the math model |
+
+## 7.3 FAQ
+
+**Do I have to change my agent's code?**
+No. The two-call loop ([chapter 4](04-integrating-agents.md#41-the-default-workflow)) is the simplest path, but the [governance plugin](https://github.com/cirwel/unitares-governance-plugin) mounts Claude Code / Codex via hooks with no loop edits, and the [host adapter](https://github.com/cirwel/unitares-host-adapter) covers other clients.
+
+**Does it block or sandbox my agent?**
+No. UNITARES is a *state layer*, not a validator or sandbox. It returns a verdict the agent reads and acts on; it does not intercept actions. Enforcement is your agent's (or a separate guardrail's) job.
+
+**Do I need Redis?**
+No. Redis is an optional session cache; the server falls back gracefully without it.
+
+**Do I need the ODE / `governance_core`?**
+No. Set `UNITARES_DISABLE_ODE=1` to run the behavioral-EISV verdict path alone. The ODE is a parallel diagnostic lens, not the verdict driver.
+
+**Why did a stable agent suddenly get a low score?**
+After ~30 check-ins, scoring is *self-relative* (z-score from the agent's own baseline). A deviation from its own norm can register even while absolute health is fine — but absolute basin-health gating means in-basin deviation is treated as information, not danger. If it `pause`d, check `margin` and the named risk components.
+
+**Can an agent game the signal by reporting high confidence?**
+It can inflate the *number*, not the *outcome*. Confidence is scored against objective results (tests, exit codes, lint) via `record_result`; persistent overconfidence lowers Integrity. Feed real outcomes back for this to work. ([§5.4](05-reading-the-signals.md#54-calibration-why-the-signal-resists-gaming).)
+
+**How much should I trust EISV?**
+As far as the falsifiability harness on *your* data lets you. The honest current read is a weak early signal with no demonstrated prevention — run [the harness](../REVIEWER_GUIDE.md#falsifiability-grade-eisv-yourself-dont-trust-this-doc) before relying on it. ([§5.7](05-reading-the-signals.md#57-dont-trust-these-numbers-blindly).)
+
+**Two processes, one agent — how do I keep identity straight?**
+A fresh process mints a fresh UUID. Pass `client_session_id` for writes within the same process; declare a real handoff with `parent_agent_id` + `spawn_reason="new_session"`. Never pass a bare UUID as proof of selfhood. ([§4.3](04-integrating-agents.md#43-identity-the-one-rule-that-matters).)
+
+**Is it safe to expose on the internet?**
+Only with both gates set — a Host/Origin allowlist *and* an auth gate (bearer or OAuth). The defaults are loopback-only and the threat model assumes a single-operator fleet; multi-tenant/public use needs a harder posture. ([§6.3](06-operating.md#63-security-posture).)
+
+## 7.4 Recovery procedures
+
+Server health, log locations, process inspection, and database reset steps are in [`../guides/TROUBLESHOOTING.md`](../guides/TROUBLESHOOTING.md#recovery-procedures). Do not run `DROP`/`TRUNCATE`/`DELETE` on the governance database without a backup and deliberate intent.
+
+## 7.5 Getting help
+
+- Symptom-indexed guide: [`../guides/TROUBLESHOOTING.md`](../guides/TROUBLESHOOTING.md)
+- Architecture disputes: [`../dev/CANONICAL_SOURCES.md`](../dev/CANONICAL_SOURCES.md) (runtime code wins)
+- Security issues: [`../../SECURITY.md`](../../SECURITY.md)
+- The paper and the wider stack: [`../../README.md#the-cirwel-stack`](../../README.md#the-cirwel-stack)
+
+---
+
+[← Operating](06-operating.md) · [Manual index](README.md)

--- a/docs/manual/README.md
+++ b/docs/manual/README.md
@@ -1,0 +1,49 @@
+# UNITARES User Manual
+
+An end-to-end, task-ordered guide to **installing, running, integrating with, reading, and operating** the UNITARES governance MCP server. It is written for two readers at once — the **operator** who stands the server up and the **integrator** who points an agent at it — and it stitches the repo's thinner, single-topic docs into one walkthrough.
+
+> This manual is a guided front door, not the canonical spec. Where it summarizes a deeper doc it links to it, and **if this manual and runtime code disagree, runtime code wins** (disputes resolve against [`../dev/CANONICAL_SOURCES.md`](../dev/CANONICAL_SOURCES.md)). For the one-paragraph pitch and the 60-second demo, start at the [repo README](../../README.md).
+
+## What UNITARES is, in one breath
+
+Runtime governance and self-telemetry for fleets of autonomous AI agents. Each agent checks in while it works; UNITARES grades it against its *own* baseline and returns one plain verdict — `proceed` / `guide` / `pause` / `reject` — plus a four-number state vector (EISV), so drift surfaces while the output still looks fine. It runs **alongside** evals (pre-deploy) and guardrails (per-action), answering a third question: *is this agent still healthy as it works?*
+
+## How to read this manual
+
+| If you want to… | Read |
+|---|---|
+| Understand the idea and the vocabulary first | [1 · Overview & concepts](01-overview.md) |
+| Get a server running on your machine | [2 · Installation](02-install.md) |
+| Run, configure, and expose the server; open the dashboard | [3 · Running the server](03-running-the-server.md) |
+| Wire an agent or MCP client into the check-in loop | [4 · Integrating agents](04-integrating-agents.md) |
+| Interpret EISV, verdicts, coherence, drift, and the knowledge graph | [5 · Reading the signals](05-reading-the-signals.md) |
+| Keep it healthy in production | [6 · Operating](06-operating.md) |
+| Fix something that's broken | [7 · Troubleshooting & FAQ](07-troubleshooting.md) |
+
+### Two fast paths
+
+- **Operator, "just make it run":** [Try it in 60 seconds](../../README.md#try-it-in-60-seconds) (Docker) → [3 · Running the server](03-running-the-server.md). Bare-metal instead: [2 · Installation](02-install.md).
+- **Integrator, "I have a server, wire my agent":** [4 · Integrating agents](04-integrating-agents.md) → [5 · Reading the signals](05-reading-the-signals.md).
+
+## Chapters
+
+1. **[Overview & concepts](01-overview.md)** — what it is, where it fits, the EISV / verdict / coherence / drift vocabulary, and the honest scope.
+2. **[Installation](02-install.md)** — Docker quickstart and the bare-metal (Postgres + AGE + pgvector) playbook.
+3. **[Running the server](03-running-the-server.md)** — entry point, ports, transports, the dashboard, environment configuration, and exposing beyond loopback.
+4. **[Integrating agents](04-integrating-agents.md)** — the check-in loop, identity rules, the full tool surface, verdict handling, and the long-running-agent SDK.
+5. **[Reading the signals](05-reading-the-signals.md)** — EISV computation, verdicts and margin, calibration, the knowledge graph, dialectic review, and how *not* to trust the numbers blindly.
+6. **[Operating](06-operating.md)** — resident agents, security posture, database ownership, config tuning, and the operator runbook map.
+7. **[Troubleshooting & FAQ](07-troubleshooting.md)** — common failures and the questions new users actually ask.
+
+## Where the canonical docs live
+
+This manual deliberately does not restate the deep references. Keep these open alongside it:
+
+- [`../UNIFIED_ARCHITECTURE.md`](../UNIFIED_ARCHITECTURE.md) — the canonical architecture and pipeline.
+- [`../EISV_COMPUTATION.md`](../EISV_COMPUTATION.md) — the exact formulas the running code computes.
+- [`../SCOPE_AND_THREAT_MODEL.md`](../SCOPE_AND_THREAT_MODEL.md) — who it's for, why an agent can't game it, what's unproven.
+- [`../REVIEWER_GUIDE.md`](../REVIEWER_GUIDE.md) — the falsifiability harness you run yourself.
+- [`../integration/MCP_CLIENTS.md`](../integration/MCP_CLIENTS.md) — client wiring and remote-connector auth.
+- [`../install/PLAYBOOK.md`](../install/PLAYBOOK.md) — the zero-assumption bare-metal install.
+- [`../operations/OPERATOR_RUNBOOK.md`](../operations/OPERATOR_RUNBOOK.md) — production operations.
+- [`../README.md`](../README.md) — the full map of the `docs/` tree.


### PR DESCRIPTION
## What

Adds a cohesive, task-ordered **user manual** under `docs/manual/`, written for both operators and integrators. It stitches the repo's existing thin, single-topic docs into one front-to-back walkthrough without duplicating their canonical depth (each chapter cross-links to the deep references).

This came out of a question — *"do I need to produce a textbook for unitares?"* No textbook requirement exists in the repo, but the follow-up ask was for "a user manual of sorts." Audience and format were chosen as **end-to-end (operators + integrators)** in a **multi-chapter directory**, matching the repo's thin-doc convention.

## Chapters

| File | Covers |
|---|---|
| `README.md` | Index, reader paths, fast tracks |
| `01-overview.md` | What it is, where it fits, EISV/verdict/coherence/drift vocabulary, honest scope |
| `02-install.md` | Docker quickstart + bare-metal Postgres/AGE/pgvector |
| `03-running-the-server.md` | Entry point, ports, transports, dashboard, env config, exposing beyond loopback |
| `04-integrating-agents.md` | Check-in loop, identity rule, full tool surface, verdict handling, SDK |
| `05-reading-the-signals.md` | EISV computation, verdicts/margin, calibration, recovery, falsifiability |
| `06-operating.md` | Residents, security posture, DB ownership, threshold tuning, runbook map |
| `07-troubleshooting.md` | Common failures + FAQ |

Also wires the manual into `docs/README.md` (reader intro + a `manual/` layout entry).

## Notes

- **Docs-only.** No code or runtime changes.
- All cross-links verified to resolve against existing files/paths.
- Deliberately preserves the project's honesty stance (deployed EISV = auditable heuristics, not the paper's information-theoretic target; "don't trust the numbers — run the falsifiability harness").
- Left as **draft** per the delivery contract — operator is the merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4DJbRYWG9oHqNjT57FVFr)_