### PR TITLE
feat(watcher): record finding resolve/dismiss as external-truth outcomes

### DIFF
--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -340,6 +340,59 @@ def _make_identity_client():
     return SyncGovernanceClient(rest_url=GOV_REST_URL, transport="rest", timeout=30)
 
 
+def build_resolution_outcome_args(
+    status: str, fingerprint: str, agent_uuid: str, reason: str | None = None
+) -> dict:
+    """Map a Watcher finding resolution to an external-truth ``outcome_event``.
+
+    A *confirmed* finding means Watcher's analytical judgment was RIGHT (a good
+    outcome); a *dismissed* finding is a false positive — Watcher was WRONG (a
+    bad outcome). The adjudication is operator/agent review, i.e. ground truth
+    from *outside* the governance loop, so ``verification_source='external_signal'``.
+
+    This is the first exogenous ground-truth channel for an EISV-bearing resident:
+    today every baselined agent's outcomes are self-referential (server_observation)
+    or self-attested, so the EISV signal is structurally unfalsifiable for them
+    (docs/proposals/eisv-maths-roadmap-v0.md Appendix B). The outcome_event handler
+    auto-snapshots the agent's EISV by ``agent_id``, so we attribute to Watcher's
+    governance UUID — creating the first row where a per-agent residual and an
+    external label coexist.
+    """
+    confirmed = status == "confirmed"
+    return {
+        "agent_id": agent_uuid,
+        "outcome_type": "watcher_finding_confirmed" if confirmed else "watcher_finding_dismissed",
+        "is_bad": not confirmed,
+        "verification_source": "external_signal",
+        "detail": {
+            "fingerprint": fingerprint,
+            "resolution": status,
+            "reason": reason or "",
+        },
+    }
+
+
+def _emit_resolution_outcome(
+    client, status: str, fingerprint: str, reason: str | None = None
+) -> None:
+    """Best-effort: record a finding resolution as an external-truth outcome_event.
+
+    Failure here must never affect the resolve/dismiss itself — the mutation has
+    already succeeded by the time this runs; this only enriches the ground-truth
+    stream.
+    """
+    try:
+        uuid = (_watcher_identity or {}).get("agent_uuid")
+        if not uuid or client is None:
+            log("resolution outcome skipped: no resolved Watcher identity", "warning")
+            return
+        args = build_resolution_outcome_args(status, fingerprint, uuid, reason)
+        client.call_tool("outcome_event", args, timeout=15)
+        log(f"recorded external-truth outcome ({status}) for finding {fingerprint}")
+    except Exception as e:  # noqa: BLE001 — best-effort, never break resolution
+        log(f"resolution outcome emit skipped: {e}", "warning")
+
+
 # ---------------------------------------------------------------------------
 # Lease-plane guard for Watcher findings mutations
 # ---------------------------------------------------------------------------
@@ -2318,6 +2371,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     # --- Identity resolution (best-effort) ---
+    client = None
     try:
         client = _make_identity_client()
         resolve_identity(client)
@@ -2329,7 +2383,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.list_findings:
         return list_findings(only_open=args.only_open)
     if args.resolve:
