### PR TITLE
Steer unbound get_governance_metrics guidance off bare identity()

### DIFF
--- a/src/governance_glossary.py
+++ b/src/governance_glossary.py
@@ -59,7 +59,7 @@ VERDICTS: Dict[str, Dict[str, str]] = {
     },
     "unbound": {
         "meaning": "No identity bound to this session.",
-        "next_action": "Call onboard() to mint an identity.",
+        "next_action": "Call onboard(force_new=true) to mint a fresh identity.",
     },
     "continue": {
         "meaning": "Synonym of proceed; legacy label still used in some payloads.",

--- a/src/mcp_handlers/core.py
+++ b/src/mcp_handlers/core.py
@@ -115,6 +115,14 @@ def unbound_metrics_payload() -> dict:
     peer next_action carries the same hint with a tool + example, and the
     wrapped verdict carries the canonical glossary entry so the two
     surfaces can't drift.
+
+    The example must point at an explicit, proof-bearing identity path.
+    Leading with bare ``identity()`` here conflicted with the strict-identity
+    contract: an arg-less, no-proof ``identity()``/``onboard()`` can mint an
+    orphan in-memory identity instead of establishing accountable selfhood.
+    For an unbound caller the safe canonical path is ``onboard(force_new=true)``
+    for a fresh process identity, or a continuity-declaring mint when this
+    process is inheriting a finished predecessor's work.
     """
     from src.governance_glossary import explain_verdict
     return {
@@ -122,14 +130,20 @@ def unbound_metrics_payload() -> dict:
         "verdict": explain_verdict("unbound"),
         "guidance": "Establish identity before reading agent metrics.",
         "next_action": {
-            "tool": "identity",
-            "example": "identity() or onboard(force_new=true, spawn_reason='new_session')",
+            "tool": "onboard",
+            "example": "onboard(force_new=true)",
             "note": (
                 "get_governance_metrics is read-only; it creates no "
-                "identity and no state for unbound callers."
+                "identity and no state for unbound callers. Mint a fresh "
+                "process identity with onboard(force_new=true); to continue "
+                "a finished predecessor's work add "
+                "parent_agent_id=<prior_uuid>, spawn_reason='new_session'. "
+                "Avoid bare identity()/onboard() — without force_new or a "
+                "proof (client_session_id / continuity_token) they can mint "
+                "an orphan identity."
             ),
         },
-        "related_tools": ["identity", "onboard", "process_agent_update"],
+        "related_tools": ["onboard", "process_agent_update", "identity"],
     }
 
 

--- a/tests/test_handlers_core.py
+++ b/tests/test_handlers_core.py
@@ -322,7 +322,11 @@ class TestGetGovernanceMetrics:
             # #428: verdict is wrapped with meaning + next_action at the
             # response surface. The bare value lives at .value.
             assert data["verdict"]["value"] == "unbound"
-            assert data["next_action"]["tool"] == "identity"
+            # The unbound next_action must steer to an explicit, proof-bearing
+            # identity path. Bare identity() can mint an orphan, so the safe
+            # canonical hint is onboard(force_new=true).
+            assert data["next_action"]["tool"] == "onboard"
+            assert "force_new=true" in data["next_action"]["example"]
             mock_mcp_server.get_or_create_monitor.assert_not_called()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What

The unbound read-purity payload from `get_governance_metrics` (served to a no-proof MCP caller) pointed its `next_action` at **bare `identity()`**:

```
"tool": "identity",
"example": "identity() or onboard(force_new=true, spawn_reason='new_session')",
```

This conflicts with the current strict-identity ("no-proof") guidance: an arg-less, no-proof `identity()`/`onboard()` can mint an **orphan in-memory identity** rather than establishing accountable selfhood. (Surfaced by a dogfood pulse as a medium-severity friction.)

## Change

Lead with the safe canonical path instead:

- `src/mcp_handlers/core.py` — `unbound_metrics_payload()` `next_action.tool` → `"onboard"`, `example` → `"onboard(force_new=true)"`. The `note` now explains the continuity-declaring mint (`parent_agent_id=<prior_uuid>, spawn_reason='new_session'`) for inheriting a finished predecessor's work, and warns that bare `identity()`/`onboard()` without `force_new` or a proof (`client_session_id` / `continuity_token`) can mint an orphan.
- `src/governance_glossary.py` — the `"unbound"` verdict `next_action` updated from bare `onboard()` to `onboard(force_new=true)` so the verdict-wrapped surface and the peer `next_action` stay in sync.
- `tests/test_handlers_core.py` — `test_get_metrics_unbound_does_not_create_monitor` now asserts the corrected `onboard` / `force_new=true` hint.

Read-purity is unchanged: the unbound path still mints nothing and still returns the `⚪ unbound` ignorance shape.

## Tests

`test_handlers_core.py`, `test_governance_glossary.py`, `test_trust_contract_lint.py`, `test_zero_observation_honesty.py`, `test_dogfood_ablation_guard.py`, `test_pre_onboard_read_identity_honesty.py` — 106 passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqbKdSs35zoBxQRNvC545h)_