### PR TITLE
feat(eisv): Stage A — per-class S setpoint (flagged OFF)

### DIFF
--- a/config/governance_config.py
+++ b/config/governance_config.py
@@ -1004,6 +1004,47 @@ def get_delta_norm_max(agent_class: str = "default") -> ScaleConstant:
 
 
 # =====================================================================
+# S-attractor setpoint (Stage A — EISV fixed-point calibration)
+# =====================================================================
+# The S equation rests at S* = (β_complexity·complexity − λ₂·C)/μ ≈ 0.091 at
+# baseline (complexity=0.5), but the *measured* healthy S is 0.17–0.31 per class
+# (HEALTHY_OPERATING_POINT_BY_CLASS). That offset makes the manifold readout
+# unthresholdable as a control signal (a healthy agent reads ~0.17, below the
+# 0.40 critical line). See docs/proposals/eisv-fixed-point-calibration-gap-v0.md.
+#
+# Fix: decay S toward a per-class setpoint σ instead of toward 0, i.e.
+# `-μ(S - σ)`. Choosing σ = healthy_S − S_SETPOINT_DRIVER_OFFSET lands the S
+# equilibrium on the measured healthy S (since S* = σ + drivers/μ).
+#
+# OFF BY DEFAULT (UNITARES_S_SETPOINT). When disabled, get_s_setpoint() returns
+# 0.0 and the dynamics are byte-identical to historical behavior. Enabling is
+# gated on red-team validation against the real agent_state corpus.
+#
+# S_SETPOINT_DRIVER_OFFSET is the baseline driver contribution to S* at
+# complexity=0.5, measured 2026-06-24 via scripts/analysis/eisv_equilibrium_gap.py
+# (integrated equilibrium S = 0.091). Regenerate if μ/β_complexity/λ₂ change.
+S_SETPOINT_DRIVER_OFFSET: float = 0.091
+
+
+def s_setpoint_enabled() -> bool:
+    """Whether the per-class S setpoint is active (UNITARES_S_SETPOINT). Default off."""
+    return os.getenv("UNITARES_S_SETPOINT", "").strip().lower() in {"1", "true", "on", "yes"}
+
+
+def get_s_setpoint(agent_class: str = "default") -> float:
+    """Per-class S decay target σ for the dynamics.
+
+    Returns 0.0 when the flag is off (historical ``-μS`` behavior). When on,
+    returns ``healthy_S(class) − S_SETPOINT_DRIVER_OFFSET`` clamped to ≥0, so the
+    S equilibrium lands on the class's measured healthy S.
+    """
+    if not s_setpoint_enabled():
+        return 0.0
+    healthy_S = get_healthy_operating_point(agent_class)[2]
+    return max(0.0, healthy_S - S_SETPOINT_DRIVER_OFFSET)
+
+
+# =====================================================================
 # Identity Honesty Part C — strict-mode gate
 # =====================================================================
 # Three ghost-creation paths are sources:

--- a/governance_core/dynamics.py
+++ b/governance_core/dynamics.py
@@ -101,6 +101,7 @@ def _derivatives(
     noise_S: float,
     complexity: float,
     sensor_eisv: Optional[State],
+    s_setpoint: float = 0.0,
 ) -> tuple:
     """
     Compute raw EISV derivatives at a given state.
@@ -116,6 +117,11 @@ def _derivatives(
         noise_S: Calibration penalty / noise term for S
         complexity: Task complexity [0, 1]
         sensor_eisv: Optional sensor state for spring coupling
+        s_setpoint: Class-conditional rest target for S. Default 0.0 makes the
+            S decay term ``-μS`` (historical behavior). When non-zero the term
+            becomes ``-μ(S - s_setpoint)``, shifting the S equilibrium toward a
+            measured-healthy operating point (see config.get_s_setpoint). Off by
+            default; gated by UNITARES_S_SETPOINT at the call site.
 
     Returns:
         (dE_dt, dI_dt, dS_dt, dV_dt) tuple
@@ -145,9 +151,10 @@ def _derivatives(
     else:
         dI_dt = A - params.gamma_I * I * (1 - I)
 
-    # S dynamics: Ṡ = -μS + λ₁‖Δη‖² - λ₂C + β_c·complexity + noise
+    # S dynamics: Ṡ = -μ(S - σ) + λ₁‖Δη‖² - λ₂C + β_c·complexity + noise
+    # σ (s_setpoint) defaults to 0.0 → -μS, the historical behavior.
     dS_dt = (
-        -params.mu * S
+        -params.mu * (S - s_setpoint)
         + lam1 * d_eta_sq
         - lam2 * C
         + params.beta_complexity * complexity
@@ -197,9 +204,10 @@ def _integrate_euler(
     noise_S: float,
     complexity: float,
     sensor_eisv: Optional[State],
+    s_setpoint: float = 0.0,
 ) -> State:
     """Forward Euler integration: x_new = x + dt * f(x)."""
-    dE, dI, dS, dV = _derivatives(state, d_eta_sq, theta, params, noise_S, complexity, sensor_eisv)
+    dE, dI, dS, dV = _derivatives(state, d_eta_sq, theta, params, noise_S, complexity, sensor_eisv, s_setpoint)
 
     E_new = clip(state.E + dE * dt, params.E_min, params.E_max)
     I_new = clip(state.I + dI * dt, params.I_min, params.I_max)
@@ -218,6 +226,7 @@ def _integrate_rk4(
     noise_S: float,
     complexity: float,
     sensor_eisv: Optional[State],
+    s_setpoint: float = 0.0,
 ) -> State:
     """
     4th-order Runge-Kutta integration.
