### PR TITLE
fix(identity): close KG liveness and naming gaps

### DIFF
--- a/src/mcp_handlers/core.py
+++ b/src/mcp_handlers/core.py
@@ -341,19 +341,17 @@ def _schedule_agent_presence_heartbeat(ctx) -> None:
     Best-effort side-effect on the check-in path. Never raises into the caller,
     and deliberately NOT routed through the activity tracker / governance-tool
     path, so the lease heartbeat cannot feed loop-detection (the auto-heartbeat
-    false-positive class). See agent_presence_lease for why this lives on the
-    check-in path rather than onboard.
+    false-positive class). See agent_presence_lease for why check-in remains a
+    liveness trigger even though onboard now acquires the initial lease.
     """
     try:
-        agent_uuid = getattr(ctx, "agent_uuid", "") or ""
-        if not agent_uuid:
-            return
-        from src.background_tasks import create_tracked_task
-        from src.mcp_handlers.identity.agent_presence_lease import heartbeat_agent_presence
+        from src.mcp_handlers.identity.agent_presence_lease import (
+            schedule_agent_presence_heartbeat,
+        )
 
-        create_tracked_task(
-            heartbeat_agent_presence(agent_uuid, getattr(ctx, "client_session_id", None)),
-            name="agent_presence_lease",
+        schedule_agent_presence_heartbeat(
+            getattr(ctx, "agent_uuid", "") or "",
+            getattr(ctx, "client_session_id", None),
         )
     except Exception as e:  # pragma: no cover - scheduling must never affect the check-in
         logger.debug(f"agent presence lease scheduling skipped: {e}")

--- a/src/mcp_handlers/identity/agent_presence_lease.py
+++ b/src/mcp_handlers/identity/agent_presence_lease.py
@@ -1,16 +1,17 @@
 """Producer side of the ephemeral-agent liveness lease.
 
