### PR TITLE
feat(lease-plane): governed-effect execute for agent_spawn → live orchestrator (fail-closed)

### DIFF
--- a/elixir/lease_plane/lib/unitares_lease_plane/application.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/application.ex
@@ -56,6 +56,26 @@ defmodule UnitaresLeasePlane.Application do
       Application.put_env(:lease_plane, :force_release_token, token)
     end
 
+    # Governed-effect `agent_spawn` execute (routes to the live orchestrator).
+    # FAIL-CLOSED on every axis: the per-type flag defaults off, and the spawn
+    # path additionally requires the orchestrator bearer to be present. With the
+    # flag unset, `execute` stays `execute_not_implemented` exactly as before.
+    Application.put_env(
+      :lease_plane,
+      :execute_agent_spawn_enabled,
+      System.get_env("UNITARES_GOVERNED_EFFECT_EXECUTE_AGENT_SPAWN") == "1"
+    )
+
+    Application.put_env(
+      :lease_plane,
+      :agent_orchestrator_url,
+      System.get_env("AGENT_ORCHESTRATOR_URL") || "http://127.0.0.1:8789"
+    )
+
+    if token = System.get_env("AGENT_ORCHESTRATOR_BEARER_TOKEN") do
+      Application.put_env(:lease_plane, :agent_orchestrator_bearer_token, token)
+    end
+
     children =
       [
         {Postgrex, postgrex_opts()},

--- a/elixir/lease_plane/lib/unitares_lease_plane/governed_effect.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/governed_effect.ex
@@ -52,11 +52,13 @@ defmodule UnitaresLeasePlane.GovernedEffect do
 
   require Logger
 
+  alias UnitaresLeasePlane.OrchestratorClient
   alias UnitaresLeasePlane.Repo
 
   @custody_modes ~w(record_only execute)
   @effect_lane "governed_effect"
   @record_only_event_type "governed_effect.record_only"
+  @execute_event_type "governed_effect.execute"
 
   # Invariant 7 (no secret leakage): payload key substrings that must never be
   # stored or logged. A credential-shaped payload is rejected, not scrubbed —
@@ -66,8 +68,10 @@ defmodule UnitaresLeasePlane.GovernedEffect do
   @doc """
   Handle a governed-effect proposal envelope. Returns:
 
-    * `{:ok, body_map}` — a 202 body (record_only recorded);
-    * `{:error, :execute_not_implemented}` — execute mode is gated;
+    * `{:ok, body_map}` — a 202 body (record_only recorded, or execute committed);
+    * `{:error, :execute_not_implemented}` — execute mode disabled / unsupported type;
+    * `{:error, :idempotency_conflict}` — same key, different digest;
+    * `{:error, :persist_failed}` / `{:error, :spawn_failed}`;
     * `{:error, detail}` — `schema_invalid` detail string.
   """
   @spec handle(map()) ::
@@ -75,12 +79,13 @@ defmodule UnitaresLeasePlane.GovernedEffect do
           | {:error, :execute_not_implemented}
           | {:error, :idempotency_conflict}
           | {:error, :persist_failed}
+          | {:error, :spawn_failed}
           | {:error, String.t()}
   def handle(%{} = body) do
     with {:ok, env} <- validate(body) do
       case env.custody_mode do
         "record_only" -> record_only(env)
-        "execute" -> {:error, :execute_not_implemented}
+        "execute" -> execute(env)
       end
     end
   end
@@ -287,6 +292,173 @@ defmodule UnitaresLeasePlane.GovernedEffect do
 
   defp idempotent_body(stored) when is_map(stored) do
     response_body(stored, Map.get(stored, "observations", []), true)
+  end
+
+  # ---- execute (agent_spawn → live orchestrator) ----
+  #
+  # First execute slice. ONLY `agent_spawn` is wired, and only when the
+  # per-type flag is on AND the orchestrator bearer is configured — otherwise
+  # `execute` stays `execute_not_implemented` exactly as before. The spawn is
+  # delegated to the already-live agent orchestrator (`:8789`), which owns the
+  # OS-process spawn, OTP supervision, lease-binding and lineage.
+  #
+  # HONESTLY DEFERRED to the next slice (NOT faked here): the §7 strong-tier
+  # re-verification and the §6 governance veto. This slice's gates are the
+  # fail-closed flag + the orchestrator's own bearer + `check_allowed` cmd
+  # allowlist. `agent_spawn` is irreversible (§5b), so there is no rollback to
+  # prove; idempotency is the load-bearing safety property here — a retry must
+  # never spawn twice.
+  defp execute(%{effect_type: "agent_spawn"} = env) do
+    if execute_agent_spawn_enabled?() do
+      execute_agent_spawn(env)
+    else
+      {:error, :execute_not_implemented}
+    end
+  end
+
+  # Every other effect_type is still gated (file_write/repo_commit/etc. land in
+  # later slices with their rollback machinery).
+  defp execute(_env), do: {:error, :execute_not_implemented}
+
+  defp execute_agent_spawn_enabled? do
+    Application.get_env(:lease_plane, :execute_agent_spawn_enabled, false) == true and
+      is_binary(Application.get_env(:lease_plane, :agent_orchestrator_bearer_token))
+  end
+
+  defp execute_agent_spawn(env) do
+    digest = idempotency_digest(env)
+
+    case Repo.governed_effect_by_idempotency_key(env.idempotency_key, @execute_event_type) do
+      # Idempotent replay — a previously committed spawn. Return the original
+      # effect_id + agent_id; DO NOT spawn again (an agent_spawn is irreversible).
+      {:ok, %{idempotency_digest: ^digest, payload: stored}} ->
+        {:ok, execute_idempotent_body(stored)}
+
+      {:ok, %{idempotency_digest: other}} when is_binary(other) ->
+        {:error, :idempotency_conflict}
+
+      {:ok, nil} ->
+        spawn_and_record(env, digest)
+
+      {:error, reason} ->
+        Logger.warning(
+          "governed_effect execute idempotency lookup failed key=#{env.idempotency_key}: " <>
+            inspect(reason)
+        )
+
+        {:error, :persist_failed}
+    end
+  end
+
+  defp spawn_and_record(env, digest) do
+    effect_id = gen_effect_id()
+
+    case OrchestratorClient.spawn_agent(orchestrator_spec(env)) do
+      {:ok, agent_id} ->
+        Logger.info(
+          "governed_effect execute agent_spawn effect_id=#{effect_id} agent_id=#{agent_id} " <>
+            "surface=#{env.surface} digest=#{binary_part(digest, 0, 12)}"
+        )
+
+        payload =
+          execute_audit_payload(effect_id, env, digest, "committed", %{"agent_id" => agent_id})
+
+        # The spawn already happened; record best-effort. A persist failure must
+        # NOT re-spawn, so we still return committed with the agent_id (the audit
+        # gap is logged), never an error that invites a retry.
+        _ = persist_execute(env, payload)
+        {:ok, execute_body(payload, agent_id)}
+
+      {:error, reason} ->
+        Logger.warning(
+          "governed_effect execute agent_spawn FAILED effect_id=#{effect_id} " <>
+            "surface=#{env.surface}: #{inspect(reason)}"
+        )
+
+        payload =
+          execute_audit_payload(effect_id, env, digest, "rejected", %{"error" => inspect(reason)})
+
+        _ = persist_execute(env, payload)
+        {:error, :spawn_failed}
+    end
+  end
+
+  # Build the orchestrator spawn spec from the effect payload. The payload
+  # carries the command (`cmd`/`args`/`env`); lineage is provisioned from the
+  # proposer so the spawned agent's parentage is correct by construction. The
+  # proposer's `client_session_id` is NEVER forwarded (Invariant 1/7 — BEAM
+  # consumes proof, the child mints its own identity under provisioned lineage).
+  defp orchestrator_spec(env) do
+    p = env.payload || %{}
+
+    base = %{
+      "cmd" => Map.get(p, "cmd"),
+      "args" => Map.get(p, "args", []),
+      "env" => Map.get(p, "env", %{})
+    }
+
+    case env.proposer_agent_uuid do
+      uuid when is_binary(uuid) ->
+        # Orchestrator lineage contract: `parent_agent_uuid` (+ optional
+        # `spawn_reason`) — verified live, a `parent_agent_id` key 422s.
+        Map.put(base, "lineage", %{
+          "parent_agent_uuid" => uuid,
+          "spawn_reason" => "governed_effect"
+        })
+
+      _ ->
+        base
+    end
+  end
+
+  defp persist_execute(env, payload) do
+    Repo.insert_governed_effect_event(%{
+      event_type: @execute_event_type,
+      agent_id: env.proposer_agent_uuid,
+      session_id: env.provenance_session_id,
+      payload: payload
+    })
+  end
+
+  defp execute_audit_payload(effect_id, env, digest, status, extra) do
+    %{
+      "effect_lane" => @effect_lane,
+      "effect_id" => effect_id,
+      "custody_mode" => "execute",
+      "status" => status,
+      "effect_type" => env.effect_type,
+      "surface" => env.surface,
+      "idempotency_key" => env.idempotency_key,
+      "idempotency_digest" => digest,
+      "proposer_agent_uuid" => env.proposer_agent_uuid
+    }
+    |> Map.merge(extra)
+  end
+
+  defp execute_body(payload, agent_id) do
+    %{
+      ok: true,
+      effect_id: payload["effect_id"],
+      custody_mode: "execute",
+      status: "committed",
+      effect_lane: @effect_lane,
+      idempotency_digest: payload["idempotency_digest"],
+      agent_id: agent_id,
+      idempotent: false
+    }
+  end
+
+  defp execute_idempotent_body(stored) when is_map(stored) do
+    %{
+      ok: true,
+      effect_id: stored["effect_id"],
+      custody_mode: "execute",
+      status: stored["status"] || "committed",
+      effect_lane: @effect_lane,
+      idempotency_digest: stored["idempotency_digest"],
+      agent_id: stored["agent_id"],
+      idempotent: true
+    }
   end
 
   # Observe-not-acquire: peek the lease state, NEVER acquire (acquiring would

--- a/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
@@ -150,6 +150,13 @@ defmodule UnitaresLeasePlane.HTTPRouter do
           reason: "could not durably record the proposal; nothing was recorded"
         })
 
