### PR TITLE
feat(orchestrator): de-inert via orchestrated dialectic reviewer (slices 2+3a+3b)

### DIFF
--- a/agents/dialectic_reviewer/__main__.py
+++ b/agents/dialectic_reviewer/__main__.py
@@ -1,0 +1,11 @@
+"""Spawnable entry point so the agent-orchestrator can run the reviewer as
+`python3 -m agents.dialectic_reviewer` (cmd/args/env spec, POST /v1/agents).
+
+All input arrives via env (the orchestrator spawn payload), parsed by
+``Thesis.from_env`` + the ``UNITARES_GOVERNANCE_URL`` / ``UNITARES_PARENT_AGENT_ID``
+vars ``reviewer.main`` already reads. Keep this a thin shim — the testable logic
+lives in ``reviewer``.
+"""
+from .reviewer import main
+
+raise SystemExit(main())

--- a/scripts/ops/com.unitares.agent-orchestrator.plist.template
+++ b/scripts/ops/com.unitares.agent-orchestrator.plist.template
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  launchd manifest for the Agent Orchestrator (Elixir/OTP, port 8789).
+
+  Supervises ephemeral agents (Claude SDK / `claude -p` / tool workers) as
+  OTP-managed Ports. KeepAlive relaunches the BEAM node if it dies; OTP restarts
+  crashed agents inside the VM. The only consumer is the local governance MCP,
+  and POST /v1/agents spawns OS processes, so the surface is 127.0.0.1-bound +
+  bearer-auth fail-closed (HTTPAuth → 503 if AGENT_ORCHESTRATOR_BEARER_TOKEN is
+  unset). No cloud host needed — see elixir/agent_orchestrator/scripts/start.sh.
+
+  Do NOT load this until a real consumer dispatches through it (the orchestrated
+  dialectic-reviewer wiring) — an idle supervisor with no caller is its own
+  inventory (2026-06-24 Wave-3 gate framing-note caveat).
+
+  Install (render __VARS__ then load):
+    sed -e "s|__UNITARES_ROOT__|$HOME/projects/unitares|g" \
+        -e "s|__HOME__|$HOME|g" \
+        scripts/ops/com.unitares.agent-orchestrator.plist.template \
+        > ~/Library/LaunchAgents/com.unitares.agent-orchestrator.plist
+    launchctl load ~/Library/LaunchAgents/com.unitares.agent-orchestrator.plist
+
+  Verify (with $AGENT_ORCHESTRATOR_BEARER_TOKEN sourced from ~/.config/cirwel/secrets.env):
+    launchctl list | grep com.unitares.agent-orchestrator
+    tail -f ~/Library/Logs/unitares-agent-orchestrator.log
+    curl -s -H "Authorization: Bearer $AGENT_ORCHESTRATOR_BEARER_TOKEN" \
+         "http://127.0.0.1:8789/v1/agents"
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.unitares.agent-orchestrator</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>__UNITARES_ROOT__/elixir/agent_orchestrator/scripts/start.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__UNITARES_ROOT__/elixir/agent_orchestrator</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/Library/Logs/unitares-agent-orchestrator.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__HOME__/Library/Logs/unitares-agent-orchestrator.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>LANG</key>
+        <string>en_US.UTF-8</string>
+    </dict>
+</dict>
+</plist>

