### PR TITLE
Simplify process update response modes

### DIFF
--- a/commands/checkin.md
+++ b/commands/checkin.md
@@ -31,7 +31,7 @@ Inputs:
 - `complexity`: estimate `0.0-1.0`
 - `confidence`: honest estimate `0.0-1.0`
 - use the active session binding or `client_session_id`; do not auto-inject `continuity_token` into `process_agent_update`
-- use `response_mode="mirror"` by default for Codex
+- use `response_mode="compact"` by default for Codex; reserve `response_mode="mirror"` for drift, guide/pause verdicts, or diagnostic review
 
 Guidelines:
 
@@ -48,6 +48,6 @@ After the call:
 - report identity-assurance or continuity warnings when they are surfaced
 - report margin or edge warnings when present
 - report any guidance briefly
-- report the mirror question when present
+- report mirror signals or reflection prompts when present
 - if verdict is `pause` or `reject`, recommend `request_dialectic_review`
 - if verdict is `guide`, summarize the guidance and adjust behavior

--- a/docs/manual/04-integrating-agents.md
+++ b/docs/manual/04-integrating-agents.md
@@ -79,7 +79,7 @@ The server exposes ~50 tools; most are consolidated behind an `action` parameter
 - **`bind_session`** — bind a session to an existing identity (cross-process anti-hijack gate).
 
 ### Check-in & metrics
-- **`process_agent_update`** / `sync_state` — the main check-in. Key params: `response_text`, `complexity` [0–1], `confidence` [0–1], `ethical_drift` ([float,float,float]), `recent_tool_results` (array of `{tool, summary, is_bad}`), `response_mode` (`minimal`/`compact`/`standard`/`full`/`mirror`/`auto`). Returns the verdict + EISV state, risk, coherence, margin.
+- **`process_agent_update`** / `sync_state` — the main check-in. Key params: `response_text`, `complexity` [0–1], `confidence` [0–1], `ethical_drift` ([float,float,float]), `recent_tool_results` (array of `{tool, summary, is_bad}`), `response_mode` (`auto`/`compact`/`mirror`/`full`; aliases: `lite`→`compact`, `verbose`→`full`; legacy: `minimal`, `standard`). Returns the verdict + EISV state, risk, coherence, margin.
 - **`get_governance_metrics`** / `check_working_state` — read-only snapshot, no state update. Fleet-scoped read when unbound.
 
 ### Knowledge graph

--- a/scripts/dev/with_checkin.py
+++ b/scripts/dev/with_checkin.py
@@ -218,7 +218,7 @@ def build_checkin_payload(result: CommandResult, context: CheckinContext) -> dic
         if context.confidence is not None
         else default_confidence(result.exit_code),
         "task_type": context.task_type or infer_task_type(workflow),
