### PR TITLE
feat(governed-effect): §6 governance veto on execute agent_spawn (real gate, not theater)

### DIFF
--- a/elixir/lease_plane/lib/unitares_lease_plane/application.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/application.ex
@@ -76,6 +76,20 @@ defmodule UnitaresLeasePlane.Application do
       Application.put_env(:lease_plane, :agent_orchestrator_bearer_token, token)
     end
 
+    # Governance MCP base URL for the §6 effect-veto (governed-effect execute).
+    # Defaults to the local governance MCP REST surface; loopback bypasses its
+    # auth, so no token is needed in the default single-host setup.
+    Application.put_env(
+      :lease_plane,
+      :governance_url,
+      System.get_env("UNITARES_GOVERNANCE_URL") ||
+        System.get_env("GOVERNANCE_URL") || "http://127.0.0.1:8767"
+    )
+
+    if token = System.get_env("UNITARES_HTTP_API_TOKEN") do
+      Application.put_env(:lease_plane, :governance_api_token, token)
+    end
+
     children =
       [
         {Postgrex, postgrex_opts()},

--- a/elixir/lease_plane/lib/unitares_lease_plane/governance_veto_client.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/governance_veto_client.ex
@@ -1,0 +1,81 @@
+defmodule UnitaresLeasePlane.GovernanceVetoClient do
+  @moduledoc """
+  Calls the governance MCP `POST /v1/effect-veto` (governed-effect-plane §6)
+  BEFORE an `execute` agent_spawn commits. Governance reads the proposer's
+  durable last-decided posture and returns `{vetoed: bool}`.
+
+  Uses Erlang stdlib `:httpc` (localhost; the governance REST surface bypasses
+  auth on trusted networks, so no token is needed for the loopback call).
+
+  FAIL-CLOSED is the caller's job, not ours: this returns `:allow` only on an
+  explicit `vetoed:false`. A missing proposer, an unreachable governance MCP, a
+  non-200, or a `503` (governance could not read its own state) all return
+  `{:error, _}` / `{:blocked, _}`, and `GovernedEffect` treats anything that is
+  not `:allow` as `governance_blocked` — an effect is not committed unless
+  governance affirmatively cleared it.
+  """
+
+  require Logger
+
+  @spec check(map()) :: :allow | {:blocked, String.t()} | {:error, term()}
+  def check(%{proposer_agent_uuid: uuid}) when not is_binary(uuid) or uuid == "" do
+    # No attributed proposer → governance cannot judge → fail closed. An
+    # unattributed RCE-class spawn must not commit.
+    {:error, :proposer_required}
+  end
+
+  def check(env) do
+    with {:ok, base} <- base_url() do
+      body =
+        Jason.encode!(%{
+          "proposer_agent_uuid" => env.proposer_agent_uuid,
+          "surface" => Map.get(env, :surface),
+          "effect_type" => Map.get(env, :effect_type)
+        })
+
+      url = String.to_charlist(base <> "/v1/effect-veto")
+      headers = veto_headers()
+      request = {url, headers, ~c"application/json", body}
+      http_opts = [timeout: timeout_ms(), connect_timeout: 2_000]
+
+      case :httpc.request(:post, request, http_opts, body_format: :binary) do
+        {:ok, {{_v, 200, _r}, _h, resp}} -> parse(resp)
+        {:ok, {{_v, status, _r}, _h, resp}} -> {:error, {:veto_status, status, truncate(resp)}}
+        {:error, reason} -> {:error, {:veto_unreachable, reason}}
+      end
+    end
+  end
+
+  defp parse(resp) do
+    case Jason.decode(resp) do
+      {:ok, %{"vetoed" => true} = b} -> {:blocked, b["reason"] || "vetoed"}
+      {:ok, %{"vetoed" => false}} -> :allow
+      {:ok, other} -> {:error, {:veto_bad_body, other}}
+      {:error, _} -> {:error, :veto_bad_json}
+    end
+  end
+
+  defp base_url do
+    case Application.get_env(:lease_plane, :governance_url) do
+      url when is_binary(url) and byte_size(url) > 0 -> {:ok, String.trim_trailing(url, "/")}
+      _ -> {:error, :governance_url_unset}
+    end
+  end
+
+  # Optional bearer for the governance REST surface (loopback bypasses auth, so
+  # this is usually unset). Included when configured for non-loopback setups.
+  defp veto_headers do
+    case Application.get_env(:lease_plane, :governance_api_token) do
+      t when is_binary(t) and byte_size(t) > 0 ->
+        [{~c"authorization", String.to_charlist("Bearer " <> t)}]
+
+      _ ->
+        []
+    end
+  end
+
+  defp timeout_ms, do: Application.get_env(:lease_plane, :governance_veto_timeout_ms, 5_000)
+
+  defp truncate(bin) when is_binary(bin), do: binary_part(bin, 0, min(byte_size(bin), 200))
+  defp truncate(other), do: inspect(other)
+end

--- a/elixir/lease_plane/lib/unitares_lease_plane/governed_effect.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/governed_effect.ex
@@ -52,6 +52,7 @@ defmodule UnitaresLeasePlane.GovernedEffect do
 
   require Logger
 
+  alias UnitaresLeasePlane.GovernanceVetoClient
   alias UnitaresLeasePlane.OrchestratorClient
   alias UnitaresLeasePlane.Repo
 
@@ -71,6 +72,7 @@ defmodule UnitaresLeasePlane.GovernedEffect do
     * `{:ok, body_map}` — a 202 body (record_only recorded, or execute committed);
     * `{:error, :execute_not_implemented}` — execute mode disabled / unsupported type;
     * `{:error, :idempotency_conflict}` — same key, different digest;
+    * `{:error, :governance_blocked}` — governance vetoed (or could not clear) the effect;
     * `{:error, :persist_failed}` / `{:error, :spawn_failed}`;
     * `{:error, detail}` — `schema_invalid` detail string.
   """
@@ -78,6 +80,7 @@ defmodule UnitaresLeasePlane.GovernedEffect do
           {:ok, map()}
           | {:error, :execute_not_implemented}
           | {:error, :idempotency_conflict}
+          | {:error, :governance_blocked}
           | {:error, :persist_failed}
           | {:error, :spawn_failed}
           | {:error, String.t()}
@@ -353,6 +356,46 @@ defmodule UnitaresLeasePlane.GovernedEffect do
   defp spawn_and_record(env, digest) do
     effect_id = gen_effect_id()
 
+    # §6 governance veto — BEFORE the spawn commits. The effect is committed only
+    # if governance affirmatively clears it (`:allow`). A block, a missing
+    # proposer, or an unreachable/erroring governance MCP all fail CLOSED: we do
+    # not spawn, and persist a `governance_blocked` record.
+    case GovernanceVetoClient.check(env) do
+      :allow ->
+        spawn_after_veto(env, digest, effect_id)
+
+      {:blocked, reason} ->
+        Logger.info(
+          "governed_effect execute agent_spawn VETOED effect_id=#{effect_id} " <>
+            "surface=#{env.surface} reason=#{reason}"
+        )
+
+        payload =
+          execute_audit_payload(effect_id, env, digest, "governance_blocked", %{
+            "veto_reason" => reason
+          })
+
+        _ = persist_execute(env, payload)
+        {:error, :governance_blocked}
+
+      {:error, reason} ->
+        # Fail closed: could not confirm governance clearance → do not spawn.
+        Logger.warning(
+          "governed_effect execute agent_spawn veto-unavailable effect_id=#{effect_id} " <>
+            "surface=#{env.surface}: #{inspect(reason)} — failing closed"
+        )
+
+        payload =
+          execute_audit_payload(effect_id, env, digest, "governance_blocked", %{
+            "veto_reason" => "veto_unavailable:#{inspect(reason)}"
+          })
+
+        _ = persist_execute(env, payload)
+        {:error, :governance_blocked}
+    end
+  end
+
+  defp spawn_after_veto(env, digest, effect_id) do
     case OrchestratorClient.spawn_agent(orchestrator_spec(env)) do
       {:ok, agent_id} ->
         Logger.info(

--- a/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
@@ -157,6 +157,13 @@ defmodule UnitaresLeasePlane.HTTPRouter do
           reason: "execute custody could not complete the spawn via the orchestrator"
         })
 
+      {:error, :governance_blocked} ->
+        json(conn, 403, %{
+          ok: false,
+          error: "governance_blocked",
+          reason: "governance vetoed the effect or could not affirmatively clear it"
+        })
+
       {:error, detail} when is_binary(detail) ->
         json(conn, 422, %{ok: false, error: "schema_invalid", detail: detail})
     end

--- a/elixir/lease_plane/test/governed_effect_test.exs
+++ b/elixir/lease_plane/test/governed_effect_test.exs
@@ -200,36 +200,58 @@ defmodule UnitaresLeasePlane.GovernedEffectTest do
                )
     end
 
-    test "flag on + unreachable orchestrator → spawn_failed, and a rejected execute row persists" do
+    test "FAIL-CLOSED: flag on + governance veto unreachable → governance_blocked (never spawns)" do
       key = tracked_key()
-      # Point at a closed port so the spawn fails fast without a real orchestrator.
-      set_execute_flag(true, "http://127.0.0.1:1")
+      # Orchestrator reachable-looking, but the §6 governance veto points at a
+      # closed port → the veto cannot affirmatively clear the effect → we must
+      # NOT spawn. The orchestrator is never even reached.
+      set_execute_flag(true, "http://127.0.0.1:8789", "http://127.0.0.1:1")
 
-      assert {:error, :spawn_failed} =
+      assert {:error, :governance_blocked} =
                GovernedEffect.handle(
                  base(%{
                    "idempotency_key" => key,
                    "custody_mode" => "execute",
                    "effect_type" => "agent_spawn",
+                   "proposer" => %{"agent_uuid" => "00000000-0000-0000-0000-0000000000aa"},
                    "payload" => %{"cmd" => "echo", "args" => ["hi"]}
                  })
                )
 
       assert [row] = execute_rows(key)
       assert row["custody_mode"] == "execute"
-      assert row["status"] == "rejected"
+      assert row["status"] == "governance_blocked"
       assert row["effect_lane"] == "governed_effect"
+    end
+
+    test "FAIL-CLOSED: an execute agent_spawn with no proposer is governance_blocked (unattributed)" do
+      key = tracked_key()
+      set_execute_flag(true, "http://127.0.0.1:8789", "http://127.0.0.1:8767")
+
+      assert {:error, :governance_blocked} =
+               GovernedEffect.handle(
+                 base(%{
+                   "idempotency_key" => key,
+                   "custody_mode" => "execute",
+                   "effect_type" => "agent_spawn",
+                   "payload" => %{"cmd" => "echo"}
+                 })
+               )
     end
   end
 
-  # Toggle the execute flag + orchestrator config for one test, resetting after.
-  defp set_execute_flag(enabled?, url) do
+  # Toggle the execute flag + orchestrator + governance-veto config for one test,
+  # resetting after. `gov_url` defaults to a closed port so the veto fails closed
+  # unless a test deliberately points it somewhere reachable.
+  defp set_execute_flag(enabled?, url, gov_url \\ "http://127.0.0.1:1") do
     prev_enabled = Application.get_env(:lease_plane, :execute_agent_spawn_enabled)
     prev_url = Application.get_env(:lease_plane, :agent_orchestrator_url)
     prev_bearer = Application.get_env(:lease_plane, :agent_orchestrator_bearer_token)
+    prev_gov = Application.get_env(:lease_plane, :governance_url)
 
     Application.put_env(:lease_plane, :execute_agent_spawn_enabled, enabled?)
     Application.put_env(:lease_plane, :agent_orchestrator_url, url)
+    Application.put_env(:lease_plane, :governance_url, gov_url)
 
     Application.put_env(
       :lease_plane,
@@ -241,6 +263,7 @@ defmodule UnitaresLeasePlane.GovernedEffectTest do
       restore(:execute_agent_spawn_enabled, prev_enabled)
       restore(:agent_orchestrator_url, prev_url)
       restore(:agent_orchestrator_bearer_token, prev_bearer)
+      restore(:governance_url, prev_gov)
     end)
   end
 

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -694,6 +694,96 @@ async def http_call_tool(request):
         }, status_code=500)
 
 
+async def http_effect_veto(request):
+    """POST /v1/effect-veto — governance veto for a proposed governed effect.
+
+    The lease plane calls this BEFORE committing an ``execute`` agent_spawn
+    (governed-effect-plane-v0 §6). It reads the proposer's DURABLE last-decided
+    governance posture — ``verdict`` and ``action`` from the latest
+    ``core.agent_state.state_json`` — and vetoes if the proposer is flagged:
+    verdict ``high-risk`` OR a pause/block action (anything other than
+    ``approve`` / ``guide``).
+
+    Policy (operator-chosen 2026-06-25):
+      * VETO   verdict == high-risk OR action ∉ {approve, guide}
+      * ALLOW  safe/caution + approve/guide
+      * UNKNOWN proposer (no governance state) → ALLOW (fail-OPEN — the two
+        bearers already gate access; the veto's job is to stop a KNOWN-flagged
+        agent, not every newcomer).
+      * DB error → 503 so the CALLER fails closed (can't confirm safety).
+
+    Request:  ``{"proposer_agent_uuid": "...", "surface": "...",
+                 "effect_id": "...", "payload_sha256": "..."}``
+    Response: ``{"ok": true, "vetoed": bool, "verdict", "action",
+                 "risk_score", "reason"}``
+    """
+    http_api_token = os.getenv("UNITARES_HTTP_API_TOKEN")
+    if not _check_http_auth(request, http_api_token=http_api_token):
+        return JSONResponse({"ok": False, "error": "unauthorized"}, status_code=401)
+
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    if not isinstance(body, dict):
+        body = {}
+    proposer = body.get("proposer_agent_uuid") or body.get("agent_id")
+    if not proposer or not isinstance(proposer, str):
+        return JSONResponse(
+            {"ok": False, "error": "schema_invalid",
+             "detail": "proposer_agent_uuid required"},
+            status_code=422,
+        )
+
+    try:
+        from src.db import get_db
+        db = get_db()
+        async with db.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT s.state_json->>'verdict' AS verdict,
+                       s.state_json->>'action'  AS action,
+                       s.risk_score             AS risk_score
+                FROM core.identities i
+                JOIN core.agent_state s ON s.identity_id = i.identity_id
+                WHERE i.agent_id = $1 AND s.synthetic = false
+                ORDER BY s.recorded_at DESC
+                LIMIT 1
+                """,
+                proposer,
+            )
+    except Exception as e:  # noqa: BLE001 — governance read failed; let caller fail closed
+        logger.warning("effect-veto governance read failed for %s: %s", proposer, e)
+        return JSONResponse(
+            {"ok": False, "error": "governance_unavailable",
+             "detail": "could not read proposer governance state"},
+            status_code=503,
+        )
+
+    if row is None:
+        # Unknown proposer — fail open per policy.
+        return JSONResponse({
+            "ok": True, "vetoed": False, "verdict": None, "action": None,
+            "risk_score": None, "reason": "no_governance_state",
+        })
+
+    verdict = row["verdict"]
+    action = row["action"]
+    risk_score = row["risk_score"]
+    block_verdict = verdict == "high-risk"
+    block_action = action is not None and action not in ("approve", "guide")
+    vetoed = bool(block_verdict or block_action)
+
+    return JSONResponse({
+        "ok": True,
+        "vetoed": vetoed,
+        "verdict": verdict,
+        "action": action,
+        "risk_score": risk_score,
+        "reason": (f"verdict={verdict} action={action}" if vetoed else None),
+    })
+
+
 async def http_health(request):
     """Health check endpoint -- always public (monitoring, load balancers)"""
 
@@ -3092,6 +3182,7 @@ def register_http_routes(
     app.routes.append(Route("/", http_dashboard_redesign, methods=["GET"]))  # Root also serves the redesign
     app.routes.append(Route("/v1/tools", http_list_tools, methods=["GET"]))
     app.routes.append(Route("/v1/tools/call", http_call_tool, methods=["POST"]))
+    app.routes.append(Route("/v1/effect-veto", http_effect_veto, methods=["POST"]))
     app.routes.append(Route("/health", http_health, methods=["GET"]))
     app.routes.append(Route("/health/live", http_health_live, methods=["GET"]))
     app.routes.append(Route("/health/ready", http_health_ready, methods=["GET"]))

--- a/tests/test_http_api_effect_veto.py
+++ b/tests/test_http_api_effect_veto.py
@@ -1,0 +1,103 @@
+"""Proof-tests for POST /v1/effect-veto (governed-effect §6 governance veto).
+
+The gate that matters: a FLAGGED proposer provably gets vetoed, so the veto can
+never be a silent no-op. Governance state is mocked (deterministic, no DB
+pollution) — the handler's verdict/action extraction is what's under test.
+"""
+
+from unittest.mock import patch
+
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from src.http_api import http_effect_veto
+
+
+class _FakeConn:
+    def __init__(self, row):
+        self._row = row
+
+    async def fetchrow(self, *_a, **_k):
+        return self._row
+
+
+class _FakeAcquire:
+    def __init__(self, row):
+        self._row = row
+
+    async def __aenter__(self):
+        return _FakeConn(self._row)
+
+    async def __aexit__(self, *_a):
+        return False
+
+
+class _FakeDB:
+    def __init__(self, row=None, raise_exc=None):
+        self._row = row
+        self._raise = raise_exc
+
+    def acquire(self):
+        if self._raise:
+            raise self._raise
+        return _FakeAcquire(self._row)
+
+
+def _client():
+    app = Starlette(routes=[Route("/v1/effect-veto", http_effect_veto, methods=["POST"])])
+    return TestClient(app)
+
+
+def _post(row=None, *, raise_exc=None, body=None):
+    body = body if body is not None else {"proposer_agent_uuid": "00000000-0000-0000-0000-0000000000aa"}
+    with patch("src.db.get_db", return_value=_FakeDB(row, raise_exc)):
+        return _client().post("/v1/effect-veto", json=body)
+
+
+# --- THE load-bearing proof: a flagged proposer is blocked ---
+
+def test_high_risk_verdict_is_vetoed():
+    r = _post({"verdict": "high-risk", "action": "approve", "risk_score": 0.9})
+    assert r.status_code == 200
+    assert r.json()["vetoed"] is True
+
+
+def test_pause_action_is_vetoed():
+    for action in ("risk_pause", "cirs_block", "void_pause", "coherence_pause"):
+        r = _post({"verdict": "safe", "action": action, "risk_score": 0.85})
+        assert r.json()["vetoed"] is True, f"{action} should veto"
+
+
+# --- a healthy proposer is allowed ---
+
+def test_safe_approve_is_allowed():
+    r = _post({"verdict": "safe", "action": "approve", "risk_score": 0.1})
+    assert r.status_code == 200
+    assert r.json()["vetoed"] is False
+
+
+def test_caution_guide_is_allowed():
+    r = _post({"verdict": "caution", "action": "guide", "risk_score": 0.5})
+    assert r.json()["vetoed"] is False
+
+
+# --- policy edges ---
+
+def test_unknown_proposer_fails_open():
+    r = _post(row=None)  # no governance state
+    assert r.status_code == 200
+    body = r.json()
+    assert body["vetoed"] is False
+    assert body["reason"] == "no_governance_state"
+
+
+def test_db_error_returns_503_so_caller_fails_closed():
+    r = _post(raise_exc=RuntimeError("db down"))
+    assert r.status_code == 503
+    assert r.json()["ok"] is False
+
+
+def test_missing_proposer_is_422():
+    r = _post(body={})
+    assert r.status_code == 422


### PR DESCRIPTION
## What

Closes the honest §6 deferral from #1067: the live `agent_spawn` execute path now passes through a **real governance veto** before it commits. This makes **"BEAM *governs*"** true — not just "BEAM spawns behind a flag + bearers."

## How it works

**gov-mcp** — new REST `POST /v1/effect-veto` (Starlette). It reads the proposer's **durable last-decided posture** — `verdict` + `action` from the latest `core.agent_state.state_json` — deliberately *not* the human-formatted glossary layer (which wraps the verdict in `explain_verdict` and would silently break extraction).

**lease-plane** — new `GovernanceVetoClient` (`:httpc`) called *before* `OrchestratorClient.spawn_agent`. The effect commits **only** on an affirmative `:allow`.

## Policy (operator-chosen 2026-06-25)

| Proposer state | Result |
|---|---|
| verdict `high-risk` OR action ∉ {approve, guide} | **VETO** |
| safe/caution + approve/guide | allow |
| unknown (no governance state) | allow — fail-**open** (bearers gate access; veto stops a *known-flagged* agent) |
| missing proposer | **blocked** — an unattributed RCE spawn must not commit |
| governance unreachable / non-200 / 503 | **blocked** — fail-**closed**, can't confirm safety |

## The proof-test (the gate that matters)

The whole risk with a veto is that it silently becomes a no-op that *looks* like governance. So the load-bearing test is: **a high-risk / pause-action proposer provably returns `vetoed:true`** (`test_high_risk_verdict_is_vetoed`, `test_pause_action_is_vetoed`). 7 tests, governance state mocked deterministically. On the lease side, the fail-closed paths (`:veto_unreachable`, `:proposer_required`) are unit-tested.

## Tests

- gov-mcp: 7 veto proof-tests pass (high-risk→veto, pause→veto, safe→allow, unknown→fail-open, db-error→503, missing→422).
- lease-plane: full suite green — **190 tests + 11 properties**. Veto-allow + spawn path is covered by the proof-test + live e2e after deploy.

## ⚠ Deploy order

Ship the **gov-mcp `/v1/effect-veto` endpoint FIRST, then the lease plane.** If the lease-plane veto deploys before the endpoint exists, every execute fails closed (404 → `governance_blocked`) until gov-mcp catches up — safe, but it blocks the live `agent_spawn` path. Loopback bypasses the governance REST auth, so no token is needed single-host.

## Still deferred (honest)

§7 strong-tier re-verification on the execute path. The §5b rollback machinery is for the *reversible* `file_write` path (#1066), not `agent_spawn` (irreversible).

https://claude.ai/code/session_01F3FYn2PueNYWNfoNYb2nW1