+      {:error, :spawn_failed} ->
+        json(conn, 502, %{
+          ok: false,
+          error: "spawn_failed",
+          reason: "execute custody could not complete the spawn via the orchestrator"
+        })
+
       {:error, detail} when is_binary(detail) ->
         json(conn, 422, %{ok: false, error: "schema_invalid", detail: detail})
     end

--- a/elixir/lease_plane/lib/unitares_lease_plane/orchestrator_client.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/orchestrator_client.ex
@@ -1,0 +1,70 @@
+defmodule UnitaresLeasePlane.OrchestratorClient do
+  @moduledoc """
+  Minimal HTTP client to the **already-live** agent orchestrator (`:8789`,
+  `com.unitares.agent-orchestrator`) for governed-effect `agent_spawn` execute.
+
+  Uses Erlang stdlib `:httpc` (no new dependency). Localhost, bearer-gated. The
+  orchestrator owns the OS-process spawn, OTP supervision, lease-binding, and
+  lineage provisioning — this client only forwards a validated spawn spec and
+  returns the assigned `agent_id`. The orchestrator's own bearer (`check_allowed`
+  cmd allowlist + `AGENT_ORCHESTRATOR_BEARER_TOKEN`) is the second gate behind
+  the lease plane's per-type execute flag; if either the URL or bearer is
+  unconfigured we fail closed.
+  """
+
+  require Logger
+
+  @doc """
+  POST a spawn spec to `<orchestrator>/v1/agents`. Returns the orchestrator's
+  assigned `agent_id` on 201, or a typed error. Never raises on transport
+  failure — the caller decides effect status from the result.
+  """
+  @spec spawn_agent(map()) :: {:ok, String.t()} | {:error, term()}
+  def spawn_agent(%{} = spec) do
+    with {:ok, base} <- base_url(),
+         {:ok, bearer} <- bearer() do
+      url = String.to_charlist(base <> "/v1/agents")
+      headers = [{~c"authorization", String.to_charlist("Bearer " <> bearer)}]
+      request = {url, headers, ~c"application/json", Jason.encode!(spec)}
+      http_opts = [timeout: timeout_ms(), connect_timeout: 2_000]
+
+      case :httpc.request(:post, request, http_opts, body_format: :binary) do
+        {:ok, {{_v, 201, _r}, _h, resp}} ->
+          parse_agent_id(resp)
+
+        {:ok, {{_v, status, _r}, _h, resp}} ->
+          {:error, {:orchestrator_status, status, truncate(resp)}}
+
+        {:error, reason} ->
+          {:error, {:orchestrator_unreachable, reason}}
+      end
+    end
+  end
+
+  defp parse_agent_id(resp) do
+    case Jason.decode(resp) do
+      {:ok, %{"ok" => true, "agent_id" => id}} when is_binary(id) -> {:ok, id}
+      {:ok, other} -> {:error, {:orchestrator_bad_body, other}}
+      {:error, _} -> {:error, :orchestrator_bad_json}
+    end
+  end
+
+  defp base_url do
+    case Application.get_env(:lease_plane, :agent_orchestrator_url) do
+      url when is_binary(url) and byte_size(url) > 0 -> {:ok, String.trim_trailing(url, "/")}
+      _ -> {:error, :orchestrator_url_unset}
+    end
+  end
+
+  defp bearer do
+    case Application.get_env(:lease_plane, :agent_orchestrator_bearer_token) do
+      t when is_binary(t) and byte_size(t) > 0 -> {:ok, t}
+      _ -> {:error, :orchestrator_bearer_unset}
+    end
+  end
+
+  defp timeout_ms, do: Application.get_env(:lease_plane, :agent_orchestrator_timeout_ms, 10_000)
+
+  defp truncate(bin) when is_binary(bin), do: binary_part(bin, 0, min(byte_size(bin), 200))
+  defp truncate(other), do: inspect(other)
+end

