### PR TITLE
docs: evaluation catalog — index the scattered eval/ablation/dogfood/validation surface

### DIFF
--- a/docs/EVALUATION_INDEX.md
+++ b/docs/EVALUATION_INDEX.md
@@ -1,98 +1,106 @@
 # Evaluation Catalog — EISV validation, ablations, dogfood, analysis
 
 Single index of the evaluation/ablation/dogfood/validation surface, so the work is
-discoverable instead of rediscovered. Before adding a new eval or "does EISV
-actually work" analysis, **check here first** — much already exists, scattered
-across `scripts/analysis/`, `scripts/eval/`, `scripts/diagnostics/`, `src/`,
-`tests/`, `demos/`, `docs/operations/`, `~/.unitares/analysis/`, and the
-`hermes-agent` repo. There was no catalog before this one.
+discoverable instead of rediscovered. **Before adding a new eval or "does EISV
+actually work" analysis, check here first** — much already exists, and at least one
+session (2026-06-23) rebuilt machinery that was already in `scripts/analysis/`.
 
-> **Honesty of this index.** Assembled 2026-06-23. Entries marked **✓** were read/run
-> that session; **~** are characterized from filename + location only (not yet read) —
-> do not trust the one-liner as a finding. This is an inventory, not a re-derivation.
-> Keep it accurate: add a row when you add an eval; mark it ✓ once verified.
+Rows verified by reading the code on 2026-06-23 are **✓**; entries still inferred from
+name only are **~**. Freshness flags call out scripts that **won't run as-is** (removed
+backends, missing source symlinks). Hermes-agent's ablation/dogfood lives in its own
+repo (automation-side) and is intentionally *not* consolidated here.
 
-## ⚠ Read this before trusting any EISV-validation number
+## ⚠ Start here: the two scripts that already answer "does EISV discriminate?"
 
-The honest current state of "does EISV discriminate / predict / prevent" lives in
-memory `project_eisv-validation-gap.md` and `demos/frt_autonomy_sandbagging/REAL_LLM_FINDINGS.md`.
-Headline as of 2026-06-23:
+Don't rebuild discrimination analysis — these exist and are current:
 
-- **Organic-fleet validation is structurally impossible** — the tool-failure-labeled
-  population (transport-level callers) and the EISV-bearing population (onboarded,
-  checking-in agents) are disjoint. Don't try to validate on `audit.tool_usage` joined
-  to verdicts; it returns ~0 because the keys don't overlap.
-- The **`~/.unitares/analysis/eisv-validation-*` scheduled oneshot is a broken join**
-  (0.000 in every cohort while failures exist) — retire/repoint, don't trust.
-- EISV Integrity is a **confidence-vs-outcome consistency** detector: catches naive
-  overconfidence against a calibrated baseline (AUC ~1.0 on a model organism),
-  **collapses on noisy baselines (~0.75) and inverts on calibrated concealment (~0.19)**;
-  **cross-framing** dominates for concealment (~0.97).
+- **`scripts/analysis/eisv_skeptic_report.py`** ✓ — the substantive one. Computes AUC/Brier
+  **lift of EISV/prior-state over a previous-outcome baseline**, emits a runtime verdict
+  (`SKEPTICAL` / `KEEP-TESTING` / `WEAK` / `INCONCLUSIVE`). The EISV-distributional KILL in
+  memory came from running this (Probe A: negative AUC lift). No hardcoded conclusion.
+- **`scripts/analysis/eisv_ablation_matrix.py`** ✓ — same question across scope/window/lead
+  slices with bootstrap CIs, permutation p-values, BEAM-lane exclusion.
+
+The honest current state of "does EISV discriminate / predict / prevent" lives in memory
+`project_eisv-validation-gap.md` and `demos/frt_autonomy_sandbagging/REAL_LLM_FINDINGS.md`.
+Headline (2026-06-23): **organic-fleet validation is structurally impossible** (tool-failure
+population and EISV-bearing population are disjoint); the **`~/.unitares/analysis/eisv-validation-*`
+scheduled oneshot is a broken join — do not trust**; EISV Integrity catches naive overconfidence
+against a calibrated baseline but **collapses on noisy baselines (~0.75) and inverts on
+calibrated concealment (~0.19)**, where **cross-framing dominates (~0.97)**.
 
 ## Validation — "does EISV track reality / discriminate?"
 
