### PR TITLE
fix(identity-ux): stateless-safe credential copy + lite outcome acks

### DIFF
--- a/src/mcp_handlers/observability/outcome_events.py
+++ b/src/mcp_handlers/observability/outcome_events.py
@@ -81,14 +81,16 @@ def _coerce_bool_flag(value: Any) -> bool:
 
 
 # Lite eisv_snapshot keys returned by default on outcome acks (#604 dogfood
-# 2026-06-24). The actual state numbers and the active source are kept; the
-# heavy self-description (state_semantics role table, source-meta blocks, the
-# sensor-divergence history list) is dropped unless include_semantics=true.
+# 2026-06-24). The actual state numbers and the active source are kept (the
+# small primary/behavioral/ode views); the heavy self-description (state_semantics
+# role table, source-meta blocks, the sensor-divergence history list) is dropped
+# unless include_semantics=true.
 _LITE_SNAPSHOT_KEYS = (
     "primary_eisv",
     "primary_eisv_source",
-    "ode_diagnostics",
     "behavioral_eisv",
+    "ode_eisv",
+    "ode_diagnostics",
 )
 
 

--- a/src/mcp_handlers/observability/outcome_events.py
+++ b/src/mcp_handlers/observability/outcome_events.py
@@ -69,6 +69,45 @@ _HARD_EXOGENOUS_TYPE_TO_CHANNEL = {
 }
 
 
+def _coerce_bool_flag(value: Any) -> bool:
+    """Interpret a JSON-ish truthy flag (bool/int/str) conservatively."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "t", "yes", "y"}
+    return False
+
+
+# Lite eisv_snapshot keys returned by default on outcome acks (#604 dogfood
+# 2026-06-24). The actual state numbers and the active source are kept; the
+# heavy self-description (state_semantics role table, source-meta blocks, the
+# sensor-divergence history list) is dropped unless include_semantics=true.
+_LITE_SNAPSHOT_KEYS = (
+    "primary_eisv",
+    "primary_eisv_source",
+    "ode_diagnostics",
+    "behavioral_eisv",
+)
+
+
+def _lite_eisv_snapshot(snapshot: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Return a small confirmation-sized view of the EISV snapshot.
+
+    Drops `state_semantics` (7 role descriptions + hierarchy), the
+    `*_source_meta` glossary blocks, and `sensor_divergence_recent` (a list of
+    up to 20 records). Returns ``None`` unchanged so a missing snapshot still
+    reads as missing. Gated behind include_semantics / response_mode="full".
+    """
+    if not snapshot:
+        return snapshot
+    lite = {k: snapshot[k] for k in _LITE_SNAPSHOT_KEYS if k in snapshot}
+    lite["semantics_omitted"] = True
+    lite["hint"] = "Pass include_semantics=true for the full EISV ontology."
+    return lite
+
+
 def _classify_hard_exogenous_signal(outcome_type: str, detail: Dict[str, Any]) -> str | None:
     """Return the hard exogenous signal source when this outcome is e-process eligible."""
     channel = _HARD_EXOGENOUS_TYPE_TO_CHANNEL.get(outcome_type)
@@ -419,12 +458,25 @@ async def _record_outcome_event_inline(arguments: Dict[str, Any]) -> Dict[str, A
             except Exception as e_seq:
                 logger.debug(f"Sequential calibration tracking skipped: {e_seq}")
 
+    # P2 (#604 dogfood 2026-06-24): record_result/outcome_event returned the full
+    # EISV ontology (`eisv_snapshot.state_semantics`: 7 role descriptions +
+    # hierarchy, plus source-meta and the sensor-divergence history list) on
+    # every ack — a large context tax for what is usually a confirmation. Default
+    # to a lite snapshot mirroring the read tools; the full ontology is opt-in via
+    # include_semantics=true (alias: response_mode="full"). The persisted `detail`
+    # row is unaffected — only the response payload is trimmed.
+    include_semantics = _coerce_bool_flag(arguments.get("include_semantics"))
+    if not include_semantics:
+        response_mode = str(arguments.get("response_mode") or "").strip().lower()
+        include_semantics = response_mode == "full"
+    response_snapshot = snapshot if include_semantics else _lite_eisv_snapshot(snapshot)
+
     return {
         "outcome_id": outcome_id,
         "outcome_type": outcome_type,
         "is_bad": is_bad,
         "outcome_score": outcome_score,
-        "eisv_snapshot": snapshot,
+        "eisv_snapshot": response_snapshot,
         "prediction_binding": prediction_binding,
         "corroboration_grade": detail.get("corroboration_grade"),
         "evidence_weight": detail.get("evidence_weight"),

--- a/src/mcp_handlers/schemas/core.py
+++ b/src/mcp_handlers/schemas/core.py
@@ -379,6 +379,18 @@ class OutcomeEventParams(AgentIdentityMixin):
             "dialectic verdicts, state transitions). external_signal for CI webhooks etc."
         ),
     )