--- a/elixir/lease_plane/lib/unitares_lease_plane/repo.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/repo.ex
@@ -683,18 +683,25 @@ defmodule UnitaresLeasePlane.Repo do
   end
 
   @doc """
-  Look up the most recent governed-effect record for an `idempotency_key`.
-  Returns `{:ok, %{idempotency_digest, payload}}` (string-keyed payload),
-  `{:ok, nil}` when none exists, or `{:error, reason}`.
+  Look up the most recent governed-effect record for an `idempotency_key` within
+  one `event_type` channel (defaults to the `record_only` shadow; `execute`
+  passes its own channel so an irreversible spawn can never double-fire on a
+  retry — the channels share no idempotency space). Returns
+  `{:ok, %{idempotency_digest, payload}}` (string-keyed payload), `{:ok, nil}`
+  when none exists, or `{:error, reason}`.
 
   The key is unindexed in `audit.events` — acceptable at shadow volume; a
   constraint-backed unique key arrives with the Phase 4 table.
   """
-  @spec governed_effect_by_idempotency_key(String.t()) ::
+  @spec governed_effect_by_idempotency_key(String.t(), String.t()) ::
           {:ok, %{idempotency_digest: String.t() | nil, payload: map()}}
           | {:ok, nil}
           | {:error, term()}