-On the check-in path, keep a fresh ``agent:/<uuid>`` remote_heartbeat presence
-lease in the lease plane so the archival gate (``has_live_agent_lease``, the
+On the onboard and check-in paths, keep a fresh ``agent:/<uuid>``
+remote_heartbeat presence lease in the lease plane so the archival gate
+(``has_live_agent_lease``, the
 consumer in ``process_binding``) can tell a live ephemeral agent from an exited
 one. This is what makes the #720 false-archival protection real for ephemeral
 agents — which today write no process binding, so binding-liveness is blind to
 them.
 
-Why the check-in path (``process_agent_update``), not onboard: substrate-agnostic
-liveness invariants belong on the check-in path. BEAM residents and raw-MCP
-agents bypass onboard, but everything that is alive checks in. First check-in
-acquires the lease; later check-ins heartbeat it.
+Why both paths: substrate-agnostic liveness invariants belong on the check-in
+path, because BEAM residents and raw-MCP agents bypass onboard. But a live MCP
+agent can do accountable work between successful onboard and first check-in, so
+onboard must acquire the initial lease too. Later check-ins heartbeat it.
 
 Safety / non-interference:
   * Fire-and-forget and best-effort — a lease failure must NEVER affect the
@@ -125,3 +126,20 @@ async def _refresh_presence(client, agent_uuid: str, client_session_id: Optional
     new_id = getattr(result, "lease_id", None)
     if new_id:
         _lease_ids[agent_uuid] = str(new_id)
+
+
+def schedule_agent_presence_heartbeat(
+    agent_uuid: Optional[str], client_session_id: Optional[str] = None
+) -> None:
+    """Schedule a best-effort presence heartbeat without affecting caller flow."""
+    try:
+        if not agent_uuid:
+            return
+        from src.background_tasks import create_tracked_task
+
+        create_tracked_task(
+            heartbeat_agent_presence(agent_uuid, client_session_id),
+            name="agent_presence_lease",
+        )
+    except Exception as e:  # pragma: no cover - scheduling must never affect callers
+        logger.debug(f"[AGENT_PRESENCE] scheduling skipped: {e}")

--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -2612,6 +2612,20 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     # sweep in src/background_tasks.py is sufficient. Users who want an
     # immediate sweep can still call the archive_orphan_agents tool.
 
+    # Presence lease: successful onboard is enough proof that this process is
+    # live, even before its first check-in. Acquire/heartbeat best-effort so the
+    # archival liveness gate does not treat onboard+tool-use agents as dead.
+    try:
+        from src.mcp_handlers.identity.agent_presence_lease import (
+            schedule_agent_presence_heartbeat,
+        )
+
+        schedule_agent_presence_heartbeat(agent_uuid, stable_session_id)
+    except Exception as _presence_err:  # pragma: no cover - defensive fail-open
+        logger.debug(
+            f"[AGENT_PRESENCE] onboard scheduling failed (non-fatal): {_presence_err}"
+        )
+
     # Use lite_response to skip redundant signature
     arguments["lite_response"] = True
     return success_response(result, agent_id=agent_uuid, arguments=arguments)

--- a/src/mcp_handlers/identity/resolution.py
+++ b/src/mcp_handlers/identity/resolution.py
@@ -80,18 +80,42 @@ def _audit_session_resolve_miss(
 _CLIENT_HINT_SHAPE = re.compile(r"^[A-Za-z0-9_-]{1,40}$")
 
 
+def _has_reserved_leading_token(value: str) -> bool:
+    """True when a generated identifier component would enter reserved space."""
+    from ..validators import RESERVED_NAMES, RESERVED_PREFIXES
+
+    normalized = value.lower().replace("-", "_")
+    leading_token = normalized.split("_", 1)[0]
+    reserved_roots = {prefix.rstrip("_") for prefix in RESERVED_PREFIXES}
+    return normalized in RESERVED_NAMES or leading_token in reserved_roots
+
+
+def _format_agent_id_component(value: str, *, reserved_prefix: str) -> str:
+    """Format a caller-derived component and neutralize reserved leading tokens."""
+    component = value.strip()
+    component = component.replace("-", " ").replace(".", " ").replace("_", " ")
+    component = "_".join(word.capitalize() for word in component.split())
+    if component and _has_reserved_leading_token(component):
+        return f"{reserved_prefix}_{component}"
+    return component
+
+
 def _is_valid_client_hint(client_hint: Optional[str]) -> bool:
     """Validate client_hint is a short identifier, not free text.
 
     `client_hint` is meant to identify the client *type* (cursor, vscode,
     claude_desktop). Free-form descriptions ("Anthropic Claude, mobile app,
     dogfooding UX review") must not become identifier fragments — descriptors
-    are not handles.
+    are not handles. Privileged namespace roots are also rejected here; the
+    caller falls back to an anonymous/detected identity instead of minting an id
+    that validate_agent_id_reserved_names later refuses.
     """
     if not client_hint:
         return False
     stripped = client_hint.strip()
     if stripped.lower() in ("unknown", "mcp", ""):
+        return False
+    if _has_reserved_leading_token(stripped):
         return False
     return bool(_CLIENT_HINT_SHAPE.match(stripped))
 
@@ -154,15 +178,11 @@ def _generate_agent_id(model_type: Optional[str] = None, client_hint: Optional[s
 
     if model_type:
         # Normalize and format model name
-        model = model_type.strip()
-        # Capitalize first letter of each word, replace separators with underscore
-        model = model.replace("-", " ").replace(".", " ").replace("_", " ")
-        model = "_".join(word.capitalize() for word in model.split())
+        model = _format_agent_id_component(model_type, reserved_prefix="Model")
 
         # Third-party clients get prefixed to prevent identity confusion
         if valid_hint and _client_differs_from_model(client_hint, model_type):
-            client = client_hint.strip().replace("_", " ").replace("-", " ")
-            client = "_".join(word.capitalize() for word in client.split())
+            client = _format_agent_id_component(client_hint, reserved_prefix="Client")
             return f"{client}_{model}_{timestamp}"
 
         return f"{model}_{timestamp}"

--- a/tests/test_agent_presence_lease.py
+++ b/tests/test_agent_presence_lease.py
@@ -1,10 +1,10 @@
 """Producer side of ephemeral-agent liveness lease (agent_presence_lease).
 
-Pins the check-in-path lease lifecycle: no-op without uuid/client, acquire-then-
-cache, heartbeat-when-cached, re-acquire-on-heartbeat-failure, and never-raises
-(fire-and-forget must never affect the check-in). The SDK request models are
-guarded-imported (None in this isolated env), so tests monkeypatch them + the
-client factory with fakes.
+Pins the lease lifecycle used by onboard and check-in: no-op without uuid/client,
+acquire-then-cache, heartbeat-when-cached, re-acquire-on-heartbeat-failure, and
+never-raises (fire-and-forget must never affect the caller). The SDK request
+models are guarded-imported (None in this isolated env), so tests monkeypatch
+them + the client factory with fakes.
 """
 
 from types import SimpleNamespace

--- a/tests/test_identity_core.py
+++ b/tests/test_identity_core.py
@@ -193,7 +193,11 @@ class TestGenerateAgentId:
             {"client_hint": "my editor"},    # invalid hint → fallback
             {"client_hint": ""},             # empty hint → fallback
             {"client_hint": "unknown"},      # filtered hint → fallback
+            {"client_hint": "governance_ui"},  # reserved hint → fallback
             {"model_type": "claude-opus-4-5", "client_hint": "claude_desktop"},
+            {"model_type": "governance-core"},
+            {"model_type": "auth-proxy"},
+            {"model_type": "governance-core", "client_hint": "admin_cli"},
             {"client_hint": "cursor"},
         ):
             minted = self.generate(**kwargs)
@@ -203,22 +207,6 @@ class TestGenerateAgentId:
                 f"gate rejects — server would refuse its own identity"
             )
             assert ok == minted
-
-        # KNOWN GAP, pinned deliberately (council 2026-06-10): a model_type
-        # or client_hint that BEGINS with a reserved family word still mints
-        # a name the gate rejects — e.g. model_type="governance-core" →
-        # "Governance_Core_<date>" → reserved prefix 'governance_' (the gate
-        # lowercases before matching). Same incident class as the anonymous
-        # fallback, for NAMED callers; rare today (no real model/client name
-        # starts with a reserved word) and the mint-side remedy is an
-        # identity-surface design call — tracked as a follow-up. Pinned here
-        # so the gap stays visible instead of silent:
-        named_collision = self.generate(model_type="governance-core")
-        _, err = validate_agent_id_reserved_names(named_collision)
-        assert err is not None, (
-            "named reserved-word collision unexpectedly resolved — update "
-            "this pin, the coupling-test scope, and close the follow-up"
-        )
 
     def test_whitespace_model_type(self):
         result = self.generate(model_type="  claude-haiku  ")
@@ -910,4 +898,3 @@ class TestSetAgentLabelStructuredIdMigration:
 # ============================================================================
 # Additional coverage: handle_identity_adapter structured_id regeneration (lines 1323-1345)
 # ============================================================================
-

--- a/tests/test_identity_handlers.py
+++ b/tests/test_identity_handlers.py
@@ -1902,6 +1902,31 @@ class TestHandleOnboardV2:
         assert "what_this_does" not in data
 
     @pytest.mark.asyncio
+    async def test_onboard_schedules_presence_lease(
+        self, patch_onboard_deps, mock_db, mock_redis
+    ):
+        """Successful onboard acquires agent:/ presence before first check-in."""
+        from src.mcp_handlers.identity import handlers as h
+
+        mock_redis.get.return_value = None
+        mock_db.get_session.return_value = None
+        mock_db.find_agent_by_label.return_value = None
+        mock_db.get_identity.side_effect = [
+            None,
+            None,
+            SimpleNamespace(identity_id="new-ident", metadata={}),
+        ]
+
+        with patch(
+            "src.mcp_handlers.identity.agent_presence_lease.schedule_agent_presence_heartbeat"
+        ) as schedule_mock:
+            result = await h.handle_onboard_v2({"client_session_id": "onboard-lease"})
+
+        data = parse_result(result)
+        assert data["success"] is True
+        schedule_mock.assert_called_once_with(data["uuid"], data["client_session_id"])
+
+    @pytest.mark.asyncio
     async def test_onboard_full_mode_restores_descriptive_envelope(
         self, patch_onboard_deps, mock_db, mock_redis
     ):

--- a/tests/test_path28_substrate_http_reject.py
+++ b/tests/test_path28_substrate_http_reject.py
@@ -270,7 +270,9 @@ async def test_force_new_bypasses_path28_and_gate() -> None:
                 # That's already statically true from the edit's
                 # location — assert by reading the source.
                 import inspect
-                src = inspect.getsource(resolution_mod.resolve_session_identity)
+                module_src = inspect.getsource(resolution_mod)
+                start = module_src.index("async def resolve_session_identity(")
+                src = module_src[start:]
                 # The gate's marker comment should appear inside the
                 # `if token_agent_uuid and not force_new:` block.
                 assert "[SUBSTRATE_HTTP_REJECT]" in src


### PR DESCRIPTION
## Summary
- acquire the agent:/ presence lease on successful onboard so live onboard+tool-use agents are visible before first sync_state
- centralize presence-lease scheduling and keep process_agent_update using the same fire-and-forget helper
- neutralize reserved-leading model_type/client_hint generated agent IDs so the server no longer mints names its reserved-prefix validator refuses
- make the PATH 2.8 static test robust to source line movement

## KG Bugs Addressed
- 2026-06-22T15:45:07.503842+00:00 — false-archival presence lease coverage gap
- 2026-06-10T13:03:46.960449+00:00 — named-caller reserved-prefix auto-mint gap

## Tests
- python3 -m pytest tests/test_identity_core.py::TestGenerateAgentId tests/test_identity_handlers.py::TestHandleOnboardV2::test_onboard_schedules_presence_lease tests/test_agent_presence_lease.py tests/test_path28_substrate_http_reject.py::test_force_new_bypasses_path28_and_gate
- ./scripts/dev/test-cache.sh — 10715 passed, 21 skipped, coverage 81.73%
- pre-push smoke — 138 passed, 9951 deselected, 1 warning

## Notes
Pre-push doc-health still reports existing orphan/ghost-tool warnings; this PR does not touch those docs.