### PR TITLE
feat(dialectic): orchestrated reviewer runner (slice 1, inert)

### DIFF
--- a/agents/dialectic_reviewer/__init__.py
+++ b/agents/dialectic_reviewer/__init__.py
@@ -1,0 +1,12 @@
+"""Orchestrated dialectic reviewer — the agent-orchestrator's first consumer.
+
+See docs/proposals/orchestrated-dialectic-reviewer-v0.md.
+"""
+from .reviewer import (
+    Thesis,
+    Verdict,
+    build_review_prompt,
+    parse_reviewer_verdict,
+)
+
+__all__ = ["Thesis", "Verdict", "build_review_prompt", "parse_reviewer_verdict"]

--- a/agents/dialectic_reviewer/reviewer.py
+++ b/agents/dialectic_reviewer/reviewer.py
@@ -212,7 +212,8 @@ async def run(thesis: Thesis, governance_url: str, parent_agent_id: Optional[str
             },
         )
         # A real check-in before exit (subagent-onboarding discipline).
-        await client.sync_state(
+        # SDK checkin() maps to the server's process_agent_update.
+        await client.checkin(
             response_text=f"dialectic review complete: agrees={verdict.agrees}"
             + (" (degraded fallback)" if verdict.degraded else ""),
             complexity=0.4,
@@ -220,7 +221,7 @@ async def run(thesis: Thesis, governance_url: str, parent_agent_id: Optional[str
         )
         return verdict
     finally:
-        await client.close()
+        await client.disconnect()
 
 
 def main() -> int:

--- a/agents/dialectic_reviewer/reviewer.py
+++ b/agents/dialectic_reviewer/reviewer.py
@@ -1,0 +1,245 @@
+"""Orchestrated dialectic reviewer — a standalone, independently-accountable
+reviewer process.
+
+The agent-orchestrator spawns this as a supervised, lease-bound child when a
+dialectic session needs a reviewer. Unlike the in-process synthetic path
+(`handle_llm_assisted_dialectic`, which hardcodes ``agrees=True`` and borrows the
+paused agent's api_key), this process:
+
+  * onboards as its OWN governance identity (strict-identity compliant),
+  * runs a heterogeneous LOCAL model (gemma4 via Ollama — no paid API) IN its own
+    process to form a *genuine* verdict that may DISAGREE,
+  * submits that verdict through the ordinary dialectic protocol tools, and
+  * exits (the orchestrator reaps it and releases its lease).
+
+Design: docs/proposals/orchestrated-dialectic-reviewer-v0.md
+
+The verdict-derivation (`parse_reviewer_verdict`) and prompt-construction
+(`build_review_prompt`) are PURE functions so the independence-critical behavior
+— that a disagreeing model produces ``agrees=False`` — is unit-tested without a
+network or a model.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+# gemma4 hides its answer behind a <think> block under thinking mode; strip it
+# before JSON extraction (mirrors llm_delegation._wants_reasoning_effort_none).
+_THINK_BLOCK = re.compile(r"<think>.*?</think>", re.DOTALL | re.IGNORECASE)
+# The model is asked for strict JSON, but local models fence it or add prose.
+_JSON_OBJECT = re.compile(r"\{.*\}", re.DOTALL)
+
+DEFAULT_MODEL = os.getenv("UNITARES_LLM_MODEL", "gemma4:latest")
+OLLAMA_BASE_URL = os.getenv("UNITARES_OLLAMA_BASE_URL", "http://localhost:11434/v1")
+SPAWN_REASON = "dialectic_reviewer"
+
+
+@dataclass
+class Thesis:
+    """What the paused agent claimed — passed in the spawn payload, not read over
+    MCP (get_dialectic_session is register=False)."""
+
+    session_id: str
+    root_cause: str = ""
+    proposed_conditions: list[str] = field(default_factory=list)
+    reasoning: str = ""
+    situation: str = ""  # free-text context about why the agent paused
+
+    @classmethod
+    def from_env(cls, env: Optional[dict[str, str]] = None) -> "Thesis":
+        env = env if env is not None else os.environ
+        sid = env.get("DIALECTIC_SESSION_ID", "")
+        raw_conditions = env.get("DIALECTIC_THESIS_CONDITIONS", "")
+        try:
+            conditions = json.loads(raw_conditions) if raw_conditions else []
+            if not isinstance(conditions, list):
+                conditions = [str(conditions)]
+        except (json.JSONDecodeError, ValueError):
+            conditions = [c.strip() for c in raw_conditions.split("\n") if c.strip()]
+        return cls(
+            session_id=sid,
+            root_cause=env.get("DIALECTIC_THESIS_ROOT_CAUSE", ""),
+            proposed_conditions=conditions,
+            reasoning=env.get("DIALECTIC_THESIS_REASONING", ""),
+            situation=env.get("DIALECTIC_THESIS_SITUATION", ""),
+        )
+
+
+@dataclass
+class Verdict:
+    agrees: bool
+    root_cause: str
+    proposed_conditions: list[str]
+    reasoning: str
+    # True when we could not extract a real model judgment and fell back to a
+    # conservative default. A fallback verdict must DISAGREE — never rubber-stamp.
+    degraded: bool = False
+
+
+def build_review_prompt(thesis: Thesis) -> str:
+    """Construct the independent-review prompt. Pure."""
+    conditions = "\n".join(f"  - {c}" for c in thesis.proposed_conditions) or "  (none proposed)"
+    return (
+        "You are an INDEPENDENT reviewer in a dialectic governance process. A paused "
+        "AI agent has proposed conditions under which it should resume work. Your job "
+        "is to genuinely evaluate the proposal — NOT to rubber-stamp it. Disagreeing is "
+        "a valid, expected outcome when the root-cause analysis is shallow, the "
+        "conditions don't address the root cause, or the agent is rationalizing.\n\n"
+        f"PAUSED AGENT'S SITUATION:\n{thesis.situation or '(not provided)'}\n\n"
+        f"PROPOSED ROOT CAUSE:\n{thesis.root_cause or '(none)'}\n\n"
+        f"PROPOSED RESUMPTION CONDITIONS:\n{conditions}\n\n"
+        f"AGENT'S REASONING:\n{thesis.reasoning or '(none)'}\n\n"
+        "Respond with STRICT JSON only, no prose outside it:\n"
+        "{\n"
+        '  "agrees": true | false,\n'
+        '  "root_cause": "your assessment of the actual root cause",\n'
+        '  "proposed_conditions": ["condition 1", "condition 2"],\n'
+        '  "reasoning": "why you agree or disagree"\n'
+        "}\n"
+        "If you disagree, set agrees=false and use proposed_conditions to state what "
+        "you would require instead. If you agree, proposed_conditions must be non-empty."
+    )
+
+
+def parse_reviewer_verdict(model_text: str) -> Verdict:
+    """Derive a Verdict from raw model output. Pure.
+
+    The independence-critical property: a model that expresses disagreement yields
+    ``agrees=False``. Anything we cannot parse degrades to a DISAGREE verdict — a
+    reviewer that cannot form a judgment must not silently approve.
+    """
+    text = _THINK_BLOCK.sub("", model_text or "").strip()
+    match = _JSON_OBJECT.search(text)
+    if not match:
+        return Verdict(
+            agrees=False,
+            root_cause="",
+            proposed_conditions=[],
+            reasoning="Reviewer model returned no parseable verdict; defaulting to "
+            "disagreement (no independent approval without a real judgment).",
+            degraded=True,
+        )
+    try:
+        obj = json.loads(match.group(0))
+    except json.JSONDecodeError:
+        return Verdict(
+            agrees=False,
+            root_cause="",
+            proposed_conditions=[],
+            reasoning="Reviewer model emitted malformed JSON; defaulting to "
+            "disagreement.",
+            degraded=True,
+        )
+
+    agrees = _coerce_bool(obj.get("agrees"))
+    conditions = obj.get("proposed_conditions") or obj.get("conditions") or []
+    if isinstance(conditions, str):
+        conditions = [conditions] if conditions else []
+    conditions = [str(c).strip() for c in conditions if str(c).strip()]
+
+    return Verdict(
+        agrees=agrees,
+        root_cause=str(obj.get("root_cause", "")).strip(),
+        proposed_conditions=conditions,
+        reasoning=str(obj.get("reasoning", "")).strip(),
+        degraded=False,
+    )
+
+
+def _coerce_bool(value: Any) -> bool:
+    """Match the server's submit_synthesis coercion (handlers.py ~1631): only an
+    explicit truthy token agrees. Absent / unknown ⇒ False (don't approve by
+    default)."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ("true", "1", "yes")
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# Async wiring (the impure shell). Kept thin; the testable logic is above.
+# --------------------------------------------------------------------------- #
+async def call_reviewer_model(prompt: str, model: str = DEFAULT_MODEL) -> str:
+    """Run the local heterogeneous model in THIS process (not via the server's
+    call_model tool, whose 30s timeout is shorter than gemma4's 43–70s budget).
+    Localhost Ollama, OpenAI-compat — no paid API."""
+    from openai import OpenAI  # local import: only the runner process needs it
+
+    client = OpenAI(base_url=OLLAMA_BASE_URL, api_key="ollama")
+    kwargs: dict[str, Any] = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": int(os.getenv("UNITARES_DIALECTIC_REVIEW_MAX_TOKENS", "1024")),
+        "temperature": 0.2,
+    }
+    resp = client.chat.completions.create(**kwargs)
+    return resp.choices[0].message.content or ""
+
+
+async def run(thesis: Thesis, governance_url: str, parent_agent_id: Optional[str]) -> Verdict:
+    """Onboard → model → claim slot + submit. Returns the Verdict for logging/tests."""
+    from unitares_sdk.client import GovernanceClient  # type: ignore
+
+    verdict = parse_reviewer_verdict(await call_reviewer_model(build_review_prompt(thesis)))
+
+    client = GovernanceClient(governance_url)
+    await client.connect()
+    try:
+        await client.onboard(
+            force_new=True,
+            parent_agent_id=parent_agent_id,
+            spawn_reason=SPAWN_REASON,
+        )
+        # Claim the open reviewer slot as first-responder (handlers.py:677/691).
+        await client.call_tool(
+            "submit_antithesis",
+            {"session_id": thesis.session_id, "reasoning": verdict.reasoning},
+        )
+        # Submit the model-derived verdict — agrees may be False (the whole point).
+        await client.call_tool(
+            "submit_synthesis",
+            {
+                "session_id": thesis.session_id,
+                "agrees": verdict.agrees,
+                "proposed_conditions": verdict.proposed_conditions,
+                "root_cause": verdict.root_cause,
+                "reasoning": verdict.reasoning,
+            },
+        )
+        # A real check-in before exit (subagent-onboarding discipline).
+        await client.sync_state(
+            response_text=f"dialectic review complete: agrees={verdict.agrees}"
+            + (" (degraded fallback)" if verdict.degraded else ""),
+            complexity=0.4,
+            confidence=0.6 if not verdict.degraded else 0.3,
+        )
+        return verdict
+    finally:
+        await client.close()
+
+
+def main() -> int:
+    import asyncio
+
+    thesis = Thesis.from_env()
+    if not thesis.session_id:
+        print("FATAL: DIALECTIC_SESSION_ID not set in spawn payload", flush=True)
+        return 2
+    governance_url = os.getenv("UNITARES_GOVERNANCE_URL") or os.getenv("GOVERNANCE_URL", "")
+    parent = os.getenv("UNITARES_PARENT_AGENT_ID") or None
+    try:
+        verdict = asyncio.run(run(thesis, governance_url, parent))
+    except Exception as exc:  # noqa: BLE001 — a reviewer crash must be loud, not silent
+        print(f"FATAL: reviewer failed: {exc!r}", flush=True)
+        return 1
+    print(f"reviewer done: agrees={verdict.agrees} degraded={verdict.degraded}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agents/dialectic_reviewer/tests/test_verdict.py
+++ b/agents/dialectic_reviewer/tests/test_verdict.py
@@ -1,0 +1,163 @@
+"""Unit tests for the orchestrated dialectic reviewer's pure logic.
+
+The independence-critical invariant: a disagreeing (or unparseable) model yields
+``agrees=False``. The current in-process synthetic path returns ``agrees=False``
+exactly zero times by construction — these tests prove the orchestrated reviewer
+can actually block.
+"""
+import json
+
+import pytest
+
+from agents.dialectic_reviewer.reviewer import (
+    Thesis,
+    Verdict,
+    build_review_prompt,
+    parse_reviewer_verdict,
+)
+
+
+# --------------------------- parse_reviewer_verdict --------------------------- #
+def test_disagreement_yields_agrees_false():
+    out = json.dumps(
+        {
+            "agrees": False,
+            "root_cause": "The agent rationalized; the real cause is unaddressed.",
+            "proposed_conditions": ["Fix the actual lock contention first"],
+            "reasoning": "Conditions don't touch the root cause.",
+        }
+    )
+    v = parse_reviewer_verdict(out)
+    assert v.agrees is False
+    assert v.degraded is False
+    assert v.proposed_conditions == ["Fix the actual lock contention first"]
+
+
+def test_agreement_yields_agrees_true_with_conditions():
+    out = '```json\n{"agrees": true, "root_cause": "transient", "proposed_conditions": ["retry once"], "reasoning": "ok"}\n```'
+    v = parse_reviewer_verdict(out)
+    assert v.agrees is True
+    assert v.proposed_conditions == ["retry once"]
+
+
+def test_string_bool_is_coerced_like_the_server():
+    assert parse_reviewer_verdict('{"agrees": "true"}').agrees is True
+    assert parse_reviewer_verdict('{"agrees": "false"}').agrees is False
+    assert parse_reviewer_verdict('{"agrees": "maybe"}').agrees is False
+
+
+def test_think_block_is_stripped_before_json():
+    out = '<think>I should be skeptical here.</think>\n{"agrees": false, "reasoning": "r"}'
+    v = parse_reviewer_verdict(out)
+    assert v.agrees is False
+    assert v.degraded is False
+
+
+def test_conditions_alias_accepted():
+    v = parse_reviewer_verdict('{"agrees": false, "conditions": ["a", "b"]}')
+    assert v.proposed_conditions == ["a", "b"]
+
+
+def test_unparseable_output_degrades_to_disagree_not_approve():
+    for junk in ["", "I think it's fine, sure.", "not json at all", "{broken json"]:
+        v = parse_reviewer_verdict(junk)
+        assert v.agrees is False, f"unparseable {junk!r} must NOT rubber-stamp"
+        assert v.degraded is True
+
+
+def test_missing_agrees_key_defaults_to_disagree():
+    v = parse_reviewer_verdict('{"reasoning": "no verdict field"}')
+    assert v.agrees is False
+    assert v.degraded is False  # JSON parsed; just no approval token
+
+
+# --------------------------- build_review_prompt --------------------------- #
+def test_prompt_frames_disagreement_as_valid():
+    prompt = build_review_prompt(
+        Thesis(session_id="s1", root_cause="rc", proposed_conditions=["c1"], reasoning="r")
+    )
+    assert "INDEPENDENT" in prompt
+    assert "rubber-stamp" in prompt.lower()
+    assert "c1" in prompt  # the proposed condition is surfaced for review
+    assert "STRICT JSON" in prompt
+
+
+# --------------------------- Thesis.from_env --------------------------- #
+def test_thesis_from_env_parses_json_conditions():
+    env = {
+        "DIALECTIC_SESSION_ID": "sess-123",
+        "DIALECTIC_THESIS_ROOT_CAUSE": "rc",
+        "DIALECTIC_THESIS_CONDITIONS": json.dumps(["x", "y"]),
+        "DIALECTIC_THESIS_REASONING": "because",
+    }
+    t = Thesis.from_env(env)
+    assert t.session_id == "sess-123"
+    assert t.proposed_conditions == ["x", "y"]
+
+
+def test_thesis_from_env_tolerates_newline_conditions():
+    env = {"DIALECTIC_SESSION_ID": "s", "DIALECTIC_THESIS_CONDITIONS": "one\ntwo\n"}
+    assert Thesis.from_env(env).proposed_conditions == ["one", "two"]
+
+
+# --------------------------- run() wiring (mocked) --------------------------- #
+@pytest.mark.asyncio
+async def test_run_submits_disagreement_through_protocol(monkeypatch):
+    """A disagreeing model must reach submit_synthesis with agrees=False."""
+    import agents.dialectic_reviewer.reviewer as r
+
+    async def fake_model(prompt, model=r.DEFAULT_MODEL):
+        return '{"agrees": false, "root_cause": "shallow", "proposed_conditions": ["real fix"], "reasoning": "no"}'
+
+    monkeypatch.setattr(r, "call_reviewer_model", fake_model)
+
+    calls: list[tuple[str, dict]] = []
+
+    class FakeClient:
+        def __init__(self, url):
+            self.url = url
+
+        async def connect(self):
+            return None
+
+        async def onboard(self, **kw):
+            calls.append(("onboard", kw))
+            return None
+
+        async def call_tool(self, name, args, **kw):
+            calls.append((name, args))
+            return {"ok": True}
+
+        async def sync_state(self, **kw):
+            calls.append(("sync_state", kw))
+            return None
+
+        async def close(self):
+            return None
+
+    # Inject the fake SDK client module so `from unitares_sdk.client import GovernanceClient` resolves.
+    import sys
+    import types
+
+    fake_mod = types.ModuleType("unitares_sdk.client")
+    fake_mod.GovernanceClient = FakeClient  # type: ignore[attr-defined]
+    pkg = types.ModuleType("unitares_sdk")
+    monkeypatch.setitem(sys.modules, "unitares_sdk", pkg)
+    monkeypatch.setitem(sys.modules, "unitares_sdk.client", fake_mod)
+
+    verdict = await r.run(
+        Thesis(session_id="sess-9", root_cause="rc", proposed_conditions=["c"], reasoning="x"),
+        governance_url="http://localhost:8767",
+        parent_agent_id="parent-uuid",
+    )
+
+    assert verdict.agrees is False
+    # onboarded with lineage + the dedicated spawn_reason
+    onboard_kw = next(c[1] for c in calls if c[0] == "onboard")
+    assert onboard_kw["force_new"] is True
+    assert onboard_kw["spawn_reason"] == r.SPAWN_REASON
+    assert onboard_kw["parent_agent_id"] == "parent-uuid"
+    # submit_synthesis carried agrees=False — the reviewer actually blocked
+    synth = [a for n, a in calls if n == "submit_synthesis"]
+    assert synth and synth[0]["agrees"] is False
+    assert synth[0]["session_id"] == "sess-9"

--- a/agents/dialectic_reviewer/tests/test_verdict.py
+++ b/agents/dialectic_reviewer/tests/test_verdict.py
@@ -100,6 +100,17 @@ def test_thesis_from_env_tolerates_newline_conditions():
     assert Thesis.from_env(env).proposed_conditions == ["one", "two"]
 
 
+# --------------------------- SDK interface conformance --------------------------- #
+def test_runner_only_calls_real_governance_client_methods():
+    """Guard against the mock lying: every GovernanceClient method run() invokes
+    must actually exist on the real SDK class. (This catches close-vs-disconnect /
+    sync_state-vs-checkin drift that mocked wiring tests cannot.)"""
+    client_mod = pytest.importorskip("unitares_sdk.client")
+    gc = client_mod.GovernanceClient
+    for method in ("connect", "onboard", "call_tool", "checkin", "disconnect"):
+        assert hasattr(gc, method), f"GovernanceClient is missing {method!r} — runner would crash live"
+
+
 # --------------------------- run() wiring (mocked) --------------------------- #
 @pytest.mark.asyncio
 async def test_run_submits_disagreement_through_protocol(monkeypatch):
@@ -128,11 +139,13 @@ async def test_run_submits_disagreement_through_protocol(monkeypatch):
             calls.append((name, args))
             return {"ok": True}
 
-        async def sync_state(self, **kw):
-            calls.append(("sync_state", kw))
+        # Method names MUST mirror the real GovernanceClient — a mock that
+        # invents names hides runtime AttributeErrors (it did, once).
+        async def checkin(self, response_text, complexity=0.3, confidence=0.7, **kw):
+            calls.append(("checkin", {"response_text": response_text, **kw}))
             return None
 
-        async def close(self):
+        async def disconnect(self):
             return None
 
     # Inject the fake SDK client module so `from unitares_sdk.client import GovernanceClient` resolves.


### PR DESCRIPTION
Slice 1 of the orchestrated dialectic reviewer — the agent-orchestrator's first real consumer (design: `docs/proposals/orchestrated-dialectic-reviewer-v0.md`, on PR #1009).

**What & why.** The in-process synthetic reviewer hardcodes `agrees=True` (handlers.py:1206/1216/2109/2119), runs under a shared `SYNTHETIC_REVIEWER_ID`, and borrows the paused agent's `api_key` — it cannot block. This adds a standalone, independently-accountable reviewer process that forms a **genuine verdict that can disagree**.

**Scope (deliberately inert).** This slice adds ONLY the runner + tests. Nothing spawns it yet — the flagged engine fork (`DIALECTIC_REVIEWER_MODE`) is slice 2. Zero blast radius on the dialectic hot path.

**Design highlights**
- Pure `parse_reviewer_verdict()`: a disagreeing **or unparseable** model → `agrees=False` (a reviewer that can't judge must not rubber-stamp). bool coercion mirrors the server.
- Local gemma4 **in the runner's own process** (own Ollama client) — sidesteps `call_model`'s 30s timeout vs gemma4's 43–70s, and is more process-independent. No paid API.
- Reads the thesis from the **spawn payload** (`get_dialectic_session` is `register=False`), not over MCP.
- Onboards strict-compliant (`force_new`, `parent_agent_id`, `spawn_reason="dialectic_reviewer"`); claims the open reviewer slot via the existing first-responder `submit_antithesis` path; submits the model-derived `agrees` via `submit_synthesis`.

**Tests (12, green).** disagree→`agrees=False`, agree, string-bool coercion, `<think>`-strip, conditions alias, unparseable→degraded-disagree, env parsing, a mocked wiring test (disagreeing model reaches `submit_synthesis(agrees=False)`), and an **SDK interface-conformance guard** (caught two real method-name bugs the mocks masked: `close`→`disconnect`, `sync_state`→`checkin`).

**Falsifiable success metric:** does an orchestrated reviewer ever return `agrees=False`? The synthetic path returns it zero times by construction.

Draft — slice 2 (engine fork) and a council pass follow. Operator merge gate.

https://claude.ai/code/session_01BLavdvZWvR1MR2BjuctPKf