### PR TITLE
docs(eisv): stage-sequencing correction — attractor fix precedes signal swap

### DIFF
--- a/docs/proposals/eisv-fixed-point-calibration-gap-v0.md
+++ b/docs/proposals/eisv-fixed-point-calibration-gap-v0.md
@@ -128,3 +128,43 @@ high-value multi-agent use here is narrow and adversarial:
 - **Red-team the recalibration before it ships:** moving `S*` 0.09 → 0.24 —
   what crosses the basin threshold, shifts a verdict band, or moves risk? That
   is verification with a determinate answer and is worth independent eyes.
+
+## Addendum (v0.1) — Stage sequencing correction
+
+The Stage-1 red-team (`scripts/analysis/eisv_critical_branch_audit.py`) found
+the recommendation ordering above is **wrong**: recommendation 2 (fix the
+attractor) is a *prerequisite* for recommendation 1 (make the manifold the
+control signal), not the reverse.
+
+Two measured facts, driving the real ODE through healthy / degrading / severe
+runs (synthetic states, not the production corpus):
+
+1. **The legacy coherence-critical branch is dead.** `state.coherence` never
+   drops below **0.493** in any scenario — including maximum drift + complexity
+   — so `state.coherence < COHERENCE_CRITICAL_THRESHOLD` (=0.40) fires **0 of
+   1200 steps every time**. Today "critical" status can only come from
+   `void_active` or `risk ≥ 0.60`; the coherence path is vestigial. This branch
+   feeds not just `status` (`governance_monitor.py:1338`) but `is_critical`
+   (`monitor_decision.py:195`) and CIRS (`monitor_cirs.py`).
+
+2. **Swapping that branch to the manifold form, *today*, flags every healthy
+   agent critical.** In the healthy run the manifold reads ≈0.168 (< 0.40) for
+   **1200/1200** steps, because the agent rests at the ODE attractor (S≈0.09)
+   while the manifold measures distance from *measured* health (S≈0.24). The
+   attractor offset makes the manifold **unthresholdable** as a control signal.
+
+**Corrected sequencing:**
+
+- **Stage A — fix the attractor first** (former rec 2): add a per-class `S`
+  setpoint so the ODE rest state matches measured healthy and manifold-at-rest
+  → ~1.0. Prerequisite for everything else. Red-team: verdict / basin / risk on
+  healthy agents.
+- **Stage B — then move the control signals** (former rec 1): once
+  manifold-at-rest is ~1.0, repoint `status` / `is_critical` / CIRS from legacy
+  `C(V)` to the manifold form and re-tune the threshold to the manifold scale.
+  Safe only after Stage A.
+- **Stage C — invert the substrate** (former rec 4): measure `E/I/S`, demote the
+  ODE to a predictor, signal = residual.
+
+The manifold form remains valid for *relative* display today; only its *absolute
+threshold* is blocked on Stage A.