-  def governed_effect_by_idempotency_key(idempotency_key) when is_binary(idempotency_key) do
+  def governed_effect_by_idempotency_key(
+        idempotency_key,
+        event_type \\ "governed_effect.record_only"
+      )
+      when is_binary(idempotency_key) and is_binary(event_type) do
     sql = """
     SELECT payload->>'idempotency_digest' AS idempotency_digest, payload::text AS payload
     FROM audit.events
@@ -703,7 +710,7 @@ defmodule UnitaresLeasePlane.Repo do
     LIMIT 1
     """
 
-    case Postgrex.query(DB, sql, ["governed_effect.record_only", idempotency_key]) do
+    case Postgrex.query(DB, sql, [event_type, idempotency_key]) do
       {:ok, %{rows: []}} ->
         {:ok, nil}
 

--- a/elixir/lease_plane/mix.exs
+++ b/elixir/lease_plane/mix.exs
@@ -14,7 +14,7 @@ defmodule UnitaresLeasePlane.MixProject do
 
   def application do
     [
-      extra_applications: [:logger],
+      extra_applications: [:logger, :inets],
       mod: {UnitaresLeasePlane.Application, []}
     ]
   end

--- a/elixir/lease_plane/test/governed_effect_test.exs
+++ b/elixir/lease_plane/test/governed_effect_test.exs
@@ -165,6 +165,83 @@ defmodule UnitaresLeasePlane.GovernedEffectTest do
     end
   end
 
