### PR TITLE
fix(schemas): honor lite=true as a bool + make response_mode self-describing

### DIFF
--- a/src/mcp_handlers/schemas/core.py
+++ b/src/mcp_handlers/schemas/core.py
@@ -283,11 +283,19 @@ class ProcessAgentUpdateParams(AgentIdentityMixin):
     )
     response_mode: Literal["minimal", "compact", "standard", "full", "mirror", "auto"] = Field(
         default="auto",
-        description="Response verbosity mode. 'mirror' returns actionable self-awareness signals instead of raw EISV. 'compact' or 'minimal' returns a smaller payload."
+        description=(
+            "Response verbosity. 'auto' (default) adapts to health — mirror when "
+            "healthy/disembodied, else minimal/standard/compact. 'mirror' returns "
+            "actionable self-awareness signals instead of raw EISV. 'standard' is a "
+            "human-readable interpretation. 'minimal' and 'compact' are both small "
+            "payloads (minimal = action + EISV snapshot + margin; compact = brief "
+            "metrics + decision). 'full' returns the complete payload unfiltered. "
+            "The 'lite' boolean below is an alias for 'minimal'."
+        )
     )
     lite: Union[bool, str, None] = Field(
         default=None,
-        description="If true, returns minimal response. Alias for response_mode='minimal'."
+        description="Boolean alias for response_mode='minimal'. Applies only when response_mode is left at 'auto' (an explicit response_mode always wins)."
     )
     auto_export_on_significance: bool = Field(
         default=False,
@@ -347,9 +355,15 @@ class ProcessAgentUpdateParams(AgentIdentityMixin):
 
     @model_validator(mode='after')
     def coerce_types(self):
-        if isinstance(self.lite, str):
-            val = str(self.lite).lower() in ('true', '1', 'yes')
-            if val and self.response_mode == "auto":
+        # `lite` is a boolean alias for response_mode='minimal'. Accept a real
+        # bool OR a truthy string — previously only the string form was honored,
+        # so an actual JSON `lite: true` was silently ignored. Only applies when
+        # response_mode is still 'auto', so an explicit response_mode always wins.
+        if self.lite is not None:
+            lite_on = self.lite if isinstance(self.lite, bool) else (
+                str(self.lite).lower() in ('true', '1', 'yes')
+            )
+            if lite_on and self.response_mode == "auto":
                 self.response_mode = "minimal"
         if isinstance(self.require_strong_identity, str):
             self.require_strong_identity = self.require_strong_identity.lower() in ('true', '1', 'yes')

--- a/tests/test_pydantic_schemas.py
+++ b/tests/test_pydantic_schemas.py
@@ -8,6 +8,21 @@ class TestPydanticSchemas:
     full coverage of the type coercions and bounds checking previously handled 
     by manual validators."""
 
+    def test_lite_alias_coerces_minimal_for_bool_and_string(self):
+        """`lite` is documented as an alias for response_mode='minimal'. It must
+        honor a real JSON bool, not only the string form (which was the bug —
+        `lite: true` was silently ignored). An explicit response_mode still wins."""
+        from src.mcp_handlers.schemas.core import ProcessAgentUpdateParams
+        # Real bool — previously ignored.
+        assert ProcessAgentUpdateParams(lite=True, response_text="T").response_mode == "minimal"
+        # Truthy string still works.
+        assert ProcessAgentUpdateParams(lite="true", response_text="T").response_mode == "minimal"
+        # Falsey leaves the default.
+        assert ProcessAgentUpdateParams(lite=False, response_text="T").response_mode == "auto"
+        assert ProcessAgentUpdateParams(response_text="T").response_mode == "auto"
+        # Explicit response_mode always wins over lite.
+        assert ProcessAgentUpdateParams(lite=True, response_mode="full", response_text="T").response_mode == "full"
+
     def test_float_bounds(self):
         """Test float range bounds are applied correctly (e.g., complexity 0.0-1.0)."""
         from src.mcp_handlers.schemas.core import ProcessAgentUpdateParams


### PR DESCRIPTION
## Context

Answering "do we have too many modes?" — I mapped the verbosity surface. The honest finding: the bigger problem isn't the *count*, it's **inconsistency across tool families** (four dialects: `process_agent_update`'s 6-value `response_mode`, `record_result`'s `lite/full`+`include_semantics`, `onboard`'s `minimal/full`, and bare `lite`/`verbose`/`include_*` bools on reads). But that consolidation is **wire-locked** — `response_mode='lite'→compact` is test-pinned (`test_lite_alias_for_compact`), and `lite` means different things in `process_agent_update` vs `check_working_state` — so it stays migration-gated.

This PR is the **safe-now slice**: one real bugfix + self-describing docs. No mode added/removed, no response shape changed.

## 1. Bugfix — `lite: true` (bool) was silently ignored

`ProcessAgentUpdateParams.lite` is documented as *"alias for `response_mode='minimal'`"*, but `coerce_types` only handled the **string** form (`isinstance(self.lite, str)`). So a natural JSON `lite: true` (an actual bool) did nothing. Now it honors a bool **or** truthy string, still only when `response_mode` is left at `'auto'` (an explicit `response_mode` always wins). This aligns behavior with the **existing documented contract** — callers already passing `response_mode` directly are unaffected.

## 2. Docs — `response_mode` is now self-describing

The Field description previously mentioned only three modes vaguely. It now enumerates all six: `auto` (adapts to health), `mirror` (signals), `standard` (interpreted), `minimal`/`compact` (small payloads, with the distinction spelled out), `full` (unfiltered) — plus the `lite` bool-alias + auto-only rule. Directly addresses the "an agent has to guess" pain.

## Tests
- New `test_lite_alias_coerces_minimal_for_bool_and_string` pins all branches (bool true → minimal, string "true" → minimal, false → auto, explicit mode wins).
- 246 schema / response-formatter / describe-tool-drift / core-update tests green — **including the unchanged `response_mode='lite'→compact` alias test** (my change touches only the `lite` *param*, not the `response_mode` *value*).

## Deferred (migration-gated, noted for the record)
Collapsing `minimal`+`compact` (near-duplicates), unifying the cross-tool `lite` vocabulary, and reconciling the `response_mode` Literal with the formatter's internal `lite`/`interpreted` aliases (reachable only via stored prefs/env, not the public param) — all change output for existing accepted values, so they need the instrument→window→remove treatment, not a delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F9PmP5CYpYDTqeud4VzEUd)_