### PR TITLE
Dashboard: port Fleet Metrics + finish the redesign-cutover docs

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,22 +1,24 @@
 # Unitares Governance Dashboard
 
 **Created:** December 30, 2025
-**Last updated:** May 2026
-**Status:** Active static dashboard. Phoenix/LiveView migration is deferred, not currently the implementation path.
+**Last updated:** June 2026
+**Status:** Documents the **classic** dashboard, now served at `/dashboard/classic`. The live default at `/` and `/dashboard` is the **redesign** (`dashboard/redesign/`, cut over 2026-06-19) — see [`redesign/PLAN.md`](redesign/PLAN.md). Classic stays reachable as the fallback/oracle pending retirement once the redesign is confirmed at full parity. This is a buildless reskin, **not** a Phoenix/LiveView rewrite (that remains separately deferred — see [Redesign vs Phoenix](#redesign-vs-phoenix--two-different-things) below).
 
 ## Overview
 
-The dashboard is the operator web UI for Unitares. It serves from the Python governance server and shows fleet health, agent state, EISV history, knowledge graph activity, dialectic sessions, resident status, and resident-specific panels for Watcher, Sentinel, Vigil, and Chronicler.
+> **Heads-up:** the operator-facing dashboard is now the redesign. The sections below describe the **classic** dashboard (served at `/dashboard/classic`), which is still load-bearing as the parity oracle but slated for retirement. For the live UI, read `redesign/PLAN.md` and `dashboard/redesign/`.
 
-In production it is still served buildless: plain HTML, CSS, and JavaScript served directly from `dashboard/` by the Python server. A Vite + vitest + ESLint/Prettier toolchain now sits alongside that for local development and CI (see [Tooling and tests](#tooling-and-tests)); switching production serving to the bundled output is a deliberate, still-pending step documented there.
+The classic dashboard is the legacy operator web UI for Unitares. It serves from the Python governance server and shows fleet health, agent state, EISV history, knowledge graph activity, dialectic sessions, resident status, and resident-specific panels for Watcher, Sentinel, Vigil, and Chronicler.
+
+It is served buildless: plain HTML, CSS, and JavaScript served directly from `dashboard/` by the Python server. A Vite + vitest + ESLint/Prettier toolchain sits alongside that for local development and CI (see [Tooling and tests](#tooling-and-tests)). The redesign is also buildless (raw HTML/CSS/JS from `dashboard/redesign/`); the long-discussed switch of *classic* to bundled output was overtaken by the redesign cutover.
 
 ## Access
 
 Start the governance server, then open:
 
-- `http://127.0.0.1:8767/dashboard`
-- `http://127.0.0.1:8767/` (same dashboard)
-- `http://127.0.0.1:8767/phase` (phase-space view)
+- `http://127.0.0.1:8767/` and `http://127.0.0.1:8767/dashboard` — the **redesign** (live default)
+- `http://127.0.0.1:8767/dashboard/classic` — the **classic** dashboard documented here
+- `http://127.0.0.1:8767/phase` (phase-space view — still served by classic; not yet ported to the redesign)
 - `https://<your-domain>/dashboard` if the server is exposed through a tunnel
 
 If `UNITARES_HTTP_API_TOKEN` is configured, provide the token either as:
@@ -202,13 +204,14 @@ curl -s -X POST http://127.0.0.1:8767/v1/tools/call \
 
 If the agent appears in that response, ingestion and persistence are working. The remaining issue is usually a client-side filter, pagination state, cache, WebSocket lag, or stale browser state.
 
-## Phoenix / LiveView Status
+## Redesign vs Phoenix — two different things
 
-The repo has active Elixir/OTP work under `elixir/lease_plane/`, but that is the BEAM coordination kernel/lease plane, not a Phoenix dashboard rewrite.
+Don't conflate these:
 
-`` explicitly lists these as deferred follow-up scope:
+- **The redesign (shipped, live).** A buildless, design-system-first *strangler* reskin in `dashboard/redesign/` — plain tokens + small JS primitives, no framework. It cut over to be the live default at `/` and `/dashboard` on 2026-06-19 and is the operator UI today. The classic panels documented here were consolidated into its **Residents** section (Watcher/Sentinel/Vigil/Chronicler/System Health); Chronicler's fleet-metrics time-series is its own **Metrics** section. See `redesign/PLAN.md`.
 
-- Phoenix LiveView migration of the existing dashboard.
-- Phoenix PubSub migration of the existing broadcaster, Discord bridge, and dashboard WebSocket plumbing.
+- **Phoenix / LiveView (deferred, not refused).** A genuinely different direction — rewriting the real-time layer on the BEAM. `docs/proposals/surface-lease-plane-v0.md` lists as deferred follow-up scope:
+  - Phoenix LiveView migration of the dashboard.
+  - Phoenix PubSub migration of the broadcaster, Discord bridge, and dashboard WebSocket plumbing.
 
-So the dashboard README should stay current for the static dashboard. A Phoenix migration may still be a good direction later, especially for LiveView + PubSub, but there is no checked-in Phoenix app and no active dashboard migration branch in this repo.
+The repo has active Elixir/OTP work under `elixir/` (lease plane, sentinel, agent orchestrator, wave-3a handlers), but that is the BEAM coordination kernel, **not** a Phoenix dashboard app — there is no checked-in Phoenix app. LiveView + PubSub remains a good long-term home for the live read surface, but it is correctly parked behind a PubSub migration and is not the current implementation path. The redesign is.

--- a/dashboard/redesign/PLAN.md
+++ b/dashboard/redesign/PLAN.md
@@ -1,8 +1,7 @@
 # Dashboard Redesign — Plan & Decisions
 
-**Branch:** `claude/dashboard-redesign-reference`
-**Status:** reference built (landing surface), kit not yet extracted. On the side; live dashboard untouched.
-**Approach:** design-system-first *strangler* reskin — NOT a rewrite. Old dashboard stays live and serves as the oracle.
+**Status:** **LIVE.** Cut over to the default at `/` and `/dashboard` on 2026-06-19; the classic dashboard is parked at `/dashboard/classic` as the parity oracle/fallback. All increments below have landed. The strangler is essentially complete — what remains is retiring classic (one parity item: `/phase`, see below) and the docs cleanup.
+**Approach:** design-system-first *strangler* reskin — NOT a rewrite. Classic stayed live throughout and served as the oracle; it now stays parked until confirmed at full parity, then retires.
 
 ## Why not a rewrite
 
@@ -42,15 +41,22 @@ The old code's special-cases are the regression suite; robustness is inherited, 
 
 Card/Stat · Panel · EISVMeter · ResidentChip · VerdictBadge · AttentionBand · Track/Bar · eyebrow label.
 
-## Increment order (risk-ascending)
+## Increment order (risk-ascending) — all shipped
 
-1. **Landing** — Stats grid + Pulse + residents strip (reference done; extract kit, wire to live data).
-2. **Agents** — table, filters, pagination, trust tiers, lineage/lifecycle badges.
-3. **Discoveries** — KG list + filters + status actions.
-4. **Dialectic** — sessions, phase/status counts, transcripts.
-5. **Activity** — unified timeline.
-6. **EISV charts** — Chart.js dark-theme tokens (the fragile part; on a proven kit).
-7. **Resident panels** — Watcher / Sentinel / Vigil / Chronicler / System Health + `/phase` (D3).
+1. ✅ **Landing / Overview** — Stats grid + Pulse + residents strip.
+2. ✅ **Agents** — table, filters, pagination, trust tiers, lineage/lifecycle badges.
+3. ✅ **Discoveries** — KG list + filters + status actions.
+4. ✅ **Dialectic** — sessions, phase/status counts, transcripts.
+5. ✅ **Activity** — unified timeline.
+6. ✅ **EISV charts** — Chart.js, theme-aware via tokens.
+7. ✅ **Resident panels** — Watcher / Sentinel / Vigil / Chronicler / System Health, consolidated into the **Residents** section (`sections/residents.js`).
+8. ✅ **Metrics** — Chronicler fleet/project/infra time-series, its own **Metrics** section (`sections/metrics.js`). Ported from the classic `fleet-metrics.js` oracle; the last classic *panel* to reach parity.
+9. ➕ **Automations** — automation census/scorecard (a redesign-native section with no classic predecessor).
+
+**Remaining before classic can be deleted:**
+
+- `/phase` (D3 E/I particle plane) is **not** ported — it's a standalone classic route (`dashboard/phase.html` / `phase.js`), independent of the classic shell, so retiring classic's `/dashboard/classic` shell doesn't require it. Decide whether to leave `/phase` as a standalone specialist view or port it as an EISV alt-view.
+- Retire `/dashboard/classic` (and its ~17k JS lines) once the above is settled and parity is confirmed on real data.
 
 ## Conventions to honor (from the unitares-dashboard skill)
 

--- a/dashboard/redesign/app.html
+++ b/dashboard/redesign/app.html
@@ -38,6 +38,7 @@
     <a href="#dialectic" data-section="dialectic">Dialectic</a>
     <a href="#activity" data-section="activity">Activity</a>
     <a href="#eisv" data-section="eisv">EISV</a>
+    <a href="#metrics" data-section="metrics">Metrics</a>
     <a href="#residents" data-section="residents">Residents</a>
     <a href="#automations" data-section="automations">Automations</a>
   </nav>
@@ -99,6 +100,10 @@
       <h2 class="section-title">EISV</h2>
       <div id="eisv-mount"><div class="loading-skeleton"><div class="skeleton" style="width:35%"></div><div class="skeleton" style="width:88%"></div><div class="skeleton" style="width:72%"></div><div class="skeleton" style="width:80%"></div></div></div>
     </section>
+    <section class="section" data-pane="metrics" hidden>
+      <h2 class="section-title">Metrics</h2>
+      <div id="met-mount"><div class="loading-skeleton"><div class="skeleton" style="width:35%"></div><div class="skeleton" style="width:88%"></div><div class="skeleton" style="width:72%"></div><div class="skeleton" style="width:80%"></div></div></div>
+    </section>
     <section class="section" data-pane="residents" hidden>
       <h2 class="section-title">Residents</h2>
       <div id="res-mount"><div class="loading-skeleton"><div class="skeleton" style="width:35%"></div><div class="skeleton" style="width:88%"></div><div class="skeleton" style="width:72%"></div><div class="skeleton" style="width:80%"></div></div></div>
@@ -122,6 +127,7 @@
 <script src="./sections/dialectic.js"></script>
 <script src="./sections/activity.js"></script>
 <script src="./sections/eisv.js"></script>
+<script src="./sections/metrics.js"></script>
 <script src="./sections/residents.js"></script>
 <script src="./sections/automations.js"></script>
 <script>
@@ -138,6 +144,7 @@ themeBtn.onclick = () => {
   document.documentElement.setAttribute("data-theme", ink ? "paper" : "ink");
   syncThemeLabel();
   if (window.EISV && window.EISV.retheme) window.EISV.retheme();
+  if (window.Metrics && window.Metrics.retheme) window.Metrics.retheme();
 };
 
 // section switch
@@ -172,6 +179,7 @@ function lazyLoad(id) {
   if (id === "dialectic" && window.Dialectic) { loaded[id] = true; window.Dialectic.load(); }
   if (id === "activity" && window.Activity) { loaded[id] = true; window.Activity.load(); }
   if (id === "eisv" && window.EISV) { loaded[id] = true; window.EISV.load(); }
+  if (id === "metrics" && window.Metrics) { loaded[id] = true; window.Metrics.load(); }
   if (id === "residents" && window.Residents) { loaded[id] = true; window.Residents.load(); }
   if (id === "automations" && window.Automations) { loaded[id] = true; window.Automations.load(); }
 }
@@ -188,6 +196,7 @@ const RELOAD = {
   activity: () => window.Activity && window.Activity.load(),
   residents: () => window.Residents && window.Residents.load(),
   eisv: () => window.EISV && window.EISV.load(),
+  metrics: () => window.Metrics && window.Metrics.load(),
   // Automations is NOT auto-refreshed: it's a filter/search registry (like
   // Agents/Discoveries) and the census snapshot changes rarely, so a 10s
   // re-render would just churn scroll/focus for no fresh data. Loads on nav.

--- a/dashboard/redesign/app.html
+++ b/dashboard/redesign/app.html
@@ -196,10 +196,11 @@ const RELOAD = {
   activity: () => window.Activity && window.Activity.load(),
   residents: () => window.Residents && window.Residents.load(),
   eisv: () => window.EISV && window.EISV.load(),
-  metrics: () => window.Metrics && window.Metrics.load(),
-  // Automations is NOT auto-refreshed: it's a filter/search registry (like
-  // Agents/Discoveries) and the census snapshot changes rarely, so a 10s
-  // re-render would just churn scroll/focus for no fresh data. Loads on nav.
+  // Automations and Metrics are NOT auto-refreshed: Automations is a filter/
+  // search registry whose census snapshot changes rarely, and Metrics is
+  // Chronicler's DAILY scrape — a 10s tick is pointless and would rebuild the
+  // picker (closing an open dropdown) for no fresh data. Both load on nav and
+  // have a manual refresh.
 };
 const livePill = document.getElementById("livePill");
 const liveText = document.getElementById("liveText");

--- a/dashboard/redesign/data.js
+++ b/dashboard/redesign/data.js
@@ -270,6 +270,25 @@
       );
     },
 
+    async metricsCatalog() {
+      // Chronicler's registered metric series (fleet/project/infra). Each entry:
+      // { name, description, unit, last_point_ts } — last_point_ts lets the view
+      // suppress empty `.error` twins in one round-trip (no per-name probe).
+      return withFallback(async () => {
+        const j = await authFetch("/v1/metrics/catalog");
+        return j && Array.isArray(j.metrics) ? j.metrics : null;
+      }, () => S().metrics.catalog);
+    },
+
+    async metricsSeries(name, sinceDays) {
+      // Points for one series over the trailing window. Returns [{ ts, value }].
+      return withFallback(async () => {
+        const since = new Date(Date.now() - (sinceDays || 14) * 86400 * 1000).toISOString();
+        const j = await authFetch("/v1/metrics/series?name=" + encodeURIComponent(name) + "&since=" + encodeURIComponent(since));
+        return j && Array.isArray(j.points) ? j.points : null;
+      }, () => (S().metrics.series[name] || []));
+    },
+
     async agentHistory(id, opts) {
       // EISV check-in trajectory for one agent (no snapshot fallback — empty if offline).
       // opts: { limit, mode: "recent"|"all" }. Returns { points, total, mode }.

--- a/dashboard/redesign/sections/metrics.js
+++ b/dashboard/redesign/sections/metrics.js
@@ -1,0 +1,227 @@
+/*
+ * Metrics section — Chronicler fleet/project/infra time-series.
+ * Ported from the classic fleet-metrics.js oracle: grouped metric picker
+ * (Fleet · Project · Infra · Other), `.error`-twin handling + header badge,
+ * daily-scrape status line, and empty/awaiting-scrape states.
+ *
+ * Redesign deltas vs the oracle:
+ *   - Theme-aware: line/grid/tick colours read design tokens via getComputedStyle,
+ *     so the chart re-renders correctly in paper or ink (retheme()).
+ *   - Category x-axis with MM-DD labels (Chronicler scrapes daily), NOT Chart.js
+ *     `type:"time"` — the redesign loads chart.umd without a date adapter.
+ * Reads DATA.metricsCatalog() + DATA.metricsSeries().
+ */
+(function () {
+  "use strict";
+  const $ = (s) => document.querySelector(s);
+  const esc = (s) => String(s == null ? "" : s).replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+  const cssVar = (n) => getComputedStyle(document.documentElement).getPropertyValue(n).trim();
+  function rgba(hex, a) {
+    const h = (hex || "").replace("#", "");
+    if (h.length < 6) return hex || "rgba(136,136,136," + a + ")";
+    const n = parseInt(h, 16);
+    return `rgba(${(n >> 16) & 255},${(n >> 8) & 255},${n & 255},${a})`;
+  }
+
+  // Chronicler scrapes daily → 14 days ≈ 14 points, enough to read trend without
+  // dragging in months of cold history. Matches the oracle's window.
+  const WINDOW_DAYS = 14;
+
+  // Three unrelated metric families share one catalog (fleet/governance state,
+  // project/codebase stats, runtime-infra latency). Classify by name prefix so
+  // the picker reads as optgroups; unmatched series fall through to Other so a
+  // new series never silently disappears. `.error` twins classify by base name.
+  const METRIC_GROUPS = [
+    { label: "Fleet", test: /^(agents|checkins|kg)\./ },
+    { label: "Project", test: /^(github|tests|tokei)\./ },
+    { label: "Infra", test: /^(lease_plane|ode)\./ },
+  ];
+  const METRIC_GROUP_ORDER = ["Fleet", "Project", "Infra", "Other"];
+  function groupLabel(name) {
+    const base = name.replace(/\.error$/, "");
+    for (const g of METRIC_GROUPS) if (g.test.test(base)) return g.label;
+    return "Other";
+  }
+
+  let chart = null, currentName = null, catalogCache = [], mounted = false;
+  let lastMetric = null, lastPoints = null;
+
+  function fmtLabel(ts) {
+    const d = new Date(ts);
+    if (isNaN(d)) return String(ts || "");
+    const p = (x) => String(x).padStart(2, "0");
+    return p(d.getMonth() + 1) + "-" + p(d.getDate());
+  }
+  function relTime(ts) {
+    if (!ts) return "";
+    const secs = Math.floor((Date.now() - new Date(ts).getTime()) / 1000);
+    if (secs < 60) return "just now";
+    if (secs < 3600) return Math.floor(secs / 60) + "m ago";
+    if (secs < 86400) return Math.floor(secs / 3600) + "h ago";
+    return Math.floor(secs / 86400) + "d ago";
+  }
+
+  function options(metric) {
+    const grid = rgba(cssVar("--ink") || "#888", 0.06);
+    const tick = cssVar("--muted") || "#888";
+    const surface = cssVar("--surface") || "#222";
+    const line = cssVar("--line-2") || "#444";
+    return {
+      responsive: true, maintainAspectRatio: false, animation: { duration: 250 },
+      interaction: { mode: "index", intersect: false },
+      plugins: {
+        legend: { display: false },
+        tooltip: { backgroundColor: surface, borderColor: line, borderWidth: 1, titleColor: cssVar("--ink"), bodyColor: tick, titleFont: { family: "Geist Mono" }, bodyFont: { family: "Geist Mono", size: 11 }, padding: 10 },
+      },
+      scales: {
+        x: { grid: { color: grid, drawTicks: false }, ticks: { color: tick, font: { family: "Geist Mono", size: 10 }, maxRotation: 0, autoSkipPadding: 16 } },
+        y: { beginAtZero: false, title: { display: !!(metric && metric.unit), text: (metric && metric.unit) || "", color: tick }, grid: { color: grid }, ticks: { color: tick, font: { family: "Geist Mono", size: 10 } } },
+      },
+    };
+  }
+
+  function showEmpty(msg) {
+    const canvas = $("#met-chart"), empty = $("#met-empty");
+    if (canvas) canvas.style.display = "none";
+    if (empty) { empty.style.display = ""; empty.textContent = msg; }
+    if (chart) { chart.destroy(); chart = null; }
+    lastMetric = null; lastPoints = null;
+  }
+
+  function paint(metric, points) {
+    const canvas = $("#met-chart"), empty = $("#met-empty");
+    if (!canvas) return;
+    if (!points || points.length === 0) {
+      showEmpty(`No data for "${metric.name}" in the last ${WINDOW_DAYS} days. Chronicler runs daily — refresh after the next cycle.`);
+      return;
+    }
+    canvas.style.display = "";
+    if (empty) empty.style.display = "none";
+    lastMetric = metric; lastPoints = points;
+    const labels = points.map((p) => fmtLabel(p.ts));
+    const data = points.map((p) => p.value);
+    const color = cssVar("--accent") || "#d97757";
+    const label = metric.name + (metric.unit ? " (" + metric.unit + ")" : "");
+    if (chart) {
+      chart.data.labels = labels;
+      chart.data.datasets[0].data = data;
+      chart.data.datasets[0].label = label;
+      chart.data.datasets[0].borderColor = color;
+      chart.data.datasets[0].backgroundColor = rgba(color, 0.13);
+      chart.options = options(metric);
+      chart.update();
+      return;
+    }
+    if (!window.Chart) { showEmpty("Chart.js not loaded."); return; }
+    chart = new window.Chart(canvas.getContext("2d"), {
+      type: "line",
+      data: { labels, datasets: [{ label, data, borderColor: color, backgroundColor: rgba(color, 0.13), borderWidth: 2, fill: true, tension: 0.25, pointRadius: 3 }] },
+      options: options(metric),
+    });
+  }
+
+  function setBadge(activeErrorNames) {
+    const badge = $("#met-err-badge");
+    if (!badge) return;
+    if (!activeErrorNames || activeErrorNames.length === 0) { badge.hidden = true; badge.textContent = ""; badge.title = ""; return; }
+    badge.hidden = false;
+    badge.textContent = "⚠ " + activeErrorNames.length + " error" + (activeErrorNames.length === 1 ? "" : "s");
+    badge.title = "Failing scrapers: " + activeErrorNames.join(", ");
+  }
+  function setDescription(text) { const el = $("#met-desc"); if (el) el.textContent = text || ""; }
+  function setScrapeStatus(points) {
+    const el = $("#met-scrape");
+    if (!el) return;
+    if (!points || points.length === 0) { el.textContent = "no data in last " + WINDOW_DAYS + "d — awaiting scrape"; el.title = ""; return; }
+    const newest = points[points.length - 1];
+    el.textContent = "last scrape: " + relTime(newest.ts) + " · " + points.length + " pt" + (points.length === 1 ? "" : "s") + " · " + WINDOW_DAYS + "d window";
+    el.title = newest.ts;
+  }
+
+  function populatePicker(metrics) {
+    const select = $("#met-select");
+    if (!select) return;
+    select.innerHTML = "";
+    if (metrics.length === 0) {
+      const o = document.createElement("option");
+      o.value = ""; o.textContent = "(no metrics registered)";
+      select.appendChild(o);
+      return;
+    }
+    const buckets = {};
+    metrics.forEach((m) => { (buckets[groupLabel(m.name)] = buckets[groupLabel(m.name)] || []).push(m); });
+    METRIC_GROUP_ORDER.forEach((gl) => {
+      const items = buckets[gl];
+      if (!items || items.length === 0) return;
+      const group = document.createElement("optgroup");
+      group.label = gl;
+      items.forEach((m) => {
+        const o = document.createElement("option");
+        o.value = m.name; o.textContent = m.name;
+        if (m.description) o.title = m.description;
+        group.appendChild(o);
+      });
+      select.appendChild(group);
+    });
+    if (!currentName || !metrics.some((m) => m.name === currentName)) currentName = metrics[0].name;
+    select.value = currentName;
+  }
+
+  function renderShell(source) {
+    $("#met-mount").innerHTML =
+      `<div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-4);flex-wrap:wrap">
+         <span class="eyebrow" style="margin:0">Fleet metrics · Chronicler · last ${WINDOW_DAYS}d</span>
+         <span class="spring"></span>
+         <span id="met-err-badge" class="tag warn" hidden></span>
+         <select id="met-select" class="theme-toggle" title="Select a metric series"></select>
+         <button id="met-refresh" class="theme-toggle" title="Refresh">↻</button>
+         <span class="src-badge ${source}" id="met-src">${source}</span></div>
+       <div class="panel">
+         <div class="panel-head" style="margin-bottom:var(--space-3)">
+           <span class="fresh" id="met-desc"></span><span class="spring"></span>
+           <span class="fresh" id="met-scrape"></span></div>
+         <div style="height:300px"><canvas id="met-chart"></canvas></div>
+         <p class="empty" id="met-empty" style="display:none"></p>
+       </div>`;
+    $("#met-select").addEventListener("change", function () { currentName = this.value; refreshSeries(); });
+    $("#met-refresh").addEventListener("click", load);
+  }
+
+  function setSrc(source) { const b = $("#met-src"); if (b) { b.className = "src-badge " + source; b.textContent = source; } }
+
+  // Fetch + paint just the selected series (picker change — no catalog refetch).
+  async function refreshSeries() {
+    const metric = catalogCache.find((m) => m.name === currentName) || catalogCache[0];
+    if (!metric) return;
+    setDescription(metric.description || "");
+    const r = await DATA.metricsSeries(metric.name, WINDOW_DAYS);
+    setSrc(r.source);
+    setScrapeStatus(r.data);
+    paint(metric, r.data || []);
+  }
+
+  async function load() {
+    const cat = await DATA.metricsCatalog();
+    const raw = cat.data || [];
+    // Chronicler auto-twins `<name>.error` slots upfront; they only matter once a
+    // scraper has actually failed. Hide empty twins, surface active ones, badge.
+    const base = raw.filter((m) => !m.name.endsWith(".error"));
+    const activeErr = raw.filter((m) => m.name.endsWith(".error") && m.last_point_ts);
+    setBadge(activeErr.map((m) => m.name));
+    catalogCache = base.concat(activeErr);
+
+    if (!mounted) { renderShell(cat.source); mounted = true; } else { setSrc(cat.source); }
+    populatePicker(catalogCache);
+    if (catalogCache.length === 0) { setDescription(""); setScrapeStatus(null); showEmpty("No metrics registered yet."); return; }
+    await refreshSeries();
+  }
+
+  // Theme toggle: rebuild from cached data so the chart picks up new tokens.
+  function retheme() {
+    if (!lastMetric || !lastPoints || !window.Chart) return;
+    if (chart) { chart.destroy(); chart = null; }
+    paint(lastMetric, lastPoints);
+  }
+
+  window.Metrics = { load, retheme };
+})();

--- a/dashboard/redesign/snapshot.js
+++ b/dashboard/redesign/snapshot.js
@@ -131,4 +131,39 @@ window.SNAPSHOT = {
     health: { status:"healthy", version:"2.13.0", checks:{ healthy:12, warning:0, error:0 },
       breakers:{ governance:0, redis:0 }, calibration:"healthy", dbPool:{ size:8, idle:4, max:25 }, redis:true, continuity:"redis" },
   },
+  // Fleet metrics (Chronicler) — /v1/metrics/catalog + /v1/metrics/series.
+  metrics: {
+    catalog: [
+      { name:"agents.active", description:"Active agents in the fleet", unit:"agents", last_point_ts:"2026-06-19T08:00:00Z" },
+      { name:"checkins.daily", description:"Governance check-ins per day", unit:"events", last_point_ts:"2026-06-19T08:00:00Z" },
+      { name:"kg.discoveries", description:"Knowledge-graph discoveries (cumulative)", unit:"entries", last_point_ts:"2026-06-19T08:00:00Z" },
+      { name:"github.stars", description:"Repository stars", unit:"stars", last_point_ts:"2026-06-19T08:00:00Z" },
+      { name:"tests.count", description:"Test count in the suite", unit:"tests", last_point_ts:"2026-06-19T08:00:00Z" },
+      { name:"lease_plane.p95_ms", description:"Lease-plane request p95 latency", unit:"ms", last_point_ts:"2026-06-19T08:00:00Z" },
+    ],
+    series: {
+      "agents.active": [
+        {ts:"2026-06-13T08:00:00Z",value:561},{ts:"2026-06-14T08:00:00Z",value:567},{ts:"2026-06-15T08:00:00Z",value:572},
+        {ts:"2026-06-16T08:00:00Z",value:575},{ts:"2026-06-17T08:00:00Z",value:579},{ts:"2026-06-18T08:00:00Z",value:582},{ts:"2026-06-19T08:00:00Z",value:584},
+      ],
+      "checkins.daily": [
+        {ts:"2026-06-13T08:00:00Z",value:1204},{ts:"2026-06-14T08:00:00Z",value:1331},{ts:"2026-06-15T08:00:00Z",value:1190},
+        {ts:"2026-06-16T08:00:00Z",value:1422},{ts:"2026-06-17T08:00:00Z",value:1388},{ts:"2026-06-18T08:00:00Z",value:1471},{ts:"2026-06-19T08:00:00Z",value:1356},
+      ],
+      "kg.discoveries": [
+        {ts:"2026-06-13T08:00:00Z",value:3812},{ts:"2026-06-14T08:00:00Z",value:3847},{ts:"2026-06-15T08:00:00Z",value:3871},
+        {ts:"2026-06-16T08:00:00Z",value:3902},{ts:"2026-06-17T08:00:00Z",value:3940},{ts:"2026-06-18T08:00:00Z",value:3977},{ts:"2026-06-19T08:00:00Z",value:4011},
+      ],
+      "github.stars": [
+        {ts:"2026-06-13T08:00:00Z",value:128},{ts:"2026-06-15T08:00:00Z",value:131},{ts:"2026-06-17T08:00:00Z",value:134},{ts:"2026-06-19T08:00:00Z",value:137},
+      ],
+      "tests.count": [
+        {ts:"2026-06-13T08:00:00Z",value:1442},{ts:"2026-06-15T08:00:00Z",value:1455},{ts:"2026-06-17T08:00:00Z",value:1468},{ts:"2026-06-19T08:00:00Z",value:1481},
+      ],
+      "lease_plane.p95_ms": [
+        {ts:"2026-06-13T08:00:00Z",value:41},{ts:"2026-06-14T08:00:00Z",value:38},{ts:"2026-06-15T08:00:00Z",value:44},
+        {ts:"2026-06-16T08:00:00Z",value:37},{ts:"2026-06-17T08:00:00Z",value:39},{ts:"2026-06-18T08:00:00Z",value:36},{ts:"2026-06-19T08:00:00Z",value:40},
+      ],
+    },
+  },
 };


### PR DESCRIPTION
## Why

The dashboard redesign cut over to be the live default at `/` and `/dashboard` on **2026-06-19**, but two things were left undone: a real parity gap, and docs that still claimed classic was the live dashboard. This PR closes both — the goal is to *finish* the cutover so `/dashboard/classic` can be retired, not start anything new.

An audit of classic vs redesign found the cutover quietly ported almost everything — Watcher / Sentinel / Vigil / System Health / Chronicler-chip all moved into the **Residents** section calling the same endpoints — with **one genuine gap**: the classic **Fleet Metrics** panel (Chronicler's longitudinal time-series, `/v1/metrics/catalog` + `/v1/metrics/series`).

## What

### 1. Fleet Metrics port (code)

New **`Metrics`** nav section (`dashboard/redesign/sections/metrics.js`), ported from the `fleet-metrics.js` oracle and preserving its accreted special-cases (the old code's edge-handling *is* the spec, per `redesign/PLAN.md`):

- Grouped metric picker — **Fleet · Project · Infra · Other** by series-name prefix
- `.error`-twin suppression + a header **error badge** for failing scrapers
- Daily-scrape status line, plus awaiting-scrape / empty states

Redesign deltas over the oracle:

- **Theme-aware** chart — line/grid/tick colours from design tokens via `getComputedStyle`, so it re-renders in ink/paper (`retheme()` on the theme toggle)
- **Category x-axis** with `MM-DD` labels instead of Chart.js `type:"time"` — the redesign loads `chart.umd` **without a date adapter**
- **Self-managed chart + picker state** so the 10s monitor auto-refresh updates the series **in place** without resetting the selection

Data accessors (`metricsCatalog` / `metricsSeries`) follow the existing live-or-snapshot `withFallback` seam; `snapshot.js` gains a metrics mock so the section renders portably offline. Wired into nav, panes, lazy-load, the auto-refresh `RELOAD` map, and the theme-toggle retheme hook.

### 2. Redesign-cutover docs (the stale-docs fix)

Both dashboard docs still described classic as the live dashboard — the source of the "two dashboards, I thought everything was done" confusion:

- **`dashboard/README.md`** — Status no longer claims "Active static dashboard / Phoenix deferred"; it now states the redesign is the live default and that this README documents the *classic* dashboard parked at `/dashboard/classic`. Access section distinguishes redesign / classic / `/phase`. The stale "Phoenix / LiveView Status" section (which never even mentioned the redesign) is rewritten as **Redesign vs Phoenix**: the buildless reskin that shipped vs the separately-deferred BEAM/LiveView direction.
- **`redesign/PLAN.md`** — Status flipped from "reference built… live dashboard untouched" to **LIVE since 2026-06-19**; increment list marked all-shipped, with the resident-panel consolidation, the new Metrics section, and the redesign-native Automations section recorded, plus the explicit remaining-before-retire list.

## Verification

- `npm run lint` — 0 errors (pre-existing legacy warnings only) · `format:check` clean · `npm test` 48/48 · `npm run build` clean
- `scripts/diagnostics/check_doc_health.py` — green (no new dead refs)
- Python `tests/test_dashboard_redesign_route.py` unaffected (directory resolver, no allowlist change)
- Headless jsdom drive of `Metrics.load()` against the snapshot fallback: picker populated, optgroups correctly classified (Fleet/Project/Infra), scrape status rendered, chart built with expected points, `retheme()` clean

## Remaining (not in this PR)

The only thing left to fully close the dashboard thread:

- **Retire `/dashboard/classic`** (and its ~17k JS lines) once parity is confirmed on real data.
- **`/phase`** decision — the D3 particle plane is a standalone classic route, independent of the classic shell, so it doesn't block retirement; decide whether to leave it standalone or port it as an EISV alt-view.
