### PR TITLE
fix(watcher): make the external-truth channel actually emit (+ precise is_bad)

### DIFF
--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -346,23 +346,26 @@ def build_resolution_outcome_args(
     """Map a Watcher finding resolution to an external-truth ``outcome_event``.
 
     A *confirmed* finding means Watcher's analytical judgment was RIGHT (a good
-    outcome); a *dismissed* finding is a false positive — Watcher was WRONG (a
-    bad outcome). The adjudication is operator/agent review, i.e. ground truth
-    from *outside* the governance loop, so ``verification_source='external_signal'``.
+    outcome). Only a ``fp`` dismissal means Watcher was WRONG (a bad outcome) —
+    that is the sole "true negative" in precision math. Other dismissals
+    (``out_of_scope``, ``wont_fix``, ``dup``, ``unclear``, ``stale``) drop a
+    *valid* finding that just won't be actioned, so Watcher was still right and
+    the outcome is NOT bad. The adjudication is operator/agent review, i.e.
+    ground truth from *outside* the loop, so ``verification_source='external_signal'``.
 
-    This is the first exogenous ground-truth channel for an EISV-bearing resident:
-    today every baselined agent's outcomes are self-referential (server_observation)
-    or self-attested, so the EISV signal is structurally unfalsifiable for them
-    (docs/proposals/eisv-maths-roadmap-v0.md Appendix B). The outcome_event handler
-    auto-snapshots the agent's EISV by ``agent_id``, so we attribute to Watcher's
-    governance UUID — creating the first row where a per-agent residual and an
-    external label coexist.
+    First exogenous ground-truth channel for an EISV-bearing resident (every
+    baselined agent's outcomes are otherwise self-referential/self-attested, so
+    the EISV signal is structurally unfalsifiable for them —
+    docs/proposals/eisv-maths-roadmap-v0.md Appendix B). The handler auto-snapshots
+    EISV by ``agent_id``, so attribute to Watcher's UUID.
     """
     confirmed = status == "confirmed"
+    # Only a false-positive dismissal is a bad outcome for Watcher (see above).
+    is_bad = (not confirmed) and (reason == "fp")
     return {
         "agent_id": agent_uuid,
         "outcome_type": "watcher_finding_confirmed" if confirmed else "watcher_finding_dismissed",
-        "is_bad": not confirmed,
+        "is_bad": is_bad,
         "verification_source": "external_signal",
         "detail": {
             "fingerprint": fingerprint,

--- a/src/mcp_handlers/observability/outcome_events.py
+++ b/src/mcp_handlers/observability/outcome_events.py
@@ -26,12 +26,16 @@ _MIN_TACTICAL_EVIDENCE_WEIGHT = GRADE_WEIGHTS[TOOL_OBSERVED]
 
 # Outcome types that are considered "bad" by default
 BAD_OUTCOME_TYPES = {"test_failed", "tool_rejected", "drawing_abandoned", "task_failed"}
-GOOD_OUTCOME_TYPES = {"test_passed", "drawing_completed", "task_completed"}
+# watcher_finding_confirmed = Watcher's analytical judgment held (good outcome).
+GOOD_OUTCOME_TYPES = {"test_passed", "drawing_completed", "task_completed", "watcher_finding_confirmed"}
 # dialectic_resolved is neutral: agreement was reached, but whether the
 # resolution holds up under the agreed conditions is a separate later test.
 # Recording it closes the dialectic→outcome_events tracking gap so downstream
 # back-tests can correlate resumption with subsequent agent state.
-NEUTRAL_OUTCOME_TYPES = {"trajectory_validated", "dialectic_resolved"}  # is_bad determined by score
+# watcher_finding_dismissed is neutral: only a 'fp' dismissal is bad, so the
+# caller (agents/watcher/agent.py) passes is_bad explicitly rather than inferring
+# it from the type.
+NEUTRAL_OUTCOME_TYPES = {"trajectory_validated", "dialectic_resolved", "watcher_finding_dismissed"}  # is_bad determined by score/explicit
 VALID_OUTCOME_TYPES = BAD_OUTCOME_TYPES | GOOD_OUTCOME_TYPES | NEUTRAL_OUTCOME_TYPES
 
 _HARD_EXOGENOUS_DETAIL_KEYS = (

--- a/src/mcp_handlers/schemas/core.py
+++ b/src/mcp_handlers/schemas/core.py
@@ -372,7 +372,7 @@ class ProcessAgentUpdateParams(AgentIdentityMixin):
 
 class OutcomeEventParams(AgentIdentityMixin):
     """Parameters for outcome_event"""
-    outcome_type: Literal["drawing_completed", "drawing_abandoned", "test_passed", "test_failed", "tool_rejected", "task_completed", "task_failed", "trajectory_validated", "dialectic_resolved"] = Field(..., description="Type of outcome event")
+    outcome_type: Literal["drawing_completed", "drawing_abandoned", "test_passed", "test_failed", "tool_rejected", "task_completed", "task_failed", "trajectory_validated", "dialectic_resolved", "watcher_finding_confirmed", "watcher_finding_dismissed"] = Field(..., description="Type of outcome event")
     outcome_score: Optional[float] = Field(None, description="Quality score 0.0 (worst) to 1.0 (best). Inferred from type if omitted.")
     is_bad: Optional[bool] = Field(None, description="Whether this is a negative outcome. Inferred from type if omitted.")
     detail: Optional[Dict[str, Any]] = Field(None, description="Type-specific metadata (e.g., mark_count, test_name, error_message)")

--- a/tests/test_watcher_resolution_outcomes.py
+++ b/tests/test_watcher_resolution_outcomes.py
@@ -1,10 +1,14 @@
 """Watcher resolution → external-truth outcome_event (the first exogenous
 ground-truth channel for an EISV-bearing resident; roadmap Appendix B).
 
-Confirmed finding = Watcher was RIGHT (good); dismissed = false positive, Watcher
-was WRONG (bad). Adjudication is outside the loop → verification_source must be
-'external_signal' so it is NOT excluded by Invariant 4.
+Confirmed = Watcher RIGHT (good). Only a 'fp' dismissal = Watcher WRONG (bad);
+other dismissals (out_of_scope/wont_fix/…) drop a VALID finding, so Watcher was
+still right. Adjudication is outside the loop → verification_source must be
+'external_signal' so it is NOT excluded by Invariant 4. The outcome_type must be
+in the handler's VALID_OUTCOME_TYPES allowlist or the emit is rejected.
 """
+import pytest
+
 from agents.watcher.agent import build_resolution_outcome_args
 
 
@@ -19,12 +23,26 @@ def test_confirmed_is_good_external_truth():
     assert a["detail"]["reason"] == "real bug"
 
 
-def test_dismissed_is_bad_external_truth():
-    a = build_resolution_outcome_args("dismissed", "def456", "watcher-uuid")
+def test_fp_dismissal_is_bad():
+    a = build_resolution_outcome_args("dismissed", "def456", "watcher-uuid", reason="fp")
     assert a["outcome_type"] == "watcher_finding_dismissed"
     assert a["is_bad"] is True                       # false positive → Watcher was wrong
-    assert a["verification_source"] == "external_signal"
-    assert a["detail"]["reason"] == ""               # optional
+
+
+@pytest.mark.parametrize("reason", ["out_of_scope", "wont_fix", "dup", "unclear", "stale", "", None])
+def test_non_fp_dismissal_is_not_bad(reason):
+    """A valid-but-unactioned finding is NOT a bad outcome — only 'fp' counts."""
+    a = build_resolution_outcome_args("dismissed", "x", "u", reason=reason)
+    assert a["is_bad"] is False
+
+
+def test_outcome_types_are_whitelisted():
+    """Both emitted types must be in the handler's VALID_OUTCOME_TYPES, or the
+    outcome_event tool rejects them (the #1061 bug: they weren't)."""
+    from src.mcp_handlers.observability.outcome_events import VALID_OUTCOME_TYPES
+    for status in ("confirmed", "dismissed"):
+        a = build_resolution_outcome_args(status, "x", "u", reason="fp")
+        assert a["outcome_type"] in VALID_OUTCOME_TYPES
 
 
 def test_verification_source_is_anchorable():


### PR DESCRIPTION
## Summary

**Live verification of #1061 found the channel never emitted.** Doing the first real adjudication (dismiss P011), the `outcome_event` tool rejected it: `Invalid value for 'outcome_type': 'watcher_finding_dismissed'`. The type is enum-validated in two places — `VALID_OUTCOME_TYPES` (`observability/outcome_events.py`) and a Pydantic `Literal` (`schemas/core.py`) — and my types were in neither. Every emit was rejected and swallowed by the best-effort guard, so overlap stayed **0** despite the repoint.

This is exactly what unit tests couldn't catch and live verification did.

## Fixes

1. **Whitelist the types** in both validation sites: `watcher_finding_confirmed` (GOOD), `watcher_finding_dismissed` (NEUTRAL — is_bad passed explicitly).
2. **Precise `is_bad`:** only a `fp` dismissal means Watcher was WRONG (the sole true-negative in precision math). `out_of_scope`/`wont_fix`/`dup`/`unclear`/`stale` dismiss a *valid* finding that just won't be actioned — Watcher was still right, so `is_bad=False`. Previously every dismissal recorded `is_bad=True`, biasing Watcher's measured precision down.

## Tests

`fp→bad`, non-fp→not-bad (parametrized over all reasons), `confirmed→good`, and a guard that **both types are in `VALID_OUTCOME_TYPES`** — the exact regression that bit #1061. 11 pass.

## Deploy note

The allowlist is **server-side**, so this needs a deploy + restart before the channel emits. After that, a resolve/dismiss moves overlap 0→1.

## Adjudication status (this session)

- **P011** (`monitor_metrics.py:65`, mutate-then-persist): dismissed `fp` — genuine false positive (in-memory TTL cache, no DB persistence, so the pattern's precondition is absent). Recorded in the findings store; pre-fix so not yet in the channel.
- **P016** (`knowledge_graph_lifecycle.py:637`): → `out_of_scope` (advisory-only audit display, no load-bearing write) — pending this fix so it records `is_bad=False` correctly.
- **P001** (`anima-mcp lifecycle.py:385`): genuine fire-and-forget → confirm, but the fix lives in anima-mcp (Pi deploy).

🤖 Generated with [Claude Code](https://claude.ai/code)
https://claude.ai/code/session_01CQTFe1noQF8hGavycWkxYC