### PR TITLE
fix(dialectic): in-process fallback when orchestrated reviewer crashes fast

### DIFF
--- a/src/mcp_handlers/dialectic/handlers.py
+++ b/src/mcp_handlers/dialectic/handlers.py
@@ -1383,6 +1383,7 @@ async def handle_submit_thesis(arguments: Dict[str, Any]) -> Sequence[TextConten
                 from .orchestrator_dispatch import (
                     orchestrated_review_enabled,
                     dispatch_orchestrated_review,
+                    reviewer_crashed_fast,
                 )
                 if orchestrated_review_enabled():
                     dispatched = await dispatch_orchestrated_review(
@@ -1397,17 +1398,24 @@ async def handle_submit_thesis(arguments: Dict[str, Any]) -> Sequence[TextConten
                         session.paused_agent_id,
                     )
                     if dispatched:
-                        result["orchestrated_review"] = True
-                        result["reviewer_dispatch"] = {
-                            "agent_id": dispatched.get("agent_id") or dispatched.get("id"),
-                            "via": "agent-orchestrator",
-                        }
-                        result["note"] = (
-                            "Independent reviewer spawned via the agent-orchestrator; "
-                            "it will claim the reviewer slot and submit its verdict. "
-                            "Poll dialectic action='get' for the antithesis/synthesis."
-                        )
-                        return success_response(result)
+                        agent_id_spawned = dispatched.get("agent_id") or dispatched.get("id")
+                        # Catch a FAST reviewer crash (bad import/url/etc, exits in
+                        # <12s) and fall back to in-process inline so the session
+                        # resolves now instead of stranding at antithesis. A success
+                        # or still-running reviewer owns the slot → async path.
+                        if not await reviewer_crashed_fast(agent_id_spawned):
+                            result["orchestrated_review"] = True
+                            result["reviewer_dispatch"] = {
+                                "agent_id": agent_id_spawned,
+                                "via": "agent-orchestrator",
+                            }
+                            result["note"] = (
+                                "Independent reviewer spawned via the agent-orchestrator; "
+                                "it will claim the reviewer slot and submit its verdict. "
+                                "Poll dialectic action='get' for the antithesis/synthesis."
+                            )
+                            return success_response(result)
+                        # reviewer crashed fast → fall through to in-process
                     # dispatch failed → fall through to in-process synthetic reviewer
 
             # End-to-end completion: when no independent live reviewer has claimed

--- a/src/mcp_handlers/dialectic/orchestrator_dispatch.py
+++ b/src/mcp_handlers/dialectic/orchestrator_dispatch.py
@@ -144,3 +144,58 @@ async def dispatch_orchestrated_review(
             "[DIALECTIC] orchestrated dispatch failed (%r); falling back to in-process", exc
         )
         return None
+
+
+async def reviewer_crashed_fast(
+    agent_id: str,
+    *,
+    await_seconds: float = 15.0,
+) -> bool:
+    """Briefly await the spawned reviewer to catch a FAST crash.
+
+    The common reviewer failure modes (bad URL, import error, wrong tool name)
+    exit within ~12s — well before gemma4 (~40-70s) could finish. We block on the
+    orchestrator's await endpoint for a short window:
+
+    - exited with non-zero status  → True  (crashed without claiming the slot;
+      the caller should fall back to the in-process synthetic reviewer inline so
+      the session resolves now instead of stranding at antithesis for the 4h reap)
+    - exited 0 / still running (504) / any error → False (the reviewer owns the
+      review; leave it on the async path — DO NOT also run in-process)
+
+    The short window keeps the whole submit_thesis call inside the dialectic
+    router's 90s budget even when a fast crash triggers the in-process fallback.
+    A reviewer that crashes AFTER this window (mid-model, rare) still relies on
+    the slower reap — acceptable; this closes the common case.
+    """
+    if not agent_id:
+        return False
+    bearer = os.environ.get("AGENT_ORCHESTRATOR_BEARER_TOKEN")
+    if not bearer:
+        return False
+    url = f"{_orchestrator_url()}/v1/agents/{agent_id}/await"
+    try:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=await_seconds + 5.0) as client:
+            resp = await client.post(
+                url,
+                json={"timeout_ms": int(await_seconds * 1000)},
+                headers={"Authorization": f"Bearer {bearer}"},
+            )
+        if resp.status_code == 504:
+            return False  # await_timeout — still running, reviewer owns it
+        if resp.status_code != 200:
+            return False  # not_found / unexpected — don't double-run
+        result = (resp.json() or {}).get("result") or {}
+        exit_status = result.get("exit_status")
+        crashed = exit_status not in (0, None)
+        if crashed:
+            logger.warning(
+                "[DIALECTIC] orchestrated reviewer %s exited %s without resolving; "
+                "falling back to in-process", agent_id, exit_status,
+            )
+        return bool(crashed)
+    except Exception as exc:  # noqa: BLE001 — can't tell ⇒ leave it to the reviewer
+        logger.warning("[DIALECTIC] reviewer await check failed (%r); leaving async", exc)
+        return False

--- a/tests/test_dialectic_orchestrated_dispatch.py
+++ b/tests/test_dialectic_orchestrated_dispatch.py
@@ -145,3 +145,39 @@ async def test_dispatch_exception_returns_none(monkeypatch):
     _patch_httpx(monkeypatch, _FakeClient(None, raise_exc=RuntimeError("conn refused")))
     out = await od.dispatch_orchestrated_review("s", {"root_cause": "x"}, None)
     assert out is None
+
+
+# --------------------------- reviewer_crashed_fast --------------------------- #
+
+@pytest.mark.asyncio
+async def test_crashed_fast_true_on_nonzero_exit(monkeypatch):
+    """Reviewer exited non-zero within the window → crashed → caller falls back."""
+    monkeypatch.setenv("AGENT_ORCHESTRATOR_BEARER_TOKEN", "tok")
+    _patch_httpx(monkeypatch, _FakeClient(_FakeResp(200, {"ok": True, "result": {"exit_status": 1}})))
+    assert await od.reviewer_crashed_fast("ag-1", await_seconds=0.01) is True
+
+
+@pytest.mark.asyncio
+async def test_crashed_fast_false_on_clean_exit(monkeypatch):
+    """Reviewer exited 0 (submitted its verdict) → not a crash → async path owns it."""
+    monkeypatch.setenv("AGENT_ORCHESTRATOR_BEARER_TOKEN", "tok")
+    _patch_httpx(monkeypatch, _FakeClient(_FakeResp(200, {"ok": True, "result": {"exit_status": 0}})))
+    assert await od.reviewer_crashed_fast("ag-2", await_seconds=0.01) is False
+
+
+@pytest.mark.asyncio
+async def test_crashed_fast_false_on_await_timeout(monkeypatch):
+    """504 await_timeout = still running (gemma4 working) → leave on async path."""
+    monkeypatch.setenv("AGENT_ORCHESTRATOR_BEARER_TOKEN", "tok")
+    _patch_httpx(monkeypatch, _FakeClient(_FakeResp(504, {"ok": False, "error": "await_timeout"})))
+    assert await od.reviewer_crashed_fast("ag-3", await_seconds=0.01) is False
+
+
+@pytest.mark.asyncio
+async def test_crashed_fast_false_on_error_or_no_bearer(monkeypatch):
+    """Can't tell (exception / no bearer) ⇒ don't double-run; leave it to the reviewer."""
+    monkeypatch.setenv("AGENT_ORCHESTRATOR_BEARER_TOKEN", "tok")
+    _patch_httpx(monkeypatch, _FakeClient(None, raise_exc=RuntimeError("boom")))
+    assert await od.reviewer_crashed_fast("ag-4", await_seconds=0.01) is False
+    monkeypatch.delenv("AGENT_ORCHESTRATOR_BEARER_TOKEN", raising=False)
+    assert await od.reviewer_crashed_fast("ag-5", await_seconds=0.01) is False

--- a/tests/test_dialectic_synthetic_review.py
+++ b/tests/test_dialectic_synthetic_review.py
@@ -178,6 +178,8 @@ async def test_orchestrated_dispatch_skips_in_process(server_patch):
         stack.enter_context(patch(f"{OD}.orchestrated_review_enabled", return_value=True))
         stack.enter_context(patch(f"{OD}.dispatch_orchestrated_review",
                                   new=AsyncMock(return_value={"ok": True, "agent_id": "agent-rev-1"})))
+        # reviewer is running/healthy (not a fast crash) → async path owns it
+        stack.enter_context(patch(f"{OD}.reviewer_crashed_fast", new=AsyncMock(return_value=False)))
         result = await handle_submit_thesis({
             "session_id": session.session_id,
             "agent_id": "agent-paused",
@@ -190,6 +192,39 @@ async def test_orchestrated_dispatch_skips_in_process(server_patch):
     # The in-process reviewer must NOT have run — the orchestrator owns this review.
     gen_anti.assert_not_called()
     assert "resolved" not in data  # slot left open for the spawned reviewer
+
+
+@pytest.mark.asyncio
+async def test_orchestrated_reviewer_fast_crash_falls_back_to_in_process(server_patch):
+    """Dispatch succeeds but the spawned reviewer crashes fast (exits non-zero
+    before claiming the slot) → fall back to in-process inline so the session
+    resolves now instead of stranding at antithesis for the 4h reap."""
+    from src.mcp_handlers.dialectic.handlers import handle_submit_thesis, ACTIVE_SESSIONS
+
+    session = _make_session(reviewer_id=None)
+    ACTIVE_SESSIONS[session.session_id] = session
+
+    import contextlib
+    with contextlib.ExitStack() as stack:
+        for p in _common_patches():
+            stack.enter_context(p)
+        stack.enter_context(patch(f"{LLM}.generate_antithesis", new=AsyncMock(return_value=_antithesis("refine"))))
+        stack.enter_context(patch(f"{LLM}.generate_synthesis", new=AsyncMock(return_value=_synthesis("RESUME"))))
+        stack.enter_context(patch(f"{OD}.orchestrated_review_enabled", return_value=True))
+        stack.enter_context(patch(f"{OD}.dispatch_orchestrated_review",
+                                  new=AsyncMock(return_value={"ok": True, "agent_id": "ag-crash"})))
+        stack.enter_context(patch(f"{OD}.reviewer_crashed_fast", new=AsyncMock(return_value=True)))
+        result = await handle_submit_thesis({
+            "session_id": session.session_id,
+            "agent_id": "agent-paused",
+            "root_cause": "rc", "proposed_conditions": ["c"], "reasoning": "r",
+        })
+
+    data = parse_result(result)
+    assert "orchestrated_review" not in data
+    # fell back inline: synthetic review ran and resolved (refine + RESUME)
+    assert data["synthetic_review"] is True
+    assert data["resolved"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Hardening the now-live orchestrated-review path (Decision A). During 3b verification, a spawned reviewer that crashed before claiming the slot (bad import/URL — exits in <12s) stranded the session at antithesis until the 4h reap. This closes that common case.

After dispatch, `reviewer_crashed_fast` briefly awaits the spawned agent (~15s via the orchestrator's `/v1/agents/:id/await`):
- **exited non-zero** → crashed → fall through to the in-process synthetic reviewer inline (session resolves now).
- **exited 0 / 504 await_timeout (still running) / any uncertainty** → leave it on the async path; the reviewer owns the slot (never double-run).

The short window keeps the whole `submit_thesis` call inside the 90s dialectic-router budget even when the fallback fires. A crash *after* the window (mid-model, rare) still relies on the slower reap — acceptable.

Tests: `reviewer_crashed_fast` unit cases + handler integration (fast crash → in-process fallback resolves). Full suite green (10672).

Closes the "dispatched-but-never-claimed" follow-up noted on #1021.

https://claude.ai/code/session_01CtHEHQFGCy33pCwVRh2hwP