### PR TITLE
feat(eisv): Stage B safety-floor probe + record L3 decisions (Φ→telemetry)

### DIFF
--- a/docs/proposals/eisv-maths-roadmap-v0.md
+++ b/docs/proposals/eisv-maths-roadmap-v0.md
@@ -227,14 +227,36 @@ First task: inventory which of these the runtime already emits (`outcome_event`,
 
 ---
 
-## 8. Open knobs — [L3], the operator's, held open
+## 8. L3 decisions — RESOLVED by operator (2026-06-25)
 
-1. **Humility floor (§4a):** does high-confidence individuality go all the way
-   (`w→0`) or keep a permanent humility term toward the class? Its *meaning* is
-   now fixed (how much external check before granting individuality, per the
-   priority ordering); only its *amount* is a value call.
-2. **Hysteresis amount (§4c):** dwell-time before a residual becomes a verdict —
-   the damping's old job, relocated to the policy. How generous is "generous".
+The ontology knobs are now decided. Recorded as direction; each lands as its own
+flagged change.
+
+0. **Φ → telemetry, not a verdict floor.** Φ stops gating decisions; the
+   per-agent residual / behavioral path becomes authoritative and Φ is kept only
+   as a telemetry field. Cleanest expression of axiom 2 (Φ is the RLHF/
+   punish-toward-ideal shape), and now *evidenced safe*: the Stage-B safety-floor
+   probe (`scripts/analysis/eisv_stage_b_safety_floor.py`, 2026-06-25) shows
+   currently-safe agents at residual p99≈6.8 vs caution ≈10 — clean separation,
+   ~1% regression floor — so demoting Φ doesn't strand healthy agents. (NB:
+   supersedes the *purpose* of the A.2 coupling — once Φ is telemetry, keeping
+   its verdict invariant is moot; A.2 stays correct as the interim while Φ still
+   gates, i.e. until this lands.)
+
+1. **Resident ground truth = "whatever we can."** No canonical per-resident
+   source required; take every exogenous signal and tier it (§7): Watcher
+   resolve/dismiss (shipped, #1061), CI/test outcomes, dialectic outcomes,
+   operator corrections. Breadth over purity-of-source; wire opportunistically,
+   weighted by trust tier.
+
+2. **Hysteresis ≈ 0.5–0.6** (§4c) — explicitly an *arbitrary starting guess*, to
+   be tuned against outcomes once the bridge accrues labels. Initial dwell/
+   smoothing constant; not derived.
+
+3. **Humility = structural, not a tuned scalar** (§4a). Per the operator: "an
+   unquantifiable thing." Stays a *stance* (nice/provocable/forgiving reciprocity,
+   §4c) expressed via anchor-coverage modulation — no humility *number* to set,
+   no floor to pick.
 
 ---
 

