### PR TITLE
docs(readme): anchor the lone EISV mention with its standard term

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ One layer of the **[CIRWEL stack](https://cirwel.github.io)** — runtime safety
 
 - **Drift surfaces while the output still looks fine.** Each agent is graded against its *own* baseline, so slow degradation shows up as integrity slipping and entropy rising before the work visibly breaks.
 - **Confidence is checked against results.** Self-reported `confidence` is scored against real evidence — tests, exit codes, tool output. An agent can inflate the number; it can't inflate its success rate.
-- **Agents get a state signal they can act on.** Each check-in returns one plain verdict — `proceed`, `guide`, `pause`, or `reject` — plus EISV state for finer policies. Humans can watch the same fleet through the optional dashboard.
+- **Agents get a state signal they can act on.** Each check-in returns one plain verdict — `proceed`, `guide`, `pause`, or `reject` — plus the agent's full health signals (the `EISV` state vector) for finer policies. Humans can watch the same fleet through the optional dashboard.
 
 ## Use UNITARES if
 


### PR DESCRIPTION
Applies the new `standard` register (#1016) to the README — the one spot where `EISV` appeared cold, unexpanded.

The README is already disciplined: it leads with "Runtime governance & self-telemetry," uses "drift"/"health signals" throughout, and names `EISV` exactly once. This adds the standard-term anchor on that single mention — lead with "health signals," keep `EISV` as the internal name. One line; no rewrite needed.

Worked example of the `standard` column alongside the pitch-deck application.