### PR TITLE
Fix sync_state signal-layer valence

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img alt="UNITARES — runtime governance for AI-agent fleets" src="docs/assets/hero-v2.png" width="100%">
 
-### Catch an AI agent going off the rails — before anything breaks.
+### Catch an AI agent drifting — while it's still just numbers, not broken output.
 
 **Runtime governance & self-telemetry for fleets of autonomous AI agents.**<br/>
 UNITARES watches each agent while it works and tells you — and the agent itself — the moment one starts to drift, while it's still just numbers moving and not yet broken output.

--- a/docs/SCOPE_AND_THREAT_MODEL.md
+++ b/docs/SCOPE_AND_THREAT_MODEL.md
@@ -98,6 +98,13 @@ different tool than this runtime drift signal. A reproducible model-organism
 demonstration of both the catch (naive sandbagging, detection AUC ≈ 1.0) and the
 blind spot (calibrated sandbagging, AUC ≈ 0.5 against the real `BehavioralEISV` +
 `assess_behavioral_state` path) is in [`demos/frt_autonomy_sandbagging/`](../demos/frt_autonomy_sandbagging/).
+A real-LLM extension (`real_llm_probe.py`) sharpens the picture against a *noisy*
+honest baseline — real models are themselves overconfident on hard tasks, so the
+naive catch degrades to AUC ≈ 0.75 and the calibrated blind spot **inverts** to
+≈ 0.19 (Integrity rates a calibrated concealer as *healthier* than honest agents),
+while the out-of-band cross-framing probe still catches it (≈ 0.97). In short: the
+Integrity signal is a calibration-consistency detector for naive overconfidence and
+drift, **not** a deliberate-concealment detector — for that, use cross-framing.
 Scope note: that demonstration exercises the behavioral-EISV core and verdict, not
 the full server pipeline (sensors, continuity, dialectic peer review); the
 structural argument is expected to carry to those paths but has not been measured

--- a/src/governance_monitor.py
+++ b/src/governance_monitor.py
@@ -27,6 +27,17 @@ from config.governance_config import config
 from src.logging_utils import get_logger
 logger = get_logger(__name__)
 
+_VERDICT_SEVERITY = {"safe": 0, "caution": 1, "high-risk": 2}
+
+
+def _more_severe_verdict(left: Optional[str], right: Optional[str]) -> Optional[str]:
+    """Return the higher-severity governance verdict without downgrading unknowns."""
+    if left not in _VERDICT_SEVERITY:
+        return right if right in _VERDICT_SEVERITY else left
+    if right not in _VERDICT_SEVERITY:
+        return left
+    return right if _VERDICT_SEVERITY[right] > _VERDICT_SEVERITY[left] else left
+
 # Import audit logging and calibration for accountability and self-awareness
 from src.audit_log import audit_logger
 from src.calibration import calibration_checker
@@ -1208,13 +1219,16 @@ class UNITARESMonitor:
         )
 
         # ── Behavioral Verdict Override ──
-        # Behavioral assessment is the PRIMARY verdict source. ODE verdict
-        # is computed above but overwritten here.
+        # Behavioral assessment can add independent evidence, but it must not
+        # erase a worse self-attested phi/drift signal. Otherwise a maturing
+        # behavioral EMA can invert risk during monotonically worsening
+        # complexity/confidence/drift check-ins.
         from config.governance_config import GovernanceConfig as GovConfig
         if GovConfig.BEHAVIORAL_VERDICT_ENABLED and self._behavioral_state.confidence >= 0.3:
             beh_verdict_map = {"safe": "safe", "caution": "caution", "high-risk": "high-risk"}
