### PR TITLE
docs(eisv): fixed-point calibration gap + signal-readout split

### DIFF
--- a/docs/proposals/eisv-fixed-point-calibration-gap-v0.md
+++ b/docs/proposals/eisv-fixed-point-calibration-gap-v0.md
@@ -1,0 +1,130 @@
+# EISV fixed-point calibration gap & the signal-readout split (v0)
+
+**Status:** finding / proposal (not yet a change)
+**Date:** 2026-06-24
+**Scope:** `governance_core/dynamics.py`, `governance_core/coherence.py`,
+`src/grounding/coherence.py`, `config/governance_config.py` (healthy operating
+points + scale constants)
+
+## TL;DR
+
+Two coupled problems make EISV-derived signals encode *the model's idea of
+health plus a class-dependent offset* rather than *this agent's drift from its
+own baseline*:
+
+1. **The legacy coherence signal is structurally pinned (~0.49) — a "cast."**
+   It is computed off the void integral `V`, which the dynamics damp to ≈0, so
+   `C = 0.5·(1+tanh(C₁·V)) ≈ 0.49`. Lowering the damping barely helps because
+   `V` is pinned by the *architecture* (the E→I coupling drives `E−I → 0`), not
+   by the damping value. The fix is not to remove the cast (destabilizing) but
+   to **read a different signal**: the manifold readout, which is out of the
+   feedback loop, has ~18× the dynamic range on the *same stable run*.
+
+2. **The ODE fixed point does not sit where healthy agents actually live.** The
+   equilibrium is `S* ≈ 0.09`, but the measured healthy operating point across
+   all classes is `S ≈ 0.17–0.31`. The disagreement is almost entirely on the
+   **S (entropy) axis**. Because the single fixed point lands at a different
+   distance from each class's empirical center, manifold-coherence-at-rest
+   varies from **0.018 (Vigil) to 0.556 (Watcher)** — a healthy agent's
+   coherence is dominated by a class-dependent offset, not by its drift.
+
+These are plausibly *the* blocker for EISV justifying itself: if the attractor
+is in the wrong place, every downstream signal inherits the error.
+
+## Evidence
+
+All numbers from the real `governance_core` integrator (`get_active_params()`,
+`DEFAULT_THETA`). Harness faithfulness verified: integrating from
+`compute_equilibrium` with zero forcing leaves the state unmoved
+(`drift = 0.00000`). Repro scripts: `scripts/analysis/eisv_cast_experiment.py`
+and `scripts/analysis/eisv_equilibrium_gap.py`.
+
+### Finding 1 — the cast, and that damping can't lift it
+
+Stress perturbation (drift + complexity for a 20s window, then recovery):
+
+| regime | signal | dynamic range |
+|---|---|---|
+| δ=0.4 (current) | legacy (V-driven, in-loop) | **0.021** |
+| δ=0.25 (lighter) | legacy (V-driven, in-loop) | 0.028 |
+| δ=0.4 (current!) | **manifold (readout, out-of-loop)** | **0.379** |
+
+Halving the damping moves the legacy range from 0.021 → 0.028 (a signal that
+needed ~10×). On the *identical δ=0.4 stable run*, the manifold readout swings
+0.379 — ~18×, with zero change to stability. The conflict between provable
+stability and discernment is an artifact of reading governance off the
+contractive accumulator `V`; it dissolves when the sensor is taken out of the
+control loop.
+
+Mechanism: at equilibrium `V* = (κ/δ)(E−I)`, and the E-dynamics actively drive
+`E → I` (α=0.42), so `E−I → 0 ⇒ V → 0 ⇒ C → 0.5·Cmax` regardless of δ.
+Coherence also *feeds back* into the state (`∂İ/∂V = β_I·dC/dV`,
+`∂Ṡ/∂V = −λ₂·dC/dV`), which is why naively lowering δ rings (the project's own
+history comment: `delta reverted from 0.25 — caused coherence spiral`). A pure
+readout has no such feedback rows and cannot ring.
+
+### Finding 2 — the attractor is miscalibrated on the S axis
+
+```
+ODE equilibrium : E=0.805  I=0.822  S=0.091   V=-0.013
+measured healthy: E≈0.73   I≈0.79   S≈0.24   (median over healthy slice, per class)
+```
+
+| class | healthy (E,I,S) | ‖Δ‖ to eq | manifold@eq |
+|---|---|---|---|
+| Lumen | (0.745, 0.800, 0.168) | 0.100 | 0.159 |
+| default | (0.726, 0.793, 0.236) | 0.168 | 0.168 |
+| Sentinel | (0.751, 0.798, 0.193) | 0.119 | 0.303 |
+| Vigil | (0.737, 0.790, 0.240) | 0.167 | 0.018 |
+| Watcher | (0.748, 0.769, 0.248) | 0.175 | 0.556 |
+| engaged_ephemeral | (0.756, 0.685, 0.307) | 0.260 | 0.387 |
+
+`E*` and `I*` are close to data (`I*` was explicitly tuned: `γ_I → 0.169 for
+I*≈0.80`). `S*` was never calibrated to the measured value — it is whatever the
+dynamics produce: at zero drift,
+`S* = (β_c·complexity − λ₂·C)/μ = (0.15·0.5 − 0.06·0.5)/0.5 ≈ 0.09`. The
+measured healthy `S ≈ 0.24` would require retuning `μ`, `β_complexity`, or
+adding a baseline term.
+
+## Why this blocks the EISV approach
+
+The manifold readout (`src/grounding/coherence.py`) is correctly calibrated to
+*measured* health — but it measures the distance of `(E,I,S)` from that point,
+and `(E,I,S)` is contractive ODE state being dragged toward `S*≈0.09`. So even
+the good readout's *inputs* are pulled away from real health, and the residual
+offset differs by class. The "coherence stuck near 0.49", the class
+homogenization, and the weak discernment are all downstream of the attractor
+being in the wrong place on the S axis.
+
+## Recommendations (ordered, cheapest first)
+
+1. **Read the readout, not the loop.** Treat the manifold form as the canonical
+   coherence and demote `coherence_legacy` to telemetry only. (~90% done since
+   PR #26; finish it.) Guarded by
+   `tests/test_grounding_coherence_dynamic_range.py`.
+2. **Recalibrate `S*` to measured healthy entropy** (~0.24, per class). Smallest
+   honest lever; turns the manifold's inputs back toward real health. Must be
+   red-teamed (see below) — `S*` interacts with the `check_basin` threshold
+   (0.5), verdict bands, and risk scoring.
+3. **Decouple coherence from the state dynamics** if the legacy form is kept at
+   all (remove the `C → I` and `C → S` feedback). Then δ can fall for dynamic
+   range with no spiral.
+4. **Longer term — invert the substrate.** Wire the grounding tiers (logprob
+   entropy, FEP free energy) so `E/I/S` are *measured*, and demote the ODE to a
+   predictive model compared against measurement. The signal becomes the
+   residual (measurement − prediction), informative by construction. Separates
+   the two stabilities: a high-dynamic-range *estimate* with a calm decision
+   *policy* (hysteresis lives in the verdict layer, not the sensor).
+
+## Process note: red-team, don't council
+
+This is a ground-truth calibration question (math + measured data), which has a
+determinate answer. A diverse-opinion design council would dilute it. The
+high-value multi-agent use here is narrow and adversarial:
+
+- **Refute the finding:** try to show `S*≈0.09` is correct and the measured 0.24
+  is the artifact (e.g., a contaminated healthy slice). If it can't be refuted,
+  it hardens.
+- **Red-team the recalibration before it ships:** moving `S*` 0.09 → 0.24 —
+  what crosses the basin threshold, shifts a verdict band, or moves risk? That
+  is verification with a determinate answer and is worth independent eyes.

--- a/scripts/analysis/eisv_cast_experiment.py
+++ b/scripts/analysis/eisv_cast_experiment.py
@@ -1,0 +1,84 @@
+"""Discernment-vs-stability experiment ("removing the cast").
+
+Drives the REAL governance_core ODE with a stress perturbation (an agent under
+elevated drift + complexity, then recovery) and compares three regimes:
+
+  A. delta=0.4 (current), read LEGACY coherence  -> the cast: stable, no range
+  B. delta=0.25 (lighter), read LEGACY coherence  -> range appears, but it RINGS
+  C. delta=0.4 (current!), read MANIFOLD coherence -> range WITHOUT ringing
+
+The point: you don't have to trade stability for discernment IF you stop reading
+the signal off the in-loop feedback variable (V) and read it off a pure readout
+(manifold distance of E/I/S from the healthy point) instead.
+"""
+import dataclasses
+import math
+
+from governance_core.dynamics import State, _derivatives, compute_equilibrium
+from governance_core.coherence import coherence as legacy_coherence
+from governance_core.parameters import get_active_params, DEFAULT_THETA
+from config.governance_config import get_healthy_operating_point, get_delta_norm_max
+
+THETA = DEFAULT_THETA
+HP = get_healthy_operating_point("default")
+DMAX = get_delta_norm_max("default").value
+
+
+def manifold_coherence(s: State) -> float:
+    dx, dy, dz = s.E - HP[0], s.I - HP[1], s.S - HP[2]
+    ratio = math.sqrt(dx * dx + dy * dy + dz * dz) / DMAX
+    return 1.0 - max(0.0, min(1.0, ratio))
+
+
+def run(delta, dt=0.05, steps=1200):
+    params = dataclasses.replace(get_active_params(), delta=delta)
+    s = compute_equilibrium(params, THETA, complexity=0.5)
+    legacy, manifold, Vs = [], [], []
+    for n in range(steps):
+        t = n * dt
+        # Stress window: sustained drift + complexity from t=10..30, then recover.
+        if 10 <= t < 30:
+            d_eta_sq, complexity = 0.5, 0.9
+        else:
+            d_eta_sq, complexity = 0.0, 0.5
+        dE, dI, dS, dV = _derivatives(s, d_eta_sq, THETA, params, 0.0, complexity, None)
+        s = State(
+            E=min(1.0, max(0.0, s.E + dt * dE)),
+            I=min(1.0, max(0.0, s.I + dt * dI)),
+            S=min(1.0, max(0.001, s.S + dt * dS)),
+            V=min(1.0, max(-1.0, s.V + dt * dV)),
+        )
+        legacy.append(legacy_coherence(s.V, THETA, params))
+        manifold.append(manifold_coherence(s))
+        Vs.append(s.V)
+    return legacy, manifold, Vs
+
+
+def ringing(series):
+    """Count direction reversals after the perturbation ends (overshoot/oscillation)."""
+    tail = series[int(len(series) * 30 / 60):]  # after t=30 (recovery phase)
+    reversals = 0
+    for i in range(2, len(tail)):
+        d1, d2 = tail[i - 1] - tail[i - 2], tail[i] - tail[i - 1]
+        if d1 * d2 < 0:
+            reversals += 1
+    return reversals
+
+
+def rng(series):
+    return max(series) - min(series)
+
+
+print(f"healthy point(default)={HP}  delta_norm_max={DMAX}")
+print(f"{'regime':<42}{'range':>10}{'reversals':>12}")
+for delta in (0.4, 0.25):
+    leg, man, V = run(delta)
+    print(f"delta={delta}  LEGACY (V-driven, in-loop)         {rng(leg):>10.3f}{ringing(leg):>12}")
+# Regime C: the STABLE delta=0.4 run, but read the manifold readout instead.
+leg, man, V = run(0.4)
+print(f"delta=0.4  MANIFOLD (readout, out-of-loop)    {rng(man):>10.3f}{ringing(man):>12}")
+print()
+# Show the actual coherence excursion (min during stress -> baseline) per signal.
+leg04, man04, _ = run(0.4)
+print(f"legacy   @delta0.4: baseline≈{leg04[0]:.3f}  worst≈{min(leg04):.3f}  swing={rng(leg04):.3f}")
+print(f"manifold @delta0.4: baseline≈{man04[0]:.3f}  worst≈{min(man04):.3f}  swing={rng(man04):.3f}")

--- a/scripts/analysis/eisv_equilibrium_gap.py
+++ b/scripts/analysis/eisv_equilibrium_gap.py
@@ -9,7 +9,7 @@ import math
 from governance_core.dynamics import State, _derivatives, compute_equilibrium
 from governance_core.parameters import get_active_params, DEFAULT_THETA
 from config.governance_config import (
-    get_healthy_operating_point, get_delta_norm_max, HEALTHY_OPERATING_POINT_BY_CLASS,
+    get_delta_norm_max, HEALTHY_OPERATING_POINT_BY_CLASS,
 )
 
 P = get_active_params()

--- a/scripts/analysis/eisv_equilibrium_gap.py
+++ b/scripts/analysis/eisv_equilibrium_gap.py
@@ -1,0 +1,47 @@
+"""Where does the ODE's fixed point sit vs. where healthy agents actually live?
+
+1. Faithfulness check: start at compute_equilibrium, integrate with ZERO forcing.
+   A true equilibrium must stay put. If it drifts, my harness is wrong.
+2. Gap: compare the ODE equilibrium (E*,I*,S*) to the measured healthy
+   operating point per class, component by component.
+"""
+import math
+from governance_core.dynamics import State, _derivatives, compute_equilibrium
+from governance_core.parameters import get_active_params, DEFAULT_THETA
+from config.governance_config import (
+    get_healthy_operating_point, get_delta_norm_max, HEALTHY_OPERATING_POINT_BY_CLASS,
+)
+
+P = get_active_params()
+TH = DEFAULT_THETA
+
+
+def integrate(s, steps, dt, d_eta_sq, complexity):
+    for _ in range(steps):
+        dE, dI, dS, dV = _derivatives(s, d_eta_sq, TH, P, 0.0, complexity, None)
+        s = State(
+            E=min(1.0, max(0.0, s.E + dt * dE)),
+            I=min(1.0, max(0.0, s.I + dt * dI)),
+            S=min(1.0, max(0.001, s.S + dt * dS)),
+            V=min(1.0, max(-1.0, s.V + dt * dV)),
+        )
+    return s
+
+
+eq = compute_equilibrium(P, TH, complexity=0.5)
+print(f"compute_equilibrium  : E={eq.E:.4f} I={eq.I:.4f} S={eq.S:.4f} V={eq.V:.4f}")
+
+# Faithfulness: zero-forcing from equilibrium should not move (complexity=0.5 matches eq)
+settled = integrate(eq, 2000, 0.05, 0.0, 0.5)
+drift = math.sqrt((settled.E-eq.E)**2 + (settled.I-eq.I)**2 + (settled.S-eq.S)**2 + (settled.V-eq.V)**2)
+print(f"after 100s zero-force : E={settled.E:.4f} I={settled.I:.4f} S={settled.S:.4f} V={settled.V:.4f}  (drift={drift:.5f})")
+
+print(f"\nper-class measured healthy point vs ODE equilibrium (E,I,S):")
+print(f"{'class':<20}{'healthy (E,I,S)':<28}{'eq (E,I,S)':<24}{'||Δ||':>8}{'manifold@eq':>13}")
+for cls, hp in HEALTHY_OPERATING_POINT_BY_CLASS.items():
+    dmax = get_delta_norm_max(cls).value
+    dx, dy, dz = eq.E - hp[0], eq.I - hp[1], eq.S - hp[2]
+    norm = math.sqrt(dx*dx + dy*dy + dz*dz)
+    man = 1.0 - max(0.0, min(1.0, norm / dmax))
+    print(f"{cls:<20}({hp[0]:.3f},{hp[1]:.3f},{hp[2]:.3f})        "
+          f"({eq.E:.3f},{eq.I:.3f},{eq.S:.3f})   {norm:>7.3f}{man:>13.3f}")

--- a/tests/test_grounding_coherence_dynamic_range.py
+++ b/tests/test_grounding_coherence_dynamic_range.py
@@ -1,0 +1,105 @@
+"""Regression guard: canonical `coherence` must be the responsive manifold form,
+not a silent passthrough of the inert legacy thermodynamic value.
+
+Context — the "stuck at ~0.49" investigation. There are two coherence fields:
+
+  * ``coherence_legacy`` — ``C(V,Θ) = 0.5·(1+tanh(C₁·V))``. The ODE damps V to
+    ≈0, so ``tanh(C₁·V)≈0`` and this value is structurally pinned near 0.49.
+    Correct by design, but it has almost no dynamic range.
+  * ``coherence`` (canonical, since PR #26) — the grounded manifold form
+    ``1 − ‖(E,I,S) − healthy‖ / Δ_max``, which *should* move with the agent's
+    state from 1.0 (at the healthy operating point) down to 0.0 (a full radius
+    off).
+
+The trap: ``compute_coherence`` silently falls back to ``_compute_heuristic``
+when ``metrics["E"/"I"/"S"]`` are missing/non-numeric, and the heuristic just
+re-emits ``metrics["coherence"]`` — i.e. the legacy ≈0.49. A canonical
+coherence stuck at 0.49 with ``coherence_source == "heuristic"`` is therefore
+this degradation, not honest math. These tests pin the responsive behavior and
+make the degradation mode explicit so it can't regress unnoticed.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from config.governance_config import get_healthy_operating_point
+from src.grounding.coherence import compute_coherence
+from src.mcp_handlers.updates.context import UpdateContext
+from src.mcp_handlers.updates.enrichments import enrich_grounding
+
+
+def _ctx(agent_class="default"):
+    return SimpleNamespace(agent_class=agent_class)
+
+
+def test_manifold_coherence_responds_to_state():
+    """Coherence must span its range with state — not sit pinned near 0.49.
+
+    At the class healthy operating point it reads ≈1.0; a full radius off it
+    reads ≈0.0; a partial deviation lands strictly between. If any future
+    change pins coherence (e.g. a silent legacy passthrough), the spread
+    assertion fails.
+    """
+    ctx = _ctx("default")
+    hE, hI, hS = get_healthy_operating_point("default")
+
+    legacy = 0.49  # the inert thermodynamic value we must NOT echo
+
+    at_healthy = compute_coherence(ctx, {"E": hE, "I": hI, "S": hS, "coherence": legacy})
+    off_point = compute_coherence(ctx, {"E": 0.5, "I": 0.5, "S": 0.5, "coherence": legacy})
+    partial = compute_coherence(ctx, {"E": hE, "I": hI, "S": hS + 0.10, "coherence": legacy})
+
+    # All three take the manifold path, not the legacy-echoing heuristic.
+    assert at_healthy.source == "manifold"
+    assert off_point.source == "manifold"
+    assert partial.source == "manifold"
+
+    # Genuine dynamic range, and none of them collapses onto the legacy 0.49.
+    assert at_healthy.value == pytest.approx(1.0, abs=1e-6)
+    assert off_point.value == pytest.approx(0.0, abs=1e-6)
+    assert 0.0 < partial.value < 1.0
+    assert at_healthy.value - off_point.value > 0.5, "coherence has no dynamic range"
+    assert abs(partial.value - legacy) > 0.01 or partial.source == "manifold"
+
+
+def test_missing_eis_exposes_legacy_passthrough_as_heuristic():
+    """Reproduce the 'stuck at 0.49' failure mode and pin its signature.
+
+    When E/I/S are absent the manifold cannot compute and coherence silently
+    echoes the legacy value — but it MUST stamp ``source == "heuristic"`` so the
+    degradation is observable rather than masquerading as a real reading.
+    """
+    ctx = _ctx("default")
+    result = compute_coherence(ctx, {"coherence": 0.49})
+
+    assert result.value == pytest.approx(0.49, abs=1e-9)
+    assert result.source == "heuristic", (
+        "legacy passthrough must be flagged heuristic, not silently surfaced as manifold"
+    )
+
+
+@pytest.mark.asyncio
+async def test_enrichment_coherence_differs_from_legacy_for_offpoint_agent():
+    """End-to-end through enrich_grounding: an off-healthy agent's canonical
+    coherence is the manifold value and is distinct from coherence_legacy.
+
+    Guards the swap site so a regression that drops E/I/S (forcing the heuristic
+    legacy echo) would surface here as ``coherence == coherence_legacy`` with a
+    heuristic source.
+    """
+    ctx = UpdateContext()
+    ctx.arguments = {}
+    ctx.result = {
+        "metrics": {"E": 0.5, "I": 0.5, "S": 0.5, "V": -0.1, "coherence": 0.49},
+    }
+    ctx.response_data = {}
+
+    await enrich_grounding(ctx)
+    m = ctx.result["metrics"]
+
+    assert m["coherence_source"] == "manifold"
+    assert m["coherence_legacy"] == 0.49
+    # (0.5,0.5,0.5) is a full radius off the default healthy point → manifold 0.0,
+    # which is decisively different from the inert legacy 0.49.
+    assert m["coherence"] != m["coherence_legacy"]
+    assert m["coherence"] == pytest.approx(0.0, abs=1e-6)


### PR DESCRIPTION
## What

Records a load-bearing pair of findings about why EISV-derived signals are weak, plus reproducible harnesses and a regression guard. **No runtime behavior change** — this is a finding/proposal doc + repro scripts + a test.

Full writeup: `docs/proposals/eisv-fixed-point-calibration-gap-v0.md`.

## The two findings

**1. Legacy coherence is structurally pinned (~0.49) — a "cast."** It reads off the void integral `V`, which the E→I coupling drives toward 0 *regardless of damping δ*. Stress-test dynamic range:

| regime | signal | range |
|---|---|---|
| δ=0.4 (current) | legacy (in-loop) | 0.021 |
| δ=0.25 (lighter) | legacy (in-loop) | 0.028 |
| δ=0.4 (current!) | **manifold (out-of-loop readout)** | **0.379** (~18×) |

The stability-vs-discernment conflict is an artifact of reading governance off a feedback variable — it dissolves when you read the out-of-loop manifold form. No damping change, no stability risk.

**2. The ODE fixed point isn't where healthy agents live.** Equilibrium `S*≈0.09`; measured healthy `S≈0.24` across all classes. `E*`/`I*` track data (`I*` was tuned); `S*` was never calibrated. The single fixed point sits at a class-dependent distance from each class's empirical center → manifold-coherence-at-rest ranges **0.018 (Vigil) → 0.556 (Watcher)**, dominated by offset rather than drift.

## Why it matters

If the attractor is in the wrong place on the S axis, every downstream EISV signal inherits the error — plausibly the core reason the approach hasn't justified itself yet.

## Contents

- `docs/proposals/eisv-fixed-point-calibration-gap-v0.md` — findings, evidence, ordered recommendations, and a "red-team not council" process note.
- `scripts/analysis/eisv_cast_experiment.py`, `eisv_equilibrium_gap.py` — reproducible harnesses on the real `governance_core` integrator (faithfulness verified: zero-force drift = 0.00000).
- `tests/test_grounding_coherence_dynamic_range.py` — guards that canonical coherence stays the responsive manifold form and never silently echoes the inert legacy value.

## Recommendations (in the doc, ordered cheapest-first)

1. Read the manifold readout, demote `coherence_legacy` to telemetry.
2. Recalibrate `S*` to measured healthy entropy (~0.24) — **red-team before shipping** (interacts with basin threshold / verdict bands / risk).
3. Decouple coherence from the state dynamics if legacy is kept.
4. Longer term: invert the substrate — measure E/I/S, demote the ODE to a predictor, signal = residual.

Draft for review — no behavior change to merge here; the recommendations are follow-ups, each gated on its own red-team.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQLaFx6ZPGPyuR3ESNRYut)_