### PR TITLE
fix(diagnostics): align tool counters with runtime registry

### DIFF
--- a/scripts/analysis/count_tools.py
+++ b/scripts/analysis/count_tools.py
@@ -68,10 +68,15 @@ def main():
     args = parser.parse_args()
 
     include_deprecated = not args.exclude_deprecated
-    by_module, total = count_tools(
-        include_hidden=args.include_hidden,
-        include_deprecated=include_deprecated,
-    )
+    try:
+        by_module, total = count_tools(
+            include_hidden=args.include_hidden,
+            include_deprecated=include_deprecated,
+        )
+    except ModuleNotFoundError as exc:
+        print(f"WARNING: Tool count unavailable ({exc})", file=sys.stderr)
+        by_module = {}
+        total = 0
 
     if args.json:
         output = {

--- a/scripts/analysis/count_tools.py
+++ b/scripts/analysis/count_tools.py
@@ -6,52 +6,90 @@ Usage:
     python scripts/analysis/count_tools.py --json       # Print as JSON
     python scripts/analysis/count_tools.py --by-module  # Breakdown by module
 """
-import sys
-import os
+from __future__ import annotations
+
+import argparse
 import json
-import re
 from collections import defaultdict
+from pathlib import Path
+import sys
 
-PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-sys.path.insert(0, PROJECT_ROOT)
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
 
-def count_tools():
-    """Count @mcp_tool decorated functions across handler modules."""
-    handlers_dir = os.path.join(PROJECT_ROOT, "src", "mcp_handlers")
-    if not os.path.isdir(handlers_dir):
-        return {}, 0
 
-    by_module = defaultdict(list)
-    total = 0
+def _registry_accessors():
+    import src.mcp_handlers  # noqa: F401 - populates decorator registry
+    from src.mcp_handlers.decorators import get_tool_definition, list_registered_tools
 
-    for fname in sorted(os.listdir(handlers_dir)):
-        if not fname.endswith(".py") or fname.startswith("_"):
+    return get_tool_definition, list_registered_tools
+
+
+def _module_bucket(module_name: str) -> str:
+    prefix = "src.mcp_handlers."
+    if module_name.startswith(prefix):
+        module_name = module_name[len(prefix):]
+    return module_name or "(unknown)"
+
+
+def count_tools(*, include_hidden: bool = False, include_deprecated: bool = True) -> tuple[dict[str, list[str]], int]:
+    """Count tools from the runtime registry that dispatch actually uses."""
+    get_tool_definition, list_registered_tools = _registry_accessors()
+    by_module: dict[str, list[str]] = defaultdict(list)
+
+    for tool_name in list_registered_tools(
+        include_hidden=include_hidden,
+        include_deprecated=include_deprecated,
+    ):
+        td = get_tool_definition(tool_name)
+        if td is None:
             continue
-        filepath = os.path.join(handlers_dir, fname)
-        with open(filepath) as f:
-            content = f.read()
+        module_name = _module_bucket(getattr(td.handler, "__module__", ""))
+        by_module[module_name].append(tool_name)
 
-        # Find @mcp_tool("tool_name") decorators
-        for match in re.finditer(r'@mcp_tool\(\s*["\'](\w+)["\']', content):
-            tool_name = match.group(1)
-            by_module[fname].append(tool_name)
-            total += 1
+    sorted_modules = {
+        module_name: sorted(tool_names)
+        for module_name, tool_names in sorted(by_module.items())
+    }
+    total = sum(len(tool_names) for tool_names in sorted_modules.values())
+    return sorted_modules, total
 
-    return dict(by_module), total
 
 def main():
-    by_module, total = count_tools()
+    parser = argparse.ArgumentParser(description="Count MCP tools")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    parser.add_argument("--by-module", action="store_true", help="Show breakdown by module")
+    parser.add_argument("--include-hidden", action="store_true", help="Include hidden/internal tools")
+    parser.add_argument(
+        "--exclude-deprecated",
+        action="store_true",
+        help="Exclude deprecated-but-callable tools",
+    )
+    args = parser.parse_args()
 
-    if "--json" in sys.argv:
-        print(json.dumps({"total": total, "by_module": by_module}, indent=2))
-    elif "--by-module" in sys.argv:
-        for module, tools in sorted(by_module.items()):
+    include_deprecated = not args.exclude_deprecated
+    by_module, total = count_tools(
+        include_hidden=args.include_hidden,
+        include_deprecated=include_deprecated,
+    )
+
+    if args.json:
+        output = {
+            "total": total,
+            "include_hidden": args.include_hidden,
+            "include_deprecated": include_deprecated,
+            "by_module": by_module,
+        }
+        print(json.dumps(output, indent=2))
+    elif args.by_module:
+        for module, tools in by_module.items():
             print(f"\n{module} ({len(tools)} tools):")
-            for t in tools:
-                print(f"  - {t}")
+            for tool_name in tools:
+                print(f"  - {tool_name}")
         print(f"\nTotal: {total} tools")
     else:
         print(f"{total} tools")
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/dev/update_docs_tool_count.py
+++ b/scripts/dev/update_docs_tool_count.py
@@ -18,7 +18,7 @@ def load_tool_count() -> int:
     try:
         _, total = count_tools()
     except ModuleNotFoundError as exc:
-        print(f"WARNING: Tool count unavailable ({exc})")
+        print(f"WARNING: Tool count unavailable ({exc})", file=sys.stderr)
         return 0
 
     return total

--- a/scripts/dev/update_docs_tool_count.py
+++ b/scripts/dev/update_docs_tool_count.py
@@ -11,9 +11,21 @@ import os
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, PROJECT_ROOT)
 
-def main():
+
+def load_tool_count() -> int:
     from scripts.analysis.count_tools import count_tools
-    _, total = count_tools()
+
+    try:
+        _, total = count_tools()
+    except ModuleNotFoundError as exc:
+        print(f"WARNING: Tool count unavailable ({exc})")
+        return 0
+
+    return total
+
+
+def main():
+    total = load_tool_count()
 
     if "--check" in sys.argv:
         if total == 0:

--- a/scripts/diagnostics/check_eisv_completeness.py
+++ b/scripts/diagnostics/check_eisv_completeness.py
@@ -6,17 +6,18 @@ This script scans code and documentation for patterns that might indicate
 incomplete EISV reporting (e.g., "E, I, S" without V).
 
 Usage:
-    python3 scripts/check_eisv_completeness.py [--fix]
+    python3 scripts/diagnostics/check_eisv_completeness.py [--fix]
 
 Exit codes:
     0 - All EISV references are complete
     1 - Found incomplete EISV references
 """
 
+import os
 import re
 import sys
 from pathlib import Path
-from typing import List, Tuple
+from typing import Iterator, List, Tuple
 
 NUMBER_RE = r'[+-]?\d+(?:\.\d+)?'
 
@@ -86,6 +87,18 @@ def should_check_file(filepath: Path) -> bool:
     return filepath.suffix in {'.py', '.md', '.txt', '.json'}
 
 
+def iter_checkable_files(project_root: Path) -> Iterator[Path]:
+    """Yield checkable files while pruning generated/cache directories."""
+    for root, dirs, files in os.walk(project_root):
+        dirs[:] = [dirname for dirname in dirs if dirname not in SKIP_DIRS]
+        root_path = Path(root)
+
+        for filename in files:
+            filepath = root_path / filename
+            if should_check_file(filepath):
+                yield filepath
+
+
 def _looks_complete_on_same_line(line: str, match: re.Match[str], pattern_name: str) -> bool:
     if 'without v' in line.lower() or 'missing v' in line.lower():
         return False
@@ -127,13 +140,7 @@ def main():
     print()
 
     # Scan all relevant files
-    for filepath in project_root.rglob('*'):
-        if not filepath.is_file():
-            continue
-
-        if not should_check_file(filepath):
-            continue
-
+    for filepath in iter_checkable_files(project_root):
         issues = check_file(filepath)
         if issues:
             all_issues.append((filepath, issues))
@@ -159,7 +166,7 @@ def main():
         print("   Please manually update the files to include V.")
     else:
         print("💡 To see suggestions for fixing, run:")
-        print("   python3 scripts/check_eisv_completeness.py --fix")
+        print("   python3 scripts/diagnostics/check_eisv_completeness.py --fix")
 
     print()
     print("📖 See docs/guides/EISV_COMPLETENESS.md for correct usage.")

--- a/tests/test_eisv_completeness.py
+++ b/tests/test_eisv_completeness.py
@@ -264,6 +264,25 @@ class TestCompletenessScript:
         assert script.should_check_file(Path("/repo/.claude/worktrees/task/docs/note.md")) is False
         assert script.should_check_file(Path("/repo/htmlcov/index.json")) is False
 
+    def test_iter_checkable_files_prunes_skipped_directories(self, tmp_path):
+        script = _load_check_script()
+        checked_file = tmp_path / "src" / "state.py"
+        skipped_venv_file = tmp_path / ".venv" / "lib" / "pkg.py"
+        skipped_worktree_file = tmp_path / ".claude" / "worktrees" / "task" / "note.md"
+
+        checked_file.parent.mkdir(parents=True)
+        skipped_venv_file.parent.mkdir(parents=True)
+        skipped_worktree_file.parent.mkdir(parents=True)
+        checked_file.write_text("ok = True\n")
+        skipped_venv_file.write_text("example = {'E': 0.1, 'I': 0.2, 'S': 0.3}\n")
+        skipped_worktree_file.write_text("E=0.1, I=0.2, S=0.3\n")
+
+        files = set(script.iter_checkable_files(tmp_path))
+
+        assert checked_file in files
+        assert skipped_venv_file not in files
+        assert skipped_worktree_file not in files
+
     def test_complete_same_line_eisv_does_not_flag(self, tmp_path):
         script = _load_check_script()
         path = tmp_path / "state.py"

--- a/tests/test_tool_count_scripts.py
+++ b/tests/test_tool_count_scripts.py
@@ -1,5 +1,6 @@
 from scripts.analysis.count_tools import count_tools
 from scripts.diagnostics.count_tools import get_total_count
+from scripts.dev import update_docs_tool_count
 
 
 def test_analysis_counter_matches_runtime_diagnostics_counter():
@@ -9,3 +10,13 @@ def test_analysis_counter_matches_runtime_diagnostics_counter():
     assert total >= 40
     assert sum(len(tool_names) for tool_names in by_module.values()) == total
     assert any(module.startswith("knowledge") for module in by_module)
+
+
+def test_dev_doc_count_checker_skips_when_runtime_deps_are_missing(monkeypatch, capsys):
+    def missing_dependency_counter():
+        raise ModuleNotFoundError("No module named 'mcp'")
+
+    monkeypatch.setattr("scripts.analysis.count_tools.count_tools", missing_dependency_counter)
+
+    assert update_docs_tool_count.load_tool_count() == 0
+    assert "Tool count unavailable" in capsys.readouterr().out

--- a/tests/test_tool_count_scripts.py
+++ b/tests/test_tool_count_scripts.py
@@ -1,10 +1,10 @@
-from scripts.analysis.count_tools import count_tools
+from scripts.analysis import count_tools as analysis_count_tools
 from scripts.diagnostics.count_tools import get_total_count
 from scripts.dev import update_docs_tool_count
 
 
 def test_analysis_counter_matches_runtime_diagnostics_counter():
-    by_module, total = count_tools()
+    by_module, total = analysis_count_tools.count_tools()
 
     assert total == get_total_count()
     assert total >= 40
@@ -19,4 +19,18 @@ def test_dev_doc_count_checker_skips_when_runtime_deps_are_missing(monkeypatch, 
     monkeypatch.setattr("scripts.analysis.count_tools.count_tools", missing_dependency_counter)
 
     assert update_docs_tool_count.load_tool_count() == 0
-    assert "Tool count unavailable" in capsys.readouterr().out
+    assert "Tool count unavailable" in capsys.readouterr().err
+
+
+def test_analysis_counter_cli_skips_when_runtime_deps_are_missing(monkeypatch, capsys):
+    def missing_dependency_counter(**_kwargs):
+        raise ModuleNotFoundError("No module named 'mcp'")
+
+    monkeypatch.setattr(analysis_count_tools, "count_tools", missing_dependency_counter)
+    monkeypatch.setattr("sys.argv", ["count_tools.py", "--by-module"])
+
+    analysis_count_tools.main()
+
+    captured = capsys.readouterr()
+    assert "Tool count unavailable" in captured.err
+    assert "Total: 0 tools" in captured.out

--- a/tests/test_tool_count_scripts.py
+++ b/tests/test_tool_count_scripts.py
@@ -1,0 +1,11 @@
+from scripts.analysis.count_tools import count_tools
+from scripts.diagnostics.count_tools import get_total_count
+
+
+def test_analysis_counter_matches_runtime_diagnostics_counter():
+    by_module, total = count_tools()
+
+    assert total == get_total_count()
+    assert total >= 40
+    assert sum(len(tool_names) for tool_names in by_module.values()) == total
+    assert any(module.startswith("knowledge") for module in by_module)


### PR DESCRIPTION
## Summary
- replace the stale static analysis tool counter with the runtime decorator registry
- keep the dev doc-count checker aligned with diagnostics count behavior
- prune skipped cache/worktree directories in the EISV completeness scanner
- add regression coverage for tool-count drift and skipped EISV traversal

## Tests
- ./scripts/dev/test-cache.sh
- pytest tests/test_tool_count_scripts.py tests/test_eisv_completeness.py -q
- python3 scripts/diagnostics/check_eisv_completeness.py
- python3 scripts/analysis/count_tools.py --json
- python3 scripts/dev/update_docs_tool_count.py --check
- python3 scripts/diagnostics/update_docs_tool_count.py --check
- ruff check scripts/analysis/count_tools.py scripts/diagnostics/check_eisv_completeness.py tests/test_tool_count_scripts.py tests/test_eisv_completeness.py
- python3 -m compileall -q scripts/analysis/count_tools.py scripts/diagnostics/check_eisv_completeness.py tests/test_tool_count_scripts.py tests/test_eisv_completeness.py