@@ -230,7 +239,7 @@ def _integrate_rk4(
     E, I, S, V = state.E, state.I, state.S, state.V
 
     # k1 = f(state)
-    k1 = _derivatives(state, d_eta_sq, theta, params, noise_S, complexity, sensor_eisv)
+    k1 = _derivatives(state, d_eta_sq, theta, params, noise_S, complexity, sensor_eisv, s_setpoint)
 
     # k2 = f(state + 0.5*dt*k1)
     s2 = State(
@@ -239,7 +248,7 @@ def _integrate_rk4(
         S=clip(S + 0.5 * dt * k1[2], params.S_min, params.S_max),
         V=clip(V + 0.5 * dt * k1[3], params.V_min, params.V_max),
     )
-    k2 = _derivatives(s2, d_eta_sq, theta, params, noise_S, complexity, sensor_eisv)
+    k2 = _derivatives(s2, d_eta_sq, theta, params, noise_S, complexity, sensor_eisv, s_setpoint)
 
     # k3 = f(state + 0.5*dt*k2)
     s3 = State(
@@ -248,7 +257,7 @@ def _integrate_rk4(
         S=clip(S + 0.5 * dt * k2[2], params.S_min, params.S_max),
         V=clip(V + 0.5 * dt * k2[3], params.V_min, params.V_max),
     )
-    k3 = _derivatives(s3, d_eta_sq, theta, params, noise_S, complexity, sensor_eisv)
+    k3 = _derivatives(s3, d_eta_sq, theta, params, noise_S, complexity, sensor_eisv, s_setpoint)
 
     # k4 = f(state + dt*k3)
     s4 = State(
@@ -257,7 +266,7 @@ def _integrate_rk4(
         S=clip(S + dt * k3[2], params.S_min, params.S_max),
         V=clip(V + dt * k3[3], params.V_min, params.V_max),
     )
-    k4 = _derivatives(s4, d_eta_sq, theta, params, noise_S, complexity, sensor_eisv)
+    k4 = _derivatives(s4, d_eta_sq, theta, params, noise_S, complexity, sensor_eisv, s_setpoint)
 
     # Combine: x_new = x + (dt/6)(k1 + 2k2 + 2k3 + k4)
     dt6 = dt / 6.0
@@ -278,6 +287,7 @@ def compute_dynamics(
     noise_S: float = 0.0,
     complexity: float = 0.5,
     sensor_eisv: Optional[State] = None,
+    s_setpoint: float = 0.0,
 ) -> State:
     """
     Compute one time step of UNITARES Phase-3 dynamics.
@@ -330,11 +340,11 @@ def compute_dynamics(
 
     if integrator == "euler":
         new_state = _integrate_euler(
-            state, d_eta_sq, theta, params, dt, noise_S, complexity, coupling_sensor,
+            state, d_eta_sq, theta, params, dt, noise_S, complexity, coupling_sensor, s_setpoint,
         )
     else:
         new_state = _integrate_rk4(
-            state, d_eta_sq, theta, params, dt, noise_S, complexity, coupling_sensor,
+            state, d_eta_sq, theta, params, dt, noise_S, complexity, coupling_sensor, s_setpoint,
         )
 
     # Post-integration: complexity-proportional entropy floor
@@ -355,6 +365,7 @@ def step_state(
     params: Optional[DynamicsParams] = None,
     complexity: float = 0.5,
     sensor_eisv: Optional[State] = None,
+    s_setpoint: float = 0.0,
 ) -> State:
     """
     Convenience wrapper for compute_dynamics with default params.
@@ -389,6 +400,7 @@ def step_state(
         noise_S=noise_S,
         complexity=complexity,
         sensor_eisv=sensor_eisv,
+        s_setpoint=s_setpoint,
     )
 
 

--- a/src/governance_monitor.py
+++ b/src/governance_monitor.py
@@ -605,6 +605,18 @@ class UNITARESMonitor:
         except Exception:
             pass  # Fail-safe: no penalty if calibration unavailable
 
+        # Stage A (EISV S-attractor calibration): per-class S rest target so the
+        # ODE equilibrium lands on measured-healthy S instead of ~0.09. Off by
+        # default (UNITARES_S_SETPOINT) — when off, s_setpoint stays 0.0 and the
+        # dynamics are unchanged. Kept zero-cost on the off path (no class
+        # resolution unless the flag is enabled).
+        from config.governance_config import get_s_setpoint, s_setpoint_enabled
+        s_setpoint = 0.0
+        if s_setpoint_enabled():
+            if not hasattr(self, "_resolved_agent_class"):
+                self._resolved_agent_class = self._resolve_agent_class()
+            s_setpoint = get_s_setpoint(self._resolved_agent_class)
+
         self.state.unitaires_state = step_state(
             state=self.state.unitaires_state,
             theta=self.state.unitaires_theta,
@@ -614,6 +626,7 @@ class UNITARESMonitor:
             params=active_params,
             complexity=complexity,  # Complexity now affects S dynamics
             sensor_eisv=coupling_sensor,  # per-source gated; None => no spring (still compared below)
+            s_setpoint=s_setpoint,  # 0.0 unless UNITARES_S_SETPOINT enabled
         )
 
         # Compare, don't couple: record model<->body divergence as a signal.

--- a/tests/test_eisv_s_setpoint.py
+++ b/tests/test_eisv_s_setpoint.py
@@ -1,0 +1,82 @@
+"""Stage A — per-class S setpoint (EISV fixed-point calibration).
+
+Guards two contracts:
+  1. OFF by default: s_setpoint=0.0 reproduces the historical `-μS` equilibrium
+     (S* ≈ 0.091) exactly — merging the change is a no-op until enabled.
+  2. ON: decaying toward σ shifts S* to σ + driver-offset, so a per-class σ =
+     healthy_S − offset lands the equilibrium on measured-healthy S and lifts the
+     manifold readout above the 0.40 critical threshold.
+
+Runs on governance_core directly — no DB / server needed.
+"""
+import math
+
+import pytest
+
+from governance_core.dynamics import State, step_state, compute_equilibrium
+from governance_core.parameters import get_active_params, DEFAULT_THETA
+from config.governance_config import (
+    get_s_setpoint, s_setpoint_enabled, get_healthy_operating_point,
+    get_delta_norm_max, S_SETPOINT_DRIVER_OFFSET, GovernanceConfig as GC,
+)
+
+P, TH = get_active_params(), DEFAULT_THETA
+
+
+def _rest(s_setpoint, steps=3000, dt=0.05):
+    s = compute_equilibrium(P, TH, complexity=0.5)
+    for _ in range(steps):
+        s = step_state(state=s, theta=TH, delta_eta=[], dt=dt, noise_S=0.0,
+                       params=P, complexity=0.5, sensor_eisv=None, s_setpoint=s_setpoint)
+    return s
+
+
+def test_setpoint_zero_reproduces_historical_equilibrium():
+    """Default (s_setpoint=0.0) must leave the S equilibrium at ~0.091."""
+    assert _rest(0.0).S == pytest.approx(0.091, abs=0.01)
+
+
+def test_default_call_matches_explicit_zero():
+    """Omitting s_setpoint == passing 0.0 (no behavior change on the hot path)."""
+    s = compute_equilibrium(P, TH, complexity=0.5)
+    a = step_state(state=s, theta=TH, delta_eta=[], dt=0.05, noise_S=0.0,
+                   params=P, complexity=0.5, sensor_eisv=None)
+    b = step_state(state=s, theta=TH, delta_eta=[], dt=0.05, noise_S=0.0,
+                   params=P, complexity=0.5, sensor_eisv=None, s_setpoint=0.0)
+    assert (a.E, a.I, a.S, a.V) == (b.E, b.I, b.S, b.V)
+
+
+def test_setpoint_shifts_equilibrium_by_offset():
+    """S* = σ + driver-offset: decaying toward σ raises the rest point linearly."""
+    sigma = 0.146  # default healthy_S − offset
+    assert _rest(sigma).S == pytest.approx(sigma + 0.091, abs=0.01)
+
+
+def test_get_s_setpoint_off_by_default():
+    assert not s_setpoint_enabled()
+    assert get_s_setpoint("default") == 0.0
+    assert get_s_setpoint("Lumen") == 0.0
+
+
+def test_get_s_setpoint_enabled(monkeypatch):
+    monkeypatch.setenv("UNITARES_S_SETPOINT", "1")
+    assert s_setpoint_enabled()
+    for cls in ("default", "Lumen", "Watcher"):
+        expected = get_healthy_operating_point(cls)[2] - S_SETPOINT_DRIVER_OFFSET
+        assert get_s_setpoint(cls) == pytest.approx(expected, abs=1e-9)
+
+
+def test_setpoint_lands_on_measured_healthy_and_clears_critical():
+    """With the per-class setpoint, S-rest ≈ measured healthy S and manifold-at-
+    rest clears the 0.40 critical threshold (the Stage-B enabler)."""
+    for cls in ("default", "Lumen", "Watcher", "Vigil"):
+        hp = get_healthy_operating_point(cls)
+        sigma = hp[2] - S_SETPOINT_DRIVER_OFFSET
+        r = _rest(sigma)
+        assert r.S == pytest.approx(hp[2], abs=0.02), f"{cls}: S-rest off target"
+        dmax = get_delta_norm_max(cls).value
+        norm = math.sqrt((r.E-hp[0])**2 + (r.I-hp[1])**2 + (r.S-hp[2])**2)
+        manifold = 1.0 - max(0.0, min(1.0, norm / dmax))
+        assert manifold >= GC.COHERENCE_CRITICAL_THRESHOLD, (
+            f"{cls}: manifold@rest {manifold:.3f} still below critical line"
+        )


### PR DESCRIPTION
## What

**Stage A** of the EISV fixed-point fix (roadmap in `docs/proposals/eisv-fixed-point-calibration-gap-v0.md`): give the ODE a per-class S rest target so its equilibrium can land on *measured-healthy* S instead of the emergent ~0.091. **Off by default — merging is a no-op.**

## Why

The S equilibrium rests at ~0.091, but measured healthy S is 0.17–0.31 per class. That offset makes the manifold coherence readout unthresholdable as a control signal (a healthy agent reads ~0.17, below the 0.40 critical line). The Stage-1 audit (#1047) showed you can't move the control signal to the manifold until this is fixed — so the attractor fix comes first.

## How

- S decay `-μS` → `-μ(S - σ)` via a new `s_setpoint` param (default `0.0` = historical behavior, **byte-identical**), threaded through `_derivatives` → integrators → `compute_dynamics` → `step_state`.
- `σ = healthy_S − S_SETPOINT_DRIVER_OFFSET` (0.091, the baseline driver contribution; provenance from `scripts/analysis/eisv_equilibrium_gap.py`), resolved per agent class via `config.get_s_setpoint()`.
- The monitor passes `s_setpoint` from the resolved class. **Off-path is zero-cost** — no class resolution unless `UNITARES_S_SETPOINT` is enabled.

## Safety

- **Default OFF** (`UNITARES_S_SETPOINT`). When off, `s_setpoint=0.0` and dynamics are unchanged — verified by `test_default_call_matches_explicit_zero` + the historical-equilibrium test, and all 233 existing monitor/math/grounding tests still pass.
- Enabling is **gated on red-team validation against the real `agent_state` corpus** (not available from this session). Synthetic verification only here.

## Tests (`tests/test_eisv_s_setpoint.py`, 6 new)

- OFF reproduces S* ≈ 0.091; omitting the param == passing 0.0.
- σ shifts S* to σ + offset (linear).
- Enabled: per-class σ = healthy_S − offset; S-rest lands on measured healthy and **manifold-at-rest clears the 0.40 critical line for default/Lumen/Watcher/Vigil**.

## Known residual (for Stage B)

Manifold-at-rest reaches ~0.58 (default), not ~1.0 — the remainder is dominated by `E*` (0.805 vs healthy ~0.73). Vigil clears by a thin margin (~0.465), so Stage B's manifold threshold should sit conservatively (~0.30) or Stage A should later also nudge `E*`.

Draft — flagged off; enable only after real-trace red-team.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQLaFx6ZPGPyuR3ESNRYut)_