### PR TITLE
fix(identity): gate PATH 2.75 X-Agent-Id recovery behind substrate-over-HTTP check (#802 parity)

### DIFF
--- a/src/mcp_handlers/middleware/identity_step.py
+++ b/src/mcp_handlers/middleware/identity_step.py
@@ -387,6 +387,68 @@ def _evict_stale_entries() -> None:
             del _transport_identity_cache[k]
 
 
+async def _maybe_recover_via_x_agent_id(
+    identity_result: Dict[str, Any],
+    x_agent_id_header: Optional[str],
+    session_key: str,
+) -> Optional[str]:
+    """PATH 2.75: rebind a freshly-created session to an existing UUID supplied
+    via the ``X-Agent-Id`` header (reconnection when the session key changed,
+    e.g. a Pi restart), UNLESS that UUID is substrate-anchored arriving over
+    HTTP.
+
+    #802 parity (council 2026-06-24): PATH 2.75 was the one sibling resume path
+    missing the ``_substrate_http_reject`` gate that PATH 1 (cache/prefix) and
+    PATH 2 (PG session) already enforce. A copyable ``X-Agent-Id`` header bearing
+    a substrate resident's UUID must not rebind the session to it over HTTP —
+    only a UDS peer (kernel-attested, ``peer_pid`` present) may recover a
+    substrate UUID. The gate is self-scoping: non-substrate UUIDs and UDS callers
+    pass through untouched, so legitimate Pi/Lumen reconnection over UDS is
+    unaffected; only the same-host copyable-header exfiltration path is denied.
+
+    Mutates ``identity_result`` in place on a successful rebind and returns the
+    (possibly rebound) bound agent UUID. On refusal or any error it leaves the
+    freshly-created identity in place — the safe denial — and never raises.
+    """
+    bound_agent_id = identity_result.get("agent_uuid")
+    if not (identity_result.get("created") and x_agent_id_header):
+        return bound_agent_id
+    is_uuid = len(x_agent_id_header) == 36 and x_agent_id_header.count("-") == 4
+    if not is_uuid:
+        return bound_agent_id
+    try:
+        from ..identity.handlers import _agent_exists_in_postgres, _cache_session
+        if not await _agent_exists_in_postgres(x_agent_id_header):
+            return bound_agent_id
+        # Substrate-over-HTTP gate — same one PATH 1/2 apply.
+        from ..identity.resolution import _substrate_http_reject
+        if await _substrate_http_reject(
+            x_agent_id_header, source="path2_75_x_agent_id_recovery"
+        ) is not None:
+            logger.warning(
+                "[DISPATCH] X-Agent-Id recovery refused for substrate-anchored "
+                "UUID %s... over HTTP; keeping freshly-created identity "
+                "(resident must connect via UNITARES_UDS_SOCKET).",
+                x_agent_id_header[:8],
+            )
+            return bound_agent_id
+        logger.info(
+            "[DISPATCH] X-Agent-Id recovery: rebinding session to existing agent "
+            "%s... (was about to create %s...)",
+            x_agent_id_header[:8], (bound_agent_id or "?")[:8],
+        )
+        identity_result["agent_uuid"] = x_agent_id_header
+        identity_result["created"] = False
+        identity_result["persisted"] = True
+        identity_result["source"] = "x_agent_id_recovery"
+        # Cache this session → UUID binding for future requests
+        await _cache_session(session_key, x_agent_id_header)
+        return x_agent_id_header
+    except Exception as e:
+        logger.debug(f"[DISPATCH] X-Agent-Id recovery failed: {e}")
+        return bound_agent_id
+
+
 async def resolve_identity(name: str, arguments: Dict[str, Any], ctx) -> Any:
     """Extract session identity, resolve onboard pin, bind agent."""
     _clear_middleware_identity(arguments)
@@ -775,31 +837,10 @@ async def resolve_identity(name: str, arguments: Dict[str, Any], ctx) -> Any:
                     token_agent_uuid=_token_agent_uuid,
                     spawn_reason="dispatch_auto_mint",
                 )