--- a/src/mcp_handlers/dialectic/handlers.py
+++ b/src/mcp_handlers/dialectic/handlers.py
@@ -1372,6 +1372,44 @@ async def handle_submit_thesis(arguments: Dict[str, Any]) -> Sequence[TextConten
             except Exception as e:
                 logger.warning(f"Could not save session after thesis: {e}")
 
+            # Escalation tier (design b): when orchestrated review is enabled and
+            # no live reviewer has claimed the slot, spawn an INDEPENDENT reviewer
+            # process through the agent-orchestrator. That process onboards with its
+            # own identity, claims the still-open slot via the multi-agent path, and
+            # submits its verdict — so on success we must NOT also run the in-process
+            # reviewer. ANY dispatch failure falls through to the in-process path
+            # below (the orchestrator being down never breaks dialectic).
+            if session.reviewer_agent_id is None:
+                from .orchestrator_dispatch import (
+                    orchestrated_review_enabled,
+                    dispatch_orchestrated_review,
+                )
+                if orchestrated_review_enabled():
+                    dispatched = await dispatch_orchestrated_review(
+                        session_id,
+                        {
+                            "root_cause": arguments.get('root_cause'),
+                            "proposed_conditions": proposed_conditions,
+                            "reasoning": arguments.get('reasoning') or "",
+                            # why the agent paused — the reviewer's situation context
+                            "situation": getattr(session, "reason", "") or "",
+                        },
+                        session.paused_agent_id,
+                    )
+                    if dispatched:
+                        result["orchestrated_review"] = True
+                        result["reviewer_dispatch"] = {
+                            "agent_id": dispatched.get("agent_id") or dispatched.get("id"),
+                            "via": "agent-orchestrator",
+                        }
+                        result["note"] = (
+                            "Independent reviewer spawned via the agent-orchestrator; "
+                            "it will claim the reviewer slot and submit its verdict. "
+                            "Poll dialectic action='get' for the antithesis/synthesis."
+                        )
+                        return success_response(result)
+                    # dispatch failed → fall through to in-process synthetic reviewer
+
             # End-to-end completion: when no independent live reviewer has claimed
             # the slot, drive the dialectic to a resolved synthesis with the local
             # synthetic reviewer instead of stranding it at awaiting_facilitation.

--- a/src/mcp_handlers/dialectic/orchestrator_dispatch.py
+++ b/src/mcp_handlers/dialectic/orchestrator_dispatch.py
@@ -1,0 +1,137 @@
+"""Dispatch an independent dialectic reviewer through the agent-orchestrator.
+
+This is the orchestrator's first live consumer (Decision A of the 2026-06-24
+Wave-3 gate). Design (b), escalation tier: the in-process synthetic reviewer
+stays the default and the fallback — orchestrated dispatch is opt-in via
+``UNITARES_DIALECTIC_ORCHESTRATED_REVIEW`` and ANY failure here returns None so
+``handle_submit_thesis`` degrades to the in-process path. The orchestrator being
+down therefore never breaks dialectic; it is an enhancement (a governed,
+own-identity, lease-capable reviewer process), not a dependency.
+
+The spawned reviewer (``python3 -m agents.dialectic_reviewer``) onboards with its
+OWN identity, claims the still-open reviewer slot via the multi-agent path
+(submit_antithesis), submits its verdict, and exits — so on successful dispatch
+the handler must NOT also run the in-process review.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from src.logging_utils import get_logger
+
+logger = get_logger(__name__)
+
+# Repo root: src/mcp_handlers/dialectic/orchestrator_dispatch.py -> repo
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def orchestrated_review_enabled() -> bool:
+    """Opt-in gate for routing reviews through the orchestrator (default OFF).
+
+    OFF preserves today's behaviour exactly (in-process synthetic reviewer). ON
+    makes the orchestrator the first-choice reviewer with in-process as fallback.
+    """
+    return os.environ.get(
+        "UNITARES_DIALECTIC_ORCHESTRATED_REVIEW", "0"
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _orchestrator_url() -> str:
+    return os.environ.get("AGENT_ORCHESTRATOR_URL", "http://127.0.0.1:8789").rstrip("/")
+
+
+def _governance_url() -> str:
+    return (
+        os.environ.get("UNITARES_GOVERNANCE_URL")
+        or os.environ.get("GOVERNANCE_URL")
+        or "http://127.0.0.1:8767"
+    )
+
+
+def _build_spec(session_id: str, thesis: Dict[str, Any], parent_agent_id: Optional[str]) -> Dict[str, Any]:
+    """Translate the thesis into an orchestrator POST /v1/agents spec.
+
+    The reviewer reads everything from env (see Thesis.from_env + reviewer.main).
+    PYTHONPATH must include the repo root and the SDK src so the spawned process
+    can import ``agents.dialectic_reviewer`` and ``unitares_sdk``.
+    """
+    conditions = thesis.get("proposed_conditions") or []
+    if not isinstance(conditions, list):
+        conditions = [str(conditions)]
+
+    pythonpath = os.pathsep.join(
+        [str(_REPO_ROOT), str(_REPO_ROOT / "agents" / "sdk" / "src")]
+    )
+    existing_pp = os.environ.get("PYTHONPATH")
+    if existing_pp:
+        pythonpath = pythonpath + os.pathsep + existing_pp
+
+    env: Dict[str, str] = {
+        "DIALECTIC_SESSION_ID": session_id,
+        "DIALECTIC_THESIS_ROOT_CAUSE": thesis.get("root_cause") or "",
+        "DIALECTIC_THESIS_CONDITIONS": json.dumps(conditions),
+        "DIALECTIC_THESIS_REASONING": thesis.get("reasoning") or "",
+        "DIALECTIC_THESIS_SITUATION": thesis.get("situation") or "",
+        "UNITARES_GOVERNANCE_URL": _governance_url(),
+        "PYTHONPATH": pythonpath,
+    }
+    if parent_agent_id:
+        env["UNITARES_PARENT_AGENT_ID"] = parent_agent_id
+
+    return {
+        "cmd": sys.executable,  # the MCP process's own interpreter has the deps
+        "args": ["-m", "agents.dialectic_reviewer"],
+        "cd": str(_REPO_ROOT),
+        "env": env,
+    }
+
+
+async def dispatch_orchestrated_review(
+    session_id: str,
+    thesis: Dict[str, Any],
+    parent_agent_id: Optional[str],
+    *,
+    timeout: float = 10.0,
+) -> Optional[Dict[str, Any]]:
+    """POST a reviewer-spawn spec to the orchestrator. Returns its JSON (the spawned
+    agent id/status) on success, or None on ANY failure (caller falls back to the
+    in-process synthetic reviewer)."""
+    bearer = os.environ.get("AGENT_ORCHESTRATOR_BEARER_TOKEN")
+    if not bearer:
+        logger.warning(
+            "[DIALECTIC] orchestrated review enabled but AGENT_ORCHESTRATOR_BEARER_TOKEN "
+            "unset; falling back to in-process synthetic reviewer"
+        )
+        return None
+
+    spec = _build_spec(session_id, thesis, parent_agent_id)
+    url = f"{_orchestrator_url()}/v1/agents"
+    try:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(
+                url, json=spec, headers={"Authorization": f"Bearer {bearer}"}
+            )
+        if resp.status_code not in (200, 201, 202):
+            logger.warning(
+                "[DIALECTIC] orchestrator spawn returned %s: %s; falling back",
+                resp.status_code, resp.text[:300],
+            )
+            return None
+        data = resp.json()
+        # The orchestrator returns {"ok": true, "agent_id": ...} (not "id").
+        logger.info(
+            "[DIALECTIC] orchestrated reviewer spawned for session %s: %s",
+            session_id[:16], data.get("agent_id") or data.get("id") or data,
+        )
+        return data
+    except Exception as exc:  # noqa: BLE001 — any failure degrades to in-process
+        logger.warning(
+            "[DIALECTIC] orchestrated dispatch failed (%r); falling back to in-process", exc
+        )
+        return None

--- a/tests/test_dialectic_orchestrated_dispatch.py
+++ b/tests/test_dialectic_orchestrated_dispatch.py
@@ -1,0 +1,130 @@
+"""Orchestrated-reviewer dispatch (the agent-orchestrator's first consumer).
+
+Design (b): in-process synthetic reviewer is the default + fallback; orchestrated
+dispatch is opt-in and degrades to None (→ in-process) on any failure.
+"""
+import json
+import sys
+import pytest
+from unittest.mock import patch
+
+from src.mcp_handlers.dialectic import orchestrator_dispatch as od
+
+
+# --------------------------- the opt-in gate --------------------------- #
+
+@pytest.mark.parametrize("val,expected", [
+    ("1", True), ("true", True), ("on", True), ("YES", True),
+    ("0", False), ("", False), ("off", False), ("no", False),
+])
+def test_gate(val, expected, monkeypatch):
+    monkeypatch.setenv("UNITARES_DIALECTIC_ORCHESTRATED_REVIEW", val)
+    assert od.orchestrated_review_enabled() is expected
+
+
+def test_gate_default_off(monkeypatch):
+    monkeypatch.delenv("UNITARES_DIALECTIC_ORCHESTRATED_REVIEW", raising=False)
+    assert od.orchestrated_review_enabled() is False
+
+
+# --------------------------- spec translation --------------------------- #
+
+def test_build_spec_marshals_thesis_and_paths():
+    spec = od._build_spec(
+        "sess-1",
+        {"root_cause": "rc", "proposed_conditions": ["a", "b"], "reasoning": "why"},
+        "parent-uuid",
+    )
+    assert spec["cmd"] == sys.executable
+    assert spec["args"] == ["-m", "agents.dialectic_reviewer"]
+    env = spec["env"]
+    assert env["DIALECTIC_SESSION_ID"] == "sess-1"
+    assert env["DIALECTIC_THESIS_ROOT_CAUSE"] == "rc"
+    assert json.loads(env["DIALECTIC_THESIS_CONDITIONS"]) == ["a", "b"]
+    assert env["DIALECTIC_THESIS_REASONING"] == "why"
+    assert env["UNITARES_PARENT_AGENT_ID"] == "parent-uuid"
+    # PYTHONPATH must let the spawned process import both packages.
+    assert "agents/sdk/src" in env["PYTHONPATH"]
+    assert str(od._REPO_ROOT) in env["PYTHONPATH"]
+
+
+def test_build_spec_omits_parent_when_absent():
+    spec = od._build_spec("s", {"root_cause": "", "proposed_conditions": [], "reasoning": ""}, None)
+    assert "UNITARES_PARENT_AGENT_ID" not in spec["env"]
+    assert json.loads(spec["env"]["DIALECTIC_THESIS_CONDITIONS"]) == []
+
+
+# --------------------------- dispatch (mocked HTTP) --------------------------- #
+
+class _FakeResp:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self, resp, *, raise_exc=None):
+        self._resp = resp
+        self._raise = raise_exc
+        self.posted = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def post(self, url, json=None, headers=None):
+        if self._raise:
+            raise self._raise
+        self.posted = {"url": url, "json": json, "headers": headers}
+        return self._resp
+
+
+def _patch_httpx(monkeypatch, client):
+    import httpx
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **k: client)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_returns_none_without_bearer(monkeypatch):
+    monkeypatch.delenv("AGENT_ORCHESTRATOR_BEARER_TOKEN", raising=False)
+    out = await od.dispatch_orchestrated_review("s", {"root_cause": "x"}, None)
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_dispatch_success_returns_payload(monkeypatch):
+    monkeypatch.setenv("AGENT_ORCHESTRATOR_BEARER_TOKEN", "tok")
+    # The orchestrator's real success shape is {"ok": true, "agent_id": ...}.
+    client = _FakeClient(_FakeResp(201, {"ok": True, "agent_id": "agent-xyz", "protocol_version": "v0.1"}))
+    _patch_httpx(monkeypatch, client)
+
+    out = await od.dispatch_orchestrated_review(
+        "sess-9", {"root_cause": "rc", "proposed_conditions": ["c"], "reasoning": "r"}, "parent"
+    )
+    assert out["agent_id"] == "agent-xyz"
+    # bearer + spec actually went on the wire
+    assert client.posted["headers"]["Authorization"] == "Bearer tok"
+    assert client.posted["json"]["env"]["DIALECTIC_SESSION_ID"] == "sess-9"
+    assert client.posted["url"].endswith("/v1/agents")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_non_2xx_returns_none(monkeypatch):
+    monkeypatch.setenv("AGENT_ORCHESTRATOR_BEARER_TOKEN", "tok")
+    _patch_httpx(monkeypatch, _FakeClient(_FakeResp(503, {"error": "service_unavailable"})))
+    out = await od.dispatch_orchestrated_review("s", {"root_cause": "x"}, None)
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_dispatch_exception_returns_none(monkeypatch):
+    monkeypatch.setenv("AGENT_ORCHESTRATOR_BEARER_TOKEN", "tok")
+    _patch_httpx(monkeypatch, _FakeClient(None, raise_exc=RuntimeError("conn refused")))
+    out = await od.dispatch_orchestrated_review("s", {"root_cause": "x"}, None)
+    assert out is None

--- a/tests/test_dialectic_synthetic_review.py
+++ b/tests/test_dialectic_synthetic_review.py
@@ -98,6 +98,9 @@ async def test_thesis_with_open_slot_resolves_via_synthetic_reviewer(server_patc
             stack.enter_context(p)
         stack.enter_context(patch(f"{LLM}.generate_antithesis", new=AsyncMock(return_value=_antithesis("refine"))))
         stack.enter_context(patch(f"{LLM}.generate_synthesis", new=AsyncMock(return_value=_synthesis("RESUME"))))
+        # Gate OFF (default): the orchestrator must NOT be touched — pin no regression.
+        no_dispatch = AsyncMock()
+        stack.enter_context(patch("src.mcp_handlers.dialectic.orchestrator_dispatch.dispatch_orchestrated_review", new=no_dispatch))
         result = await handle_submit_thesis({
             "session_id": session.session_id,
             "agent_id": "agent-paused",
@@ -109,6 +112,8 @@ async def test_thesis_with_open_slot_resolves_via_synthetic_reviewer(server_patc
     data = parse_result(result)
     assert data["success"] is True
     assert data["synthetic_review"] is True
+    assert "orchestrated_review" not in data
+    no_dispatch.assert_not_called()
     assert data["reviewer_agent_id"] == "llm-synthetic-reviewer"
     assert data["recommendation"] == "RESUME"
     assert data["resolved"] is True
@@ -149,6 +154,72 @@ async def test_disputed_thesis_does_not_auto_resolve_even_on_resume(server_patch
     # Recommendation may still read RESUME, but it must NOT bind to a resolution.
     assert data["resolved"] is False
     assert session.phase != DialecticPhase.RESOLVED
+
+
+OD = "src.mcp_handlers.dialectic.orchestrator_dispatch"
+
+
+@pytest.mark.asyncio
+async def test_orchestrated_dispatch_skips_in_process(server_patch):
+    """Escalation tier (design b): when orchestrated review is enabled and the
+    dispatch succeeds, the handler returns the dispatch result WITHOUT running the
+    in-process synthetic reviewer (generate_antithesis must not be called)."""
+    from src.mcp_handlers.dialectic.handlers import handle_submit_thesis, ACTIVE_SESSIONS
+
+    session = _make_session(reviewer_id=None)
+    ACTIVE_SESSIONS[session.session_id] = session
+    gen_anti = AsyncMock(return_value=_antithesis())
+
+    import contextlib
+    with contextlib.ExitStack() as stack:
+        for p in _common_patches():
+            stack.enter_context(p)
+        stack.enter_context(patch(f"{LLM}.generate_antithesis", new=gen_anti))
+        stack.enter_context(patch(f"{OD}.orchestrated_review_enabled", return_value=True))
+        stack.enter_context(patch(f"{OD}.dispatch_orchestrated_review",
+                                  new=AsyncMock(return_value={"ok": True, "agent_id": "agent-rev-1"})))
+        result = await handle_submit_thesis({
+            "session_id": session.session_id,
+            "agent_id": "agent-paused",
+            "root_cause": "rc", "proposed_conditions": ["c"], "reasoning": "r",
+        })
+
+    data = parse_result(result)
+    assert data["orchestrated_review"] is True
+    assert data["reviewer_dispatch"]["agent_id"] == "agent-rev-1"
+    # The in-process reviewer must NOT have run — the orchestrator owns this review.
+    gen_anti.assert_not_called()
+    assert "resolved" not in data  # slot left open for the spawned reviewer
+
+
+@pytest.mark.asyncio
+async def test_orchestrated_dispatch_failure_falls_back_to_in_process(server_patch):
+    """If dispatch returns None (orchestrator down / no bearer), the handler
+    degrades to the in-process synthetic reviewer — dialectic still completes."""
+    from src.mcp_handlers.dialectic.handlers import handle_submit_thesis, ACTIVE_SESSIONS
+
+    session = _make_session(reviewer_id=None)
+    ACTIVE_SESSIONS[session.session_id] = session
+
+    import contextlib
+    with contextlib.ExitStack() as stack:
+        for p in _common_patches():
+            stack.enter_context(p)
+        stack.enter_context(patch(f"{LLM}.generate_antithesis", new=AsyncMock(return_value=_antithesis("refine"))))
+        stack.enter_context(patch(f"{LLM}.generate_synthesis", new=AsyncMock(return_value=_synthesis("RESUME"))))
+        stack.enter_context(patch(f"{OD}.orchestrated_review_enabled", return_value=True))
+        stack.enter_context(patch(f"{OD}.dispatch_orchestrated_review", new=AsyncMock(return_value=None)))
+        result = await handle_submit_thesis({
+            "session_id": session.session_id,
+            "agent_id": "agent-paused",
+            "root_cause": "rc", "proposed_conditions": ["c"], "reasoning": "r",
+        })
+
+    data = parse_result(result)
+    assert "orchestrated_review" not in data
+    # Fell back to in-process: synthetic review ran and resolved (refine + RESUME).
+    assert data["synthetic_review"] is True
+    assert data["resolved"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Decision A of the Wave-3 gate: the agent-orchestrator gets its first live consumer** — an independent dialectic reviewer spawned through it. Builds on #1020 (reviewer onboard fix), #1019 (verdict binding).

## What's in this PR
- **`__main__.py`** (slice 3a) — reviewer spawnable as `python3 -m agents.dialectic_reviewer`.
- **`com.unitares.agent-orchestrator.plist.template`** (slice 2) — launchd manifest (KeepAlive; 127.0.0.1:8789; bearer fail-closed). No cloud host.
- **`orchestrator_dispatch.py` + handler wiring** (slice 3b) — when `UNITARES_DIALECTIC_ORCHESTRATED_REVIEW=1` and no live reviewer, `handle_submit_thesis` POSTs a spawn spec to the orchestrator; the spawned reviewer onboards (own identity), claims the open slot, submits its verdict (bound by #1019), exits.

## Design (b): enhancement, not dependency
In-process synthetic reviewer stays the **default** (gate off) and the **fallback** — any dispatch failure degrades to it, so the orchestrator being down never breaks dialectic. On success the handler returns early (no double-review).

## Council (code-reviewer + live-verifier) folded in
- response field is `agent_id` not `id` (live-verified the orchestrator's actual shape); pass `situation`=session.reason; gate-off test pins dispatch-never-called.
- live-verified: `POST /v1/agents` field names match, `cmd_allowlist=nil` (sys.executable passes), first-responder slot-claim wired, gemma4 reachable, #1019 on master.
- Noted non-blocking follow-ups: reviewer model call is sync-in-async (but runs pre-MCP-connect in a single-purpose subprocess); dispatched-but-never-claimed slot reaps in 4h.

## Launch (separate, operator-gated)
Mint `AGENT_ORCHESTRATOR_BEARER_TOKEN` → secrets.env + gov-mcp env; set `UNITARES_DIALECTIC_ORCHESTRATED_REVIEW=1`; start the orchestrator; then live e2e: a real dialectic resolves via a reviewer spawned through the orchestrator.

Full suite green (10652).

https://claude.ai/code/session_01CtHEHQFGCy33pCwVRh2hwP