+    include_semantics: Union[bool, str, None] = Field(
+        default=False,
+        description=(
+            "If true, the response's eisv_snapshot carries the full EISV ontology "
+            "(state_semantics role table + hierarchy). Default false returns a lite "
+            "confirmation-sized snapshot. Alias: response_mode='full'."
+        ),
+    )
+    response_mode: Optional[Literal["lite", "full"]] = Field(
+        default=None,
+        description="'full' is an alias for include_semantics=true; 'lite' (default) returns the small snapshot.",
+    )
 
 
 class CirsProtocolParams(AgentIdentityMixin):

--- a/src/mcp_handlers/schemas/identity.py
+++ b/src/mcp_handlers/schemas/identity.py
@@ -13,7 +13,12 @@ class IdentityParams(AgentIdentityMixin):
     )
     name: Optional[str] = Field(
         default=None,
-        description="Optional display name to set"
+        description=(
+            "Optional COSMETIC display name. Sets `display_name` only — it does "
+            "NOT change your public structured handle (`agent_id`) or the registry "
+            "key (`uuid`). For cross-tool threading, key on `uuid` (the identity "
+            "key), not on this name."
+        )
     )
     model_type: Optional[str] = Field(
         default=None,
@@ -43,7 +48,13 @@ class OnboardParams(AgentIdentityMixin):
     """
     name: Optional[str] = Field(
         default=None,
-        description="Optional display name to set"
+        description=(
+            "Optional COSMETIC display name. Sets `display_name` only — it does "
+            "NOT set your public structured handle (`agent_id`); the cosmetic name "
+            "and the public handle deliberately diverge. The canonical identifier "
+            "for cross-tool reference is `uuid` (is_identity_key:true in the "
+            "response). Thread that, not the display name."
+        )
     )
     model_type: Optional[str] = Field(
         default=None,

--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -90,22 +90,36 @@ def _how_to_strengthen(
     Returns ``None`` for `strong` (no action needed). Mirrors
     `services.identity_payloads._how_to_strengthen` so the write-path
     assurance block agrees with the identity()/onboard read-path block.
+
+    Leads with `continuity_token` (#604 dogfood 2026-06-24): on stateless
+    transports an echoed `client_session_id` resolves to a fresh per-call
+    identity, so the continuity_token is the proof that works on both
+    stateless and session-maintaining transports. Kept word-identical with
+    `services.identity_payloads._how_to_strengthen`.
     """
     if tier == "strong":
         return None
     if proof_origin == "server_inferred":
         return (
-            "binding was server-inferred (not caller-proven); pass the "
-            "client_session_id from your onboard response explicitly in each "
-            "call to reach strong"
+            "binding was server-inferred (not caller-proven); echo the "
+            "continuity_token from your onboard response on each call to reach "
+            "strong (it resolves on stateless and session-maintaining "
+            "transports alike). A session-maintaining client may instead pass "
+            "an explicit client_session_id"
         )
     if tier == "medium":
-        return "pass an explicit client_session_id in each call to reach strong"
+        return (
+            "echo the continuity_token from your onboard response on each call "
+            "to reach strong; a session-maintaining client may instead pass an "
+            "explicit client_session_id"
+        )
     # weak
     return (
-        "pass the client_session_id from your onboard response in each call to "
-        "reach strong; cross-process resumes need continuity_token + agent_uuid "
-        "(PATH 0)"
+        "echo the continuity_token from your onboard response on each call to "
+        "reach strong — it works on stateless transports (e.g. claude.ai) "
+        "where an echoed client_session_id resolves to a fresh per-call "
+        "identity. A session-maintaining client may instead pass an explicit "
+        "client_session_id"
     )
 
 

--- a/src/services/identity_payloads.py
+++ b/src/services/identity_payloads.py
@@ -129,9 +129,12 @@ def build_identity_response_data(
             if continuity_token:
                 response_data["session_continuity"]["continuity_token"] = continuity_token
                 response_data["session_continuity"]["instruction"] = (
-                    "Use client_session_id for continuity within this process. "
-                    "continuity_token is only for proof-owned PATH 0 rebinds "
-                    "with agent_uuid."
+                    "To prove ownership on later calls, echo this continuity_token "
+                    "— it resolves your identity on stateless transports (e.g. "
+                    "claude.ai) where an echoed client_session_id alone resolves to "
+                    "a fresh per-call identity, and on session-maintaining clients "
+                    "alike. Session-maintaining clients (Claude Code, Claude "
+                    "Desktop) bind client_session_id automatically."
                 )
         response_data["session_continuity"]["resolution_source"] = continuity_source
         response_data["session_continuity"]["token_support"] = continuity_support
@@ -312,13 +315,50 @@ def build_onboard_response_data(
         model_type=None,
         proof_origin=proof_origin,
     )
+    # P1 (#604 dogfood 2026-06-24): a freshly minted identity resolves its own
+    # onboard call weakly (there was no prior proof to present), so the assurance
+    # block would otherwise greet a clean onboard with a `weak`/0.35 tier and a
+    # "how_to_strengthen" scold the agent cannot yet act on. Reframe it: this is
+    # the expected baseline at mint, not a deficiency, and the continuity_token
+    # handed back below is the concrete next action that reaches strong. We do
+    # not inflate the tier (the binding genuinely is unproven until the agent
+    # echoes the token) — we relabel it honestly and make the path actionable.
+    _fresh_mint = bool(is_new or force_new)
+    _assurance = identity_context.get("identity_assurance")
+    if _fresh_mint and isinstance(_assurance, dict) and _assurance.get("tier") != "strong":
+        _assurance["baseline"] = "fresh_identity"
+        if continuity_token:
+            _assurance["baseline_note"] = (
+                "Expected baseline for a just-minted identity — not a deficiency. "
+                "Echo the continuity_token from this response on your next call to "
+                "reach strong."
+            )
+            _assurance["how_to_strengthen"] = (
+                "echo the continuity_token from this onboard response on your next "
+                "call to reach strong (works on stateless and session-maintaining "
+                "transports alike)"
+            )
+        else:
+            _assurance["baseline_note"] = (
+                "Expected baseline for a just-minted identity — not a deficiency. "
+                "Your binding strengthens as you check in."
+            )
+    # Ownership-proof field for args_full templates. On stateless transports an
+    # echoed client_session_id resolves to a fresh per-call identity (#604
+    # dogfood 2026-06-24), so when a continuity_token was issued we hand it back
+    # as the proof that resolves on both stateless and session-maintaining
+    # transports. Falls back to client_session_id when no token is available.
+    if continuity_token:
+        ownership_proof = {"continuity_token": continuity_token}
+    else:
+        ownership_proof = {"client_session_id": stable_session_id}
     next_calls = [
         {
             "tool": "process_agent_update",
             "why": "Log your work. Call after completing tasks.",
             "args_min": {"response_text": "...", "complexity": 0.5},
             "args_full": {
-                "client_session_id": stable_session_id,
+                **ownership_proof,
                 "response_text": "Summary of what you did",
                 "complexity": 0.5,
                 "confidence": 0.8,
@@ -328,13 +368,13 @@ def build_onboard_response_data(
             "tool": "get_governance_metrics",
             "why": "Check your state (energy, coherence, etc.)",
             "args_min": {},
-            "args_full": {"client_session_id": stable_session_id},
+            "args_full": {**ownership_proof},
         },
         {
             "tool": "identity",
             "why": "Rename yourself or check identity later",
             "args_min": {},
-            "args_full": {"client_session_id": stable_session_id, "name": "YourName"},
+            "args_full": {**ownership_proof, "name": "YourName"},
         },
     ]
     client_tips = {
@@ -363,7 +403,17 @@ def build_onboard_response_data(
             )
         welcome_message = thread_context["honest_message"]
     elif is_new:
-        welcome = f"Welcome! Your session ID is `{stable_session_id}`. Pass this as `client_session_id` in all calls."
+        if continuity_token:
+            welcome = (
+                f"Welcome! Your identity is created (session `{stable_session_id}`). "
+                f"To prove ownership on later calls, echo the continuity_token from "
+                f"this response."
+            )
+        else:
+            welcome = (
+                f"Welcome! Your session ID is `{stable_session_id}`. "
+                f"Pass this as `client_session_id` in all calls."
+            )
         welcome_message = "Your identity is created. Use the templates below to get started."
     elif was_archived:
         welcome = f"Reactivated '{friendly_name}'. Session: `{stable_session_id}`."
@@ -475,9 +525,14 @@ def build_onboard_response_data(
         if "session_continuity" in result:
             result["session_continuity"]["continuity_token"] = continuity_token
             result["session_continuity"]["instruction"] = (
-                "Use client_session_id for continuity within this process. "
-                "continuity_token is only for proof-owned PATH 0 rebinds "
-                "with agent_uuid."
+                "To prove ownership on later calls, echo this continuity_token "
+                "— it resolves your identity on stateless transports (e.g. "
+                "claude.ai) where an echoed client_session_id alone resolves to "
+                "a fresh per-call identity, and on session-maintaining clients "
+                "alike. Session-maintaining clients (Claude Code, Claude "
+                "Desktop) bind client_session_id automatically, so you only "
+                "need to thread a credential by hand when tools don't already "
+                "recognize you."
             )
 
     if verbose:
@@ -624,22 +679,40 @@ def _how_to_strengthen(
     needed) so the assurance block stays lean (#734). Mirrored in
     `mcp_handlers/updates/phases.py` so the read- and write-path assurance
     blocks agree.
+
+    Leads with `continuity_token` as the ownership proof (#604 dogfood
+    2026-06-24): on stateless transports (e.g. claude.ai streamable HTTP,
+    which carries no stable Mcp-Session-Id) an echoed `client_session_id`
+    resolves to a fresh per-call identity, so telling the agent to echo it
+    was the exact failing path. The continuity_token from onboard()/identity()
+    resolves correctly on BOTH stateless and session-maintaining transports,
+    so it is the safe default. Session-maintaining clients (Claude Code's
+    hook chain, Claude Desktop) bind client_session_id automatically and so
+    do not need the agent to thread either field by hand.
     """
     if tier == "strong":
         return None
     if proof_origin == "server_inferred":
         return (
-            "binding was server-inferred (not caller-proven); pass the "
-            "client_session_id from your onboard response explicitly in each "
-            "call to reach strong"
+            "binding was server-inferred (not caller-proven); echo the "
+            "continuity_token from your onboard response on each call to reach "
+            "strong (it resolves on stateless and session-maintaining "
+            "transports alike). A session-maintaining client may instead pass "
+            "an explicit client_session_id"
         )
     if tier == "medium":
-        return "pass an explicit client_session_id in each call to reach strong"
+        return (
+            "echo the continuity_token from your onboard response on each call "
+            "to reach strong; a session-maintaining client may instead pass an "
+            "explicit client_session_id"
+        )
     # weak
     return (
-        "pass the client_session_id from your onboard response in each call to "
-        "reach strong; cross-process resumes need continuity_token + agent_uuid "
-        "(PATH 0)"
+        "echo the continuity_token from your onboard response on each call to "
+        "reach strong — it works on stateless transports (e.g. claude.ai) "
+        "where an echoed client_session_id resolves to a fresh per-call "
+        "identity. A session-maintaining client may instead pass an explicit "
+        "client_session_id"
     )
 
 

--- a/tests/test_identity_payloads.py
+++ b/tests/test_identity_payloads.py
@@ -306,8 +306,9 @@ def test_strong_assurance_has_no_strengthen_breadcrumb():
 
 
 def test_weak_server_inferred_assurance_explains_how_to_reach_strong():
-    """The canonical #732 case: weak because server-inferred. The breadcrumb
-    tells the agent to pass client_session_id explicitly."""
+    """The canonical #732 case: weak because server-inferred. Post-#604 the
+    breadcrumb LEADS with continuity_token (works on stateless transports) and
+    still mentions client_session_id for session-maintaining clients."""
     context = build_identity_response_context(
         agent_uuid="uuid-w",
         agent_id="agent-w",
@@ -320,7 +321,9 @@ def test_weak_server_inferred_assurance_explains_how_to_reach_strong():
     assert assurance["tier"] == "weak"
     hint = assurance["how_to_strengthen"]
     assert "server-inferred" in hint
-    assert "client_session_id" in hint
+    # #604: continuity_token is the primary proof (works on both transports).
+    assert "continuity_token" in hint
+    assert hint.index("continuity_token") < hint.index("client_session_id")
 
 
 def test_medium_assurance_breadcrumb_points_at_explicit_session():
@@ -333,7 +336,73 @@ def test_medium_assurance_breadcrumb_points_at_explicit_session():
     )
     assurance = context["identity_assurance"]
     assert assurance["tier"] == "medium"
-    assert "client_session_id" in assurance["how_to_strengthen"]
+    hint = assurance["how_to_strengthen"]
+    # #604: continuity_token leads; client_session_id remains as the
+    # session-maintaining-client alternative.
+    assert "continuity_token" in hint
+    assert "client_session_id" in hint
+    assert hint.index("continuity_token") < hint.index("client_session_id")
+
+
+def test_how_to_strengthen_read_and_write_paths_stay_in_parity():
+    """The read-path (identity_payloads) and write-path (updates.phases)
+    breadcrumbs are mirrored by contract — guard against drift."""
+    from src.services.identity_payloads import _how_to_strengthen as read_path
+    from src.mcp_handlers.updates.phases import _how_to_strengthen as write_path
+
+    cases = [
+        ("strong", "continuity_token", None),
+        ("medium", "pinned_onboard_session", None),
+        ("weak", "ip_ua_fingerprint", "server_inferred"),
+        ("weak", "unknown", None),
+    ]
+    for tier, source_key, proof_origin in cases:
+        assert read_path(tier, source_key, proof_origin) == write_path(
+            tier, source_key, proof_origin
+        )
+
+
+# ── #604 (dogfood 2026-06-24): credential copy is stateless-transport-safe ──
+
+
+def test_onboard_session_continuity_instruction_leads_with_continuity_token():
+    """An agent that follows the onboard session_continuity instruction must be
+    told to echo continuity_token (the proof that resolves on stateless
+    transports), not client_session_id (which resolves to a fresh per-call
+    identity there)."""
+    payload = build_onboard_response_data(**_onboard_kwargs())
+    instruction = payload["session_continuity"]["instruction"]
+    assert "continuity_token" in instruction
+    assert payload["session_continuity"]["continuity_token"] == "token-min"
+
+
+def test_onboard_next_calls_thread_continuity_token_as_ownership_proof():
+    """The verbose next_calls templates hand back continuity_token as the
+    ownership proof so an agent copying args_full reaches strong on its 2nd
+    call (P0 acceptance)."""
+    payload = build_onboard_response_data(**_onboard_kwargs())
+    for call in payload["next_calls"]:
+        args_full = call["args_full"]
+        assert args_full.get("continuity_token") == "token-min"
+        assert "client_session_id" not in args_full
+
+
+def test_fresh_mint_weak_binding_is_framed_as_baseline_not_deficiency():
+    """P1: a just-minted identity that resolves weakly is relabeled as expected
+    baseline with an actionable path (echo continuity_token), not a scold."""
+    payload = build_onboard_response_data(
+        **_onboard_kwargs(
+            is_new=True,
+            force_new=True,
+            continuity_source="unknown",  # fresh mint has no prior proof → weak
+            response_mode="minimal",
+        )
+    )
+    assurance = payload["identity_assurance"]
+    assert assurance["tier"] != "strong"
+    assert assurance["baseline"] == "fresh_identity"
+    assert "not a deficiency" in assurance["baseline_note"]
+    assert "continuity_token" in assurance["how_to_strengthen"]
 
 
 # ── #734: onboard response_mode="minimal" lean envelope ──

--- a/tests/test_outcome_calibration.py
+++ b/tests/test_outcome_calibration.py
@@ -288,6 +288,9 @@ class TestExplicitOutcomeEventCalibration:
             from src.mcp_handlers.observability.outcome_events import handle_outcome_event
             result = await handle_outcome_event({
                 'outcome_type': 'task_completed',
+                # state_semantics is gated behind include_semantics (#604 P2);
+                # this test asserts the full split semantics attach.
+                'include_semantics': True,
             })
 
         parsed = parse_result(result)

--- a/tests/test_outcome_events_lite_snapshot.py
+++ b/tests/test_outcome_events_lite_snapshot.py
@@ -1,0 +1,73 @@
+"""P2 (#604 dogfood 2026-06-24): record_result/outcome_event default to a
+lite eisv_snapshot; the full EISV ontology (state_semantics role table +
+hierarchy, source-meta, sensor-divergence history) is opt-in.
+"""
+
+from src.mcp_handlers.observability.outcome_events import (
+    _coerce_bool_flag,
+    _lite_eisv_snapshot,
+    _LITE_SNAPSHOT_KEYS,
+)
+
+
+def _full_snapshot():
+    return {
+        "eisv": {"E": 0.1, "I": 0.2, "S": 0.3, "V": 0.0},
+        "primary_eisv": {"E": 0.1, "I": 0.2, "S": 0.3, "V": 0.0},
+        "primary_eisv_source": "behavioral",
+        "primary_eisv_source_meta": {"name": "behavioral", "desc": "..."},
+        "behavioral_eisv": {"E": 0.1, "I": 0.2, "S": 0.3, "V": 0.0, "confidence": 0.9},
+        "ode_eisv": {"E": 0.1, "I": 0.2, "S": 0.3, "V": 0.0},
+        "ode_diagnostics": {"phi": 0.5, "verdict": "proceed", "regime": "STABLE"},
+        "sensor_divergence": None,
+        "sensor_divergence_recent": [{"E": 0.01}] * 20,
+        "state_semantics": {
+            "primary_eisv_role": "...",
+            "behavioral_eisv_role": "...",
+            "ode_eisv_role": "...",
+            "ode_diagnostics_role": "...",
+            "sensor_divergence_role": "...",
+            "measurement_policy_contract": "...",
+            "hierarchy": ["1.", "2."],
+        },
+    }
+
+
+class TestCoerceBoolFlag:
+    def test_bool_true(self):
+        assert _coerce_bool_flag(True) is True
+
+    def test_string_true_variants(self):
+        for v in ("true", "1", "yes", "y", "T", " True "):
+            assert _coerce_bool_flag(v) is True
+
+    def test_falsey(self):
+        for v in (False, 0, "", "no", "false", None, "0"):
+            assert _coerce_bool_flag(v) is False
+
+
+class TestLiteSnapshot:
+    def test_lite_drops_heavy_ontology(self):
+        lite = _lite_eisv_snapshot(_full_snapshot())
+        # The expensive self-description is gone.
+        assert "state_semantics" not in lite
+        assert "primary_eisv_source_meta" not in lite
+        assert "sensor_divergence_recent" not in lite
+        # The actual state numbers and active source survive.
+        assert lite["primary_eisv"] == {"E": 0.1, "I": 0.2, "S": 0.3, "V": 0.0}
+        assert lite["primary_eisv_source"] == "behavioral"
+        assert lite["semantics_omitted"] is True
+        assert "include_semantics" in lite["hint"]
+
+    def test_lite_keys_are_subset_of_full(self):
+        full = _full_snapshot()
+        for k in _LITE_SNAPSHOT_KEYS:
+            assert k in full
+
+    def test_none_passthrough(self):
+        assert _lite_eisv_snapshot(None) is None
+
+    def test_lite_is_much_smaller_than_full(self):
+        full = _full_snapshot()
+        lite = _lite_eisv_snapshot(full)
+        assert len(repr(lite)) < len(repr(full))

--- a/tests/test_strict_proof_origin.py
+++ b/tests/test_strict_proof_origin.py
@@ -65,7 +65,12 @@ def test_weak_write_assurance_carries_strengthen_breadcrumb():
         "explicit_client_session_id", None, proof_origin="server_inferred"
     )
     assert a["tier"] == "weak"
-    assert "client_session_id" in a["how_to_strengthen"]
+    hint = a["how_to_strengthen"]
+    # #604: write-path breadcrumb leads with continuity_token (resolves on
+    # stateless transports) — kept in parity with the read-path block.
+    assert "continuity_token" in hint
+    assert "client_session_id" in hint
+    assert hint.index("continuity_token") < hint.index("client_session_id")
 
 
 # ── Gate: strict write precondition ────────────────────────────────────


### PR DESCRIPTION
## Context

Agent-facing identity UX fixes from the 2026-06-24 MCP dogfood (KG `2026-06-24T04:21:44.987486+00:00`, root cause #604). A fresh agent on the claude.ai stateless streamable transport found the new-agent onboarding path *actively misdirects*: the returned guidance tells the agent to echo `client_session_id`, which on a stateless transport resolves to a fresh per-call identity. These changes fix the **agent-facing surface** — not server-side resolution (transport-specific per #604) and not `STRICT_IDENTITY_REQUIRED` enforcement (#425). The copy fixes are safe on all transports.

## Changes

**P0 — credential copy is now stateless-transport-safe.** `continuity_token` resolves correctly on *both* stateless and session-maintaining transports, so it now leads:
- `_how_to_strengthen` breadcrumb (read-path `services/identity_payloads.py` **and** write-path `updates/phases.py`, kept word-identical with a parity guard test)
- onboard `session_continuity.instruction` (previously said "continuity_token is only for PATH 0 rebinds" — the exact misdirection)
- `next_calls` `args_full` templates now thread `continuity_token` as the ownership proof
- the new-identity `welcome` string

Acceptance: an agent that literally follows the returned guidance reaches `strong` on its 2nd call.

**P1 — fresh onboard is framed as baseline, not deficiency.** A just-minted identity resolves its own onboard call weakly (no prior proof existed). Instead of greeting a clean onboard with a `weak`/0.35 tier + a scold the agent can't act on, the assurance block is relabeled `baseline=fresh_identity` with a `baseline_note` and an actionable `how_to_strengthen` (echo the `continuity_token` handed back). The tier is **not** inflated — the binding genuinely is unproven until the token is echoed.

**P2 — `record_result`/`outcome_event` default to a lite ack.** The full EISV ontology (`state_semantics`: 7 role descriptions + hierarchy, `*_source_meta`, the sensor-divergence history list) is dropped from the default response and gated behind `include_semantics=true` (alias `response_mode="full"`). The persisted `detail` row is unchanged.

**P3 (sub-item) — `name=` split documented.** The `name` param description on `onboard`/`identity` now states it sets the cosmetic `display_name` only and deliberately does not set the public structured handle (`agent_id`); `uuid` is the canonical cross-tool identifier.

## Scope notes / deferred
- **P3 (full canonical-handle restructure)** and **P4 (mirror default / signal hoisting)** are intentionally not in this PR. `response_mode="auto"` already resolves to `mirror` for the healthy disembodied common case, and outcome payloads already surface `corroboration_grade`/`evidence_weight`/`claim_risk` at the top level — so the high-value parts of P4 are already in place. The remaining P3 restructure touches a writer-locked, cross-repo identity surface and is better done as its own change.
- No changes to server-side identity resolution or `STRICT_IDENTITY_REQUIRED`.

## Tests
- Updated read/write `how_to_strengthen` assertions to lock the `continuity_token` lead + a parity guard between the two impls.
- New `tests/test_outcome_events_lite_snapshot.py` for the lite-snapshot helpers.
- New P0/P1 onboard-payload tests (session_continuity instruction, next_calls templates, fresh-mint baseline framing).
- Focused suites green under Python 3.12: identity payloads, strict proof-origin, schemas, describe-tool drift, observability handlers, core update, response formatter, update workflow, handlers core, enrichment pipeline. CI is the full gate.

## Follow-up
On merge, close the loop: `knowledge(action='update', discovery_id='2026-06-24T04:21:44.987486+00:00', status='resolved', ...)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F9PmP5CYpYDTqeud4VzEUd)_