-        bound_agent_id = identity_result.get("agent_uuid")
-
-        # PATH 2.75: X-Agent-Id UUID recovery
-        # If session resolution created a NEW identity but X-Agent-Id header contains
-        # a known UUID, rebind to the existing agent instead of creating a duplicate.
-        # This handles reconnection when session key changes (e.g., Pi restart).
-        if identity_result.get("created") and x_agent_id_header:
-            is_uuid = len(x_agent_id_header) == 36 and x_agent_id_header.count("-") == 4
-            if is_uuid:
-                try:
-                    from ..identity.handlers import _agent_exists_in_postgres, _cache_session
-                    if await _agent_exists_in_postgres(x_agent_id_header):
-                        logger.info(
-                            f"[DISPATCH] X-Agent-Id recovery: rebinding session to existing "
-                            f"agent {x_agent_id_header[:8]}... (was about to create {bound_agent_id[:8]}...)"
-                        )
-                        bound_agent_id = x_agent_id_header
-                        identity_result["agent_uuid"] = x_agent_id_header
-                        identity_result["created"] = False
-                        identity_result["persisted"] = True
-                        identity_result["source"] = "x_agent_id_recovery"
-                        # Cache this session → UUID binding for future requests
-                        await _cache_session(session_key, x_agent_id_header)
-                except Exception as e:
-                    logger.debug(f"[DISPATCH] X-Agent-Id recovery failed: {e}")
+        # PATH 2.75: X-Agent-Id UUID recovery (substrate-over-HTTP gated, #802).
+        bound_agent_id = await _maybe_recover_via_x_agent_id(
+            identity_result, x_agent_id_header, session_key
+        )
 
         # Mark dispatch-created identities as ephemeral
         if identity_result.get("created") and not identity_result.get("persisted"):