--- a/scripts/analysis/eisv_stage_b_safety_floor.py
+++ b/scripts/analysis/eisv_stage_b_safety_floor.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Stage B safety-floor — would a per-agent RESIDUAL statistic shift healthy
+agents' verdicts? (Non-regression; computable now, no outcome labels needed.)
+
+B proposes judging an agent on its residual from its OWN baseline rather than on
+absolute Φ. Before any of that ships, the safety floor (roadmap §6.1-6.2): does
+the residual flag agents who are currently healthy? If currently-safe check-ins
+carry low residuals, the residual is non-regressive; if many carry high
+residuals, swapping to it would pause healthy agents.
+
+residual = Σ over {E,I,S,V} |current_axis − baseline_mean| / baseline_std
+           (per-agent z-distance from its own Welford baseline)
+
+This needs no exogenous labels (that's B's *justification*, blocked on the
+anchor bridge). It only asks: is the residual *consistent with current health*?
+
+Caveat: "healthy" is proxied by the current (Φ-based) verdict — the very signal
+we're moving away from — so agreement is necessary, not sufficient. A residual
+that flags a currently-"safe" agent is either a regression OR a case where Φ was
+too lax; this probe can't tell which without outcomes. It bounds the regression
+risk, it doesn't bless the residual.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+
+import psycopg2
+import psycopg2.extras
+
+
+def welford_std(d):
+    c = d.get("count", 0)
+    if not c or c < 2:
+        return None
+    v = d.get("m2", 0.0) / c
+    return math.sqrt(v) if v > 0 else None
+
+
+def residual(beisv):
+    bs = beisv.get("baseline_stats") or {}
+    z = 0.0
+    for ax in ("E", "I", "S", "V"):
+        d = bs.get(ax)
+        cur = beisv.get(ax)
+        if not d or cur is None:
+            return None
+        std = welford_std(d)
+        if not std:
+            return None
+        z += abs(float(cur) - d.get("mean", 0.0)) / std
+    return z
+
+
+def pct(xs, p):
+    if not xs:
+        return None
+    xs = sorted(xs)
+    k = (len(xs) - 1) * p
+    f = math.floor(k)
+    return xs[f] if f == len(xs) - 1 else xs[f] + (xs[f + 1] - xs[f]) * (k - f)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db-url", default="postgresql://postgres:postgres@localhost:5432/governance")
+    ap.add_argument("--days", type=int, default=7)
+    args = ap.parse_args()
+    conn = psycopg2.connect(args.db_url)
+
+    by_verdict = {}  # verdict -> [residual,...]
+    n_rows = 0
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(
+            """
+            SELECT state_json->'behavioral_eisv' AS beisv, state_json->>'verdict' AS verdict
+            FROM core.agent_state
+            WHERE recorded_at > now() - (%s::int * interval '1 day')
+              AND state_json ? 'behavioral_eisv'
+              AND state_json->'behavioral_eisv'->'warmup'->>'is_baselined' = 'true'
+              AND state_json ? 'verdict'
+            """,
+            (args.days,),
+        )
+        for r in cur:
+            beisv = r["beisv"]
+            if isinstance(beisv, str):
+                beisv = json.loads(beisv)
+            z = residual(beisv)
+            if z is None:
+                continue
+            n_rows += 1
+            by_verdict.setdefault(r["verdict"], []).append(z)
+    conn.close()
+
+    print(f"baselined check-ins with computable residual (last {args.days}d): N={n_rows}\n")
+    print(f"{'verdict':<12}{'n':>7}{'resid p50':>11}{'p90':>9}{'p99':>9}")
+    print("-" * 48)
+    safe = by_verdict.get("safe", [])
+    for v in sorted(by_verdict, key=lambda k: -len(by_verdict[k])):
+        xs = by_verdict[v]
+        print(f"{v:<12}{len(xs):>7}{pct(xs,0.5):>11.2f}{pct(xs,0.9):>9.2f}{pct(xs,0.99):>9.2f}")
+
+    # Regression bound: pick a threshold at the safe-verdict p99 and ask what it
+    # would do. A residual policy thresholded above healthy variation should flag
+    # ~0 currently-safe agents (the floor) while still separating non-safe.
+    if safe and len(safe) > 50:
+        thr = pct(safe, 0.99)
+        non_safe = [z for v, xs in by_verdict.items() if v != "safe" for z in xs]
+        fp = sum(1 for z in safe if z > thr) / len(safe)
+        tp = (sum(1 for z in non_safe if z > thr) / len(non_safe)) if non_safe else None
+        print(f"\nThreshold = safe-verdict p99 = {thr:.2f}")
+        print(f"  false-positive rate among currently-safe : {fp:.1%}  (regression floor — want low)")
+        if tp is not None:
+            print(f"  flag rate among currently non-safe        : {tp:.1%}  (want >> fp)")
+            verdict = ("SEPARATES — residual is non-regressive here" if tp > 3 * max(fp, 0.01)
+                       else "WEAK — residual does not cleanly separate at this threshold")
+            print(f"  → {verdict}")
+        else:
+            print("  (no non-safe check-ins in window to measure separation)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Two things: (1) the **Stage B safety-floor probe** — does a per-agent residual statistic flag currently-healthy agents? — and (2) records the operator's **L3 decisions** (2026-06-25), resolving roadmap §8.

## Safety-floor result (live, N=6379 baselined check-ins)

| verdict | n | resid p50 | p90 | p99 |
|---|---|---|---|---|
| safe | 6371 | 2.73 | 5.15 | **6.77** |
| caution | 8 | 9.99 | 10.17 | **10.22** |

At threshold = safe-p99 (6.77): **1% false-positive floor** among currently-safe, **100%** flag rate on caution → **clean separation, non-regressive.** Swapping toward the residual does not strand healthy agents.

*Honest caveat (in-file):* only 8 non-safe samples, and "safe" is the Φ-proxy — this **bounds regression risk**, it does not externally validate the residual. That needs the anchor bridge accruing outcome labels.

## L3 decisions recorded (§8)

- **Φ → telemetry, not a verdict floor.** The residual/behavioral path becomes authoritative; Φ kept as a telemetry field. The safety-floor above is the evidence it's safe. Supersedes the *purpose* of the A.2 coupling once it lands (A.2 stays correct as the interim while Φ still gates).
- **Resident ground truth = "whatever we can"** — tier every exogenous source (Watcher #1061, CI, dialectic, operator), breadth over purity.
- **Hysteresis ≈ 0.5–0.6** — arbitrary starting guess, tune against outcomes.
- **Humility = structural**, not a tuned scalar.

## Next

Φ→telemetry is now the headline buildable: demote Φ from the verdict/risk floor (`monitor_phi`/`monitor_risk` — remove the `more_severe` Φ floor) to telemetry-only, flagged + red-teamed like A.2, with this safety-floor as its justification.

🤖 Generated with [Claude Code](https://claude.ai/code)
https://claude.ai/code/session_01CQTFe1noQF8hGavycWkxYC