### PR TITLE
chore: disable Claude attribution on commits and PRs in cloud sessions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,12 @@ data/processes/
 data/watcher/
 
 # Claude Code / Cursor local state (machine-specific, never commit)
-.claude/
+# Ignore everything under .claude/ EXCEPT the committed settings.json, which
+# carries shared, repo-level config (e.g. attribution) that cloud/web sessions
+# read from the fresh clone. The machine-local overlay (.claude/CLAUDE.md) and
+# .claude/settings.local.json stay ignored.
+.claude/*
+!.claude/settings.json
 .hypothesis/
 data/gov-data-preserve/
 *.log


### PR DESCRIPTION
## What

Stop Claude Code from signing off as itself on commits and PRs — both in local runs and in **web/cloud sessions**.

## How

Adds a committed `.claude/settings.json`:

```json
{
  "attribution": {
    "commit": "",
    "pr": ""
  }
}
```

- `attribution.commit = ""` → no `Co-Authored-By: Claude` trailer (and no `Generated with Claude Code`) appended to commit messages.
- `attribution.pr = ""` → no `🤖 Generated with Claude Code` line appended to PR bodies.

These are the current canonical settings (the old `includeCoAuthoredBy` boolean is deprecated).

## Why the `.gitignore` change

`.claude/` was previously ignored in full, so a committed settings file would never reach a cloud session (which only sees the fresh clone). The ignore is narrowed to `.claude/*` with a `!.claude/settings.json` re-include, so:

- ✅ `.claude/settings.json` is tracked and ships to cloud/web sessions.
- ✅ the machine-local `.claude/CLAUDE.md` overlay stays ignored.
- ✅ `.claude/settings.local.json` stays ignored.

Per the official docs, cloud sessions read attribution config from the committed `.claude/settings.json` in the cloned repo, so this takes effect for Claude-authored PRs created from the web.

This commit itself was made with attribution already suppressed, consistent with the existing CLAUDE.md "Do not include Co-Authored-By lines" policy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQLaFx6ZPGPyuR3ESNRYut)_