+  describe "execute / agent_spawn (first execute slice)" do
+    test "fail-closed: agent_spawn execute is execute_not_implemented when the flag is off" do
+      # default state — flag unset
+      assert {:error, :execute_not_implemented} =
+               GovernedEffect.handle(
+                 base(%{"custody_mode" => "execute", "effect_type" => "agent_spawn"})
+               )
+    end
+
+    test "only agent_spawn is wired — other effect_types stay gated even with the flag on" do
+      set_execute_flag(true, "http://127.0.0.1:8789")
+
+      assert {:error, :execute_not_implemented} =
+               GovernedEffect.handle(
+                 base(%{"custody_mode" => "execute", "effect_type" => "file_write"})
+               )
+    end
+
+    test "flag on + unreachable orchestrator → spawn_failed, and a rejected execute row persists" do
+      key = tracked_key()
+      # Point at a closed port so the spawn fails fast without a real orchestrator.
+      set_execute_flag(true, "http://127.0.0.1:1")
+
+      assert {:error, :spawn_failed} =
+               GovernedEffect.handle(
+                 base(%{
+                   "idempotency_key" => key,
+                   "custody_mode" => "execute",
+                   "effect_type" => "agent_spawn",
+                   "payload" => %{"cmd" => "echo", "args" => ["hi"]}
+                 })
+               )
+
+      assert [row] = execute_rows(key)
+      assert row["custody_mode"] == "execute"
+      assert row["status"] == "rejected"
+      assert row["effect_lane"] == "governed_effect"
+    end
+  end
+
+  # Toggle the execute flag + orchestrator config for one test, resetting after.
+  defp set_execute_flag(enabled?, url) do
+    prev_enabled = Application.get_env(:lease_plane, :execute_agent_spawn_enabled)
+    prev_url = Application.get_env(:lease_plane, :agent_orchestrator_url)
+    prev_bearer = Application.get_env(:lease_plane, :agent_orchestrator_bearer_token)
+
+    Application.put_env(:lease_plane, :execute_agent_spawn_enabled, enabled?)
+    Application.put_env(:lease_plane, :agent_orchestrator_url, url)
+
+    Application.put_env(
+      :lease_plane,
+      :agent_orchestrator_bearer_token,
+      "test-orchestrator-bearer"
+    )
+
+    on_exit(fn ->
+      restore(:execute_agent_spawn_enabled, prev_enabled)
+      restore(:agent_orchestrator_url, prev_url)
+      restore(:agent_orchestrator_bearer_token, prev_bearer)
+    end)
+  end
+
+  defp restore(key, nil), do: Application.delete_env(:lease_plane, key)
+  defp restore(key, val), do: Application.put_env(:lease_plane, key, val)
+
+  defp execute_rows(key) do
+    %{rows: rows} =
+      Postgrex.query!(
+        UnitaresLeasePlane.DB,
+        "SELECT payload::text FROM audit.events " <>
+          "WHERE event_type = 'governed_effect.execute' AND payload->>'idempotency_key' = $1",
+        [key]
+      )
+
+    Enum.map(rows, fn [payload_text] -> Jason.decode!(payload_text) end)
+  end
+
   # --- audit.events probes (the durable governed-effect sink) ---
 
   defp governed_effect_rows(key) do

