### PR TITLE
perf(state-lock): advisory-lock backend — the (A.2) Wave-3 falsifier [HOLD deploy]

### DIFF
--- a/src/services/update_workflow_service.py
+++ b/src/services/update_workflow_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import time
 from pathlib import Path
 from typing import Sequence
@@ -65,6 +66,10 @@ async def run_process_update_workflow(ctx, *, serializer=None) -> Sequence[TextC
 
         try:
             async with ctx.mcp_server.lock_manager.acquire_agent_lock_async(ctx.agent_id, timeout=5.0, max_retries=3):
+                # Separate the lock-acquisition wait from the locked-update work so
+                # the (A.2) falsifier can attribute any p99 change to the lock itself
+                # rather than confounding it with the work under the lock.
+                _tick("lock_acquire")
                 early_exit = await execute_locked_update(ctx)
                 _tick("locked_update")
                 if early_exit:
@@ -75,22 +80,31 @@ async def run_process_update_workflow(ctx, *, serializer=None) -> Sequence[TextC
         except TimeoutError:
             _tick("lock_timeout")
             cleaned = False
-            try:
-                from src.lock_cleanup import cleanup_stale_state_locks
-                project_root = Path(__file__).resolve().parent.parent
-                cleanup_result = await ctx.loop.run_in_executor(
-                    None, cleanup_stale_state_locks, project_root, 60.0, False
-                )
-                if cleanup_result["cleaned"] > 0:
-                    logger.info(f"Auto-recovery: Cleaned {cleanup_result['cleaned']} stale lock(s) after timeout")
-                    cleaned = True
-            except Exception as cleanup_error:
-                logger.warning(f"Could not perform emergency lock cleanup: {cleanup_error}")
-
-            cleanup_msg = (
-                "The system has automatically cleaned stale locks. " if cleaned
-                else "Automatic lock cleanup was attempted but did not resolve the issue. "
+            # Stale *file* locks only exist on the fcntl backend; under the advisory
+            # backend a timeout means a live PostgreSQL session holds the lock, so the
+            # file-oriented cleanup would no-op and emit a misleading message. Skip it.
+            advisory_backend = (
+                os.environ.get("UNITARES_AGENT_LOCK_BACKEND", "advisory").strip().lower() == "advisory"
             )
+            if not advisory_backend:
+                try:
+                    from src.lock_cleanup import cleanup_stale_state_locks
+                    project_root = Path(__file__).resolve().parent.parent
+                    cleanup_result = await ctx.loop.run_in_executor(
+                        None, cleanup_stale_state_locks, project_root, 60.0, False
+                    )
+                    if cleanup_result["cleaned"] > 0:
+                        logger.info(f"Auto-recovery: Cleaned {cleanup_result['cleaned']} stale lock(s) after timeout")
+                        cleaned = True
+                except Exception as cleanup_error:
+                    logger.warning(f"Could not perform emergency lock cleanup: {cleanup_error}")
+
+            if advisory_backend:
+                cleanup_msg = "Another live session currently holds the lock. "
+            elif cleaned:
+                cleanup_msg = "The system has automatically cleaned stale locks. "
+            else:
+                cleanup_msg = "Automatic lock cleanup was attempted but did not resolve the issue. "
             return [error_response(
                 f"Failed to acquire lock for agent '{ctx.agent_id}' after automatic retries and cleanup. "
                 f"This usually means another active process is updating this agent. "

--- a/src/state_locking.py
+++ b/src/state_locking.py
@@ -20,6 +20,14 @@ from contextlib import contextmanager, asynccontextmanager
 from typing import Optional
 
 
+# Fixed namespace for agent-state advisory locks. Using the TWO-argument
+# advisory-lock form (key1=namespace, key2=hashtext(agent_id)) keeps these locks
+# in a Postgres lock space that is disjoint from the SINGLE-argument form used by
+# scripts/dev/lease_plane_deprecate.py — two-arg and one-arg advisory locks never
+# collide even on equal key values. Value is a positive int4 ('AGNT').
+_AGENT_LOCK_NAMESPACE = 0x41474E54
+
+
 def is_process_alive(pid: int) -> bool:
     """Check if a process with given PID is still running"""
     try:
@@ -300,11 +308,106 @@ class StateLockManager:
     @asynccontextmanager
     async def acquire_agent_lock_async(self, agent_id: str, timeout: float = 5.0, max_retries: int = 3):
         """
-        Async version of acquire_agent_lock - uses asyncio.sleep() instead of time.sleep()
+        Async exclusive lock for agent state updates.
+
+        Backend is selectable via ``UNITARES_AGENT_LOCK_BACKEND`` so the deploy is
+        instantly reversible without a code change:
+
+        - ``advisory`` (default): a PostgreSQL session-scoped advisory lock
+          (``pg_try_advisory_lock(hashtext(agent_id))``). No file-lock spin-wait,
+          so the ~15s ``fcntl`` ``LOCK_NB`` + ``sleep(0.1)`` ceiling that dominated
+          the ``process_agent_update`` p99 tail disappears. Different agents never
+          contend (distinct keys); the connection is held only across the critical
+          section and the lock auto-releases if the connection drops. This path is
+          the RFC (A.2) disconfirmer: if it collapses p99 < 2.0s, the tail was the
+          file lock, not the substrate.
+        - ``fcntl``: the legacy file-based lock, preserved verbatim as a fallback.
+
+        Args:
+            agent_id: Agent identifier
+            timeout: Timeout per retry attempt in seconds
+            max_retries: Maximum number of retry attempts with cleanup
+        """
+        backend = os.environ.get("UNITARES_AGENT_LOCK_BACKEND", "advisory").strip().lower()
+        if backend == "advisory":
+            async with self._acquire_agent_lock_async_advisory(
+                agent_id, timeout=timeout, max_retries=max_retries
+            ):
+                yield
+        else:
+            async with self._acquire_agent_lock_async_fcntl(
+                agent_id, timeout=timeout, max_retries=max_retries
+            ):
+                yield
+
+    @asynccontextmanager
+    async def _acquire_agent_lock_async_advisory(
+        self, agent_id: str, timeout: float = 5.0, max_retries: int = 3
+    ):
+        """PostgreSQL advisory-lock implementation of the async agent lock.
+
+        The advisory lock is session-scoped, so it MUST be released on the same
+        connection that acquired it — hence the connection is held open across the
+        ``yield``. Per-agent contention is rare (each agent hashes to a distinct
+        key), so in the common path ``pg_try_advisory_lock`` succeeds on the first
+        poll and the connection is held only for the duration of the critical
+        section, the same window the file lock covered.
+        """
+        import asyncio
+        from src.db import get_db
+
+        # Mirror the fcntl ceiling (timeout per attempt × attempts) as a single
+        # total budget so the worst-case wait is unchanged, minus the spin tax.
+        total_budget = float(timeout) * max(1, int(max_retries))
+        poll_interval = 0.05
+
+        # Two-argument advisory form (namespace, hashtext(agent_id)) — disjoint
+        # lock space from the single-arg form used elsewhere (lease_plane_deprecate).
+        acquire_sql = f"SELECT pg_try_advisory_lock({_AGENT_LOCK_NAMESPACE}, hashtext($1))"
+        release_sql = f"SELECT pg_advisory_unlock({_AGENT_LOCK_NAMESPACE}, hashtext($1))"
+
+        db = get_db()
+        async with db.acquire() as conn:
+            acquired = False
+            deadline = time.monotonic() + total_budget
+            while True:
+                acquired = bool(await conn.fetchval(acquire_sql, agent_id))
+                if acquired or time.monotonic() >= deadline:
+                    break
+                await asyncio.sleep(poll_interval)
+
+            if not acquired:
+                # Same exception type the call site already handles (TimeoutError);
+                # the advisory backend has no stale lock files to clean, so the
+                # caller's file-oriented cleanup is skipped (see update_workflow_service).
+                raise TimeoutError(
+                    f"Lock timeout for agent '{agent_id}' after {total_budget:.1f}s (advisory backend). "
+                    f"Another process may be updating this agent."
+                )
+
+            try:
+                yield
+            finally:
+                # Shield the unlock from anyio cancellation: if the handler is
+                # cancelled (e.g. client disconnect) at exactly this await, an
+                # unshielded unlock could be interrupted before the SQL is sent,
+                # returning a still-locked connection to the pool for the next
+                # borrower to inherit. shield() lets the release complete. A truly
+                # dropped connection releases its session locks automatically.
+                try:
+                    await asyncio.shield(conn.fetchval(release_sql, agent_id))
+                except Exception:
+                    # Never let an unlock failure mask the real in-context error.
+                    pass
+
+    @asynccontextmanager
+    async def _acquire_agent_lock_async_fcntl(self, agent_id: str, timeout: float = 5.0, max_retries: int = 3):
+        """
+        Legacy file-based async lock - uses asyncio.sleep() instead of time.sleep()
         to avoid blocking the event loop.
-        
+
         Use this in async handlers (like MCP handlers) to prevent blocking.
-        
+
         Args:
             agent_id: Agent identifier
             timeout: Timeout per retry attempt in seconds

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,12 @@ os.environ.setdefault(
     str(Path(__file__).resolve().parent.parent / "config" / "resident_progress.example.json"),
 )
 
+# Agent-state lock backend. Production defaults to the PostgreSQL advisory lock
+# (src/state_locking.py), but most tests exercise the lock with a mocked/absent
+# DB and assert file-lock semantics — so the suite defaults to the fcntl backend.
+# Tests covering the advisory path opt in explicitly via monkeypatch.setenv.
+os.environ.setdefault("UNITARES_AGENT_LOCK_BACKEND", "fcntl")
+
 # Filter ResourceWarnings globally before any imports
 warnings.filterwarnings("ignore", category=ResourceWarning)
 

--- a/tests/test_state_locking.py
+++ b/tests/test_state_locking.py
@@ -133,9 +133,10 @@ class TestLockDirSelfHeal:
             assert (lock_dir / "healed_agent.lock").exists()
 
     @pytest.mark.asyncio
-    async def test_async_acquire_recreates_removed_lock_dir(self, tmp_path):
-        """Async acquire must also self-heal a removed lock dir."""
+    async def test_async_acquire_recreates_removed_lock_dir(self, tmp_path, monkeypatch):
+        """Async acquire must also self-heal a removed lock dir (fcntl backend)."""
         import shutil
+        monkeypatch.setenv("UNITARES_AGENT_LOCK_BACKEND", "fcntl")
         lock_dir = tmp_path / "locks"
         mgr = StateLockManager(lock_dir=lock_dir)
         shutil.rmtree(lock_dir)
@@ -448,6 +449,15 @@ class TestAcquireAgentLock:
 # ============================================================================
 
 class TestAcquireAgentLockAsync:
+    """File-lock (fcntl) backend behavior of the async lock.
+
+    These assert on-disk ``.lock`` semantics, so they pin the fcntl backend;
+    the advisory backend (now the default) is covered separately below.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _pin_fcntl_backend(self, monkeypatch):
+        monkeypatch.setenv("UNITARES_AGENT_LOCK_BACKEND", "fcntl")
 
     @pytest.mark.asyncio
     async def test_async_acquire_and_release(self, tmp_path):
@@ -558,3 +568,114 @@ class TestAcquireAgentLockAsync:
             await other_task()
 
         assert other_task_ran
+
+
+# ============================================================================
+# acquire_agent_lock_async — advisory (PostgreSQL) backend (default)
+# ============================================================================
+
+class _FakeConn:
+    """Records pg_try_advisory_lock / pg_advisory_unlock calls; scriptable acquire result."""
+
+    def __init__(self, acquire_results):
+        # acquire_results: list of truthy/falsy values returned by successive
+        # pg_try_advisory_lock calls (last value repeats once exhausted).
+        self._acquire_results = list(acquire_results)
+        self.calls = []
+
+    async def fetchval(self, sql, *args):
+        self.calls.append((sql, args))
+        if "pg_try_advisory_lock" in sql:
+            if len(self._acquire_results) > 1:
+                return self._acquire_results.pop(0)
+            return self._acquire_results[0] if self._acquire_results else True
+        if "pg_advisory_unlock" in sql:
+            return True
+        return None
+
+
+class _FakeDB:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def acquire(self):
+        conn = self._conn
+
+        class _Ctx:
+            async def __aenter__(self_inner):
+                return conn
+
+            async def __aexit__(self_inner, *exc):
+                return False
+
+        return _Ctx()
+
+
+class TestAcquireAgentLockAsyncAdvisory:
+    """Advisory (PostgreSQL) backend — the default. get_db() is mocked so these
+    run without a live database."""
+
+    @pytest.mark.asyncio
+    async def test_advisory_is_default_backend(self, tmp_path, monkeypatch):
+        """With no env override, the advisory path runs (no .lock file written)."""
+        monkeypatch.delenv("UNITARES_AGENT_LOCK_BACKEND", raising=False)
+        conn = _FakeConn([True])
+        monkeypatch.setattr("src.db.get_db", lambda: _FakeDB(conn))
+
+        mgr = StateLockManager(lock_dir=tmp_path)
+        async with mgr.acquire_agent_lock_async("adv_agent", timeout=2.0, max_retries=1):
+            # No file lock is created on the advisory path.
+            assert not (tmp_path / "adv_agent.lock").exists()
+
+        sqls = " ".join(c[0] for c in conn.calls)
+        assert "pg_try_advisory_lock" in sqls
+        assert "pg_advisory_unlock" in sqls
+
+    @pytest.mark.asyncio
+    async def test_advisory_acquire_and_unlock_same_key(self, tmp_path, monkeypatch):
+        """Lock and unlock are issued for the same agent id (hashtext key)."""
+        monkeypatch.setenv("UNITARES_AGENT_LOCK_BACKEND", "advisory")
+        conn = _FakeConn([True])
+        monkeypatch.setattr("src.db.get_db", lambda: _FakeDB(conn))
+
+        mgr = StateLockManager(lock_dir=tmp_path)
+        async with mgr.acquire_agent_lock_async("same_key", timeout=2.0, max_retries=1):
+            pass
+
+        lock_calls = [c for c in conn.calls if "pg_try_advisory_lock" in c[0]]
+        unlock_calls = [c for c in conn.calls if "pg_advisory_unlock" in c[0]]
+        assert lock_calls and unlock_calls
+        assert lock_calls[0][1] == ("same_key",)
+        assert unlock_calls[0][1] == ("same_key",)
+
+    @pytest.mark.asyncio
+    async def test_advisory_unlock_runs_on_exception(self, tmp_path, monkeypatch):
+        """The advisory lock is released even when the body raises."""
+        monkeypatch.setenv("UNITARES_AGENT_LOCK_BACKEND", "advisory")
+        conn = _FakeConn([True])
+        monkeypatch.setattr("src.db.get_db", lambda: _FakeDB(conn))
+
+        mgr = StateLockManager(lock_dir=tmp_path)
+        with pytest.raises(ValueError):
+            async with mgr.acquire_agent_lock_async("adv_exc", timeout=2.0, max_retries=1):
+                raise ValueError("boom")
+
+        assert any("pg_advisory_unlock" in c[0] for c in conn.calls)
+
+    @pytest.mark.asyncio
+    async def test_advisory_timeout_raises_timeouterror(self, tmp_path, monkeypatch):
+        """When pg_try_advisory_lock never succeeds, TimeoutError is raised and
+        no unlock is issued (we never held the lock)."""
+        monkeypatch.setenv("UNITARES_AGENT_LOCK_BACKEND", "advisory")
+        conn = _FakeConn([False])  # never acquires
+        monkeypatch.setattr("src.db.get_db", lambda: _FakeDB(conn))
+
+        mgr = StateLockManager(lock_dir=tmp_path)
+        with pytest.raises(TimeoutError):
+            async with mgr.acquire_agent_lock_async("adv_to", timeout=0.1, max_retries=1):
+                pass
+
+        # The poll loop must actually have run (more than one try) before giving up...
+        assert len([c for c in conn.calls if "pg_try_advisory_lock" in c[0]]) > 1
+        # ...and no unlock is issued, because the lock was never held.
+        assert not any("pg_advisory_unlock" in c[0] for c in conn.calls)


### PR DESCRIPTION
## What & why

Swaps the async agent-state lock (`acquire_agent_lock_async`) from an **fcntl file-lock spin-wait** to a **PostgreSQL advisory lock**, behind `UNITARES_AGENT_LOCK_BACKEND` (default `advisory`; `fcntl` keeps the legacy path for instant rollback — no redeploy).

This is the **RFC (A.2) disconfirmer** from the 2026-06-24 Wave-3 gate framing. The fcntl path polls `LOCK_EX|LOCK_NB` with `sleep(0.1)` up to `timeout=5.0 × max_retries=3 = ~15s`. That ceiling matches the live `process_agent_update` tail exactly (p99 ~4.7s, **max 15118ms**) while ODE math is ~1.3% of the handler p99 — i.e. the tail is **the lock, not the substrate**.

**If live p99 collapses < 2.0s under the advisory backend, the full Wave-3 BEAM handler-dispatch port becomes moot.** One-file-ish, reversible, no BEAM.

## ⚠️ HOLD — do not merge/deploy yet

Build + council only. **Deploy is the operator's call** (lands on the hot single-writer lock surface right after the 2026-06-22 strict-identity flip). The 7-day p99 measurement clock starts on deploy; read `audit.tool_usage.latency_ms` for `process_agent_update` ~7 days post-deploy.

- p99 < 2.0s → tail was the file lock; **don't port**, freeze the BEAM-forward tree.
- p99 still high → architectural-ceiling case strengthens *with evidence*; next step is a scoped (γ)/(β) probe, not the full port.

## Council (architect + code-reviewer + live-verifier) — fixes folded in

- **Two-arg advisory form** `pg_try_advisory_lock(<ns>, hashtext(agent_id))` — disjoint lock space from the single-arg form used by `scripts/dev/lease_plane_deprecate.py` (verifier *refuted* "nothing else uses advisory locks"). Eliminates cross-user key collision.
- **Shielded unlock** — prevents an anyio-cancelled handler from returning a still-locked connection to the pool for the next borrower to inherit.
- **Backend-aware timeout handler** — skips the file-oriented stale-lock cleanup + its misleading operator message under the advisory backend.
- **`lock_acquire` perf tick** — so a null A.2 result is interpretable (lock-wait vs work-under-lock no longer conflated).

**Cross-checked:** architect's pool-exhaustion concern was ground-truthed by the live-verifier as not-a-practical-risk at current load (pool 5/25, same-agent overlap median 20ms). Documented production follow-up if A.2 confirms: a dedicated out-of-pool connection for the held lock.

**Blast radius:** verifier confirmed the only hot caller is `update_workflow_service.py:67`; identity-middleware / proof_origin surface untouched.

## Tests

Advisory-path coverage added (`TestAcquireAgentLockAsyncAdvisory`); fcntl tests pinned to the fcntl backend; suite defaults to fcntl via `conftest` so DB-less tests keep file-lock semantics. **Full suite green (10624 passed, 81.69% cov).** Two-arg acquire/release also verified against the live DB.

https://claude.ai/code/session_01CtHEHQFGCy33pCwVRh2hwP