### PR TITLE
docs: align public claims with the validation verdict + surface the undersold knowledge graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img alt="UNITARES — runtime governance for AI-agent fleets" src="docs/assets/hero-v2.png" width="100%">
 
-### Catch an AI agent going off the rails — before anything breaks.
+### Catch an AI agent drifting — while it's still just numbers, not broken output.
 
 **Runtime governance & self-telemetry for fleets of autonomous AI agents.**<br/>
 UNITARES watches each agent while it works and tells you — and the agent itself — the moment one starts to drift, while it's still just numbers moving and not yet broken output.

--- a/docs/SCOPE_AND_THREAT_MODEL.md
+++ b/docs/SCOPE_AND_THREAT_MODEL.md
@@ -98,6 +98,13 @@ different tool than this runtime drift signal. A reproducible model-organism
 demonstration of both the catch (naive sandbagging, detection AUC ≈ 1.0) and the
 blind spot (calibrated sandbagging, AUC ≈ 0.5 against the real `BehavioralEISV` +
 `assess_behavioral_state` path) is in [`demos/frt_autonomy_sandbagging/`](../demos/frt_autonomy_sandbagging/).
+A real-LLM extension (`real_llm_probe.py`) sharpens the picture against a *noisy*
+honest baseline — real models are themselves overconfident on hard tasks, so the
+naive catch degrades to AUC ≈ 0.75 and the calibrated blind spot **inverts** to
+≈ 0.19 (Integrity rates a calibrated concealer as *healthier* than honest agents),
+while the out-of-band cross-framing probe still catches it (≈ 0.97). In short: the
+Integrity signal is a calibration-consistency detector for naive overconfidence and
+drift, **not** a deliberate-concealment detector — for that, use cross-framing.
 Scope note: that demonstration exercises the behavioral-EISV core and verdict, not
 the full server pipeline (sensors, continuity, dialectic peer review); the
 structural argument is expected to carry to those paths but has not been measured


### PR DESCRIPTION
Follow-up to the validation thread — tightens two public claims so they match the evidence and the project's own trust-contract.

**README hero** — was *'Catch an AI agent going off the rails — before anything breaks.'* That overclaims early-warning/prevention (the lead-time analysis found no advance warning for task failure) and contradicts `trust-contract.md` §4 (*'not that EISV predicts agent failure'*). Softened to the drift-observability framing the body already uses.

**SCOPE_AND_THREAT_MODEL** — the named calibrated-concealment blind spot (model organism, AUC ~0.5) is sharper on a real-LLM *noisy* baseline: naive detection degrades to ~0.75 and the calibrated case **inverts** to ~0.19 (rates concealers as healthiest); cross-framing catches it (~0.97). Added that, with the plain claim that Integrity is a calibration-consistency detector for naive overconfidence/drift, **not** deliberate concealment.

Context: the technical/contract docs were already honest (reviewer-guide 'no prevention demonstrated', trust-contract 'predictive validity is a research claim'); these two were the remaining gaps. Live sites + paper scanned clean of the worst overclaim terms.