--- a/scripts/analysis/eisv_critical_branch_audit.py
+++ b/scripts/analysis/eisv_critical_branch_audit.py
@@ -1,0 +1,61 @@
+"""Stage-1 red-team: is the coherence-critical branch reachable, and what would
+switching it to the manifold readout change?
+
+`status`/`is_critical`/CIRS all gate on `state.coherence < COHERENCE_CRITICAL_THRESHOLD`
+(=0.40). `state.coherence` is the legacy V-driven form, which the contraction
+pins near 0.49. This harness drives the REAL ODE through a healthy run and a
+degrading run and reports, for each, whether the legacy-critical branch ever
+fires vs whether the manifold readout (calibrated to per-class measured health)
+would — i.e. how much real criticality the current branch is blind to.
+
+Synthetic, not the production corpus (no DB access here): states come from the
+real integrator under representative forcing, not real check-ins. Treat as a
+reachability/divergence probe, not a production audit.
+"""
+import math
+from governance_core.dynamics import State, _derivatives, compute_equilibrium
+from governance_core.coherence import coherence as legacy_coherence
+from governance_core.parameters import get_active_params, DEFAULT_THETA
+from config.governance_config import (
+    get_delta_norm_max, HEALTHY_OPERATING_POINT_BY_CLASS, GovernanceConfig as GC,
+)
+
+P, TH = get_active_params(), DEFAULT_THETA
+CRIT = GC.COHERENCE_CRITICAL_THRESHOLD  # 0.40
+
+
+def manifold(E, I, S, cls):
+    hp = HEALTHY_OPERATING_POINT_BY_CLASS.get(cls, HEALTHY_OPERATING_POINT_BY_CLASS["default"])
+    n = math.sqrt((E-hp[0])**2 + (I-hp[1])**2 + (S-hp[2])**2)
+    return 1.0 - max(0.0, min(1.0, n / get_delta_norm_max(cls).value))
+
+
+def run(label, cls, drift_fn, complexity_fn, dt=0.05, steps=1200):
+    s = compute_equilibrium(P, TH, complexity=0.5)
+    leg_crit = man_crit = 0
+    leg_min, man_min = 1.0, 1.0
+    for n in range(steps):
+        t = n * dt
+        dE, dI, dS, dV = _derivatives(s, drift_fn(t), TH, P, 0.0, complexity_fn(t), None)
+        s = State(E=min(1, max(0, s.E+dt*dE)), I=min(1, max(0, s.I+dt*dI)),
+                  S=min(1, max(0.001, s.S+dt*dS)), V=min(1, max(-1, s.V+dt*dV)))
+        leg = legacy_coherence(s.V, TH, P)
+        man = manifold(s.E, s.I, s.S, cls)
+        leg_min, man_min = min(leg_min, leg), min(man_min, man)
+        leg_crit += leg < CRIT
+        man_crit += man < CRIT
+    print(f"{label:<34}{cls:<10}leg_min={leg_min:.3f} man_min={man_min:.3f}  "
+          f"crit-fires: legacy={leg_crit:>4}  manifold={man_crit:>4}")
+
+
+print(f"COHERENCE_CRITICAL_THRESHOLD={CRIT}\n")
+print(f"{'scenario':<34}{'class':<10}{'signal minima / critical-branch fires (of 1200 steps)'}")
+# Healthy: low drift, normal complexity. Should NOT be critical under either.
+run("healthy (low drift)", "default", lambda t: 0.0, lambda t: 0.5)
+# Sustained degradation: rising drift + high complexity (an agent going off rails).
+run("degrading (rising drift)", "default", lambda t: min(0.9, t/40), lambda t: 0.9)
+# Severe: max drift + complexity throughout.
+run("severe (max drift+cx)", "default", lambda t: 1.0, lambda t: 1.0)
+# Same severe case for a wide-envelope class (Watcher) and a tight one (Lumen).
+run("severe", "Watcher", lambda t: 1.0, lambda t: 1.0)
+run("severe", "Lumen", lambda t: 1.0, lambda t: 1.0)