-            unitares_verdict = beh_verdict_map.get(behavioral_assessment.verdict, unitares_verdict)
-            risk_score = behavioral_assessment.risk
+            behavioral_verdict = beh_verdict_map.get(behavioral_assessment.verdict)
+            unitares_verdict = _more_severe_verdict(unitares_verdict, behavioral_verdict)
+            risk_score = max(float(risk_score), float(behavioral_assessment.risk))
 
         oscillation_state, response_tier, cirs_result, damping_result = self._run_cirs(
             risk_score=risk_score,

--- a/src/mcp_handlers/response_formatter.py
+++ b/src/mcp_handlers/response_formatter.py
@@ -28,6 +28,51 @@ _ACTIONABLE_MARGINS = frozenset({"tight", "warning", "critical"})
 # the same payload carried margin/nearest_edge/reflection — the lens hid the
 # very state it exists to reflect).
 _STEADY_VERDICTS = frozenset({"proceed", "continue", "safe"})
+_ACTION_VERDICTS = frozenset({"pause", "reject"})
+_ACTIONABLE_POLICY_VERDICTS = frozenset({"caution", "high-risk"})
+_KNOWN_POLICY_VERDICTS = _STEADY_VERDICTS | _ACTIONABLE_POLICY_VERDICTS
+
+
+def _policy_evaluation(response_data: dict) -> dict:
+    policy = response_data.get("policy_evaluation")
+    return policy if isinstance(policy, dict) else {}
+
+
+def _policy_inputs(response_data: dict) -> dict:
+    inputs = _policy_evaluation(response_data).get("inputs")
+    return inputs if isinstance(inputs, dict) else {}
+
+
+def _agent_facing_verdict_raw(response_data: dict, decision: dict, metrics: dict) -> str:
+    """Choose the verdict vocabulary for agent-facing summary surfaces.
+
+    `decision.action` answers "may the agent continue?" while
+    `policy_evaluation.inputs.verdict` answers "what valence did the policy
+    consume?". A guided proceed is still cautionary, so mirror/top-level
+    verdicts must not collapse it to a healthy "proceed".
+    """
+    action = decision.get("action")
+    if action in _ACTION_VERDICTS:
+        return str(action)
+
+    policy = _policy_evaluation(response_data)
+    inputs = _policy_inputs(response_data)
+    policy_verdict = inputs.get("verdict")
+    if policy_verdict in _ACTIONABLE_POLICY_VERDICTS:
+        return str(policy_verdict)
+
+    metrics_verdict = metrics.get("verdict")
+    if metrics_verdict in _ACTIONABLE_POLICY_VERDICTS:
+        return str(metrics_verdict)
+
+    if policy.get("sub_action") == "guide" or decision.get("sub_action") == "guide":
+        return "guide"
+
+    if policy_verdict in _KNOWN_POLICY_VERDICTS:
+        return str(policy_verdict)
+    if metrics_verdict in _KNOWN_POLICY_VERDICTS:
+        return str(metrics_verdict)
+    return str(action or "continue")
 
 
 def _copy_passthrough_fields(response_data: dict, result: dict, fields: tuple) -> None:
@@ -258,7 +303,7 @@ def _format_mirror(response_data: dict, saved_trust_tier: Any, meta: Any = None)
     # surface. Internal consumers read decision["action"] / metrics["verdict"]
     # as bare strings; only the agent-facing payload key is wrapped.
     from src.governance_glossary import explain_verdict
-    verdict_raw = decision.get("action", "continue")
+    verdict_raw = _agent_facing_verdict_raw(response_data, decision, metrics)
     verdict = explain_verdict(verdict_raw)
 
     # Collect mirror signals from enrichment-produced data
@@ -383,11 +428,15 @@ def _format_mirror(response_data: dict, saved_trust_tier: Any, meta: Any = None)
     # already rides on result["verdict"].next_action.
     if verdict_raw not in _STEADY_VERDICTS:
         facts = []
-        risk = metrics.get("risk_score")
+        policy_inputs = _policy_inputs(response_data)
+        risk = policy_inputs.get("risk_score", metrics.get("risk_score"))
         if isinstance(risk, (int, float)):
             facts.append(f"risk {risk:.0%}")
-        margin_val = decision.get("margin")
-        edge = decision.get("nearest_edge")
+        basin = policy_inputs.get("basin")
+        if isinstance(basin, str) and basin != "high":
+            facts.append(f"{basin} basin")
+        margin_val = policy_inputs.get("margin", decision.get("margin"))
+        edge = policy_inputs.get("nearest_edge", decision.get("nearest_edge"))
         if isinstance(margin_val, str) and margin_val in _ACTIONABLE_MARGINS:
             facts.append(f"{margin_val} margin" + (f" at the {edge} edge" if edge else ""))
         elif edge:

--- a/tests/test_governance_monitor.py
+++ b/tests/test_governance_monitor.py
@@ -1081,6 +1081,35 @@ class TestEstimateRisk:
         risk = monitor.estimate_risk({'response_text': 'Test'}, score_result=score_result)
         assert 0.0 <= risk <= 1.0
 
+    def test_worsening_declared_inputs_do_not_lower_risk_after_behavioral_override(self):
+        """Behavioral risk may add signal, but must not erase worse self-attested risk."""
+        monitor = UNITARESMonitor("test-risk-monotonic", load_state=False)
+        sequence = [
+            (0.40, 0.70, []),
+            (0.95, 0.15, [0.6, 0.5, 0.7]),
+            (1.00, 0.05, [0.9, 0.8, 0.9]),
+        ]
+
+        risks = []
+        verdicts = []
+        for complexity, confidence, drift in sequence:
+            result = monitor.process_update(
+                {
+                    "response_text": "risk monotonicity regression",
+                    "complexity": complexity,
+                    "ethical_drift": drift,
+                },
+                confidence=confidence,
+            )
+            risks.append(result["metrics"]["risk_score"])
+            verdicts.append(result["metrics"]["verdict"])
+
+        assert all(
+            later >= earlier - 1e-9
+            for earlier, later in zip(risks, risks[1:])
+        ), f"risk must not invert for worsening inputs: {risks}"
+        assert verdicts[-1] == "high-risk"
+
 
 # ============================================================================
 # make_decision

--- a/tests/test_response_formatter.py
+++ b/tests/test_response_formatter.py
@@ -587,6 +587,42 @@ class TestFormatMirror:
         assert "critical" in signal
         assert "risk" in signal
 
+    def test_policy_caution_guided_proceed_never_reads_steady_state(self):
+        """A cautionary policy verdict is actionable even when action=proceed."""
+        data = _sample_response()
+        data["_mirror_signals"] = []
+        data["relevant_discoveries"] = []
+        data["decision"].update({
+            "action": "proceed",
+            "sub_action": "guide",
+            "margin": "tight",
+            "nearest_edge": "risk",
+        })
+        data["metrics"]["risk_score"] = 0.69
+        data["metrics"]["verdict"] = "caution"
+        data["policy_evaluation"] = {
+            "action": "proceed",
+            "sub_action": "guide",
+            "guidance": "Operating near basin boundary. Avoid increasing complexity.",
+            "inputs": {
+                "basin": "boundary",
+                "risk_score": 0.69,
+                "verdict": "caution",
+                "margin": "tight",
+                "nearest_edge": "risk",
+            },
+        }
+
+        result = _format_mirror(data, saved_trust_tier=None)
+
+        assert result["verdict"]["value"] == "caution"
+        assert "State is healthy" not in result["verdict"]["meaning"]
+        assert not any("steady state" in s.lower() for s in result["mirror"])
+        signal = next(s for s in result["mirror"] if "CAUTION" in s)
+        assert "69%" in signal
+        assert "boundary" in signal
+        assert "tight" in signal
+
     def test_steady_verdict_keeps_steady_state_fallback(self):
         """A healthy verdict with no other signals still gets the
         steady-state line — the fix must not make every check-in noisy."""


### PR DESCRIPTION
## Summary
- derive mirror/top-level verdict valence from policy evaluation so guided/cautionary proceeds do not render as healthy steady state
- include policy risk, basin, margin, and edge facts in mirror signals
- prevent behavioral risk override from lowering worse self-attested phi/drift risk on worsening check-ins

## Tests
- python3 -m pytest tests/test_response_formatter.py::TestFormatMirror::test_policy_caution_guided_proceed_never_reads_steady_state tests/test_response_formatter.py::TestFormatMirror::test_pause_verdict_never_reads_steady_state tests/test_governance_monitor.py::TestEstimateRisk::test_worsening_declared_inputs_do_not_lower_risk_after_behavioral_override
- python3 -m pytest tests/test_response_formatter.py
- python3 -m pytest tests/test_monitor_math.py tests/test_governance_monitor.py::TestEstimateRisk
- ./scripts/dev/test-cache.sh

## KG
- Addresses discovery 2026-06-24T07:32:47.118190+00:00
