### PR TITLE
chore(identity): instrument the S1-d continuity_token deprecation false-path (window prep)

### DIFF
--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -77,6 +77,41 @@ def _broadcaster():
         return None
 
 
+_s1d_false_reached_logged = False
+
+
+def _log_s1d_false_observation_once() -> None:
+    """S1-d telemetry (council 2026-06-24; docs/ontology/plan.md S20 follow-up).
+
+    The cross-process ``continuity_token`` resume path is believed dead: the
+    S1-c reject gate (``_continuity_token_resume_rejected``) provably precedes
+    both ``_emit_continuity_token_deprecation`` call sites, so
+    ``used_token_for_resume`` is expected to always be False at runtime. But that
+    cannot be proven from this repo against an untested cross-repo (gov-plugin /
+    HTTP shim) dispatch path.
+
+    The True case is already audited (``log_continuity_token_deprecated_accept``).
+    The False case was *silent*, so "observed False" could only be inferred from
+    the absence of accept events — which is weaker, since absence could equally
+    mean the surface is never reached at all. This log-once (one line per
+    process) positively records that the deprecation surface WAS reached with
+    ``used_token_for_resume=False``. A clean telemetry window is therefore: this
+    line present AND zero ``continuity_token.deprecated_accept`` audits =>
+    the deprecation residue is safe to retire (S1-d). Bounded to one emission per
+    process so the common path adds no per-onboard log noise.
+    """
+    global _s1d_false_reached_logged
+    if _s1d_false_reached_logged:
+        return
+    _s1d_false_reached_logged = True
+    logger.info(
+        "[S1-d] continuity_token deprecation surface reached with "
+        "used_token_for_resume=False (expected — confirms the S1-c reject gate "
+        "holds). Zero continuity_token.deprecated_accept audits over a telemetry "
+        "window => the deprecation residue is safe to retire."
+    )
+
+
 def _emit_continuity_token_deprecation(
     *,
     response_dict: Dict[str, Any],
@@ -101,6 +136,7 @@ def _emit_continuity_token_deprecation(
  ``used_token_for_resume``. .
     """
     if not used_token_for_resume:
+        _log_s1d_false_observation_once()
         return
     issued_at = extract_token_iat(str(token_str)) if token_str else None
     dep_block = build_token_deprecation_block(

--- a/tests/test_s1_continuity_token_narrow.py
+++ b/tests/test_s1_continuity_token_narrow.py
@@ -744,6 +744,42 @@ def test_emit_helper_noop_when_not_resume(monkeypatch):
     assert response == {"existing": "value"}
 
 
+def test_emit_helper_logs_s1d_false_observation_once(monkeypatch, caplog):
+    """S1-d telemetry: the False (non-deprecating) path now positively records
+    that the deprecation surface was reached with used_token_for_resume=False,
+    once per process — so 'observed False' can be confirmed rather than only
+    inferred from the absence of accept audits. The audit/mutation behavior is
+    unchanged (still a no-op)."""
+    import logging
+    from src.mcp_handlers.identity import handlers as H
+
+    # Reset the per-process latch so the assertion is deterministic.
+    monkeypatch.setattr(H, "_s1d_false_reached_logged", False)
+
+    response: dict = {"existing": "value"}
+    with caplog.at_level(logging.INFO):
+        H._emit_continuity_token_deprecation(
+            response_dict=response,
+            used_token_for_resume=False,
+            token_str="v1.aaa.bbb",
+            agent_uuid="x",
+            response_agent_id="y",
+        )
+        # Second call in the same process must NOT log again (bounded noise).
+        H._emit_continuity_token_deprecation(
+            response_dict=response,
+            used_token_for_resume=False,
+            token_str="v1.aaa.bbb",
+            agent_uuid="x",
+            response_agent_id="y",
+        )
+
+    s1d_lines = [r for r in caplog.records if "[S1-d]" in r.getMessage()]
+    assert len(s1d_lines) == 1, "telemetry must log exactly once per process"
+    assert "used_token_for_resume=False" in s1d_lines[0].getMessage()
+    # No mutation on the False path — behavior unchanged.
+    assert response == {"existing": "value"}
+
 def test_emit_helper_swallows_audit_failure(tmp_path, monkeypatch, caplog):
     """Audit emission failures must not propagate to the request path."""
     from src.mcp_handlers.identity.handlers import _emit_continuity_token_deprecation


### PR DESCRIPTION
## What

The **instrument** step of `instrument → window → remove` for the dead cross-process `continuity_token` resume residue (council 2026-06-24 held item; `plan.md` S20 follow-up). **Not a removal** — it just makes the eventual removal *provable*, additively.

## Why this and not "add instrumentation everywhere"

I checked first: most deprecation candidates are **already** instrumented — `response_mode` usage via `mirror_signal.emit`, and the **True** (deprecating) `continuity_token` path via `log_continuity_token_deprecated_accept`. So a broad telemetry PR would be redundant.

The one genuine gap: `_emit_continuity_token_deprecation` returns **silently** when `used_token_for_resume` is False. So "observed False over a window" could only be *inferred* from the absence of accept audits — which is weaker, because absence could equally mean the surface is **never reached at all** (e.g. via an untested cross-repo gov-plugin / HTTP-shim dispatch the council flagged). That ambiguity is exactly why the council put S1-d in `needs_migration`.

## Change

`_emit_continuity_token_deprecation` now logs **once per process** when reached with `used_token_for_resume=False`:

```
[S1-d] continuity_token deprecation surface reached with used_token_for_resume=False
(expected — confirms the S1-c reject gate holds). Zero continuity_token.deprecated_accept
audits over a telemetry window => the deprecation residue is safe to retire.
```

So a **clean window is now positive**: `[S1-d]` line present **AND** zero `continuity_token.deprecated_accept` audits ⇒ the residue (`build_token_deprecation_block`, the emit body, the 5 pinning tests) is safe to delete in a follow-up PR. Bounded to one emission per process, so the common onboard/identity path adds no log noise. Audit + response-mutation behavior on the False path are **unchanged** (still a no-op).

## Tests
- New `test_emit_helper_logs_s1d_false_observation_once` — asserts exactly one `[S1-d]` log per process (latch reset via monkeypatch), and that the no-op behavior is preserved.
- 162 S1-continuity + identity-handler tests green.

## Scope
Writer-locked identity surface; additive log only — no behavior, response shape, or proof-path change. Independent of the open #1041 (different file). The actual S1-d *removal* remains a deliberate follow-up gated on the window + a cross-repo (`gh pr list` both repos) check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F9PmP5CYpYDTqeud4VzEUd)_