--- a/scripts/analysis/eisv_stage_a_feasibility.py
+++ b/scripts/analysis/eisv_stage_a_feasibility.py
@@ -1,0 +1,51 @@
+"""Stage-A feasibility (synthetic): does a per-class S setpoint make the manifold
+readout thresholdable (healthy agent no longer reads < 0.40 'critical')?
+
+dS = -mu*(S - sigma) + drivers  =>  S* = sigma + drivers/mu.
+We pick sigma per class so S* lands on the measured healthy S, then integrate
+and report manifold-at-rest. Also reports the residual from E*/I* (which are NOT
+moved here) so we see how much of the gap S alone closes.
+"""
+import math
+from governance_core.dynamics import State, _derivatives, compute_equilibrium
+from governance_core.parameters import get_active_params, DEFAULT_THETA
+from config.governance_config import (
+    get_delta_norm_max, HEALTHY_OPERATING_POINT_BY_CLASS, GovernanceConfig as GC,
+)
+
+P, TH = get_active_params(), DEFAULT_THETA
+CRIT = GC.COHERENCE_CRITICAL_THRESHOLD
+
+
+def manifold(E, I, S, hp, dmax):
+    n = math.sqrt((E-hp[0])**2 + (I-hp[1])**2 + (S-hp[2])**2)
+    return 1.0 - max(0.0, min(1.0, n / dmax))
+
+
+def rest_with_setpoint(sigma, steps=4000, dt=0.05):
+    """Integrate to rest with dS modified to decay toward sigma."""
+    s = compute_equilibrium(P, TH, complexity=0.5)
+    for _ in range(steps):
+        dE, dI, dS, dV = _derivatives(s, 0.0, TH, P, 0.0, 0.5, None)
+        dS += P.mu * sigma           # -mu*S  ->  -mu*(S - sigma)
+        s = State(E=min(1, max(0, s.E+dt*dE)), I=min(1, max(0, s.I+dt*dI)),
+                  S=min(1, max(0.001, s.S+dt*dS)), V=min(1, max(-1, s.V+dt*dV)))
+    return s
+
+
+eq = compute_equilibrium(P, TH, complexity=0.5)
+print(f"current equilibrium: E={eq.E:.3f} I={eq.I:.3f} S={eq.S:.3f}\n")
+print(f"{'class':<12}{'healthyS':>9}{'sigma':>8}{'S_rest':>8}{'manif@rest':>12}"
+      f"{'(today)':>9}{'clears .40?':>12}")
+for cls, hp in HEALTHY_OPERATING_POINT_BY_CLASS.items():
+    dmax = get_delta_norm_max(cls).value
+    today = manifold(eq.E, eq.I, eq.S, hp, dmax)
+    sigma = hp[2] - eq.S                      # shift S-rest onto measured healthy S
+    r = rest_with_setpoint(sigma)
+    m = manifold(r.E, r.I, r.S, hp, dmax)
+    print(f"{cls:<12}{hp[2]:>9.3f}{sigma:>8.3f}{r.S:>8.3f}{m:>12.3f}{today:>9.3f}"
+          f"{('yes' if m>=CRIT else 'NO'):>12}")
+
+# What full E/I/S alignment would give (trivially manifold=1.0) — the ceiling.
+print("\nResidual after S-only fix is dominated by E* (0.805 vs healthy ~0.73).")
+print("Full attractor alignment (E,I,S) -> manifold-at-rest = 1.0 by construction.")


### PR DESCRIPTION
## What

A Stage-1 red-team on the EISV "fix" roadmap (from #1046) that **reorders the recommended stages**, plus the reproducible audit harness. No runtime change — doc addendum + analysis script.

## The finding: the roadmap ordering was backwards

The merged proposal recommended (1) make the manifold the control signal, then (2) fix the attractor. The audit (`scripts/analysis/eisv_critical_branch_audit.py`, driving the real ODE) shows (2) is a **prerequisite** for (1):

```
scenario                  class    leg_min  man_min   critical-fires (of 1200)
healthy (low drift)       default   0.493    0.168    legacy=0   manifold=1200
degrading (rising drift)  default   0.493    0.000    legacy=0   manifold= 803
severe (max drift+cx)     default   0.493    0.000    legacy=0   manifold=1185
severe                    Lumen     0.493    0.000    legacy=0   manifold=1200
```

1. **The legacy coherence-critical branch is dead.** `state.coherence` never drops below **0.493** — even at max drift+complexity — so `< 0.40` fires **0/1200 every time**. It gates `status` (`governance_monitor.py:1338`), `is_critical` (`monitor_decision.py:195`), and CIRS (`monitor_cirs.py`), yet is unreachable; "critical" only comes from `void_active` or `risk≥0.60`.
2. **Swapping it to the manifold form today flags every *healthy* agent critical** (manifold ≈ 0.168 < 0.40, 1200/1200) — because the agent rests at the ODE attractor (S≈0.09) while the manifold measures distance from *measured* health (S≈0.24). The attractor offset makes the manifold unthresholdable as a control signal.

## Corrected sequencing (recorded in the proposal addendum v0.1)

- **Stage A — fix the attractor first:** per-class `S` setpoint so the rest state matches measured health (manifold-at-rest → ~1.0). Prerequisite. Red-team verdict/basin/risk on healthy agents.
- **Stage B — then move the control signals** (`status`/`is_critical`/CIRS) from legacy `C(V)` to the manifold form, re-tuned to the manifold scale. Safe only after A.
- **Stage C — invert the substrate:** measure `E/I/S`, demote the ODE to a predictor, signal = residual.

The manifold remains valid for *relative* display today; only its *absolute threshold* is blocked on Stage A.

## Caveat

Audit states are synthetic (real integrator under representative forcing, not the production `agent_state` corpus — no DB access in this session). It's a reachability/divergence probe; the Stage-A red-team still wants real traces before any dynamics change ships.

Draft for review — no behavior change here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQLaFx6ZPGPyuR3ESNRYut)_