--- a/elixir/lease_plane/test/support/lease_test_helpers.ex
+++ b/elixir/lease_plane/test/support/lease_test_helpers.ex
@@ -56,7 +56,7 @@ defmodule LeaseTestHelpers do
   def cleanup_governed_effect(idempotency_key) when is_binary(idempotency_key) do
     Postgrex.query!(
       DB,
-      "DELETE FROM audit.events WHERE event_type = 'governed_effect.record_only' " <>
+      "DELETE FROM audit.events WHERE event_type LIKE 'governed_effect.%' " <>
         "AND payload->>'idempotency_key' = $1",
       [idempotency_key]
     )


### PR DESCRIPTION
## What

The **first real `execute` slice** of the governed-effect plane. Wires `POST /v1/effects` with `custody_mode=execute` + `effect_type=agent_spawn` to the **already-live** agent orchestrator (`:8789`), which owns the OS-process spawn, OTP supervision, lease-binding, and lineage.

This is the answer to "what's holding us back": for `agent_spawn`, execute isn't a from-scratch RCE build — the orchestrator was de-inerted 2026-06-23 and already spawns governed agents live. This slice gives that capability a first-class governed-effect envelope (idempotent, recorded, identity-attributed), behind a fail-closed flag.

## Fail-closed on every axis

`execute` stays `execute_not_implemented` (exactly as today) unless **both**:
- `UNITARES_GOVERNED_EFFECT_EXECUTE_AGENT_SPAWN=1` (per-type flag, default **off**), **and**
- the orchestrator bearer (`AGENT_ORCHESTRATOR_BEARER_TOKEN`) is configured.

Only `agent_spawn` is wired; every other `effect_type` stays gated. The orchestrator's own bearer + `check_allowed` cmd allowlist are the second gate behind the flag.

## Changes

- **`OrchestratorClient`** — minimal `:httpc` `POST /v1/agents` with bearer (no new dep; adds `:inets`).
- **`governed_effect.ex` `execute/1`** — `agent_spawn` only; **idempotent** via a *separate* `governed_effect.execute` channel so an irreversible spawn can never double-fire on a retry; persists the execute record to `audit.events` (`effect_lane`), committed or rejected.
- **`application.ex`** loads the flag + orchestrator URL/bearer at boot.
- **`repo.ex`** idempotency lookup generalized to take an `event_type` channel.
- **`http_router.ex`** maps `spawn_failed → 502`.

## Live smoke caught a real bug

Running the happy path against the **live orchestrator** surfaced that its lineage object wants `parent_agent_uuid`, not `parent_agent_id` — my first spec would have **422'd every production spawn**. Fixed and re-verified: a real spawn returned an `agent_id`. (This is exactly the class of thing unit tests against a mock miss.)

## Honestly deferred (NOT faked)

- **§7 strong-tier re-verification** and the **§6 governance veto** — the governance envelope's deeper gates. This slice's gates are the flag + the orchestrator's bearer/allowlist. `agent_spawn` is irreversible (§5b) so there's no rollback to prove; **idempotency is the load-bearing safety property** here, and it's covered.

## Tests

- Fail-closed default (flag off → `execute_not_implemented`), only-`agent_spawn`, failure-path (`unreachable orchestrator → spawn_failed` + a persisted `rejected` record).
- Full `lease_plane` suite green: **188 tests + 11 properties, 0 failures**. Test rows cleaned up by key.
- Happy path (`201 → committed` + `agent_id`) verified by **live smoke** against the running orchestrator.

## Deploy note (why I'm leaving this DRAFT, not self-merging)

Unlike the additive shadow PRs, this **spawns processes** when enabled. Going live needs the lease plane's `start.sh`/plist to pass `AGENT_ORCHESTRATOR_BEARER_TOKEN` and `UNITARES_GOVERNED_EFFECT_EXECUTE_AGENT_SPAWN=1`. Your review + deploy call — I haven't merged or deployed it.

https://claude.ai/code/session_01F3FYn2PueNYWNfoNYb2nW1