### PR TITLE
fix(lease-plane): guard governed-effect idempotency lookup against a NULL digest

### DIFF
--- a/elixir/lease_plane/lib/unitares_lease_plane/repo.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/repo.ex
@@ -714,6 +714,16 @@ defmodule UnitaresLeasePlane.Repo do
       {:ok, %{rows: []}} ->
         {:ok, nil}
 
+      # A row whose payload has no `idempotency_digest` (manual insert, migration
+      # replay, or a future code branch) is unusable for the digest comparison —
+      # treat it as not-found so the caller persists fresh, rather than returning
+      # a `digest: nil` map that matches none of the caller's case clauses
+      # (`^digest` / `is_binary(other)` / `nil` / `{:error, _}`) and raises
+      # CaseClauseError on the retry. The current writer always sets the digest;
+      # this guards the corrupt/legacy-row edge.
+      {:ok, %{rows: [[nil, _payload_text]]}} ->
+        {:ok, nil}
+
       {:ok, %{rows: [[digest, payload_text]]}} ->
         {:ok, %{idempotency_digest: digest, payload: decode_payload(payload_text)}}
 

--- a/elixir/lease_plane/test/governed_effect_test.exs
+++ b/elixir/lease_plane/test/governed_effect_test.exs
@@ -163,6 +163,23 @@ defmodule UnitaresLeasePlane.GovernedEffectTest do
       assert {:error, :idempotency_conflict} =
                GovernedEffect.handle(base(%{"idempotency_key" => key, "surface" => "repo://b"}))
     end
+
+    test "a stored row with a NULL idempotency_digest does not crash the retry (CaseClauseError guard)" do
+      key = tracked_key()
+      # Simulate a corrupt/legacy row: a record_only event for this key whose
+      # payload has no idempotency_digest. The lookup must treat it as not-found
+      # (persist fresh) rather than returning a digest:nil map that matches no
+      # case clause and raises CaseClauseError.
+      Postgrex.query!(
+        UnitaresLeasePlane.DB,
+        "INSERT INTO audit.events (ts, event_type, payload) " <>
+          "VALUES (now(), 'governed_effect.record_only', ($1::text)::jsonb)",
+        [Jason.encode!(%{"idempotency_key" => key, "effect_lane" => "governed_effect"})]
+      )
+
+      assert {:ok, body} = GovernedEffect.handle(base(%{"idempotency_key" => key}))
+      refute body.idempotent
+    end
   end
 
   describe "execute / agent_spawn (first execute slice)" do


### PR DESCRIPTION
Closes the latent CaseClauseError flagged in the #1066/#1067 council pass: a stored governed_effect row with no `idempotency_digest` made the lookup return a `digest: nil` map matching no caller case clause → crash on retry. Today unreachable (the writer always sets the digest); this guards the corrupt/legacy-row edge at the Repo layer (one fix covers both record_only and execute callers). Test reproduces it. Full lease_plane suite green (189 + 11).

https://claude.ai/code/session_01F3FYn2PueNYWNfoNYb2nW1