### PR TITLE
feat(eisv): Stage 0 — exogenous anchor tiering for outcome_events

### DIFF
--- a/scripts/analysis/outcome_anchor_inventory.py
+++ b/scripts/analysis/outcome_anchor_inventory.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Stage 0 — reproducible inventory of the exogenous anchor budget.
+
+Tiers ``audit.outcome_events`` by ``verification_source`` using the canonical
+mapping in ``src.grounding.outcome_anchors`` (Invariant 4: self-referential and
+unknown-provenance rows are EXCLUDED), and reports the externally-anchored label
+budget that bounds B's falsifiability gate.
+
+This is the command form of the roadmap's Appendix-A recon — run it to see how
+the budget has grown, and to catch regressions (e.g. a new verification_source
+that is silently EXCLUDED, or the test_failed wiring gap closing).
+
+Usage:
+    PYTHONPATH=. python3 scripts/analysis/outcome_anchor_inventory.py
+    PYTHONPATH=. python3 scripts/analysis/outcome_anchor_inventory.py --db-url ...
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+try:
+    import psycopg2
+except ImportError:
+    print("ERROR: psycopg2 not installed. Run: pip install psycopg2-binary", file=sys.stderr)
+    sys.exit(1)
+
+from src.grounding.outcome_anchors import AnchorTier, tier_for_source  # noqa: E402
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--db-url", default="postgresql://postgres:postgres@localhost:5432/governance")
+    args = ap.parse_args()
+
+    conn = psycopg2.connect(args.db_url)
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT COALESCE(verification_source, '(null)'),
+                   count(*),
+                   sum(CASE WHEN is_bad THEN 1 ELSE 0 END)
+            FROM audit.outcome_events
+            GROUP BY 1 ORDER BY 2 DESC
+            """
+        )
+        rows = cur.fetchall()
+
+    print(f"{'verification_source':<32}{'tier':<20}{'count':>9}{'bad':>8}")
+    print("-" * 69)
+    by_tier = {t: [0, 0] for t in AnchorTier}
+    for source, count, bad in rows:
+        bad = int(bad or 0)
+        src = None if source == "(null)" else source
+        tier = tier_for_source(src)
+        by_tier[tier][0] += count
+        by_tier[tier][1] += bad
+        print(f"{source:<32}{tier.value:<20}{count:>9}{bad:>8}")
+
+    print("\nBy tier:")
+    for t in AnchorTier:
+        c, b = by_tier[t]
+        print(f"  {t.value:<20} count={c:>8}  bad={b:>6}")
+
+    trusted_c, trusted_bad = by_tier[AnchorTier.TRUSTED_EXTERNAL]
+    soft_c, soft_bad = by_tier[AnchorTier.SOFT_SELF_ATTESTED]
+    excl_c, _ = by_tier[AnchorTier.EXCLUDED]
+    total = trusted_c + soft_c + excl_c
+    print(f"\nExogenous anchor budget (TRUSTED_EXTERNAL): {trusted_c} events, {trusted_bad} bad")
+    print(f"  (+soft self-attested if opted in: +{soft_c} events, +{soft_bad} bad)")
+    if total:
+        print(f"Self-referential / unknown EXCLUDED: {excl_c}/{total} "
+              f"({100*excl_c/total:.0f}%) — Invariant 4 in effect")
+
+    # Gap check: is the most objective bad anchor (a failing test) flowing?
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT count(*) FROM audit.outcome_events
+            WHERE outcome_type = 'test_failed' AND verification_source = 'external_signal'
+            """
+        )
+        test_failed_external = cur.fetchone()[0]
+    flag = "  ⚠ WIRING GAP — CI/test failures not reaching outcome_events" if test_failed_external < 10 else ""
+    print(f"\nexternally-verified test_failed events: {test_failed_external}{flag}")
+
+    conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/analysis/stage_b_viability.py
+++ b/scripts/analysis/stage_b_viability.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Stage B viability probe — can the per-agent residual be validated against
+externally-anchored outcomes *at all* yet?
+
+B's falsifiability gate (roadmap §6.3) needs the SAME agents to have (a) a
+behavioral baseline (→ residual) and (b) externally-anchored outcomes (→ ground
+truth label). This probe measures that overlap first, and only computes the
+AUC(residual vs Φ) comparison if the overlap is non-empty.
+
+Finding (2026-06-25): the two are **disjoint populations** — externally-anchored
+outcomes carry no EISV and come from agents with no baseline, while EISV-rich
+residents receive only self-referential outcomes (Invariant-4 excluded). So B is
+not yet falsifiable for a data reason, not a thin-label reason. This probe is the
+regression guard: when the overlap appears, it starts emitting the AUC.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import psycopg2
+
+DIAG = {
+    "anchored outcomes (external_signal)":
+        "SELECT count(*) FROM audit.outcome_events WHERE verification_source='external_signal'",
+    "  ...carrying EISV (eisv_phi not null)":
+        "SELECT count(*) FROM audit.outcome_events WHERE verification_source='external_signal' AND eisv_phi IS NOT NULL",
+    "distinct agents with anchored outcomes":
+        "SELECT count(DISTINCT agent_id) FROM audit.outcome_events WHERE verification_source='external_signal'",
+    "  ...that have ANY EISV state row":
+        """SELECT count(DISTINCT i.identity_id)
+           FROM (SELECT DISTINCT agent_id FROM audit.outcome_events WHERE verification_source='external_signal') x
+           JOIN core.identities i ON i.agent_id=x.agent_id
+           JOIN core.agent_state s ON s.identity_id=i.identity_id""",
+    "  ...that are BASELINED (→ residual computable)":
+        """SELECT count(DISTINCT i.identity_id)
+           FROM (SELECT DISTINCT agent_id FROM audit.outcome_events WHERE verification_source='external_signal') x
+           JOIN core.identities i ON i.agent_id=x.agent_id
+           JOIN core.agent_state s ON s.identity_id=i.identity_id
+           WHERE s.state_json->'behavioral_eisv'->'warmup'->>'is_baselined'='true'""",
+    "OVERLAP: anchored outcomes joinable to a prior baselined state":
+        """SELECT count(*) FROM audit.outcome_events e
+           JOIN core.identities i ON i.agent_id=e.agent_id
+           WHERE e.verification_source='external_signal'
+             AND EXISTS (SELECT 1 FROM core.agent_state s
+               WHERE s.identity_id=i.identity_id AND s.recorded_at<=e.ts
+               AND s.state_json->'behavioral_eisv'->'warmup'->>'is_baselined'='true')""",
+}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db-url", default="postgresql://postgres:postgres@localhost:5432/governance")
+    args = ap.parse_args()
+    conn = psycopg2.connect(args.db_url)
+
+    print("=== Stage B viability: EISV ∩ exogenous-anchor population overlap ===")
+    overlap = 0
+    with conn.cursor() as cur:
+        for label, sql in DIAG.items():
+            cur.execute(sql)
+            v = cur.fetchone()[0]
+            print(f"  {label:<52} {v}")
+            if label.startswith("OVERLAP"):
+                overlap = v
+    conn.close()
+
+    print()
+    if overlap < 20:
+        print(f"VERDICT: B not yet falsifiable — overlap={overlap}. The anchored-outcome")
+        print("population and the EISV/baseline population are effectively disjoint.")
+        print("Prerequisite (deeper than 'wire test_failed'): EISV-bearing agents must")
+        print("RECEIVE and SNAPSHOT externally-anchored outcomes. Until then B's §6.3 gate")
+        print("is structurally uncomputable — the validation-gap pathology, by construction.")
+        return 0
+    print(f"overlap={overlap} ≥ 20 — residual-vs-Φ AUC is now computable; wire it here.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/grounding/outcome_anchors.py
+++ b/src/grounding/outcome_anchors.py
@@ -1,0 +1,111 @@
+"""Stage 0 — exogenous anchor tiering for ``audit.outcome_events``.
+
+The EISV maths roadmap (docs/proposals/eisv-maths-roadmap-v0.md) needs an
+*exogenous* anchor: a signal that comes from outside the governance loop, so the
+loop's references stay externally falsifiable. The substrate already exists —
+``audit.outcome_events`` carries per-agent outcomes with an ``is_bad`` label, the
+EISV state at the outcome moment, and a ``verification_source`` provenance field.
+
+But (recon 2026-06-25) ~88% of those rows are **self-referential** — the
+governance loop validating its own trajectories (``server_observation`` /
+``trajectory_validated``). Roadmap **Invariant 4**: *a signal derived from the
+loop cannot anchor the loop.* This module is the single place that maps a
+``verification_source`` to a trust tier and exposes the canonical filter that the
+outcome-gated baseline update (§4b) and B's falsifiability gate (§6) read from.
+Centralising it prevents a future caller from anchoring on the echo by accident.
+
+Tier mapping (from the measured provenance distribution):
+
+    external_signal             -> TRUSTED_EXTERNAL  (task/test outcomes verified
+                                                      outside the loop)
+    agent_reported_tool_result  -> SOFT_SELF_ATTESTED (the agent attests its own
+                                                       result — gameable)
+    server_observation          -> EXCLUDED  (the loop observing itself)
+    <null> / anything else      -> EXCLUDED  (unknown provenance can't anchor)
+
+Only TRUSTED_EXTERNAL counts as an anchor by default. SOFT may be opted in for
+analyses that tolerate self-attestation, but never silently.
+
+Gold-vs-strong separation *within* ``external_signal`` (operator correction vs
+CI vs verified tool failure) is a later refinement — it likely lives in the
+``detail`` jsonb and is not yet distinguished here.
+"""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional
+
+
+class AnchorTier(str, Enum):
+    """Trust tier of an outcome's provenance (roadmap §7)."""
+
+    TRUSTED_EXTERNAL = "trusted_external"      # external_signal — exogenous
+    SOFT_SELF_ATTESTED = "soft_self_attested"  # agent_reported_tool_result — gameable
+    EXCLUDED = "excluded"                       # self-referential / unknown provenance
+
+
+# Verification-source string -> tier. Anything not listed (including NULL) is
+# EXCLUDED: unknown provenance cannot anchor the loop (Invariant 4).
+_TIER_BY_SOURCE = {
+    "external_signal": AnchorTier.TRUSTED_EXTERNAL,
+    "agent_reported_tool_result": AnchorTier.SOFT_SELF_ATTESTED,
+    "server_observation": AnchorTier.EXCLUDED,  # explicit: the loop observing itself
+}
+
+
+def tier_for_source(verification_source: Optional[str]) -> AnchorTier:
+    """Classify a ``verification_source`` into its trust tier.
+
+    NULL/empty/unknown -> EXCLUDED (provenance we cannot vouch for is not an
+    anchor). ``server_observation`` is mapped EXCLUDED explicitly because it is
+    the loop's self-validation — the single most common value and the one that
+    would silently build the echo chamber if treated as an outcome.
+    """
+    if not verification_source:
+        return AnchorTier.EXCLUDED
+    return _TIER_BY_SOURCE.get(verification_source, AnchorTier.EXCLUDED)
+
+
+def is_exogenous_anchor(
+    verification_source: Optional[str],
+    *,
+    include_soft: bool = False,
+) -> bool:
+    """True if this outcome may anchor the loop.
+
+    Default = TRUSTED_EXTERNAL only. ``include_soft=True`` also admits
+    agent-self-attested outcomes — never the default, and callers must opt in
+    explicitly so self-attestation is a visible choice, not an accident.
+    """
+    tier = tier_for_source(verification_source)
+    if tier is AnchorTier.TRUSTED_EXTERNAL:
+        return True
+    if include_soft and tier is AnchorTier.SOFT_SELF_ATTESTED:
+        return True
+    return False
+
+
+# --- Canonical SQL predicates -------------------------------------------------
+# The single source of truth for "which outcome_events rows may anchor". Use
+# these in any query that feeds a baseline update or a falsifiability gate, so
+# the Invariant-4 exclusion is applied uniformly and is greppable.
+
+#: Externally-anchored outcomes only (default — the honest anchor set).
+ANCHORED_OUTCOMES_SQL = "verification_source = 'external_signal'"
+
+#: Externally-anchored + soft self-attested (opt-in; tolerate gameable signal).
+ANCHORED_OUTCOMES_WITH_SOFT_SQL = (
+    "verification_source IN ('external_signal', 'agent_reported_tool_result')"
+)
+
+#: Rows that must NEVER anchor — self-referential or unknown provenance. Useful
+#: for an assertion / audit that nothing leaked the loop's self-validation in.
+EXCLUDED_OUTCOMES_SQL = (
+    "(verification_source IS NULL "
+    "OR verification_source NOT IN ('external_signal', 'agent_reported_tool_result'))"
+)
+
+
+def anchored_outcomes_predicate(*, include_soft: bool = False) -> str:
+    """Return the SQL predicate selecting anchorable outcome rows."""
+    return ANCHORED_OUTCOMES_WITH_SOFT_SQL if include_soft else ANCHORED_OUTCOMES_SQL

--- a/tests/test_outcome_anchors.py
+++ b/tests/test_outcome_anchors.py
@@ -1,0 +1,69 @@
+"""Stage 0 — exogenous anchor tiering (src/grounding/outcome_anchors.py).
+
+Guards Invariant 4 (a signal derived from the loop cannot anchor the loop): the
+self-referential ``server_observation`` source and unknown/NULL provenance must
+never be treated as anchors, and soft self-attestation must require explicit
+opt-in.
+"""
+import pytest
+
+from src.grounding.outcome_anchors import (
+    AnchorTier,
+    tier_for_source,
+    is_exogenous_anchor,
+    anchored_outcomes_predicate,
+    ANCHORED_OUTCOMES_SQL,
+    ANCHORED_OUTCOMES_WITH_SOFT_SQL,
+)
+
+
+@pytest.mark.parametrize("source,expected", [
+    ("external_signal", AnchorTier.TRUSTED_EXTERNAL),
+    ("agent_reported_tool_result", AnchorTier.SOFT_SELF_ATTESTED),
+    ("server_observation", AnchorTier.EXCLUDED),
+    (None, AnchorTier.EXCLUDED),
+    ("", AnchorTier.EXCLUDED),
+    ("something_new_we_havent_tiered", AnchorTier.EXCLUDED),
+])
+def test_tier_mapping(source, expected):
+    assert tier_for_source(source) is expected
+
+
+def test_unknown_provenance_is_excluded_not_admitted():
+    """Default-deny: a source we have not explicitly tiered must NOT anchor.
+
+    Guards against a new verification_source silently leaking into the anchor
+    set (it would have to be added to _TIER_BY_SOURCE deliberately)."""
+    assert tier_for_source("future_source") is AnchorTier.EXCLUDED
+    assert is_exogenous_anchor("future_source") is False
+    assert is_exogenous_anchor("future_source", include_soft=True) is False
+
+
+def test_self_referential_never_anchors():
+    """Invariant 4: the loop observing itself cannot anchor the loop."""
+    assert is_exogenous_anchor("server_observation") is False
+    assert is_exogenous_anchor("server_observation", include_soft=True) is False
+    assert is_exogenous_anchor(None) is False
+
+
+def test_exogenous_default_is_trusted_only():
+    assert is_exogenous_anchor("external_signal") is True
+    # soft is NOT admitted by default
+    assert is_exogenous_anchor("agent_reported_tool_result") is False
+
+
+def test_soft_requires_explicit_optin():
+    assert is_exogenous_anchor("agent_reported_tool_result", include_soft=True) is True
+    # but trusted still passes, and excluded still fails, under opt-in
+    assert is_exogenous_anchor("external_signal", include_soft=True) is True
+    assert is_exogenous_anchor("server_observation", include_soft=True) is False
+
+
+def test_sql_predicates_exclude_self_referential():
+    assert "server_observation" not in ANCHORED_OUTCOMES_SQL
+    assert "server_observation" not in ANCHORED_OUTCOMES_WITH_SOFT_SQL
+    assert ANCHORED_OUTCOMES_SQL == "verification_source = 'external_signal'"
+    assert anchored_outcomes_predicate() == ANCHORED_OUTCOMES_SQL
+    assert anchored_outcomes_predicate(include_soft=True) == ANCHORED_OUTCOMES_WITH_SOFT_SQL
+    # the soft predicate admits exactly the two non-excluded sources
+    assert "agent_reported_tool_result" in ANCHORED_OUTCOMES_WITH_SOFT_SQL


### PR DESCRIPTION
## Summary

First real **Stage 0** increment of the EISV maths roadmap (#1059, §7 / Invariant 4). The anchor substrate already exists in `audit.outcome_events` — but **95% of its rows cannot anchor the loop**, and this centralises that exclusion before anything reads the table as ground truth.

**No migration, no schema change** — pure classification + a read-only report.

## Why

The roadmap needs an *exogenous* anchor so the loop's references stay externally falsifiable. `audit.outcome_events` looked ready (per-agent, `is_bad`, EISV-at-outcome, `verification_source`). But the recon (#1059 Appendix A) found the dominant signal is the governance loop validating its **own** trajectories. **Invariant 4: a signal derived from the loop cannot anchor the loop.** Using the table unfiltered would build the exact echo chamber the roadmap prevents.

## What

- **`src/grounding/outcome_anchors.py`** — single source of truth for `verification_source → AnchorTier`:
  - `external_signal` → **TRUSTED_EXTERNAL** (exogenous)
  - `agent_reported_tool_result` → **SOFT_SELF_ATTESTED** (gameable; opt-in only)
  - `server_observation` / `null` / anything unrecognised → **EXCLUDED** (default-deny)
  - canonical SQL predicates so the exclusion is applied uniformly and is greppable.
- **`tests/test_outcome_anchors.py`** (11) — guards default-deny, self-referential exclusion, soft opt-in, and the SQL predicates.
- **`scripts/analysis/outcome_anchor_inventory.py`** — reproducible budget report.

## Live numbers (today)

```
trusted_external     1,632 events   498 bad     ← the real anchor budget
soft_self_attested   2,095 events    36 bad     (opt-in)
excluded            75,485 events            ← 95%, Invariant 4 in effect
externally-verified test_failed: 1  ⚠ WIRING GAP
```

So B's falsifiability gate has ~498 exogenous bad labels to work with — enough for high-population classes, thin for rare ones (the roadmap says so, this quantifies it). And the most objective bad anchor — a failing test — is essentially unwired.

## Next

(2) wire CI/test-failed into `outcome_events`; (3) B's safety-floor gate over the anchored set. Both depend on this classification being the only door to the anchor.

🤖 Generated with [Claude Code](https://claude.ai/code)
https://claude.ai/code/session_01CQTFe1noQF8hGavycWkxYC