### PR TITLE
docs: label the cross-machine install audit as a point-in-time record

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,8 +9,8 @@ For a single, task-ordered walkthrough that stitches the docs below into one gui
 | You are… | Read in this order |
 |---|---|
 | **A reviewer / first-time visitor** | [repo README](../README.md) → [`UNIFIED_ARCHITECTURE.md`](UNIFIED_ARCHITECTURE.md) → [`ontology/identity.md`](ontology/identity.md) → [`ontology/paper-positioning.md`](ontology/paper-positioning.md) |
-| **Integrating an MCP client** | [`integration/MCP_CLIENTS.md`](integration/MCP_CLIENTS.md) → [`guides/START_HERE.md`](guides/START_HERE.md) → [`guides/TROUBLESHOOTING.md`](guides/TROUBLESHOOTING.md) |
-| **Installing / deploying** | [`install/PLAYBOOK.md`](install/PLAYBOOK.md) → [`install/cross-machine-surface.md`](install/cross-machine-surface.md) → [`operations/OPERATOR_RUNBOOK.md`](operations/OPERATOR_RUNBOOK.md) |
+| **Integrating an MCP client** | [`manual/04-integrating-agents.md`](manual/04-integrating-agents.md) → [`integration/MCP_CLIENTS.md`](integration/MCP_CLIENTS.md) → [`guides/TROUBLESHOOTING.md`](guides/TROUBLESHOOTING.md) |
+| **Installing / deploying** | [`manual/02-install.md`](manual/02-install.md) → [`install/PLAYBOOK.md`](install/PLAYBOOK.md) → [`operations/OPERATOR_RUNBOOK.md`](operations/OPERATOR_RUNBOOK.md) |
 | **Working on the identity layer** | [`../AGENTS.md`](../AGENTS.md) → [`ontology/README.md`](ontology/README.md) → [`ontology/identity.md`](ontology/identity.md) → [`ontology/plan.md`](ontology/plan.md) |
 
 ## Layout
@@ -47,8 +47,8 @@ User- and integrator-facing how-tos. Thin by design — most architecture lives 
 
 ### `install/` — installation
 
-- [`PLAYBOOK.md`](install/PLAYBOOK.md) — bare-metal install playbook (Homebrew Postgres, native Python). Docker path is in the repo README.
-- [`cross-machine-surface.md`](install/cross-machine-surface.md) — multi-machine surface setup
+- [`PLAYBOOK.md`](install/PLAYBOOK.md) — bare-metal install playbook (Homebrew Postgres, native Python). Docker path is in the repo README. **Live reference** — keep this current.
+- [`cross-machine-surface.md`](install/cross-machine-surface.md) — *point-in-time install-surface audit (2026-04-24), preserved as a record.* Inventory of machine-varying values; useful background for a cross-machine setup, but the install path itself is `PLAYBOOK.md`, not this.
 
 ### `integration/` — MCP and client wiring
 

--- a/docs/install/cross-machine-surface.md
+++ b/docs/install/cross-machine-surface.md
@@ -1,5 +1,7 @@
 # Cross-Machine Install Surface
 
+> **Point-in-time record, preserved by design.** This is a dated audit (2026-04-24), not a live install guide — branch names, PR states, and line numbers below reflect the repo *as audited* and are intentionally not kept current. For the actual install path use [`PLAYBOOK.md`](PLAYBOOK.md); read this for background on *which* values vary across machines and why. The regression guard for these values lives in `tests/test_install_surface.py`.
+
 A grep-derived inventory of every value in this repo that varies between machines, plus an explicit list of values that **intentionally** vary and must not be unified.
 
 **Audit date:** 2026-04-24 against `chore/install-audit` branch.


### PR DESCRIPTION
## What

Follow-up to #1006 (the user manual). Tightens the one genuine case where archival/point-in-time content was surfaced in a reader path that implied it was evergreen reference.

`install/cross-machine-surface.md` is a **dated audit** (`Audit date: 2026-04-24`, branch/PR references frozen at writing), but `docs/README.md` listed it in the linear **"Installing / deploying"** reader path right beside `PLAYBOOK.md` — so a newcomer following that path hit a stale point-in-time audit as if it were a live install step.

## Changes

- **Banner** on `install/cross-machine-surface.md` marking it a point-in-time record and pointing readers to `PLAYBOOK.md` for the actual install path.
- **Relabel** its `docs/README.md` layout entry as a preserved dated record; mark `PLAYBOOK.md` as the live reference.
- **Reweave** the reader-path table onto the new manual chapters (`manual/02-install.md`, `manual/04-integrating-agents.md`) and drop the dated audit from the linear install path.

## Deliberately *not* changed

- The `proposals/` RFC archive and dated finding records (`*-2026-*`, `ablation-initiates-finding-2026-06-16.md`, dated `ontology/` audits, `ontology/plan.md`). Those read like session/PR summaries **by policy** — `proposals/README.md` states they are point-in-time records preserved as-written, and the dead-ref check exempts that folder. Rewriting them would destroy their archival value, and `proposals/` is a flagged single-writer surface.
- No rewrite of the audit's body — only framing/labeling.

Docs-only. Left as **draft** — operator is the merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4DJbRYWG9oHqNjT57FVFr)_