### PR TITLE
fix(identity): make onboard next_step name the ownership credential (#604 follow-up)

### DIFF
--- a/src/services/identity_payloads.py
+++ b/src/services/identity_payloads.py
@@ -350,8 +350,22 @@ def build_onboard_response_data(
     # transports. Falls back to client_session_id when no token is available.
     if continuity_token:
         ownership_proof = {"continuity_token": continuity_token}
+        # next_step must be self-sufficient: an agent that reads only this hint
+        # (and not the welcome / how_to_strengthen / next_calls) still needs to
+        # know which credential to present, otherwise on a stateless transport
+        # it sends no proof and hits identity_required (#604 dogfood follow-up).
+        next_step = (
+            "Call process_agent_update with response_text describing your work — "
+            "echo the continuity_token from this response as your ownership proof "
+            "to reach 'strong' (it resolves on stateless and session-maintaining "
+            "transports alike)."
+        )
     else:
         ownership_proof = {"client_session_id": stable_session_id}
+        next_step = (
+            "Call process_agent_update with response_text describing your work; "
+            "pass your client_session_id for attribution."
+        )
     next_calls = [
         {
             "tool": "process_agent_update",
@@ -442,7 +456,7 @@ def build_onboard_response_data(
             "is_new": is_new,
             "client_session_id": stable_session_id,
             "identity_assurance": identity_context["identity_assurance"],
-            "next_step": "Call process_agent_update with response_text describing your work",
+            "next_step": next_step,
             "provisional_lineage": bool(provisional_lineage),
             "response_mode": "minimal",
         }
@@ -480,7 +494,7 @@ def build_onboard_response_data(
         "identity_context": identity_context,
         "identity_assurance": identity_context["identity_assurance"],
         "date_context": {"date": datetime.now().strftime("%Y-%m-%d"), "source": "mcp-server"},
-        "next_step": "Call process_agent_update with response_text describing your work",
+        "next_step": next_step,
     }
     if identity_resolution_outcome:
         result["identity_resolution_outcome"] = identity_resolution_outcome

--- a/tests/test_identity_payloads.py
+++ b/tests/test_identity_payloads.py
@@ -443,7 +443,9 @@ def test_onboard_minimal_mode_drops_nested_ontology_and_verbose_extras():
     assert payload["client_session_id"] == "sess-min"
     assert payload["identity_assurance"]["tier"] == "strong"
     assert payload["identity_resolution_outcome"] == "minted_fresh"
-    assert payload["next_step"]
+    # next_step is self-sufficient: it names the continuity_token credential so
+    # an agent reading only this hint still presents proof (#604 follow-up).
+    assert "continuity_token" in payload["next_step"]
     # Functional fields retained.
     assert payload["continuity_token"] == "token-min"
 
@@ -454,6 +456,20 @@ def test_onboard_minimal_mode_drops_nested_ontology_and_verbose_extras():
     assert "workflow" not in payload
     assert "tool_mode" not in payload
     assert "system_activity" not in payload
+
+
+def test_next_step_names_continuity_token_when_issued():
+    """#604 follow-up: next_step must be self-sufficient. With a token it names
+    continuity_token; without one it falls back to client_session_id — never a
+    bare 'call process_agent_update' that leaves a stateless agent unproven."""
+    full = build_onboard_response_data(**_onboard_kwargs())
+    assert "continuity_token" in full["next_step"]
+    minimal = build_onboard_response_data(**_onboard_kwargs(response_mode="minimal"))
+    assert "continuity_token" in minimal["next_step"]
+    # No token issued → fall back to client_session_id guidance, not silence.
+    no_token = build_onboard_response_data(**_onboard_kwargs(continuity_token=None))
+    assert "client_session_id" in no_token["next_step"]
+    assert "continuity_token" not in no_token["next_step"]
 
 
 def test_onboard_full_mode_is_unchanged_default():


### PR DESCRIPTION
## What

Closes the one residual the live dogfood flagged: the top-level onboard `next_step` was terse and named **no credential** —

```
"next_step": "Call process_agent_update with response_text describing your work"
```

An agent that reads *only* `next_step` (not the `welcome` / `how_to_strengthen` / `next_calls`) sends no proof and, on a stateless transport, hits `identity_required`. The credential guidance existed elsewhere in the payload but not in the one field labeled "do this next."

## Fix

`next_step` is now self-sufficient and branches on whether a token was issued:
- **with `continuity_token`:** *"Call process_agent_update with response_text describing your work — echo the continuity_token from this response as your ownership proof to reach 'strong' (it resolves on stateless and session-maintaining transports alike)."*
- **without one:** falls back to client_session_id guidance — never a bare "call process_agent_update" that leaves a stateless agent unproven.

Applied to **both** the minimal and full onboard envelopes. Pure agent-facing copy — no behavior, response-field, or proof-path change.

## Tests
- Strengthened the minimal-mode assertion (`continuity_token` now in `next_step`).
- New `test_next_step_names_continuity_token_when_issued` pins both branches (token → names continuity_token; no token → names client_session_id, not silence).
- 51 identity-payload + s1-continuity tests green.

## Scope
Writer-locked identity surface; agent-facing copy only; no `AGENTS.md`/`CLAUDE.md` shared block, no migrations, no wire-shape change. Consistent with the #1022 P0/P1 copy direction (continuity_token as the stateless-safe ownership proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F9PmP5CYpYDTqeud4VzEUd)_