-        return _run_with_watcher_findings_lease(
+        rc = _run_with_watcher_findings_lease(
             f"resolve {args.resolve}",
             lambda: update_finding_status(
                 args.resolve,
@@ -2339,8 +2393,11 @@ def main(argv: list[str] | None = None) -> int:
             ),
             holder_agent_id=args.agent_id,
         )
+        if rc == 0:
+            _emit_resolution_outcome(client, "confirmed", args.resolve, args.reason)
+        return rc
     if args.dismiss:
-        return _run_with_watcher_findings_lease(
+        rc = _run_with_watcher_findings_lease(
             f"dismiss {args.dismiss}",
             lambda: update_finding_status(
                 args.dismiss,
@@ -2350,6 +2407,9 @@ def main(argv: list[str] | None = None) -> int:
             ),
             holder_agent_id=args.agent_id,
         )
+        if rc == 0:
+            _emit_resolution_outcome(client, "dismissed", args.dismiss, args.reason)
+        return rc
     if args.sweep_stale:
         return _run_with_watcher_findings_lease(
             "sweep stale findings",

--- a/tests/test_watcher_resolution_outcomes.py
+++ b/tests/test_watcher_resolution_outcomes.py
@@ -1,0 +1,39 @@
+"""Watcher resolution → external-truth outcome_event (the first exogenous
+ground-truth channel for an EISV-bearing resident; roadmap Appendix B).
+
+Confirmed finding = Watcher was RIGHT (good); dismissed = false positive, Watcher
+was WRONG (bad). Adjudication is outside the loop → verification_source must be
+'external_signal' so it is NOT excluded by Invariant 4.
+"""
+from agents.watcher.agent import build_resolution_outcome_args
+
+
+def test_confirmed_is_good_external_truth():
+    a = build_resolution_outcome_args("confirmed", "abc123", "watcher-uuid", reason="real bug")
+    assert a["agent_id"] == "watcher-uuid"          # attribute to Watcher → EISV snapshot is Watcher's
+    assert a["outcome_type"] == "watcher_finding_confirmed"
+    assert a["is_bad"] is False                      # Watcher's judgment held
+    assert a["verification_source"] == "external_signal"
+    assert a["detail"]["fingerprint"] == "abc123"
+    assert a["detail"]["resolution"] == "confirmed"
+    assert a["detail"]["reason"] == "real bug"
+
+
+def test_dismissed_is_bad_external_truth():
+    a = build_resolution_outcome_args("dismissed", "def456", "watcher-uuid")
+    assert a["outcome_type"] == "watcher_finding_dismissed"
+    assert a["is_bad"] is True                       # false positive → Watcher was wrong
+    assert a["verification_source"] == "external_signal"
+    assert a["detail"]["reason"] == ""               # optional
+
+
+def test_verification_source_is_anchorable():
+    """The emitted source must pass the Stage-0 anchor filter, not be excluded.
+
+    (outcome_anchors ships on the Stage-0 anchor-tiering branch; skip until merged.)
+    """
+    import pytest
+    anchors = pytest.importorskip("src.grounding.outcome_anchors")
+    for status in ("confirmed", "dismissed"):
+        a = build_resolution_outcome_args(status, "fp", "u")
+        assert anchors.is_exogenous_anchor(a["verification_source"]) is True


### PR DESCRIPTION
## Summary

Creates the **first exogenous ground-truth channel for an EISV-bearing resident**, directly attacking the deepest validation gap surfaced this session (roadmap #1059, Appendix B). Additive, best-effort, fires only on operator `--resolve`/`--dismiss`. **No change to resolve/dismiss behavior; no governance decision affected.**

## Why

Every one of the 32 baselined agents has outcomes that are *self-referential* (`server_observation`) or *self-attested* — **zero** externally-anchored outcomes. So the residents the system most wants to validate are structurally unfalsifiable, and Stage B's falsifiability gate has anchor∩EISV overlap = **0**.

A Watcher finding **confirmed** = its judgment was RIGHT (good outcome); **dismissed** = false positive, WRONG (bad outcome). That adjudication is review from *outside* the loop — genuine ground truth — and it already happens; it was just being lost to commit messages.

## What

- `build_resolution_outcome_args()` — pure mapping (status → outcome args), unit-tested. `confirmed → is_bad=False`, `dismissed → is_bad=True`, `verification_source='external_signal'` (passes the Stage-0 anchor filter, not Invariant-4-excluded), attributed to Watcher's UUID so the handler's EISV auto-snapshot is Watcher's.
- `_emit_resolution_outcome()` — best-effort emit after a successful resolution (`rc==0`); any failure logs and never touches the resolution.
- wired into `main()` `--resolve`/`--dismiss`; client init guarded.

Each resolution now creates a row where a **per-agent residual and an external label coexist** — moving the overlap off zero. The viability probe (`stage_b_viability.py`, #1060) auto-emits the residual-vs-Φ AUC once these accrue.

## Verification

Unit tests pass (the anchor cross-check skips until #1060 merges). The integration points are confirmed live: the `outcome_event` handler accepts `verification_source` and auto-snapshots EISV by `agent_id`; `SyncGovernanceClient.call_tool` injects the session. Live end-to-end proof lands on the next real resolve/dismiss (no synthetic write, to avoid polluting the anchor stream).

## Stack

Pairs with #1059 (roadmap + Appendix B) and #1060 (Stage 0 anchor tiering + viability probe). This is the **population bridge** half (a): EISV-bearing agent now receives + snapshots external truth.

🤖 Generated with [Claude Code](https://claude.ai/code)
https://claude.ai/code/session_01CQTFe1noQF8hGavycWkxYC