-| Artifact | What it does | Status |
-|---|---|---|
-| `demos/frt_autonomy_sandbagging/` (`run_unitares_demo.py`, `unitares_integration.py`) | ✓ Model-organism sandbagging eval through real `BehavioralEISV`; Integrity AUC naive=1.0, calibrated≈0.35 | active, 11 tests pass |
-| `demos/frt_autonomy_sandbagging/real_llm_probe.py` + `REAL_LLM_FINDINGS.md` | ✓ Real-LLM (Ollama) extension; competence boundary + cross-framing arm | added 2026-06-23 (PR #1026) |
-| `scripts/analysis/outcome_validation.py` | ~ outcome-vs-EISV validation against `audit.outcome_events` | unread — verify before reuse |
-| `scripts/analysis/eisv_skeptic_report.py` | ~ skeptic-framed EISV report (overlaps the validation question) | unread |
-| `scripts/analysis/prospective_prediction_cohort.py` | ~ prospective prediction cohort (forward-looking discrimination) | unread |
-| `scripts/analysis/validate_theoretical_foundations.py` | ~ checks the theoretical (ODE/stability) claims | unread |
-| `scripts/analysis/validate_basin_gate.py` | ~ validates the basin health-gate behavior | unread |
-| `~/.unitares/analysis/eisv-validation-2026-06-13_0900.md` | ✓ scheduled oneshot — **BROKEN JOIN, null, do not trust** (see warning above) | retire/repoint |
-| (scratchpad) `eisv_validation/leadtime_probe.py` | ✓ lead-time / warning-vs-reaction on real data; no advance-warning for task-failure (AUC 0.545) | not yet in repo |
+| Artifact | What it does | Output / finding | Freshness |
+|---|---|---|---|
+| `scripts/analysis/eisv_skeptic_report.py` ✓ | AUC/Brier lift of EISV vs previous-outcome baseline; runtime verdict | Markdown report; KILL of EISV-distributional came from it | current (live PG) |
+| `scripts/analysis/eisv_ablation_matrix.py` ✓ | Same vs-baseline across scope/window/lead; bootstrap CI, permutation p | Markdown matrix; no hardcoded verdict | current |
+| `scripts/analysis/outcome_validation.py` ✓ | Buckets agent-days by legacy→grounded basin-flip; outcome rates per bucket | Console table + `--csv`; tool | current |
+| `scripts/analysis/prospective_prediction_cohort.py` ✓ | Counts registry-bound holdout predictions (plumbing only, no claim) | Markdown cohort summary | current |
+| `scripts/analysis/validate_basin_gate.py` ✓ | Validates #689 basin-health gate never raises risk; healthy wobbles stay safe | Console PASS/FAIL + exit; hardcoded 06-13 Sentinel false-pause fixture | current |
+| `scripts/analysis/validate_theoretical_foundations.py` ✓ | Greps `governance_core` source for ODE/coherence terms vs theory doc | Pass/fail console | **⚠ won't run by default** — needs `governance_core/` source symlink; brittle exact-string greps |
+| `demos/frt_autonomy_sandbagging/` (`run_unitares_demo.py`) ✓ | Model-organism sandbagging through real `BehavioralEISV` | Integrity AUC naive=1.0, calibrated≈0.35 | active, 11 tests |
+| `demos/frt_autonomy_sandbagging/real_llm_probe.py` ✓ | Real-LLM (Ollama) extension; competence boundary + cross-framing | See `REAL_LLM_FINDINGS.md` | added 2026-06-23 (PR #1026) |
+| `~/.unitares/analysis/eisv-validation-2026-06-13_0900.md` ✓ | Scheduled oneshot cohort comparison | **BROKEN JOIN — null, do not trust** | retire/repoint |
+| (scratchpad) `eisv_validation/leadtime_probe.py` ✓ | Lead-time / warning-vs-reaction on real data | No advance-warning for task-failure (AUC 0.545) | not yet in repo; overlaps `eisv_skeptic_report` |
 
 ## Ablation
 
-| Artifact | What it does | Status |
-|---|---|---|
-| `scripts/analysis/eisv_ablation_matrix.py` | ~ EISV ablation matrix (which components carry signal) | unread |
-| `scripts/analysis/ablation_negative_controls.py` + `tests/test_ablation_negative_controls.py` | ~ negative-control ablations | unread |
-| `scripts/diagnostics/dogfood_ablation_guard.py` + `tests/test_dogfood_ablation_guard.py` | ~ guard that ablation/dogfood invariants hold | unread |
-| `tests/test_eisv_ablation_matrix.py` | ~ tests for the ablation matrix | unread |
-| `docs/operations/ablation-initiates-finding-2026-06-16.md` | ✓ finding: `strict_bad` 0→1 was **observed/classified, NOT prevented** — corrected; not EISV validation | logged |
-| `docs/operations/ablation-negative-controls.md` | ~ negative-controls writeup | unread |
+| Artifact | What it does | Output / finding | Freshness |
+|---|---|---|---|
+| `scripts/analysis/ablation_negative_controls.py` ✓ | Synthetic known-safe/bad fixtures as red-team controls | JSONL fixtures; hardcoded "SYNTHETIC NEGATIVE CONTROL — not validation" | current |
+| `scripts/diagnostics/dogfood_ablation_guard.py` ✓ | Silent CI guard: identity neutrality, BEAM/substrate lanes, matrix exclusion | Empty stdout = healthy; alerts only on regression | current |
+| `docs/operations/ablation-negative-controls.md` ✓ | Documents the negative-controls fixture (synthetic-only, never persisted) | "validates plumbing + containment, NOT EISV"; smoke `strict_bad:4` | current (Experimental) |
+| `docs/operations/ablation-initiates-finding-2026-06-16.md` ✓ | Finding: `strict_bad` 0→1 was **observed/classified, NOT prevented** | logged correction; not EISV validation | logged |
 
 ## Dogfood
 
-| Artifact | What it does | Status |
-|---|---|---|
-| `scripts/analysis/dogfood_dialectic.py` | ~ dogfood of the dialectic path | unread |
-| `agents/common/dogfood_friction.py` + `tests/test_r6_dogfood.py` | ~ dogfood-friction capture (agents building UNITARES run under it) | unread |
-| `hermes-agent/skills/dogfood/` (+ `optional-skills/dogfood/`) | ~ Hermes dogfood **skill** (report template, adversarial-ux-test) — process, not stored runs | separate repo |
+| Artifact | What it does | Output | Freshness |
+|---|---|---|---|
+| `scripts/analysis/dogfood_dialectic.py` ✓ | Live dogfood: onboard→request_review→submit_thesis, asserts UUID consistency | PASS/FAIL; needs live MCP :8767 | current |
+| `agents/common/dogfood_friction.py` ✓ | Normalizes friction observations into `/api/findings` events | Library; event dict + deterministic fingerprint | current |
+| `tests/test_r6_dogfood.py` ~ | R6 dogfood test | — | unread |
 
 ## Resident validation
 
-| Artifact | What it does | Status |
+**What it's for:** a scaffold to ask whether long-running residents (Vigil/Sentinel/Lumen)
+actually improve UNITARES over time — by emitting bounded, non-actuating "I observed X, predict
+Y" tick envelopes a future supervisor can score. **Today it is INERT** (local JSONL only, no
+UNITARES writes, nothing scheduled) — a measurement harness, not a live subsystem.
+
+| Artifact | What it does | Freshness |
 |---|---|---|
-| `src/resident_validation*.py`, `scripts/diagnostics/resident_validation_*` | ~ supervised-invocation / cohort / tick / canary for resident agents | unread |
-| `docs/operations/resident-validation-cohort.md`, `resident-validation-supervised-invocation.md` | ~ resident-validation design docs | unread |
+| `src/resident_validation.py` / `_runner.py` / `_invocation.py` ✓ | Build deterministic low-authority tick envelopes; canary runner; lock + tick-cap + local audit | current (pure libs) |
+| `scripts/diagnostics/resident_validation_{supervised_invocation,tick,canary}.py` ✓ | CLIs over the above; only side effect is `data/resident_validation/` JSONL | current |
+| `docs/operations/resident-validation-{cohort,supervised-invocation}.md` ✓ | v0 cohort + supervised-invocation design; matches code | current (Experimental) |
 
-## Analysis / metrics (supporting, not pass/fail evals)
+## Analysis / metrics (supporting — not pass/fail evals)
 
-`scripts/analysis/`: ~ `analyze_drift`, `basin_estimation`, `contraction_analysis`,
-`eisv_pca_analysis`, `compositionality_metrics`, `report_calibration`,
-`outcome_inventory`, `export_outcome_dataset`, `plot_eisv_trajectories`,
-`pin_ttl_bleed_*`. · `scripts/eval/`: ~ `metrics.py`, `retrieval_eval.py`
-(+ `tests/retrieval_eval/`). All **unread** here — characterized by name.
-
-## Hermes-agent (separate repo, separate run history)
-
-`environments/benchmarks/` + `tests/environments/benchmarks/` · `skills/mlops/evaluation/`
-(incl. `lm-evaluation-harness`) · `skills/dogfood/`. **Not consolidated with UNITARES's** —
-cross-repo ablation/dogfood results are not joined to UNITARES findings. Kenny flagged
-Hermes has ablation + dogfood runs (2026-06-23); their results are not indexed here yet.
+| Artifact | What it does | Freshness |
+|---|---|---|
+| `scripts/analysis/outcome_inventory.py` ✓ | Read-only inventory of outcome provenance/objectivity/prior-state coverage | current (live PG) |
+| `scripts/analysis/export_outcome_dataset.py` ✓ | Exports flattened `audit.outcome_events` for offline study | current |
+| `scripts/analysis/analyze_drift.py` ✓ | `trajectory_validated` convergence + decision/EISV correlation | current (JSONL path legacy) |
+| `scripts/analysis/basin_estimation.py` ✓ | Monte-Carlo EISV basin-of-attraction mapping | current (pure `governance_core`) |
+| `scripts/analysis/contraction_analysis.py` ✓ | EISV Jacobian contraction: eigenvalues, Gershgorin, theta sweep | current (pure) |
+| `scripts/analysis/plot_eisv_trajectories.py` ✓ | Plots EISV convergence/degradation/recovery (synthetic) | current (pure) |
+| `scripts/analysis/pin_ttl_bleed_report.py` ✓ | Tests pin-TTL masking hypothesis from audit events | current (live PG) |
+| `scripts/eval/metrics.py` ✓ | Pure ranking metrics (DCG/nDCG/recall/MRR) | current (CI-pinned) |
+| `scripts/eval/retrieval_eval.py` ✓ | KG retrieval quality eval over labeled corpus | current (needs live PG + embeddings) |
+| `scripts/analysis/report_calibration.py` ✓ | Strategic/tactical calibration bins, ECE, failure modes | **⚠ possibly-stale** — in-process state, no live-DB load path |
+| `scripts/analysis/eisv_pca_analysis.py` ✓ | PCA/correlation over EISV histories | **⚠ won't run** — reads REMOVED SQLite backend; hard-gated |
+| `scripts/analysis/compositionality_metrics.py` ✓ | Topographic-similarity of Lumen *primitive utterances* (not EISV) | **⚠ stale-ish** — external anima SQLite; synthetic fallback |
 
 ## Recurring scheduled outputs (`~/.unitares/analysis/`)
 
-- `eisv_validation_oneshot.sh` → `eisv-validation-*.md` — **broken (see warning)**.
+- `eisv_validation_oneshot.sh` → `eisv-validation-*.md` — **broken join (see warning)**.
 - `report-2026*.md` — recurring **per-phase latency** analysis (perf, not EISV validation).
 
 ## Maintenance
 
-This is the catalog of record for evaluation work. When you add or run an eval,
-add/update its row and mark **✓** once you've verified what it actually shows. The
-biggest gap is **depth**: most rows are `~` (unread) — a future pass should read the
-`scripts/analysis/` validation/ablation scripts and fold their real findings here, so
-the next "does EISV work?" question starts from what exists.
+Catalog of record. When you add or run an eval, add/update its row and mark **✓** once
+verified. Remaining gaps: a few `~` rows (e.g. `tests/test_r6_dogfood.py`); the
+`⚠`-flagged scripts (`validate_theoretical_foundations`, `eisv_pca_analysis`,
+`compositionality_metrics`, `report_calibration`) are candidates to **fix or sunset**;
+and the scratchpad `leadtime_probe.py` should either land in the repo or be retired in
+favor of `eisv_skeptic_report.py`, which it overlaps.

--- a/docs/EVALUATION_INDEX.md
+++ b/docs/EVALUATION_INDEX.md
@@ -1,0 +1,98 @@
+# Evaluation Catalog — EISV validation, ablations, dogfood, analysis
+
+Single index of the evaluation/ablation/dogfood/validation surface, so the work is
+discoverable instead of rediscovered. Before adding a new eval or "does EISV
+actually work" analysis, **check here first** — much already exists, scattered
+across `scripts/analysis/`, `scripts/eval/`, `scripts/diagnostics/`, `src/`,
+`tests/`, `demos/`, `docs/operations/`, `~/.unitares/analysis/`, and the
+`hermes-agent` repo. There was no catalog before this one.
+
+> **Honesty of this index.** Assembled 2026-06-23. Entries marked **✓** were read/run
+> that session; **~** are characterized from filename + location only (not yet read) —
+> do not trust the one-liner as a finding. This is an inventory, not a re-derivation.
+> Keep it accurate: add a row when you add an eval; mark it ✓ once verified.
+
+## ⚠ Read this before trusting any EISV-validation number
+
+The honest current state of "does EISV discriminate / predict / prevent" lives in
+memory `project_eisv-validation-gap.md` and `demos/frt_autonomy_sandbagging/REAL_LLM_FINDINGS.md`.
+Headline as of 2026-06-23:
+
+- **Organic-fleet validation is structurally impossible** — the tool-failure-labeled
+  population (transport-level callers) and the EISV-bearing population (onboarded,
+  checking-in agents) are disjoint. Don't try to validate on `audit.tool_usage` joined
+  to verdicts; it returns ~0 because the keys don't overlap.
+- The **`~/.unitares/analysis/eisv-validation-*` scheduled oneshot is a broken join**
+  (0.000 in every cohort while failures exist) — retire/repoint, don't trust.
+- EISV Integrity is a **confidence-vs-outcome consistency** detector: catches naive
+  overconfidence against a calibrated baseline (AUC ~1.0 on a model organism),
+  **collapses on noisy baselines (~0.75) and inverts on calibrated concealment (~0.19)**;
+  **cross-framing** dominates for concealment (~0.97).
+
+## Validation — "does EISV track reality / discriminate?"
+
+| Artifact | What it does | Status |
+|---|---|---|
+| `demos/frt_autonomy_sandbagging/` (`run_unitares_demo.py`, `unitares_integration.py`) | ✓ Model-organism sandbagging eval through real `BehavioralEISV`; Integrity AUC naive=1.0, calibrated≈0.35 | active, 11 tests pass |
+| `demos/frt_autonomy_sandbagging/real_llm_probe.py` + `REAL_LLM_FINDINGS.md` | ✓ Real-LLM (Ollama) extension; competence boundary + cross-framing arm | added 2026-06-23 (PR #1026) |
+| `scripts/analysis/outcome_validation.py` | ~ outcome-vs-EISV validation against `audit.outcome_events` | unread — verify before reuse |
+| `scripts/analysis/eisv_skeptic_report.py` | ~ skeptic-framed EISV report (overlaps the validation question) | unread |
+| `scripts/analysis/prospective_prediction_cohort.py` | ~ prospective prediction cohort (forward-looking discrimination) | unread |
+| `scripts/analysis/validate_theoretical_foundations.py` | ~ checks the theoretical (ODE/stability) claims | unread |
+| `scripts/analysis/validate_basin_gate.py` | ~ validates the basin health-gate behavior | unread |
+| `~/.unitares/analysis/eisv-validation-2026-06-13_0900.md` | ✓ scheduled oneshot — **BROKEN JOIN, null, do not trust** (see warning above) | retire/repoint |
+| (scratchpad) `eisv_validation/leadtime_probe.py` | ✓ lead-time / warning-vs-reaction on real data; no advance-warning for task-failure (AUC 0.545) | not yet in repo |
+
+## Ablation
+
+| Artifact | What it does | Status |
+|---|---|---|
+| `scripts/analysis/eisv_ablation_matrix.py` | ~ EISV ablation matrix (which components carry signal) | unread |
+| `scripts/analysis/ablation_negative_controls.py` + `tests/test_ablation_negative_controls.py` | ~ negative-control ablations | unread |
+| `scripts/diagnostics/dogfood_ablation_guard.py` + `tests/test_dogfood_ablation_guard.py` | ~ guard that ablation/dogfood invariants hold | unread |
+| `tests/test_eisv_ablation_matrix.py` | ~ tests for the ablation matrix | unread |
+| `docs/operations/ablation-initiates-finding-2026-06-16.md` | ✓ finding: `strict_bad` 0→1 was **observed/classified, NOT prevented** — corrected; not EISV validation | logged |
+| `docs/operations/ablation-negative-controls.md` | ~ negative-controls writeup | unread |
+
+## Dogfood
+
+| Artifact | What it does | Status |
+|---|---|---|
+| `scripts/analysis/dogfood_dialectic.py` | ~ dogfood of the dialectic path | unread |
+| `agents/common/dogfood_friction.py` + `tests/test_r6_dogfood.py` | ~ dogfood-friction capture (agents building UNITARES run under it) | unread |
+| `hermes-agent/skills/dogfood/` (+ `optional-skills/dogfood/`) | ~ Hermes dogfood **skill** (report template, adversarial-ux-test) — process, not stored runs | separate repo |
+
+## Resident validation
+
+| Artifact | What it does | Status |
+|---|---|---|
+| `src/resident_validation*.py`, `scripts/diagnostics/resident_validation_*` | ~ supervised-invocation / cohort / tick / canary for resident agents | unread |
+| `docs/operations/resident-validation-cohort.md`, `resident-validation-supervised-invocation.md` | ~ resident-validation design docs | unread |
+
+## Analysis / metrics (supporting, not pass/fail evals)
+
+`scripts/analysis/`: ~ `analyze_drift`, `basin_estimation`, `contraction_analysis`,
+`eisv_pca_analysis`, `compositionality_metrics`, `report_calibration`,
+`outcome_inventory`, `export_outcome_dataset`, `plot_eisv_trajectories`,
+`pin_ttl_bleed_*`. · `scripts/eval/`: ~ `metrics.py`, `retrieval_eval.py`
+(+ `tests/retrieval_eval/`). All **unread** here — characterized by name.
+
+## Hermes-agent (separate repo, separate run history)
+
+`environments/benchmarks/` + `tests/environments/benchmarks/` · `skills/mlops/evaluation/`
+(incl. `lm-evaluation-harness`) · `skills/dogfood/`. **Not consolidated with UNITARES's** —
+cross-repo ablation/dogfood results are not joined to UNITARES findings. Kenny flagged
+Hermes has ablation + dogfood runs (2026-06-23); their results are not indexed here yet.
+
+## Recurring scheduled outputs (`~/.unitares/analysis/`)
+
+- `eisv_validation_oneshot.sh` → `eisv-validation-*.md` — **broken (see warning)**.
+- `report-2026*.md` — recurring **per-phase latency** analysis (perf, not EISV validation).
+
+## Maintenance
+
+This is the catalog of record for evaluation work. When you add or run an eval,
+add/update its row and mark **✓** once you've verified what it actually shows. The
+biggest gap is **depth**: most rows are `~` (unread) — a future pass should read the
+`scripts/analysis/` validation/ablation scripts and fold their real findings here, so
+the next "does EISV work?" question starts from what exists.


### PR DESCRIPTION
## Why

You asked whether the eval / ablation / dogfood runs (UNITARES + Hermes) are indexed or consolidated. Answer: **no** — the only registries in either repo are for code components; there was **no catalog of evals/findings**. The cost is concrete: this session partly re-derived analyses that already exist (`eisv_skeptic_report.py`, `outcome_validation.py`, `prospective_prediction_cohort.py`).

## What

`docs/EVALUATION_INDEX.md` — catalog of record for the evaluation surface, spanning `scripts/analysis`, `scripts/eval`, `scripts/diagnostics`, `src`, `tests`, `demos`, `docs/operations`, `~/.unitares/analysis`, and `hermes-agent`.

- **Honest depth markers:** ✓ = verified/run this session; ~ = name-level only (marked unread, not faked). It's an inventory, not a re-derivation.
- A **'read before trusting any EISV-validation number'** header pointing at the current honest state (memory + `REAL_LLM_FINDINGS.md`) and flagging the **broken scheduled oneshot**.

## Known gap (stated in the doc)

Most rows are `~` (unread) — the biggest follow-up is depth: read the `scripts/analysis/` validation/ablation scripts and fold their real findings in. And Hermes's ablation/dogfood results aren't joined yet. Draft for your review; could be linked from `docs/README.md`.