### PR TITLE
fix(dialectic-reviewer): pass required name to onboard (slice 1 of orchestrator de-inert)

### DIFF
--- a/agents/dialectic_reviewer/reviewer.py
+++ b/agents/dialectic_reviewer/reviewer.py
@@ -36,6 +36,7 @@ _JSON_OBJECT = re.compile(r"\{.*\}", re.DOTALL)
 DEFAULT_MODEL = os.getenv("UNITARES_LLM_MODEL", "gemma4:latest")
 OLLAMA_BASE_URL = os.getenv("UNITARES_OLLAMA_BASE_URL", "http://localhost:11434/v1")
 SPAWN_REASON = "dialectic_reviewer"
+REVIEWER_NAME = "DialecticReviewer"
 
 
 @dataclass
@@ -191,6 +192,7 @@ async def run(thesis: Thesis, governance_url: str, parent_agent_id: Optional[str
     await client.connect()
     try:
         await client.onboard(
+            name=REVIEWER_NAME,  # required first arg of GovernanceClient.onboard
             force_new=True,
             parent_agent_id=parent_agent_id,
             spawn_reason=SPAWN_REASON,

--- a/agents/dialectic_reviewer/tests/test_verdict.py
+++ b/agents/dialectic_reviewer/tests/test_verdict.py
@@ -167,6 +167,9 @@ async def test_run_submits_disagreement_through_protocol(monkeypatch):
     assert verdict.agrees is False
     # onboarded with lineage + the dedicated spawn_reason
     onboard_kw = next(c[1] for c in calls if c[0] == "onboard")
+    # `name` is the REQUIRED first arg of GovernanceClient.onboard — without it the
+    # runner TypeErrors on every spawn (the blocker that made the runner inert).
+    assert onboard_kw["name"] == r.REVIEWER_NAME
     assert onboard_kw["force_new"] is True
     assert onboard_kw["spawn_reason"] == r.SPAWN_REASON
     assert onboard_kw["parent_agent_id"] == "parent-uuid"


### PR DESCRIPTION
Slice 1 of de-inerting the agent-orchestrator behind its first consumer (the orchestrated dialectic reviewer, #1013).

**Blocker:** the runner called `GovernanceClient.onboard(...)` without the required first positional `name` (`agents/sdk/.../client.py:358`) → `TypeError` on every spawn. This is the "fix before slice 2" item from the dialectic notes. The unit test missed it because the mock used `onboard(self, **kw)`, more permissive than the real signature.

**Fix:** pass `name=REVIEWER_NAME`; add an assertion that onboard receives `name`. Isolated agent code (no server importers); 12 runner tests green.

Remaining slices to actually de-inert: (2) launch the orchestrator as a service (`elixir/agent_orchestrator/scripts/start.sh`, boots :8789) under launchd; (3) wire the dialectic flow to spawn the reviewer *through* the orchestrator (lease-bound, verdict-captured, clean-exit) instead of the in-process path.

https://claude.ai/code/session_01CtHEHQFGCy33pCwVRh2hwP