### PR TITLE
feat(dev): agent-runnable S1-d deprecation-window checker

### DIFF
--- a/scripts/dev/check_s1d_deprecation_window.py
+++ b/scripts/dev/check_s1d_deprecation_window.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""S1-d deprecation-window checker — lets an agent (resident / cron / doctor)
+decide whether the dead cross-process ``continuity_token`` resume residue is
+safe to retire, instead of a human eyeballing logs.
+
+Background (docs/ontology/plan.md S20; PRs #1042 telemetry):
+  - The retired cross-process resume path emits a
+    ``continuity_token_deprecated_accept`` audit event whenever it is actually
+    taken (``used_token_for_resume=True``). It is believed never taken (the S1-c
+    reject gate precedes the emit), but that can't be proven from the repo alone.
+  - The False path additionally logs a once-per-process ``[S1-d]`` line so that
+    "surface reached, observed False" is positively confirmable, not merely
+    inferred from the absence of accept events.
+
+A window is CLEAN ⇒ safe to delete the residue when, over the window:
+  (1) ZERO ``continuity_token_deprecated_accept`` events, AND
+  (2) the ``[S1-d]`` reached-marker is present (the surface IS exercised, so the
+      zero-accepts is "gate holds", not "code path never runs").
+
+This script reads the audit JSONL (and, optionally, a server log for the
+marker), and exits 0 (clean / safe) or 1 (dirty / not-yet). It is meant to be
+run ON the deployment where ``data/audit_log.jsonl`` lives — a stateless API
+client cannot see that file. Pure stdlib; importable core for testing.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+ACCEPT_EVENT = "continuity_token_deprecated_accept"
+S1D_MARKER = "[S1-d]"
+DEFAULT_WINDOW_DAYS = 14
+
+
+def _parse_ts(value: Any) -> Optional[datetime]:
+    """Parse an ISO timestamp; return None on anything unparseable."""
+    if not isinstance(value, str):
+        return None
+    try:
+        # Audit entries use datetime.now().isoformat() (naive local). Tolerate a
+        # trailing 'Z' just in case a future writer emits UTC.
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).replace(tzinfo=None)
+    except ValueError:
+        return None
+
+
+def scan_audit_window(
+    audit_lines: Iterable[str],
+    *,
+    window_days: int,
+    now: datetime,
+    marker_lines: Optional[Iterable[str]] = None,
+) -> Dict[str, Any]:
+    """Pure core: scan audit JSONL lines for in-window deprecated_accept events.
+
+    ``marker_lines`` (optional) is any iterable of log lines to scan for the
+    ``[S1-d]`` reached-marker. When omitted, ``surface_reached`` is None
+    (unknown) and the verdict is downgraded from CLEAN to UNCONFIRMED.
+    """
+    cutoff = now - timedelta(days=window_days)
+    scanned = 0
+    accepts_in_window: List[Dict[str, Any]] = []
+    for line in audit_lines:
+        line = line.strip()
+        if not line:
+            continue
+        scanned += 1
+        try:
+            entry = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(entry, dict) or entry.get("event_type") != ACCEPT_EVENT:
+            continue
+        ts = _parse_ts(entry.get("timestamp"))
+        if ts is None or ts < cutoff:
+            continue
+        accepts_in_window.append(entry)
+
+    surface_reached: Optional[bool] = None
+    if marker_lines is not None:
+        surface_reached = any(S1D_MARKER in str(l) for l in marker_lines)
+
+    n_accepts = len(accepts_in_window)
+    if n_accepts > 0:
+        verdict = "DIRTY"
+    elif surface_reached is True:
+        verdict = "CLEAN"
+    else:
+        # Zero accepts but we cannot confirm the surface was exercised.
+        verdict = "UNCONFIRMED"
+
+    return {
+        "verdict": verdict,
+        "safe_to_retire": verdict == "CLEAN",
+        "window_days": window_days,
+        "cutoff": cutoff.isoformat(),
+        "events_scanned": scanned,
+        "deprecated_accept_in_window": n_accepts,
+        "samples": accepts_in_window[:5],
+        "surface_reached": surface_reached,
+    }
+
+
+def _read_lines(path: Optional[Path]) -> Optional[List[str]]:
+    if path is None:
+        return None
+    if not path.exists():
+        return None
+    return path.read_text(errors="replace").splitlines()
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    repo_root = Path(__file__).resolve().parents[2]
+    parser.add_argument(
+        "--audit-log",
+        type=Path,
+        default=repo_root / "data" / "audit_log.jsonl",
+        help="Path to the audit JSONL (default: <repo>/data/audit_log.jsonl).",
+    )
+    parser.add_argument(
+        "--server-log",
+        type=Path,
+        default=None,
+        help="Optional server log file to scan for the [S1-d] reached-marker. "
+        "Required to reach a CLEAN (vs UNCONFIRMED) verdict.",
+    )
+    parser.add_argument("--window-days", type=int, default=DEFAULT_WINDOW_DAYS)
+    parser.add_argument("--json", action="store_true", help="Emit JSON only.")
+    args = parser.parse_args(argv)
+
+    audit_lines = _read_lines(args.audit_log)
+    if audit_lines is None:
+        msg = (
+            f"audit log not found at {args.audit_log} — run this ON the deployment "
+            "where data/audit_log.jsonl lives, or pass --audit-log."
+        )
+        if args.json:
+            print(json.dumps({"verdict": "NO_AUDIT_LOG", "safe_to_retire": False, "error": msg}))
+        else:
+            print(f"⚠️  {msg}", file=sys.stderr)
+        return 2
+
+    result = scan_audit_window(
+        audit_lines,
+        window_days=args.window_days,
+        now=datetime.now(),
+        marker_lines=_read_lines(args.server_log),
+    )
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        v = result["verdict"]
+        icon = {"CLEAN": "✅", "UNCONFIRMED": "🟡", "DIRTY": "❌"}.get(v, "❓")
+        print(f"{icon}  S1-d deprecation window: {v}")
+        print(f"    window: last {result['window_days']}d (since {result['cutoff']})")
+        print(f"    audit events scanned: {result['events_scanned']}")
+        print(f"    continuity_token_deprecated_accept in window: {result['deprecated_accept_in_window']}")
+        print(f"    [S1-d] surface-reached marker: {result['surface_reached']}")
+        if v == "CLEAN":
+            print("    → SAFE TO RETIRE: 0 deprecated accepts AND the surface is confirmed reached.")
+        elif v == "UNCONFIRMED":
+            print("    → 0 deprecated accepts, but pass --server-log with the [S1-d] marker "
+                  "(or wait for #1042 to deploy + accrue traffic) to confirm the path runs.")
+        else:
+            print("    → NOT SAFE: the deprecated cross-process resume path is still in use.")
+    # exit 0 only on a positive CLEAN verdict; 1 otherwise (dirty/unconfirmed).
+    return 0 if result["safe_to_retire"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_s1d_deprecation_window.py
+++ b/tests/test_check_s1d_deprecation_window.py
@@ -1,0 +1,71 @@
+"""Tests for the S1-d deprecation-window checker (scripts/dev)."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+
+from scripts.dev.check_s1d_deprecation_window import scan_audit_window, ACCEPT_EVENT
+
+NOW = datetime(2026, 6, 24, 12, 0, 0)
+
+
+def _accept(ts: datetime) -> str:
+    return json.dumps({"event_type": ACCEPT_EVENT, "timestamp": ts.isoformat(), "details": {}})
+
+
+def _other(ts: datetime, et: str = "mirror_signal.emit") -> str:
+    return json.dumps({"event_type": et, "timestamp": ts.isoformat()})
+
+
+def test_clean_window_with_marker_is_safe():
+    audit = [_other(NOW - timedelta(days=1)), _other(NOW - timedelta(hours=2))]
+    res = scan_audit_window(audit, window_days=14, now=NOW, marker_lines=["...[S1-d] reached..."])
+    assert res["verdict"] == "CLEAN"
+    assert res["safe_to_retire"] is True
+    assert res["deprecated_accept_in_window"] == 0
+    assert res["surface_reached"] is True
+
+
+def test_zero_accepts_without_marker_is_unconfirmed():
+    audit = [_other(NOW - timedelta(days=1))]
+    # No marker_lines provided → cannot confirm the surface was exercised.
+    res = scan_audit_window(audit, window_days=14, now=NOW)
+    assert res["verdict"] == "UNCONFIRMED"
+    assert res["safe_to_retire"] is False
+    assert res["surface_reached"] is None
+    # Marker file present but lacking the token → still unconfirmed.
+    res2 = scan_audit_window(audit, window_days=14, now=NOW, marker_lines=["unrelated log line"])
+    assert res2["verdict"] == "UNCONFIRMED"
+    assert res2["surface_reached"] is False
+
+
+def test_accept_in_window_is_dirty():
+    audit = [_accept(NOW - timedelta(days=2)), _other(NOW)]
+    res = scan_audit_window(audit, window_days=14, now=NOW, marker_lines=["[S1-d]"])
+    assert res["verdict"] == "DIRTY"
+    assert res["safe_to_retire"] is False
+    assert res["deprecated_accept_in_window"] == 1
+    assert len(res["samples"]) == 1
+
+
+def test_accept_outside_window_is_ignored():
+    audit = [_accept(NOW - timedelta(days=40))]  # older than the 14d window
+    res = scan_audit_window(audit, window_days=14, now=NOW, marker_lines=["[S1-d]"])
+    assert res["deprecated_accept_in_window"] == 0
+    assert res["verdict"] == "CLEAN"
+
+
+def test_malformed_and_blank_lines_tolerated():
+    audit = ["", "  ", "not json at all", "{bad json", _accept(NOW - timedelta(days=1))]
+    res = scan_audit_window(audit, window_days=14, now=NOW, marker_lines=["[S1-d]"])
+    # Only the one valid in-window accept counts; junk lines don't crash.
+    assert res["deprecated_accept_in_window"] == 1
+    assert res["verdict"] == "DIRTY"
+
+
+def test_window_size_respected():
+    audit = [_accept(NOW - timedelta(days=10))]
+    # 7-day window excludes a 10-day-old accept.
+    assert scan_audit_window(audit, window_days=7, now=NOW, marker_lines=["[S1-d]"])["verdict"] == "CLEAN"
+    # 14-day window includes it.
+    assert scan_audit_window(audit, window_days=14, now=NOW, marker_lines=["[S1-d]"])["verdict"] == "DIRTY"


### PR DESCRIPTION
## What

You were right to push back on "operator-gated" — the telemetry window is an **agent** job. I'd mis-framed it because the *stateless claude.ai session* I run as can only see per-agent governance state (`export`/`get_governance_metrics`), not the server-wide audit log. But a **resident agent / cron / the doctor — anything running on the deployment where `data/audit_log.jsonl` lives** — can absolutely decide this automatically. This PR gives that agent the tool.

## The checker

`scripts/dev/check_s1d_deprecation_window.py` reads the audit JSONL (and, optionally, a server log for the `[S1-d]` reached-marker from #1042) and emits a verdict + exit code:

| Verdict | Exit | Meaning |
|---|---|---|
| **CLEAN** | 0 | 0 `continuity_token_deprecated_accept` in the window **AND** the `[S1-d]` surface-reached marker present ⇒ **safe to retire** the residue |
| **UNCONFIRMED** | 1 | 0 accepts, but the reached-marker wasn't supplied — could mean the path never runs; pass `--server-log` or wait for #1042 to deploy + accrue traffic |
| **DIRTY** | 1 | the deprecated cross-process resume path is **still in use** |
| **NO_AUDIT_LOG** | 2 | not run on the deployment (a stateless client can't see the file — which is *why* this is a resident/cron job) |

Why the two-signal verdict matters: zero accepts alone is ambiguous (it could mean "gate holds" *or* "code path never runs"). Pairing it with the `[S1-d]` reached-marker makes CLEAN a **positive** statement — the surface IS exercised and observed False — which is exactly what the council asked for before deletion.

## Tests
Pure stdlib, importable core (`scan_audit_window`); 6 unit tests cover clean/dirty/unconfirmed, in/out-of-window, window-size, and malformed-line tolerance. CLI smoke-verified (correct verdicts + exit codes).

## Scope
Dev/ops tooling only — no runtime code touched. Left **unwired** (scheduling it into a cron / the doctor / a resident sweep is deployment config, per the CLAUDE.md "this repo doesn't vendor hook chains" rule). This is window prep; the actual residue deletion stays a deliberate follow-up gated on a CLEAN verdict + a cross-repo `gh pr list` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F9PmP5CYpYDTqeud4VzEUd)_