### PR TITLE
fix(dialectic-reviewer): live-found fixes — orchestrated reviewer now completes e2e

### DIFF
--- a/agents/dialectic_reviewer/reviewer.py
+++ b/agents/dialectic_reviewer/reviewer.py
@@ -197,15 +197,18 @@ async def run(thesis: Thesis, governance_url: str, parent_agent_id: Optional[str
             parent_agent_id=parent_agent_id,
             spawn_reason=SPAWN_REASON,
         )
-        # Claim the open reviewer slot as first-responder (handlers.py:677/691).
+        # Claim the open reviewer slot as first-responder. The bare submit_*
+        # handlers are register=False; the public MCP surface is the `dialectic`
+        # umbrella tool (action='antithesis'/'synthesis'). (live-found 2026-06-23)
         await client.call_tool(
-            "submit_antithesis",
-            {"session_id": thesis.session_id, "reasoning": verdict.reasoning},
+            "dialectic",
+            {"action": "antithesis", "session_id": thesis.session_id, "reasoning": verdict.reasoning},
         )
         # Submit the model-derived verdict — agrees may be False (the whole point).
         await client.call_tool(
-            "submit_synthesis",
+            "dialectic",
             {
+                "action": "synthesis",
                 "session_id": thesis.session_id,
                 "agrees": verdict.agrees,
                 "proposed_conditions": verdict.proposed_conditions,

--- a/agents/dialectic_reviewer/tests/test_verdict.py
+++ b/agents/dialectic_reviewer/tests/test_verdict.py
@@ -173,7 +173,12 @@ async def test_run_submits_disagreement_through_protocol(monkeypatch):
     assert onboard_kw["force_new"] is True
     assert onboard_kw["spawn_reason"] == r.SPAWN_REASON
     assert onboard_kw["parent_agent_id"] == "parent-uuid"
-    # submit_synthesis carried agrees=False — the reviewer actually blocked
-    synth = [a for n, a in calls if n == "submit_synthesis"]
+    # The reviewer submits via the `dialectic` umbrella tool (action=...), not the
+    # bare submit_* names (which are register=False on the MCP surface).
+    dialectic_calls = [a for n, a in calls if n == "dialectic"]
+    anti = [a for a in dialectic_calls if a.get("action") == "antithesis"]
+    synth = [a for a in dialectic_calls if a.get("action") == "synthesis"]
+    assert anti and anti[0]["session_id"] == "sess-9"
+    # synthesis carried agrees=False — the reviewer actually blocked
     assert synth and synth[0]["agrees"] is False
     assert synth[0]["session_id"] == "sess-9"

--- a/src/mcp_handlers/dialectic/orchestrator_dispatch.py
+++ b/src/mcp_handlers/dialectic/orchestrator_dispatch.py
@@ -45,11 +45,20 @@ def _orchestrator_url() -> str:
 
 
 def _governance_url() -> str:
-    return (
+    # The reviewer passes this straight to GovernanceClient(mcp_url=...), whose
+    # streamable-http transport needs the /mcp/ path — a bare base URL makes
+    # session.initialize() hang then cancel (live-found 2026-06-23). Normalize a
+    # pathless URL so either form (base or full mcp_url) works.
+    raw = (
         os.environ.get("UNITARES_GOVERNANCE_URL")
         or os.environ.get("GOVERNANCE_URL")
-        or "http://127.0.0.1:8767"
+        or "http://127.0.0.1:8767/mcp/"
     )
+    from urllib.parse import urlparse
+
+    if urlparse(raw).path in ("", "/"):
+        raw = raw.rstrip("/") + "/mcp/"
+    return raw
 
 
 def _build_spec(session_id: str, thesis: Dict[str, Any], parent_agent_id: Optional[str]) -> Dict[str, Any]:

--- a/tests/test_dialectic_orchestrated_dispatch.py
+++ b/tests/test_dialectic_orchestrated_dispatch.py
@@ -54,6 +54,23 @@ def test_build_spec_omits_parent_when_absent():
     assert json.loads(spec["env"]["DIALECTIC_THESIS_CONDITIONS"]) == []
 
 
+@pytest.mark.parametrize("env_val,expected", [
+    (None, "http://127.0.0.1:8767/mcp/"),                       # default has the path
+    ("http://127.0.0.1:8767", "http://127.0.0.1:8767/mcp/"),    # bare base → append
+    ("http://127.0.0.1:8767/", "http://127.0.0.1:8767/mcp/"),   # trailing slash only
+    ("http://host:9000/mcp/", "http://host:9000/mcp/"),         # full mcp_url untouched
+])
+def test_governance_url_normalizes_to_mcp_path(env_val, expected, monkeypatch):
+    """The reviewer passes this to GovernanceClient(mcp_url=...) which needs /mcp/.
+    A bare base URL made session.initialize() hang (live-found 2026-06-23)."""
+    monkeypatch.delenv("GOVERNANCE_URL", raising=False)
+    if env_val is None:
+        monkeypatch.delenv("UNITARES_GOVERNANCE_URL", raising=False)
+    else:
+        monkeypatch.setenv("UNITARES_GOVERNANCE_URL", env_val)
+    assert od._governance_url() == expected
+
+
 # --------------------------- dispatch (mocked HTTP) --------------------------- #
 
 class _FakeResp:


### PR DESCRIPTION
Live verification of #1021 (slice 3b) on the running system surfaced two bugs in the reviewer code (#1013), inert until now and never executed:

1. **governance URL needs `/mcp/`.** The dispatcher passed a bare `http://127.0.0.1:8767` to `GovernanceClient(mcp_url=...)`; the streamable-http transport hung in `session.initialize()` → cancelled (reviewer exited status=1 `connect() failed: CancelledError`). `_governance_url()` now normalizes a pathless URL to `.../mcp/`.
2. **bare tool names aren't exposed.** The reviewer called `submit_antithesis`/`submit_synthesis` (`register=False`) → "Unknown tool". Switched to the public `dialectic` umbrella (`action='antithesis'/'synthesis'`).

## Live proof (after both fixes)
Full round-trip succeeded on the running MCP: the orchestrator spawned a reviewer that onboarded with its **own identity** (`DialecticReviewer_daff7ce8`), claimed the open slot, ran gemma4, and submitted a genuine **`agrees=false`** verdict with substantive pushback. The session did **not** auto-resolve (consistent with #1019). **The agent-orchestrator is now serving live reviews — Decision A de-inert complete.**

Tests: URL-normalization cases; reviewer test asserts the `dialectic` action calls. Full suite green (10656).

> Note: these same two fixes were hot-applied to the deploy worktree to verify live; this PR lands them on master and the deploy worktree will be reconciled to it.

https://claude.ai/code/session_01CtHEHQFGCy33pCwVRh2hwP