--- a/src/mcp_handlers/middleware/identity_step.py
+++ b/src/mcp_handlers/middleware/identity_step.py
@@ -425,17 +425,18 @@ async def _maybe_recover_via_x_agent_id(
         if await _substrate_http_reject(
             x_agent_id_header, source="path2_75_x_agent_id_recovery"
         ) is not None:
+            # Do not log the header-derived UUID (CodeQL: clear-text logging of
+            # header data). The refused substrate UUID is already recorded by
+            # _substrate_http_reject's own [SUBSTRATE_HTTP_REJECT] warning.
             logger.warning(
-                "[DISPATCH] X-Agent-Id recovery refused for substrate-anchored "
-                "UUID %s... over HTTP; keeping freshly-created identity "
-                "(resident must connect via UNITARES_UDS_SOCKET).",
-                x_agent_id_header[:8],
+                "[DISPATCH] X-Agent-Id recovery refused: a substrate-anchored "
+                "UUID may not be recovered over HTTP; keeping the freshly-created "
+                "identity (resident must connect via UNITARES_UDS_SOCKET)."
             )
             return bound_agent_id
         logger.info(
-            "[DISPATCH] X-Agent-Id recovery: rebinding session to existing agent "
-            "%s... (was about to create %s...)",
-            x_agent_id_header[:8], (bound_agent_id or "?")[:8],
+            "[DISPATCH] X-Agent-Id recovery: rebinding the freshly-created "
+            "session to the existing agent named in the X-Agent-Id header."
         )
         identity_result["agent_uuid"] = x_agent_id_header
         identity_result["created"] = False

--- a/tests/test_path2_75_x_agent_id_gate.py
+++ b/tests/test_path2_75_x_agent_id_gate.py
@@ -1,0 +1,133 @@
+"""PATH 2.75 (X-Agent-Id UUID recovery) substrate-over-HTTP gate (#802 parity).
+
+PATH 2.75 lets a freshly-created dispatch session rebind to an existing UUID
+supplied via the ``X-Agent-Id`` header (reconnection when the session key
+changed, e.g. a Pi restart). It was the one sibling resume path that did NOT
+apply ``_substrate_http_reject`` — the gate PATH 1 (cache/prefix) and PATH 2
+(PG session) already enforce — so a copyable ``X-Agent-Id`` header bearing a
+substrate resident's UUID could rebind to it over HTTP, evading the #802 closure.
+
+This pins both directions: the legitimate non-substrate / UDS recovery still
+works, and the substrate-over-HTTP exfiltration path is refused (the session
+keeps its freshly-created identity).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.mcp_handlers.middleware.identity_step import _maybe_recover_via_x_agent_id
+
+SUBSTRATE_UUID = "f92dcea8-4786-412a-a0eb-362c273382f5"
+PLAIN_UUID = "00000000-1111-2222-3333-444444444444"
+
+_HANDLERS = "src.mcp_handlers.identity.handlers"
+_RES = "src.mcp_handlers.identity.resolution"
+
+
+def _fresh_result(created_uuid="aaaaaaaa-0000-0000-0000-000000000000"):
+    return {"created": True, "agent_uuid": created_uuid}
+
+
+def _signals(peer_pid=None, fp="ip-x:ua-x"):
+    return SimpleNamespace(peer_pid=peer_pid, ip_ua_fingerprint=fp)
+
+
+def _claim(label="com.unitares.sentinel"):
+    return SimpleNamespace(expected_launchd_label=label)
+
+
+# ── isolated branch coverage (gate mocked) ─────────────────────────────────
+
+class TestRecoveryBranches:
+    @pytest.mark.asyncio
+    async def test_non_substrate_uuid_rebinds(self):
+        """The legitimate recovery: a known non-substrate UUID over HTTP rebinds
+        the freshly-created session (the branch that previously had no test)."""
+        result = _fresh_result()
+        with patch(f"{_HANDLERS}._agent_exists_in_postgres", new=AsyncMock(return_value=True)), \
+             patch(f"{_HANDLERS}._cache_session", new=AsyncMock()) as cache, \
+             patch(f"{_RES}._substrate_http_reject", new=AsyncMock(return_value=None)):
+            bound = await _maybe_recover_via_x_agent_id(result, PLAIN_UUID, "sess-key")
+        assert bound == PLAIN_UUID
+        assert result["agent_uuid"] == PLAIN_UUID
+        assert result["created"] is False
+        assert result["persisted"] is True
+        assert result["source"] == "x_agent_id_recovery"
+        cache.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_substrate_uuid_refused_no_rebind(self):
+        """A substrate UUID whose gate refuses (over HTTP) must NOT rebind — the
+        session keeps its freshly-created identity (safe denial)."""
+        result = _fresh_result()
+        original = result["agent_uuid"]
+        refusal = {"resume_failed": True, "error": "substrate_anchored_uuid_requires_uds"}
+        with patch(f"{_HANDLERS}._agent_exists_in_postgres", new=AsyncMock(return_value=True)), \
+             patch(f"{_HANDLERS}._cache_session", new=AsyncMock()) as cache, \
+             patch(f"{_RES}._substrate_http_reject", new=AsyncMock(return_value=refusal)):
+            bound = await _maybe_recover_via_x_agent_id(result, SUBSTRATE_UUID, "sess-key")
+        assert bound == original
+        assert result["agent_uuid"] == original
+        assert result["created"] is True
+        assert "source" not in result or result["source"] != "x_agent_id_recovery"
+        cache.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_not_created_is_noop(self):
+        result = {"created": False, "agent_uuid": PLAIN_UUID}
+        with patch(f"{_HANDLERS}._agent_exists_in_postgres", new=AsyncMock(return_value=True)) as exists:
+            bound = await _maybe_recover_via_x_agent_id(result, SUBSTRATE_UUID, "k")
+        assert bound == PLAIN_UUID
+        exists.assert_not_awaited()  # short-circuits before any DB work
+
+    @pytest.mark.asyncio
+    async def test_non_uuid_header_is_noop(self):
+        result = _fresh_result("bbbbbbbb-0000-0000-0000-000000000000")
+        with patch(f"{_HANDLERS}._agent_exists_in_postgres", new=AsyncMock(return_value=True)) as exists:
+            bound = await _maybe_recover_via_x_agent_id(result, "not-a-uuid", "k")
+        assert bound == "bbbbbbbb-0000-0000-0000-000000000000"
+        exists.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unknown_uuid_is_noop(self):
+        result = _fresh_result()
+        original = result["agent_uuid"]
+        with patch(f"{_HANDLERS}._agent_exists_in_postgres", new=AsyncMock(return_value=False)), \
+             patch(f"{_RES}._substrate_http_reject", new=AsyncMock(return_value=None)) as gate:
+            bound = await _maybe_recover_via_x_agent_id(result, PLAIN_UUID, "k")
+        assert bound == original
+        gate.assert_not_awaited()  # never reaches the gate for an unknown UUID
+
+
+# ── end-to-end wiring through the REAL gate (its deps mocked) ───────────────
+
+class TestGateWiring:
+    @pytest.mark.asyncio
+    async def test_substrate_over_http_refused(self):
+        """No peer_pid (HTTP) + substrate claim → real gate refuses → no rebind."""
+        result = _fresh_result()
+        original = result["agent_uuid"]
+        with patch(f"{_HANDLERS}._agent_exists_in_postgres", new=AsyncMock(return_value=True)), \
+             patch(f"{_HANDLERS}._cache_session", new=AsyncMock()), \
+             patch("src.mcp_handlers.context.get_session_signals", return_value=_signals(peer_pid=None)), \
+             patch("src.substrate.verification.fetch_substrate_claim", new=AsyncMock(return_value=_claim())):
+            bound = await _maybe_recover_via_x_agent_id(result, SUBSTRATE_UUID, "k")
+        assert bound == original
+        assert result["created"] is True
+
+    @pytest.mark.asyncio
+    async def test_substrate_over_uds_rebinds(self):
+        """peer_pid present (UDS, kernel-attested) → real gate defers → legitimate
+        Pi/Lumen reconnection still recovers the substrate UUID."""
+        result = _fresh_result()
+        with patch(f"{_HANDLERS}._agent_exists_in_postgres", new=AsyncMock(return_value=True)), \
+             patch(f"{_HANDLERS}._cache_session", new=AsyncMock()), \
+             patch("src.mcp_handlers.context.get_session_signals", return_value=_signals(peer_pid=4321)), \
+             patch("src.substrate.verification.fetch_substrate_claim", new=AsyncMock(return_value=_claim())):
+            bound = await _maybe_recover_via_x_agent_id(result, SUBSTRATE_UUID, "k")
+        assert bound == SUBSTRATE_UUID
+        assert result["agent_uuid"] == SUBSTRATE_UUID
+        assert result["source"] == "x_agent_id_recovery"


### PR DESCRIPTION
## What

Closes the latent gate-bypass the simplification council surfaced (held item #1 / council "needs_migration" PATH 2.75). **Security-relevant; additive; no legitimate path changes behavior.**

PATH 2.75 (X-Agent-Id UUID recovery in the dispatch middleware) rebinds a freshly-created session to any existing UUID found in PostgreSQL, with **no substrate gate** — so a copyable `X-Agent-Id: <substrate-resident-uuid>` header could rebind the session to a substrate resident's identity over HTTP, **evading the `_substrate_http_reject` gate that PATH 1 (cache/prefix) and PATH 2 (PG session) already enforce** (#802).

## Fix

PATH 2.75 now calls the **same** `_substrate_http_reject` gate before rebinding. The gate is self-scoping:
- **UDS caller** (`peer_pid` present, kernel-attested) → passes through → legitimate **Pi/Lumen reconnection over UDS is unaffected**.
- **Non-substrate UUID** (no `core.substrate_claims` row) → passes through → normal session-key-change recovery still works.
- **Substrate UUID over HTTP** (no peer_pid) → refused; the session simply keeps its freshly-created identity (safe denial, never raises).

**Why this can't break Lumen:** the same gate is already live on PATH 1/2, so any substrate resident is *already* required to connect over UDS. Closing this one sibling hole cannot newly break a resident that is already functioning under that constraint — it only restores consistency.

## Refactor

The inline PATH 2.75 block is extracted into a named, unit-testable helper `_maybe_recover_via_x_agent_id` (the council's "named gated path" step (3)). The middleware call site is now one line.

## Tests (7 new, all green)

- `test_non_substrate_uuid_rebinds` — pins the legitimate recovery branch that previously had **no test**.
- `test_substrate_uuid_refused_no_rebind` — substrate-over-HTTP is denied; identity stays created.
- `test_not_created_is_noop`, `test_non_uuid_header_is_noop`, `test_unknown_uuid_is_noop` — short-circuit branches.
- `TestGateWiring` — end-to-end through the **real** `_substrate_http_reject` (patching only its `get_session_signals` + `fetch_substrate_claim` deps): substrate-over-HTTP refused, substrate-over-UDS rebinds.

Existing `#802`/S19 suites (`test_identity_substrate_prefix_gate_802`, `test_path28_substrate_http_reject`, `test_s19_e2e_regression`) unchanged and green.

## Scope / single-writer
Writer-locked identity surface; no in-flight identity PRs at branch time. Only touches `middleware/identity_step.py` (the PATH 2.75 block) + a new test file. No `AGENTS.md`/`CLAUDE.md` shared block, no migrations, no wire-field or response-shape change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F9PmP5CYpYDTqeud4VzEUd)_