### PR TITLE
docs(readme): frame Anima as physical testbed

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ UNITARES watches each agent while it works and tells you — and the agent itsel
 [![Paper v6](https://img.shields.io/badge/paper-v6-8957e5?style=for-the-badge&labelColor=0f171f)](https://github.com/cirwel/unitares-paper-v6)
 [![Verify it yourself](https://img.shields.io/badge/verify-it_yourself-f5a623?style=for-the-badge&labelColor=0f171f)](docs/REVIEWER_GUIDE.md)
 
-One layer of the **[CIRWEL stack](https://cirwel.github.io)** — runtime safety infrastructure for autonomous agents, *after* deployment. UNITARES is the governed fleet; [Anima](https://github.com/cirwel/anima-mcp) is its self-sensing edge counterpart. [Full index ↗](https://cirwel.github.io)
+One layer of the **[CIRWEL stack](https://cirwel.github.io)** — runtime safety infrastructure for autonomous agents, *after* deployment. UNITARES is the governed fleet; [Anima](https://github.com/cirwel/anima-mcp) is its physical edge testbed. [Full index ↗](https://cirwel.github.io)
 
 </div>
 
@@ -212,7 +212,7 @@ UNITARES is the governance runtime at the center of a larger body of work. The f
 |---|---|
 | [**unitares-governance-plugin**](https://github.com/cirwel/unitares-governance-plugin) | Mount any agent into governance — Claude Code / Codex plugin that wires check-ins, dialectic review, and verdicts into the loop via hooks |
 | [**unitares-host-adapter**](https://github.com/cirwel/unitares-host-adapter) | Thin client bindings — Hermes, Claude Code, Goose, and arbitrary OpenAI-compatible clients |
-| [**anima-mcp**](https://github.com/cirwel/anima-mcp) | The self-sensing edge counterpart — the same EISV model on physical hardware; the longitudinal source cited in the papers |
+| [**anima-mcp**](https://github.com/cirwel/anima-mcp) | Physical longitudinal testbed — the same EISV model mapped from Raspberry Pi sensor/system telemetry; the source cited in the papers |
 | [**fermata**](https://github.com/cirwel/fermata) | Governed-effect runtime seed — agents *propose* effects; only governed effects *commit* |
 | [**unitares-discord-bridge**](https://github.com/cirwel/unitares-discord-bridge) | Governance events, agent presence, and system health as a live Discord server |
 | [**eisv-lumen**](https://github.com/cirwel/eisv-lumen) | Governance benchmark dataset — [32,181 labeled EISV trajectories](https://huggingface.co/datasets/hikewa/unitares-eisv-trajectories) (20,655 real) |

--- a/docs/UNIFIED_ARCHITECTURE.md
+++ b/docs/UNIFIED_ARCHITECTURE.md
@@ -175,19 +175,19 @@ UNITARES has run continuously in production since November 2025 on a **single-op
 
 Multi-tenant or public-facing deployment will benefit from a harder auth posture than the current defaults. Vulnerability reports: [`SECURITY.md`](../SECURITY.md).
 
-## Case Study: Lumen (Embodied Agent)
+## Case Study: Lumen (Physical Sensor Agent)
 
-One of the registered agents is [Lumen](https://github.com/cirwel/anima-mcp) — an embodied creature on a Raspberry Pi 4 that checks in to Unitares every ~180 seconds (configurable via `ANIMA_GOVERNANCE_INTERVAL_SECONDS`).
+One of the registered agents is [Lumen](https://github.com/cirwel/anima-mcp) — a Raspberry Pi 4 sensor-backed agent that checks in to Unitares every ~180 seconds (configurable via `ANIMA_GOVERNANCE_INTERVAL_SECONDS`).
 
 What makes Lumen distinctive as an agent:
 
-- **Physical sensors** (temperature, humidity, pressure, light) feed into "anima" dimensions (warmth, clarity, stability, presence), which are mapped to EISV for governance check-ins
+- **Physical sensors** (temperature, humidity, pressure, light) feed into labeled Anima dimensions (warmth, clarity, stability, presence), which are mapped to EISV for governance check-ins
 - **Autonomous drawing** driven by a local EISV instance (DrawingEISV) that shares the same math but runs independently — coherence modulates how long Lumen draws and how picky it is about saving
 - **Proprioceptive loop** — the light sensor reads Lumen's own LEDs, making clarity partly self-referential
 
 Lumen demonstrates that Unitares can govern agents with very different architectures — from ephemeral CLI agents that check in once to persistent embodied systems with continuous sensor streams. The same EISV dynamics, the same verdicts, the same knowledge graph.
 
-For Lumen's internal architecture (sensors, neural bands, DrawingEISV, LED pipeline), see [anima-mcp](https://github.com/cirwel/anima-mcp).
+For Lumen's internal architecture (sensors, neural bands, DrawingEISV, LED pipeline, and creature-facing interface), see [anima-mcp](https://github.com/cirwel/anima-mcp).
 
 ---
 


### PR DESCRIPTION
Summary:
- Reframe Anima in the UNITARES README as the physical edge testbed rather than a self-sensing counterpart.
- Update the CIRWEL stack entry to lead with Raspberry Pi sensor/system telemetry mapped into EISV.
- Tighten the Lumen case study title and first sentence around physical sensor-backed check-ins.

Validation:
- git diff --check
- python3 scripts/diagnostics/check_doc_health.py README.md docs/UNIFIED_ARCHITECTURE.md (passes with unrelated existing warnings)
- ./scripts/dev/test-cache.sh --staged (10686 passed, 22 skipped, coverage 81.75%)
- git prepr --scope "Anima physical testbed framing"