-        "response_mode": "minimal",
+        "response_mode": "compact",
         "recent_tool_results": [
             {
                 "kind": infer_evidence_kind(workflow, result.argv),

--- a/src/mcp_handlers/core.py
+++ b/src/mcp_handlers/core.py
@@ -367,8 +367,8 @@ async def handle_process_agent_update(arguments: Dict[str, Any]) -> Sequence[Tex
         task_type: "divergent" (exploring) or "convergent" (focused)
         complexity: 0.0-1.0 how complex was this work
         confidence: 0.0-1.0 how confident are you
-        lite: If true, returns minimal response (action + margin only). Alias for response_mode='minimal'
-        response_mode: 'minimal' (action only), 'compact' (brief metrics), 'standard' (interpreted), 'full' (everything), 'auto' (adapts to health - default)
+        lite: If true, returns compact response. Alias for response_mode='compact'
+        response_mode: 'auto' (compact unless action is needed), 'compact' (brief metrics), 'mirror' (actionable diagnostics), 'full' (everything). Legacy: 'minimal' and 'standard'.
 
     No api_key needed - identity is bound to session via UUID.
     """
@@ -398,7 +398,7 @@ async def handle_process_agent_update(arguments: Dict[str, Any]) -> Sequence[Tex
     # LITE MODE SHORTHAND
     if arguments.get("lite") in (True, "true", "1", 1):
         if not arguments.get("response_mode"):
-            arguments["response_mode"] = "minimal"
+            arguments["response_mode"] = "compact"
 
     logger.info(f"[SESSION_DEBUG] process_agent_update() entry: args_keys={list(arguments.keys()) if arguments else []}")
 

--- a/src/mcp_handlers/introspection/tool_introspection.py
+++ b/src/mcp_handlers/introspection/tool_introspection.py
@@ -1312,7 +1312,8 @@ async def handle_describe_tool(arguments: Dict[str, Any]) -> Sequence[TextConten
                     },
                     "sync_state": {
                         "basic": "sync_state(response_text=\"Fixed bug\", complexity=0.3, confidence=0.9)",
-                        "mirror": "sync_state(response_text=\"Finished task\", complexity=0.5, response_mode=\"mirror\")",
+                        "compact": "sync_state(response_text=\"Finished task\", complexity=0.5, response_mode=\"compact\")",
+                        "diagnostic_mirror": "sync_state(response_text=\"Reviewing drift\", complexity=0.5, response_mode=\"mirror\")",
                     },
                     "check_working_state": {
                         "basic": "check_working_state()",

--- a/src/mcp_handlers/response_formatter.py
+++ b/src/mcp_handlers/response_formatter.py
@@ -1,5 +1,5 @@
 """
-Response Formatter — Filters process_agent_update response by verbosity mode.
+Response Formatter — filters process_agent_update responses by agent-facing mode.
 
 Extracted from core.py to reduce its size and make response modes independently testable.
 """
@@ -31,6 +31,13 @@ _STEADY_VERDICTS = frozenset({"proceed", "continue", "safe"})
 _ACTION_VERDICTS = frozenset({"pause", "reject"})
 _ACTIONABLE_POLICY_VERDICTS = frozenset({"caution", "high-risk"})
 _KNOWN_POLICY_VERDICTS = _STEADY_VERDICTS | _ACTIONABLE_POLICY_VERDICTS
+_SUPPORTED_RESPONSE_MODES = frozenset({"compact", "full", "mirror", "minimal", "standard"})
+_RESPONSE_MODE_ALIASES = {
+    "lite": "compact",
+    "verbose": "full",
+    "interpreted": "standard",
+}
+_ACTIONABLE_HEALTH_STATUSES = frozenset({"at_risk", "critical"})
 
 
 def _policy_evaluation(response_data: dict) -> dict:
@@ -86,6 +93,60 @@ def _copy_passthrough_fields(response_data: dict, result: dict, fields: tuple) -
         if value is not None:
             result[field] = value
 
+
+def _coerce_response_mode(value: Any) -> str:
+    """Return the canonical spelling for one response mode value."""
+    mode = str(value or "auto").strip().lower()
+    if not mode:
+        mode = "auto"
+    return _RESPONSE_MODE_ALIASES.get(mode, mode)
+
+
+def _auto_response_mode(response_data: dict) -> str:
+    """Pick the default shape for process_agent_update.
+
+    Routine check-ins get one stable compact shape. Mirror is reserved for
+    payloads that are already actionable: pause/reject, guide/caution/high-risk,
+    or an explicitly at-risk/critical health status.
+    """
+    metrics = response_data.get("metrics", {}) if isinstance(response_data.get("metrics"), dict) else {}
+    decision = response_data.get("decision", {}) if isinstance(response_data.get("decision"), dict) else {}
+    health_status = (
+        response_data.get("health_status")
+        or metrics.get("health_status")
+        or response_data.get("status")
+        or "healthy"
+    )
+
+    action = decision.get("action")
+    policy = _policy_evaluation(response_data)
+    policy_inputs = _policy_inputs(response_data)
+    policy_verdict = policy_inputs.get("verdict")
+    metrics_verdict = metrics.get("verdict")
+
+    if (
+        health_status in _ACTIONABLE_HEALTH_STATUSES
+        or action in _ACTION_VERDICTS
+        or policy_verdict in _ACTIONABLE_POLICY_VERDICTS
+        or metrics_verdict in _ACTIONABLE_POLICY_VERDICTS
+        or policy.get("sub_action") == "guide"
+        or decision.get("sub_action") == "guide"
+    ):
+        return "mirror"
+    return "compact"
+
+
+def _resolve_response_mode(raw_mode: Any, response_data: dict) -> str:
+    """Normalize aliases and resolve auto into the actual response shape."""
+    mode = _coerce_response_mode(raw_mode)
+    if mode == "auto":
+        return _auto_response_mode(response_data)
+    if mode in _SUPPORTED_RESPONSE_MODES:
+        return mode
+    logger.debug("Unknown process_agent_update response_mode=%r; using compact", raw_mode)
+    return "compact"
+
+
 def _emit_mirror_signal_records(response_data: dict, response_mode: str, meta: Any) -> None:
     """Phase 0 mirror-effectiveness instrumentation (mirror-effectiveness-measurement-v0).
 
@@ -128,12 +189,17 @@ def format_response(
 
     Priority: per-call response_mode > agent preferences > env var > auto
 
-    Modes:
-    - "auto": Select mode based on health_status
-    - "standard"/"interpreted": Human-readable interpretation via GovernanceState
-    - "minimal": Action + EISV snapshot + margin
-    - "compact"/"lite": Brief metrics + decision summary
-    - "full": No filtering (return as-is)
+    Preferred modes:
+    - "auto": compact for routine check-ins, mirror for actionable states
+    - "compact": brief metrics + decision summary
+    - "mirror": actionable self-awareness signals
+    - "full": no filtering (return as-is)
+
+    Compatibility modes:
+    - "lite": alias for compact
+    - "verbose": alias for full
+    - "standard"/"interpreted": human-readable interpretation via GovernanceState
+    - "minimal": legacy bare action + EISV snapshot + margin
 
     Args:
         response_data: The complete response dict built by process_agent_update
@@ -166,33 +232,14 @@ def format_response(
         pass
 
     # Priority: per-call > agent pref > env var > auto
-    response_mode = (
+    raw_response_mode = (
         arguments.get("response_mode") or
         agent_verbosity_pref or
         os.getenv("UNITARES_PROCESS_UPDATE_RESPONSE_MODE", "auto")
-    ).strip().lower()
+    )
+    response_mode = _resolve_response_mode(raw_response_mode, response_data)
 
     using_default_mode = not arguments.get("response_mode") and not agent_verbosity_pref
-
-    # AUTO MODE: Adaptive verbosity based on health status
-    if response_mode == "auto":
-        metrics = response_data.get("metrics", {}) if isinstance(response_data.get("metrics"), dict) else {}
-        health_status = (
-            response_data.get("health_status") or
-            metrics.get("health_status") or
-            response_data.get("status") or
-            "healthy"
-        )
-        # Auto-select mirror for disembodied agents (no sensor_data)
-        has_sensor_data = response_data.get("_has_sensor_data", False)
-        if health_status == "healthy" and not has_sensor_data:
-            response_mode = "mirror"
-        elif health_status == "healthy":
-            response_mode = "minimal"
-        elif health_status in ("at_risk", "critical"):
-            response_mode = "standard"
-        else:
-            response_mode = "compact"
 
     # Phase 0 mirror-effectiveness instrumentation: emit structured signal
     # records (every resolved mode) with surfaced = (mode == "mirror"), so the
@@ -209,7 +256,7 @@ def format_response(
         response_data = _format_mirror(response_data, saved_trust_tier, meta=meta)
 
     # STANDARD MODE: Human-readable interpretation
-    elif response_mode in ("standard", "interpreted"):
+    elif response_mode == "standard":
         response_data = _format_standard(response_data, task_type, saved_trust_tier)
 
     # MINIMAL MODE: Bare essentials
@@ -217,7 +264,7 @@ def format_response(
         response_data = _format_minimal(response_data, using_default_mode, saved_trust_tier)
 
     # COMPACT MODE: Brief metrics + decision
-    elif response_mode in ("compact", "lite"):
+    elif response_mode == "compact":
         response_data = _format_compact(response_data, using_default_mode, saved_trust_tier)
 
     # Strip optional context for minimal/compact/mirror (reduce noise for established agents)
@@ -566,7 +613,7 @@ def _format_minimal(response_data: dict, using_default_mode: bool, saved_trust_t
     if nearest_edge:
         result["nearest_edge"] = nearest_edge
     if using_default_mode:
-        result["_tip"] = "Set verbosity: update_agent_metadata(preferences={'verbosity':'minimal'})"
+        result["_tip"] = "Legacy minimal mode is bare; prefer response_mode='compact' for routine check-ins."
     if saved_trust_tier:
         # Minimal mode is intentionally terse — emit the name string only.
         # Agents wanting tier-scale + meaning should use mirror/compact.
@@ -646,7 +693,7 @@ def _format_compact(response_data: dict, using_default_mode: bool, saved_trust_t
         from src.governance_glossary import explain_trust_tier
         result["trust_tier"] = explain_trust_tier(saved_trust_tier)
     if using_default_mode:
-        result["_tip"] = "Verbosity options: response_mode='minimal'|'compact'|'full', or set permanently via update_agent_metadata(preferences={'verbosity':'minimal'})"
+        result["_tip"] = "Routine mode is compact. Use response_mode='mirror' for diagnostics or 'full' for raw payload."
     if "thread_context" in response_data:
         result["thread_context"] = response_data["thread_context"]
     if "identity_assurance" in response_data:

--- a/src/mcp_handlers/schemas/core.py
+++ b/src/mcp_handlers/schemas/core.py
@@ -281,21 +281,31 @@ class ProcessAgentUpdateParams(AgentIdentityMixin):
             "bootstrap rows are labeled synthetic internally."
         ),
     )
-    response_mode: Literal["minimal", "compact", "standard", "full", "mirror", "auto"] = Field(
+    response_mode: Literal[
+        "auto",
+        "compact",
+        "mirror",
+        "full",
+        "minimal",
+        "standard",
+        "lite",
+        "verbose",
+        "interpreted",
+    ] = Field(
         default="auto",
         description=(
-            "Response verbosity. 'auto' (default) adapts to health — mirror when "
-            "healthy/disembodied, else minimal/standard/compact. 'mirror' returns "
-            "actionable self-awareness signals instead of raw EISV. 'standard' is a "
-            "human-readable interpretation. 'minimal' and 'compact' are both small "
-            "payloads (minimal = action + EISV snapshot + margin; compact = brief "
-            "metrics + decision). 'full' returns the complete payload unfiltered. "
-            "The 'lite' boolean below is an alias for 'minimal'."
+            "Agent-facing response shape. Prefer 'auto' or 'compact' for routine "
+            "check-ins. 'auto' resolves to compact for steady states and mirror "
+            "for actionable at-risk/guide/pause states. 'mirror' returns "
+            "actionable self-awareness signals. 'full' returns the complete "
+            "payload. Compatibility aliases: 'lite' -> compact, 'verbose' -> "
+            "full, 'interpreted' -> standard. 'minimal' and 'standard' remain "
+            "legacy explicit modes for skinny or human-interpreted payloads."
         )
     )
     lite: Union[bool, str, None] = Field(
         default=None,
-        description="Boolean alias for response_mode='minimal'. Applies only when response_mode is left at 'auto' (an explicit response_mode always wins)."
+        description="Boolean alias for response_mode='compact'. Applies only when response_mode is left at 'auto' (an explicit response_mode always wins)."
     )
     auto_export_on_significance: bool = Field(
         default=False,
@@ -355,7 +365,14 @@ class ProcessAgentUpdateParams(AgentIdentityMixin):
 
     @model_validator(mode='after')
     def coerce_types(self):
-        # `lite` is a boolean alias for response_mode='minimal'. Accept a real
+        response_aliases = {
+            "lite": "compact",
+            "verbose": "full",
+            "interpreted": "standard",
+        }
+        self.response_mode = response_aliases.get(self.response_mode, self.response_mode)
+
+        # `lite` is a boolean alias for response_mode='compact'. Accept a real
         # bool OR a truthy string — previously only the string form was honored,
         # so an actual JSON `lite: true` was silently ignored. Only applies when
         # response_mode is still 'auto', so an explicit response_mode always wins.
@@ -364,7 +381,7 @@ class ProcessAgentUpdateParams(AgentIdentityMixin):
                 str(self.lite).lower() in ('true', '1', 'yes')
             )
             if lite_on and self.response_mode == "auto":
-                self.response_mode = "minimal"
+                self.response_mode = "compact"
         if isinstance(self.require_strong_identity, str):
             self.require_strong_identity = self.require_strong_identity.lower() in ('true', '1', 'yes')
         return self

--- a/src/mcp_handlers/updates/pipeline.py
+++ b/src/mcp_handlers/updates/pipeline.py
@@ -37,10 +37,10 @@ def enrichment(order: int, *, lite_safe: bool = False):
     """Register a function in the enrichment pipeline at *order*.
 
     lite_safe=True marks the enrichment as response-shaping only — safe to
-    skip when the caller requested response_mode='minimal' (the lite path
-    used by embedded brokers like anima-broker that read action+margin and
-    discard the rest). Default False keeps existing behavior for callers
-    that use non-lite modes.
+    skip when the caller explicitly requested response_mode='minimal' (the
+    legacy skinny path used by embedded brokers that read action+margin and
+    discard the rest). Default False keeps existing behavior for callers that
+    use richer modes.
     """
     def decorator(fn: Callable) -> Callable:
         _ENRICHMENTS.append(_EnrichmentEntry(
@@ -63,11 +63,11 @@ async def run_enrichment_pipeline(ctx) -> None:
     runs serially today; this instrumentation is the prerequisite for
     deciding which enrichments are safe to parallelize.
     """
-    is_lite = (getattr(ctx, "arguments", None) or {}).get("response_mode") == "minimal"
+    is_minimal = (getattr(ctx, "arguments", None) or {}).get("response_mode") == "minimal"
     timings: List[tuple[str, int]] = []
     for entry in _ENRICHMENTS:
-        if is_lite and entry.lite_safe:
-            timings.append((entry.name, -1))  # -1 sentinel = skipped (lite)
+        if is_minimal and entry.lite_safe:
+            timings.append((entry.name, -1))  # -1 sentinel = skipped (minimal)
             continue
         start = time.perf_counter()
         try:

--- a/src/tool_descriptions.py
+++ b/src/tool_descriptions.py
@@ -80,7 +80,8 @@ _DESCRIPTION_APPENDICES = {
     ),
     "process_agent_update": (
         "\n\nCURRENT HIGH-VALUE PARAMETERS:\n"
-        "- response_mode: minimal | compact | standard | full | mirror | auto\n"
+        "- response_mode: auto | compact | mirror | full "
+        "(aliases: lite->compact, verbose->full; legacy: minimal, standard)\n"
         "- require_strong_identity: reject updates unless identity assurance is strong\n"
         "- recent_tool_results: list of ToolResultEvidence items, shaped as "
         "{tool, summary, is_bad}; kind is inferred when omitted\n"

--- a/tests/test_core_update.py
+++ b/tests/test_core_update.py
@@ -617,8 +617,8 @@ class TestProcessAgentUpdate:
             assert "error" in data or "unexpected" in json.dumps(data).lower()
 
     @pytest.mark.asyncio
-    async def test_lite_alias_sets_minimal_response_mode(self, mock_server, mock_monitor):
-        """lite=true sets response_mode to minimal."""
+    async def test_lite_alias_sets_compact_response_mode(self, mock_server, mock_monitor):
+        """lite=true sets response_mode to compact."""
         agent_uuid = "test-uuid-lite"
         meta = _make_metadata(status="active", total_updates=5)
         mock_server.agent_metadata = {agent_uuid: meta}

--- a/tests/test_pydantic_schemas.py
+++ b/tests/test_pydantic_schemas.py
@@ -8,20 +8,27 @@ class TestPydanticSchemas:
     full coverage of the type coercions and bounds checking previously handled 
     by manual validators."""
 
-    def test_lite_alias_coerces_minimal_for_bool_and_string(self):
-        """`lite` is documented as an alias for response_mode='minimal'. It must
+    def test_lite_alias_coerces_compact_for_bool_and_string(self):
+        """`lite` is documented as an alias for response_mode='compact'. It must
         honor a real JSON bool, not only the string form (which was the bug —
         `lite: true` was silently ignored). An explicit response_mode still wins."""
         from src.mcp_handlers.schemas.core import ProcessAgentUpdateParams
         # Real bool — previously ignored.
-        assert ProcessAgentUpdateParams(lite=True, response_text="T").response_mode == "minimal"
+        assert ProcessAgentUpdateParams(lite=True, response_text="T").response_mode == "compact"
         # Truthy string still works.
-        assert ProcessAgentUpdateParams(lite="true", response_text="T").response_mode == "minimal"
+        assert ProcessAgentUpdateParams(lite="true", response_text="T").response_mode == "compact"
         # Falsey leaves the default.
         assert ProcessAgentUpdateParams(lite=False, response_text="T").response_mode == "auto"
         assert ProcessAgentUpdateParams(response_text="T").response_mode == "auto"
         # Explicit response_mode always wins over lite.
         assert ProcessAgentUpdateParams(lite=True, response_mode="full", response_text="T").response_mode == "full"
+
+    def test_response_mode_aliases_are_canonicalized(self):
+        from src.mcp_handlers.schemas.core import ProcessAgentUpdateParams
+
+        assert ProcessAgentUpdateParams(response_text="T", response_mode="lite").response_mode == "compact"
+        assert ProcessAgentUpdateParams(response_text="T", response_mode="verbose").response_mode == "full"
+        assert ProcessAgentUpdateParams(response_text="T", response_mode="interpreted").response_mode == "standard"
 
     def test_float_bounds(self):
         """Test float range bounds are applied correctly (e.g., complexity 0.0-1.0)."""

--- a/tests/test_response_formatter.py
+++ b/tests/test_response_formatter.py
@@ -420,31 +420,30 @@ class TestFormatResponse:
         result = format_response(data, {"response_mode": "lite"})
         assert result["_mode"] == "compact"
 
-    def test_auto_mode_healthy_becomes_mirror_for_disembodied(self):
+    def test_verbose_alias_for_full(self):
+        data = _sample_response()
+        original_keys = set(data.keys())
+        result = format_response(data, {"response_mode": "verbose"})
+        assert set(result.keys()) == original_keys
+
+    def test_auto_mode_healthy_becomes_compact_for_disembodied(self):
         data = _sample_response()
         data["health_status"] = "healthy"
         result = format_response(data, {"response_mode": "auto"})
-        assert result["_mode"] == "mirror"  # Disembodied (no sensor_data) -> mirror
+        assert result["_mode"] == "compact"
 
-    def test_auto_mode_healthy_becomes_minimal_for_embodied(self):
+    def test_auto_mode_healthy_becomes_compact_for_embodied(self):
         data = _sample_response()
         data["health_status"] = "healthy"
         data["_has_sensor_data"] = True
         result = format_response(data, {"response_mode": "auto"})
-        assert result["_mode"] == "minimal"  # Embodied (has sensor_data) -> minimal
+        assert result["_mode"] == "compact"
 
-    def test_auto_mode_at_risk_becomes_standard(self):
-        """auto mode with at_risk health should become standard (needs GovernanceState)."""
+    def test_auto_mode_at_risk_becomes_mirror(self):
         data = _sample_response()
         data["health_status"] = "at_risk"
-        # Standard mode needs GovernanceState imports — mock them
-        mock_state = MagicMock()
-        mock_state.interpret_state.return_value = {"summary": "At risk"}
-        with patch("src.mcp_handlers.response_formatter.GovernanceState", return_value=mock_state, create=True):
-            with patch("src.mcp_handlers.response_formatter._format_standard") as mock_std:
-                mock_std.return_value = {"_mode": "standard", "state": "at risk"}
-                result = format_response(data, {"response_mode": "auto"})
-                mock_std.assert_called_once()
+        result = format_response(data, {"response_mode": "auto"})
+        assert result["_mode"] == "mirror"
 
     def test_auto_mode_unknown_becomes_compact(self):
         data = _sample_response()
@@ -475,9 +474,7 @@ class TestFormatResponse:
         # Same end-to-end check for mirror mode.
         data = _sample_response()
         data["trajectory_identity"]["trust_tier"] = {"tier": 3, "name": "verified"}
-        # Force mirror via no sensor_data + healthy.
-        data["health_status"] = "healthy"
-        result = format_response(data, {"response_mode": "auto"})
+        result = format_response(data, {"response_mode": "mirror"})
         assert result["_mode"] == "mirror"
         tt = result["trust_tier"]
         assert tt["name"] == "verified"
@@ -1030,19 +1027,19 @@ class TestFormatResponseMirror:
         result = format_response(data, {"response_mode": "mirror"})
         assert result["_mode"] == "mirror"
 
-    def test_auto_selects_mirror_for_disembodied(self):
+    def test_auto_selects_compact_for_steady_disembodied(self):
         data = _sample_response()
         data["health_status"] = "healthy"
         data["_has_sensor_data"] = False
         result = format_response(data, {"response_mode": "auto"})
-        assert result["_mode"] == "mirror"
+        assert result["_mode"] == "compact"
 
-    def test_auto_selects_minimal_for_embodied(self):
+    def test_auto_selects_compact_for_steady_embodied(self):
         data = _sample_response()
         data["health_status"] = "healthy"
         data["_has_sensor_data"] = True
         result = format_response(data, {"response_mode": "auto"})
-        assert result["_mode"] == "minimal"
+        assert result["_mode"] == "compact"
 
     def test_strip_context_applied_for_mirror(self):
         data = _sample_response()

--- a/tests/test_with_checkin.py
+++ b/tests/test_with_checkin.py
@@ -53,7 +53,7 @@ def test_build_checkin_payload_records_successful_s22_evidence():
     from src.mcp_handlers.schemas.core import ProcessAgentUpdateParams
 
     ProcessAgentUpdateParams.model_validate(payload)
-    assert payload["response_mode"] == "minimal"
+    assert payload["response_mode"] == "compact"
     assert payload["client_session_id"] == "sid-123"
     assert "continuity_token" not in payload
     assert payload["task_type"] == "testing"


### PR DESCRIPTION
Summary:
- make compact the routine process_agent_update shape and reserve mirror for actionable/diagnostic states
- canonicalize aliases so lite -> compact, verbose -> full, interpreted -> standard
- update check-in guidance, tool descriptions, with_checkin payloads, and tests

Tests:
- python3 -m pytest tests/test_response_formatter.py tests/test_pydantic_schemas.py tests/test_with_checkin.py tests/test_describe_tool_drift.py -q
- python3 -m pytest tests/test_core_update.py -q
- python3 -m pytest tests/test_tool_schema_validation.py tests/test_provenance_context.py -q
- python3 -m pytest tests/test_enrichment_pipeline.py -q
- ./scripts/dev/test-cache.sh (10760 passed, 21 skipped, coverage 81.71%)

Notes:
- pre-push smoke passed; doc-health hook reported pre-existing orphan-doc/ghost-tool warnings.