### PR TITLE
fix(tool-modes): make operator_recovery wire surface advertisable

### DIFF
--- a/src/tool_modes.py
+++ b/src/tool_modes.py
@@ -115,12 +115,14 @@ OPERATOR_READONLY_MODE_TOOLS: Set[str] = {
 OPERATOR_RECOVERY_MODE_TOOLS: Set[str] = OPERATOR_READONLY_MODE_TOOLS | {
     # Recovery tools
     "operator_resume_agent",      # Resume stuck agents (operator-only)
-    "check_recovery_options",     # Check if agent is recoverable
-    
+    "self_recovery",              # Recoverability check + recovery (action=check/quick/review)
+
     # Knowledge graph write (for audit trail)
-    "store_knowledge_graph",      # Log interventions
+    # `knowledge` (action="store") is inherited from readonly; `leave_note` is the
+    # low-friction path. Both are register=True wire tools — no standalone
+    # `store_knowledge_graph` entry, which is register=False and never surfaces.
     "leave_note",                 # Quick notes
-    
+
     # Agent lifecycle (limited)
     "mark_response_complete",     # Mark agents as waiting_input
 }

--- a/tests/test_lite_wire_surface.py
+++ b/tests/test_lite_wire_surface.py
@@ -32,9 +32,17 @@ sys.path.insert(0, str(project_root))
 # the registry. Must happen before reading get_tool_registry().
 import src.mcp_handlers  # noqa: F401
 
+import pytest
+
 from src.mcp_handlers.decorators import get_tool_registry
 from src.mcp_handlers.tool_stability import AGENT_WORKFLOW_ALIASES, resolve_tool_alias
-from src.tool_modes import LITE_MODE_TOOLS, get_tools_for_mode
+from src.tool_modes import (
+    LITE_MODE_TOOLS,
+    MINIMAL_MODE_TOOLS,
+    OPERATOR_READONLY_MODE_TOOLS,
+    OPERATOR_RECOVERY_MODE_TOOLS,
+    get_tools_for_mode,
+)
 
 
 def _lite_wire_surface() -> set[str]:
@@ -90,6 +98,36 @@ def test_every_lite_tool_is_backed_by_handler_or_alias():
     assert not unbacked, (
         "LITE_MODE_TOOLS entries with no register=True handler and no alias "
         f"— these would silently never appear on the wire: {unbacked}"
+    )
+
+
+@pytest.mark.parametrize(
+    "mode_name, mode_tools",
+    [
+        ("minimal", MINIMAL_MODE_TOOLS),
+        ("lite", LITE_MODE_TOOLS),
+        ("operator_readonly", OPERATOR_READONLY_MODE_TOOLS),
+        ("operator_recovery", OPERATOR_RECOVERY_MODE_TOOLS),
+    ],
+)
+def test_every_mode_tool_is_backed_by_handler_or_alias(mode_name, mode_tools):
+    """Every tool listed in ANY deployable mode set must be a real wire tool.
+
+    A name is a wire tool only if it is a register=True handler or a workflow
+    alias. A register=False handler (reachable solely via a consolidated
+    action-router, e.g. the old `store_knowledge_graph` / `check_recovery_options`
+    entries) is NOT standalone-advertisable, so listing it in a mode set silently
+    promises a tool the server never exposes. This guards that drift across every
+    mode, not just lite.
+    """
+    registry = set(get_tool_registry().keys())
+    aliases = {a for a in AGENT_WORKFLOW_ALIASES if resolve_tool_alias(a)[1] is not None}
+    backed = registry | aliases
+
+    unbacked = sorted(mode_tools - backed)
+    assert not unbacked, (
+        f"{mode_name} mode lists tools with no register=True handler and no alias "
+        f"— these would never appear on the wire: {unbacked}"
     )
 
 


### PR DESCRIPTION
## Context

Follow-up to #1068. That PR's wire-surface guard surfaced a latent inconsistency in `OPERATOR_RECOVERY_MODE_TOOLS` (`src/tool_modes.py`): it listed two `register=False` handlers that are only reachable through a consolidated action-router, so they would **never** surface as standalone MCP wire tools in operator-recovery mode. The mode set promised tools the server never exposes.

## Fix

| Old entry | Problem | Resolution |
|---|---|---|
| `store_knowledge_graph` | `register=False`; reachable only via `knowledge(action="store")` | **Dropped** — redundant. `knowledge` is already inherited from `operator_readonly` and `leave_note` is in the set; both are `register=True`. |
| `check_recovery_options` | `register=False`; it is `action="check"` under the consolidated `self_recovery` tool | **Replaced with `self_recovery`** (`register=True`), which exposes `check` plus the `quick`/`review` recovery actions. |

No operator capability is lost — KG writes and recoverability checks remain fully reachable via `register=True` wire tools.

## Test

Extends the wire-surface CI guard (`tests/test_lite_wire_surface.py`) with a parametrized **backing check over every deployable mode set** (`minimal`, `lite`, `operator_readonly`, `operator_recovery`): every listed tool must be a `register=True` handler or a workflow alias. This catches the `register=False`-in-a-mode-set drift class beyond just lite mode.

Verified with a mutation test: re-introducing the two old entries fails the new guard with the exact names. Full run: `tests/test_lite_wire_surface.py` (7) + `tests/test_tool_modes.py` (34) → 41 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRJJBCigoTJEwqbf5gAMss)_