### PR TITLE
feat(governed-effect): §7 strong-tier re-certification on execute agent_spawn

### DIFF
--- a/docs/proposals/governed-effect-s7-strong-tier-recert.md
+++ b/docs/proposals/governed-effect-s7-strong-tier-recert.md
@@ -1,0 +1,182 @@
+# Governed-Effect §7 — Strong-Tier Re-Certification (design v0.2, council-folded)
+
+Extends the live §6 governance veto (#1073) with the contract §2/§7 gate:
+**an `execute` agent_spawn commits only if the proposer's identity tier
+re-verifies as `strong`** — without trusting a self-asserted tier.
+
+## The problem (grounded, not rediscovered)
+
+Tier is **not durable**. There is no `tier`/`proof_origin`/`assurance` column
+in `core` or `audit`; `state_json` does not carry it. Tier is computed
+per-request from the caller's *live* proof — `_tier_for_source(source)` at
+`src/mcp_handlers/updates/phases.py:74`, gated by `proof_origin` at
+`_compute_identity_assurance` (:126). The strict gate keys on
+`caller_proven = (proof_origin == "caller_asserted")`.
+
+**The trap:** `proof_origin == "server_inferred"` is *always* weak
+(phases.py:149). A `client_session_id` resolved fresh at gov-mcp — which never
+saw the proposer's original proof — is `server_inferred` → weak → would block
+*every* effect. So the proof the effect carries must be one gov-mcp can verify
+to the proposer's *real* tier without a fresh transport resolution.
+
+## The proof: continuity_token (resolves Open-Q1)
+
+The transport-robust proof is the **continuity_token** (`v1.<payload>.<sig>`,
+HMAC-SHA256 over the secret in `_get_continuity_secret`). It is self-contained:
+it carries `aid` (agent_uuid) and `exp`, and verifies cryptographically with no
+transport context. `client_session_id` is rejected — it only re-certifies if
+resolved fresh, which stamps `server_inferred` → weak (the trap).
+
+A successfully-verified continuity_token resolves to source
+`"continuity_token"`, which is in `_STRONG_IDENTITY_SOURCES`
+(phases.py:40) → `_tier_for_source` returns **strong**. So:
+
+> **verified, unexpired token whose `aid` == claimed proposer ⇒ strong; anything
+> else ⇒ not strong ⇒ veto.**
+
+## The verifier: reuse canonical crypto primitives (resolves Open-Q2)
+
+Do **not** run the full transport identity-resolution pipeline (it resolves
+fresh → `server_inferred` → weak). Reuse the existing single-sourced crypto
+primitives in `src/mcp_handlers/identity/session.py`:
+
+- `resolve_continuity_token(token)` — verifies HMAC **and `exp`** (freshness);
+  returns the `sid` or `None`. Called with `model_type=None, user_agent=None`
+  so the optional model-pin check is skipped (server-side re-verify has no
+  transport context; the token's HMAC+exp+aid are sufficient).
+- `extract_token_agent_uuid(token)` — verifies HMAC, returns `aid`.
+
+Recert = the composition: token resolves (HMAC + fresh) **AND**
+`extract_token_agent_uuid(token) == proposer_agent_uuid`. We require freshness
+(via `resolve_continuity_token`'s `exp` check) — an irreversible spawn must not
+re-certify on a stale token, unlike the resume-after-idle path that
+`extract_token_agent_uuid` deliberately serves.
+
+The gov-mcp process **already holds the secret** (it mints the tokens via
+`onboard`), so no new secret/config is needed.
+
+## On no-proof / unresolvable: FAIL CLOSED (resolves Open-Q3)
+
+No token, malformed token, expired token, bad signature, or `aid` mismatch →
+`tier_ok = false` → effect is **vetoed**. A weak/medium proposer is provably
+blocked. This is the non-negotiable gate — it can never be a silent no-op.
+
+### §7 dominates every allow path (council must-fix #1)
+
+The §6 endpoint had **two** allow exits, and §6 deliberately fails *open* for an
+unknown proposer (no governance state) via an early return — the bearer gates
+access; §6's job is to stop a *known-flagged* agent. §7 is a different gate and
+must apply on **both** exits, or the unknown-proposer path silently bypasses it.
+So `tier_ok` is computed *before* the DB read, and the `row is None` branch
+returns `vetoed = not tier_ok` (not an unconditional `false`). An unknown
+proposer with **no token** is now blocked.
+
+### Intent (council must-fix #2)
+
+The composition is: **§7 gates identity strength, §6 gates behavioral
+verdict.** A *strong, never-flagged* identity may spawn (§6 fails open, §7
+passes); a *weak/unverified* identity may not, regardless of governance history.
+This is deliberate — requiring prior governance history would block every
+legitimate fresh proposer on an RCE surface that is already bearer-gated.
+
+## Encapsulated gate (council must-fix #4)
+
+The security invariant ("fresh HMAC AND `aid == proposer`") is single-sourced as
+`recertify_strong_tier(token, proposer_uuid) -> bool` in
+`identity/session.py`, unit-tested directly — **not** re-assembled inline at the
+REST call site (where a future edit could drop `exp` by using `extract_*` alone,
+or lose the `aid` binding by using `resolve_*` alone — note `resolve_*` returns
+`sid`, not `aid`).
+
+## Single proposer value — no veto/spawn TOCTOU (council must-fix #3)
+
+The lease plane derives the proposer identity **once** (`env.proposer_agent_uuid`
+from the envelope) and reuses that single value for (a) the veto's
+`proposer_agent_uuid`, (b) the `aid` the token must match (checked at gov-mcp),
+and (c) the committed spawn's lineage (`orchestrator_spec` `parent_agent_uuid`).
+gov-mcp binds the token to that *same* claimed proposer (`aid == proposer`), and
+the lease plane never re-resolves attribution from the token `aid` — so the
+identity §6 judges, §7 certifies, and the spawn attributes to cannot diverge.
+
+## Integration
+
+### gov-mcp — `POST /v1/effect-veto` (`src/http_api.py:697`)
+
+Extend the existing endpoint. Read an optional `proposer_continuity_token` from
+the body. Compute `tier_ok`:
+
+- token present + `resolve_continuity_token` non-None + `extract_token_agent_uuid
+  == proposer_agent_uuid` → `tier = "strong"`, `tier_ok = true`.
+- otherwise → `tier = "weak"|"unverified"`, `tier_ok = false`.
+
+`vetoed = block_verdict OR block_action OR (not tier_ok)`. New response fields:
+`tier`, `tier_ok`. The existing verdict/action veto is unchanged and still runs
+(both gates compose; either trips the veto). Reason string names which gate
+fired.
+
+Backward-compat note: the endpoint previously had **no** tier gate. Adding a
+`tier_ok=false`-by-default-when-token-absent gate is what makes §7 real — but it
+means a caller that does not forward the token is now blocked. The lease plane
+(the only caller) is updated in lockstep, so there is no external caller to
+break. The recert applies **only to `execute`** effects (the lease plane only
+calls the veto on execute agent_spawn today); record_only never reaches here.
+
+### lease plane — carry + forward the token (transient, never stored)
+
+The continuity_token is a **credential** (Invariant 7/1): forward-for-verify is
+fine, storing is not.
+
+- `governed_effect.ex validate/1` — the token can NOT live in `payload`
+  (`@credential_key_substrings` at line 67 rejects it). Carry it in the
+  **`proposer` object** as `proposer.continuity_token`; extract it into a
+  transient `env.proposer_continuity_token` that is **never** written to any
+  `audit_payload`/`execute_audit_payload` (those reference only named keys).
+- `GovernanceVetoClient.check/1` — add `proposer_continuity_token` to the POST
+  body. Nothing else changes; `:blocked`/`:error` still fail closed to
+  `governance_blocked` (403), already wired in `spawn_and_record`.
+
+The token is consumed (forwarded for verification) and dropped — it appears in
+no persisted payload and no log line.
+
+## The non-negotiable proof-test gate
+
+Mirrors #1073's "no silent no-op" discipline:
+
+- **Python (`tests/test_http_api_effect_veto.py`):** a strong proposer
+  (verdict=safe/approve) **with a valid token** → `vetoed:false`; the **same
+  proposer with NO token** → `vetoed:true` (tier gate fires); with an
+  **expired/tampered token** → `vetoed:true`; with a **token whose `aid`
+  mismatches** the proposer → `vetoed:true`. So the tier check provably blocks
+  and provably allows — never a no-op.
+- **Elixir (lease_plane test):** an `execute` agent_spawn whose envelope
+  forwards a valid strong token commits (202); the same envelope with the token
+  stripped is `governance_blocked` (403) and **nothing spawns**. Assert the
+  token appears in no persisted `audit.events` payload.
+
+## Deploy order
+
+Same as #1073: **gov-mcp first** (it must understand `proposer_continuity_token`
+and the new `tier_ok` semantics), **then lease plane** (which starts forwarding
+the token). If lease plane forwards before gov-mcp is updated, gov-mcp ignores
+the unknown field — but then `tier_ok` defaults false → fail-closed → blocked
+until gov-mcp catches up. Safe-by-construction (fails closed, never open).
+
+## Accepted residual risk + successor (council suggested)
+
+§7 proves *identity strength*, not *per-effect authorization*. A captured
+continuity_token replayed by a holder of the lease-plane bearer can spawn as the
+strong identity for the token's life (~1h TTL). Bounding factors today: the
+lease-plane bearer gate (`LEASE_PLANE_BEARER_TOKEN`), the §6 verdict gate, and
+the ~1h `exp`. Idempotency does **not** bound replay (a new `effect_id` +
+re-used token re-executes). The principled successor — **effect-binding**: the
+proposer signs `(effect_id, payload_sha256)` at propose-time so the proof covers
+*this* spawn — is filed for a later increment; the continuity_token cannot carry
+it (pre-minted, doesn't cover the effect).
+
+**Freshness cliff + sanctioned refresh:** the ~1h TTL is the token's
+identity-rebind window, repurposed here as effect-freshness. A proposer whose
+token minted >1h ago fails closed mid-session. The sanctioned escape is to
+**re-mint via `onboard`/rebind before proposing** — NOT to drop the `exp` check.
+`recertify_strong_tier` deliberately uses `resolve_continuity_token` (checks
+`exp`) and never `extract_token_agent_uuid` alone, so this cliff cannot be
+"fixed" by silently weakening the gate.

--- a/elixir/lease_plane/lib/unitares_lease_plane/governance_veto_client.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/governance_veto_client.ex
@@ -1,8 +1,17 @@
 defmodule UnitaresLeasePlane.GovernanceVetoClient do
   @moduledoc """
-  Calls the governance MCP `POST /v1/effect-veto` (governed-effect-plane §6)
-  BEFORE an `execute` agent_spawn commits. Governance reads the proposer's
-  durable last-decided posture and returns `{vetoed: bool}`.
+  Calls the governance MCP `POST /v1/effect-veto` (governed-effect-plane §6+§7)
+  BEFORE an `execute` agent_spawn commits. Governance composes two gates and
+  returns `{vetoed: bool}`:
+
+    * §6 — the proposer's durable last-decided verdict/action posture;
+    * §7 — strong-tier re-certification of the forwarded
+      `proposer_continuity_token`. The token is the proposer's transport-robust
+      HMAC proof; governance re-verifies it server-side to the `strong` tier.
+      It is forwarded for verification only and is never stored or logged here
+      (Invariant 1/7). When the proposer carried no token it is OMITTED from
+      the body (not sent as `null`) → governance reads it absent → §7 fails
+      closed → vetoed.
 
   Uses Erlang stdlib `:httpc` (localhost; the governance REST surface bypasses
   auth on trusted networks, so no token is needed for the loopback call).
@@ -26,12 +35,7 @@ defmodule UnitaresLeasePlane.GovernanceVetoClient do
 
   def check(env) do
     with {:ok, base} <- base_url() do
-      body =
-        Jason.encode!(%{
-          "proposer_agent_uuid" => env.proposer_agent_uuid,
-          "surface" => Map.get(env, :surface),
-          "effect_type" => Map.get(env, :effect_type)
-        })
+      body = Jason.encode!(build_veto_body(env))
 
       url = String.to_charlist(base <> "/v1/effect-veto")
       headers = veto_headers()
@@ -43,6 +47,29 @@ defmodule UnitaresLeasePlane.GovernanceVetoClient do
         {:ok, {{_v, status, _r}, _h, resp}} -> {:error, {:veto_status, status, truncate(resp)}}
         {:error, reason} -> {:error, {:veto_unreachable, reason}}
       end
+    end
+  end
+
+  @doc """
+  Build the veto request body (pre-encode) from an effect env. §7 proof: the
+  proposer's `continuity_token` is forwarded when present, and the key is
+  OMITTED entirely when absent/blank — so an unauthenticated proposer is judged
+  on a missing token (fail-closed at the veto), never sent an explicit `null`.
+
+  Public for unit-testability (assert forwarding without standing up a server);
+  not part of the stable API.
+  """
+  @spec build_veto_body(map()) :: map()
+  def build_veto_body(env) do
+    base = %{
+      "proposer_agent_uuid" => Map.get(env, :proposer_agent_uuid),
+      "surface" => Map.get(env, :surface),
+      "effect_type" => Map.get(env, :effect_type)
+    }
+
+    case Map.get(env, :proposer_continuity_token) do
+      t when is_binary(t) and t != "" -> Map.put(base, "proposer_continuity_token", t)
+      _ -> base
     end
   end
 

--- a/elixir/lease_plane/lib/unitares_lease_plane/governed_effect.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/governed_effect.ex
@@ -127,6 +127,14 @@ defmodule UnitaresLeasePlane.GovernedEffect do
     proposer_agent_uuid = nested_string(body, "proposer", "agent_uuid")
     provenance_session_id = nested_string(body, "provenance", "session_id")
 
+    # §7 strong-tier re-cert proof — the proposer's continuity_token, carried in
+    # the `proposer` object (NOT `payload`, which `credential_shaped?` would
+    # reject). CREDENTIAL: forwarded transiently to the governance veto for
+    # re-verification, then dropped. It is NEVER written to any audit_payload,
+    # response body, or log line (Invariant 1/7); keep it out of every
+    # `inspect(env)`. Used only by the execute path (`GovernanceVetoClient`).
+    proposer_continuity_token = nested_string(body, "proposer", "continuity_token")
+
     cond do
       not (is_binary(idem) and byte_size(idem) > 0) ->
         {:error, "idempotency_key required (non-empty string)"}
@@ -159,7 +167,9 @@ defmodule UnitaresLeasePlane.GovernedEffect do
            required_leases: leases,
            payload: payload || %{},
            proposer_agent_uuid: proposer_agent_uuid,
-           provenance_session_id: provenance_session_id
+           provenance_session_id: provenance_session_id,
+           # CREDENTIAL — transient, never persisted/logged (see comment above).
+           proposer_continuity_token: proposer_continuity_token
          }}
     end
   end
@@ -305,12 +315,14 @@ defmodule UnitaresLeasePlane.GovernedEffect do
   # delegated to the already-live agent orchestrator (`:8789`), which owns the
   # OS-process spawn, OTP supervision, lease-binding and lineage.
   #
-  # HONESTLY DEFERRED to the next slice (NOT faked here): the §7 strong-tier
-  # re-verification and the §6 governance veto. This slice's gates are the
-  # fail-closed flag + the orchestrator's own bearer + `check_allowed` cmd
-  # allowlist. `agent_spawn` is irreversible (§5b), so there is no rollback to
-  # prove; idempotency is the load-bearing safety property here — a retry must
-  # never spawn twice.
+  # Gates before commit (all fail-closed): the per-type flag + the
+  # orchestrator's own bearer + `check_allowed` cmd allowlist, the §6 governance
+  # veto (verdict/action), AND the §7 strong-tier re-certification — the veto
+  # endpoint re-verifies the proposer's forwarded continuity_token to the
+  # `strong` tier; a proposer that does not re-certify strong is blocked the
+  # same as a flagged one (`GovernanceVetoClient.check/1`). `agent_spawn` is
+  # irreversible (§5b), so there is no rollback to prove; idempotency is the
+  # load-bearing safety property here — a retry must never spawn twice.
   defp execute(%{effect_type: "agent_spawn"} = env) do
     if execute_agent_spawn_enabled?() do
       execute_agent_spawn(env)

--- a/elixir/lease_plane/test/governed_effect_test.exs
+++ b/elixir/lease_plane/test/governed_effect_test.exs
@@ -113,7 +113,7 @@ defmodule UnitaresLeasePlane.GovernedEffectTest do
       assert row["idempotency_digest"] == body.idempotency_digest
     end
 
-    test "proposer.agent_uuid is stored as attribution; client_session_id is never stored" do
+    test "proposer.agent_uuid is stored as attribution; credentials are never stored" do
       key = tracked_key()
       agent = "11111111-2222-3333-4444-555555555555"
 
@@ -123,7 +123,9 @@ defmodule UnitaresLeasePlane.GovernedEffectTest do
                    "idempotency_key" => key,
                    "proposer" => %{
                      "agent_uuid" => agent,
-                     "client_session_id" => "SECRET-cs-token"
+                     "client_session_id" => "SECRET-cs-token",
+                     # §7 proof carried in the proposer object — also a credential.
+                     "continuity_token" => "v1.SECRET-continuity-payload.SECRET-sig"
                    },
                    "provenance" => %{"session_id" => "prov-sess-7"}
                  })
@@ -132,9 +134,11 @@ defmodule UnitaresLeasePlane.GovernedEffectTest do
       assert {agent_id, session_id, payload_text} = governed_effect_attribution(key)
       assert agent_id == agent
       assert session_id == "prov-sess-7"
-      # Invariant 7: the credential must appear nowhere in the durable record.
+      # Invariant 1/7: neither credential may appear anywhere in the durable record.
       refute payload_text =~ "SECRET-cs-token"
       refute payload_text =~ "client_session_id"
+      refute payload_text =~ "SECRET-continuity-payload"
+      refute payload_text =~ "continuity_token"
     end
   end
 
@@ -237,6 +241,77 @@ defmodule UnitaresLeasePlane.GovernedEffectTest do
                    "payload" => %{"cmd" => "echo"}
                  })
                )
+    end
+
+    test "§7: a forwarded continuity_token never leaks into the persisted record" do
+      key = tracked_key()
+      # Gov veto unreachable → fail-closed regardless of the token (the token's
+      # only effect is being forwarded for verification). The point of THIS test
+      # is the no-leak invariant: even on the blocked path, the credential must
+      # appear nowhere in the durable governance_blocked row.
+      set_execute_flag(true, "http://127.0.0.1:8789", "http://127.0.0.1:1")
+
+      assert {:error, :governance_blocked} =
+               GovernedEffect.handle(
+                 base(%{
+                   "idempotency_key" => key,
+                   "custody_mode" => "execute",
+                   "effect_type" => "agent_spawn",
+                   "proposer" => %{
+                     "agent_uuid" => "00000000-0000-0000-0000-0000000000aa",
+                     "continuity_token" => "v1.SECRET-s7-payload.SECRET-s7-sig"
+                   },
+                   "payload" => %{"cmd" => "echo", "args" => ["hi"]}
+                 })
+               )
+
+      assert [row] = execute_rows(key)
+      assert row["status"] == "governance_blocked"
+      row_text = Jason.encode!(row)
+      refute row_text =~ "SECRET-s7-payload"
+      refute row_text =~ "continuity_token"
+    end
+  end
+
+  describe "§7 GovernanceVetoClient body forwarding" do
+    alias UnitaresLeasePlane.GovernanceVetoClient
+
+    test "the continuity_token is forwarded when present" do
+      body =
+        GovernanceVetoClient.build_veto_body(%{
+          proposer_agent_uuid: "00000000-0000-0000-0000-0000000000aa",
+          surface: "agent:x",
+          effect_type: "agent_spawn",
+          proposer_continuity_token: "v1.payload.sig"
+        })
+
+      assert body["proposer_continuity_token"] == "v1.payload.sig"
+      assert body["proposer_agent_uuid"] == "00000000-0000-0000-0000-0000000000aa"
+    end
+
+    test "the key is OMITTED (not null) when the token is absent or blank" do
+      for token <- [nil, ""] do
+        body =
+          GovernanceVetoClient.build_veto_body(%{
+            proposer_agent_uuid: "00000000-0000-0000-0000-0000000000aa",
+            surface: "agent:x",
+            effect_type: "agent_spawn",
+            proposer_continuity_token: token
+          })
+
+        refute Map.has_key?(body, "proposer_continuity_token"),
+               "token=#{inspect(token)} should be omitted, not sent as null"
+      end
+
+      # also when the env never carried the key at all
+      body =
+        GovernanceVetoClient.build_veto_body(%{
+          proposer_agent_uuid: "00000000-0000-0000-0000-0000000000aa",
+          surface: "agent:x",
+          effect_type: "agent_spawn"
+        })
+
+      refute Map.has_key?(body, "proposer_continuity_token")
     end
   end
 

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -698,24 +698,36 @@ async def http_effect_veto(request):
     """POST /v1/effect-veto — governance veto for a proposed governed effect.
 
     The lease plane calls this BEFORE committing an ``execute`` agent_spawn
-    (governed-effect-plane-v0 §6). It reads the proposer's DURABLE last-decided
-    governance posture — ``verdict`` and ``action`` from the latest
-    ``core.agent_state.state_json`` — and vetoes if the proposer is flagged:
-    verdict ``high-risk`` OR a pause/block action (anything other than
-    ``approve`` / ``guide``).
+    (governed-effect-plane-v0 §6 + §7). Two independent gates compose; either
+    trips the veto:
 
-    Policy (operator-chosen 2026-06-25):
-      * VETO   verdict == high-risk OR action ∉ {approve, guide}
-      * ALLOW  safe/caution + approve/guide
-      * UNKNOWN proposer (no governance state) → ALLOW (fail-OPEN — the two
-        bearers already gate access; the veto's job is to stop a KNOWN-flagged
-        agent, not every newcomer).
+      §6 (verdict) — reads the proposer's DURABLE last-decided governance
+      posture (``verdict``/``action`` from the latest
+      ``core.agent_state.state_json``) and vetoes a flagged proposer:
+      verdict ``high-risk`` OR a pause/block action (∉ {approve, guide}).
+
+      §7 (tier) — re-certifies the proposer's IDENTITY tier as ``strong`` from
+      a forwarded ``proposer_continuity_token`` (HMAC + expiry, aid==proposer),
+      WITHOUT a fresh transport resolution. A proposer that does not
+      re-certify as strong is vetoed. This gate applies on EVERY path,
+      including the unknown-proposer branch §6 alone fails open.
+
+    Policy:
+      * VETO   §6 flagged  OR  §7 not strong (no/invalid/expired/mismatched token)
+      * ALLOW  safe/caution + approve/guide  AND  strong-tier re-cert
+      * UNKNOWN proposer (no governance state) → §6 fails OPEN, but §7 still
+        applies: allowed only if the token re-certifies strong (a strong,
+        never-flagged identity may spawn; a weak/unverified one may not).
       * DB error → 503 so the CALLER fails closed (can't confirm safety).
 
-    Request:  ``{"proposer_agent_uuid": "...", "surface": "...",
-                 "effect_id": "...", "payload_sha256": "..."}``
+    The ``proposer_continuity_token`` is a credential: verified transiently,
+    never read into the DB query, the response body, or any log line
+    (Invariant 7).
+
+    Request:  ``{"proposer_agent_uuid": "...", "proposer_continuity_token": "v1...",
+                 "surface": "...", "effect_type": "..."}``
     Response: ``{"ok": true, "vetoed": bool, "verdict", "action",
-                 "risk_score", "reason"}``
+                 "risk_score", "tier", "tier_ok", "reason"}``
     """
     http_api_token = os.getenv("UNITARES_HTTP_API_TOKEN")
     if not _check_http_auth(request, http_api_token=http_api_token):
@@ -734,6 +746,21 @@ async def http_effect_veto(request):
              "detail": "proposer_agent_uuid required"},
             status_code=422,
         )
+
+    # §7 strong-tier re-certification (governed-effect-plane-v0 §2/§7). The
+    # proposer forwards its continuity_token (transport-robust HMAC proof); we
+    # re-verify it server-side to the `strong` tier WITHOUT a fresh transport
+    # resolution (that would stamp server_inferred → weak — the trap that would
+    # block every effect). This gate DOMINATES every allow path below: a
+    # proposer that does not re-certify as strong is vetoed regardless of its
+    # governance verdict — including the unknown-proposer branch that §6 alone
+    # fails OPEN. Fail-closed: a missing, malformed, expired, or aid-mismatched
+    # token → tier_ok False → vetoed. The token is consumed for verification
+    # only — never read into the DB query, the response, or any log line.
+    from src.mcp_handlers.identity.session import recertify_strong_tier
+    tier_ok = recertify_strong_tier(body.get("proposer_continuity_token"), proposer)
+    tier = "strong" if tier_ok else "unverified"
+    tier_reason = None if tier_ok else "tier_recert_failed:not_strong_identity"
 
     try:
         from src.db import get_db
@@ -761,10 +788,20 @@ async def http_effect_veto(request):
         )
 
     if row is None:
-        # Unknown proposer — fail open per policy.
+        # Unknown proposer. §6 (verdict) fails OPEN for newcomers — the two
+        # bearers already gate access and the veto's job is to stop a KNOWN-
+        # flagged agent. But §7 (tier) still applies: a newcomer must STILL
+        # re-certify as a strong identity to commit an RCE-class spawn. So an
+        # unknown proposer is allowed only when its token re-certifies strong;
+        # no/invalid token → vetoed. This is the intended composition —
+        # "a strong, never-flagged identity may spawn; a weak/unverified one
+        # may not" — not an emergent property of the old early return.
         return JSONResponse({
-            "ok": True, "vetoed": False, "verdict": None, "action": None,
-            "risk_score": None, "reason": "no_governance_state",
+            "ok": True,
+            "vetoed": not tier_ok,
+            "verdict": None, "action": None, "risk_score": None,
+            "tier": tier, "tier_ok": tier_ok,
+            "reason": (tier_reason if not tier_ok else "no_governance_state"),
         })
 
     verdict = row["verdict"]
@@ -772,7 +809,18 @@ async def http_effect_veto(request):
     risk_score = row["risk_score"]
     block_verdict = verdict == "high-risk"
     block_action = action is not None and action not in ("approve", "guide")
-    vetoed = bool(block_verdict or block_action)
+    # §6 verdict/action gate OR §7 tier gate — either trips the veto.
+    vetoed = bool(block_verdict or block_action or (not tier_ok))
+
+    if vetoed:
+        reasons = []
+        if block_verdict or block_action:
+            reasons.append(f"verdict={verdict} action={action}")
+        if not tier_ok:
+            reasons.append(tier_reason)
+        reason = " ; ".join(reasons)
+    else:
+        reason = None
 
     return JSONResponse({
         "ok": True,
@@ -780,7 +828,9 @@ async def http_effect_veto(request):
         "verdict": verdict,
         "action": action,
         "risk_score": risk_score,
-        "reason": (f"verdict={verdict} action={action}" if vetoed else None),
+        "tier": tier,
+        "tier_ok": tier_ok,
+        "reason": reason,
     })
 
 

--- a/src/mcp_handlers/identity/session.py
+++ b/src/mcp_handlers/identity/session.py
@@ -368,6 +368,46 @@ def resolve_continuity_token(
         return None
 
 
+def recertify_strong_tier(token: object, proposer_uuid: object) -> bool:
+    """Governed-effect §7 server-side strong-tier re-certification.
+
+    Returns ``True`` iff ``token`` is a valid, UNEXPIRED continuity token whose
+    ``aid`` claim equals ``proposer_uuid`` — i.e. the proposer cryptographically
+    proves a ``continuity_token``-sourced identity, which is in
+    ``_STRONG_IDENTITY_SOURCES`` (``updates.phases``) and so maps to the
+    ``strong`` tier. Every other input — missing/blank token or proposer, a
+    malformed/tampered token, an expired token, or an ``aid`` that does not
+    match the claimed proposer — returns ``False`` so the §7 gate fails CLOSED.
+
+    This is the single source of the §7 security invariant: "fresh HMAC AND
+    aid == claimed proposer." It is deliberately built from the canonical token
+    primitives rather than the full transport identity-resolution pipeline —
+    a fresh transport resolution stamps ``server_inferred`` → weak (the trap
+    that would block every effect). Reusing the primitives keeps the
+    HMAC/secret/expiry logic single-sourced so a future caller cannot
+    re-derive the gate wrong (``extract_*`` alone drops the expiry check;
+    ``resolve_*`` alone returns ``sid`` and ignores ``aid``).
+
+    Freshness IS required here: an ``agent_spawn`` is irreversible, so
+    ``resolve_continuity_token`` (HMAC + ``exp``) gates it — NOT the
+    resume-after-idle ``extract_token_agent_uuid`` path that intentionally
+    skips expiry.
+    """
+    if not token or not isinstance(token, str):
+        return False
+    if not proposer_uuid or not isinstance(proposer_uuid, str):
+        return False
+    # Freshness + signature: resolve_continuity_token verifies the HMAC AND the
+    # `exp` claim (returns None on either failure). Its return value is the
+    # `sid`, which we deliberately discard — the §7 binding is on `aid`.
+    if resolve_continuity_token(token) is None:
+        return False
+    # Ownership binding: the token must attest the CLAIMED proposer, closing the
+    # confused-deputy path (present A's token while claiming proposer=B).
+    aid = extract_token_agent_uuid(token)
+    return bool(aid) and aid == proposer_uuid
+
+
 def _normalize_pin_client_hint(client_hint: Optional[str]) -> Optional[str]:
     """Normalize client hint for scoped pin keys."""
     if not client_hint:

--- a/tests/test_http_api_effect_veto.py
+++ b/tests/test_http_api_effect_veto.py
@@ -1,17 +1,57 @@
-"""Proof-tests for POST /v1/effect-veto (governed-effect §6 governance veto).
+"""Proof-tests for POST /v1/effect-veto (governed-effect §6 verdict veto + §7
+strong-tier re-certification).
 
-The gate that matters: a FLAGGED proposer provably gets vetoed, so the veto can
-never be a silent no-op. Governance state is mocked (deterministic, no DB
-pollution) — the handler's verdict/action extraction is what's under test.
+Two gates compose; either trips the veto. The gates that matter, both proven
+here so neither can be a silent no-op:
+
+  §6 — a FLAGGED proposer (high-risk/paused) is vetoed.
+  §7 — a proposer that does NOT re-certify as a `strong` identity (no token,
+       bad/expired token, or a token whose aid ≠ the claimed proposer) is
+       vetoed, EVEN with a clean §6 verdict. A valid strong token flips it to
+       allowed — so §7 provably blocks AND provably allows.
+
+Governance state is mocked (deterministic, no DB pollution). Continuity tokens
+are minted with the real `create_continuity_token` under a test HMAC secret set
+for the whole module, so the §7 path is exercised end-to-end (real HMAC + exp),
+not stubbed.
 """
 
+import os
+import time
 from unittest.mock import patch
 
+import pytest
 from starlette.applications import Starlette
 from starlette.routing import Route
 from starlette.testclient import TestClient
 
 from src.http_api import http_effect_veto
+from src.mcp_handlers.identity import session as session_mod
+
+# A fixed proposer the minted tokens attest (token `aid` must equal this for §7
+# to pass). A different UUID is used for the aid-mismatch case.
+PROPOSER = "00000000-0000-0000-0000-0000000000aa"
+OTHER_UUID = "00000000-0000-0000-0000-0000000000bb"
+TEST_SECRET = "test-continuity-secret-0123456789abcdef"
+
+
+@pytest.fixture(autouse=True)
+def _continuity_secret_env():
+    """The HMAC secret must be present for BOTH mint and server-side verify —
+    `_get_continuity_secret()` reads env on each call. Without it
+    `resolve_continuity_token` returns None and every token looks invalid."""
+    with patch.dict(os.environ, {"UNITARES_CONTINUITY_TOKEN_SECRET": TEST_SECRET}):
+        yield
+
+
+def _token(aid=PROPOSER, *, mint_at=None):
+    """Mint a real continuity token for `aid`. `mint_at` (epoch seconds) lets a
+    test mint a token in the past so its `exp` (mint_at + ttl) is already
+    elapsed at verify time — exercising the real expiry check."""
+    if mint_at is None:
+        return session_mod.create_continuity_token(aid, f"sid-{aid[:8]}")
+    with patch.object(session_mod.time, "time", return_value=mint_at):
+        return session_mod.create_continuity_token(aid, f"sid-{aid[:8]}")
 
 
 class _FakeConn:
@@ -49,13 +89,21 @@ def _client():
     return TestClient(app)
 
 
-def _post(row=None, *, raise_exc=None, body=None):
-    body = body if body is not None else {"proposer_agent_uuid": "00000000-0000-0000-0000-0000000000aa"}
+def _post(row=None, *, raise_exc=None, body=None, token="__valid__"):
+    """POST a veto request. By default forwards a VALID strong token for
+    PROPOSER so §6 behavior can be tested in isolation. Pass ``token=None`` to
+    omit it, or a specific token string to exercise §7 failure modes."""
+    if body is None:
+        body = {"proposer_agent_uuid": PROPOSER}
+        if token == "__valid__":
+            token = _token()
+        if token is not None:
+            body = {**body, "proposer_continuity_token": token}
     with patch("src.db.get_db", return_value=_FakeDB(row, raise_exc)):
         return _client().post("/v1/effect-veto", json=body)
 
 
-# --- THE load-bearing proof: a flagged proposer is blocked ---
+# ── §6 verdict gate — a flagged proposer is blocked (tier satisfied) ──────────
 
 def test_high_risk_verdict_is_vetoed():
     r = _post({"verdict": "high-risk", "action": "approve", "risk_score": 0.9})
@@ -69,27 +117,92 @@ def test_pause_action_is_vetoed():
         assert r.json()["vetoed"] is True, f"{action} should veto"
 
 
-# --- a healthy proposer is allowed ---
+# ── a healthy proposer WITH a strong token is allowed ─────────────────────────
 
-def test_safe_approve_is_allowed():
+def test_safe_approve_with_strong_token_is_allowed():
     r = _post({"verdict": "safe", "action": "approve", "risk_score": 0.1})
     assert r.status_code == 200
-    assert r.json()["vetoed"] is False
+    body = r.json()
+    assert body["vetoed"] is False
+    assert body["tier"] == "strong"
+    assert body["tier_ok"] is True
 
 
-def test_caution_guide_is_allowed():
+def test_caution_guide_with_strong_token_is_allowed():
     r = _post({"verdict": "caution", "action": "guide", "risk_score": 0.5})
     assert r.json()["vetoed"] is False
 
 
-# --- policy edges ---
+# ── §7 tier gate — THE load-bearing proof: not-strong is blocked ──────────────
+# Same clean §6 verdict (safe/approve) in every case below; only the identity
+# proof varies. So these prove §7 alone flips the decision — never a no-op.
 
-def test_unknown_proposer_fails_open():
-    r = _post(row=None)  # no governance state
+_CLEAN = {"verdict": "safe", "action": "approve", "risk_score": 0.1}
+
+
+def test_no_token_is_vetoed_even_with_clean_verdict():
+    r = _post(_CLEAN, token=None)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["vetoed"] is True
+    assert body["tier_ok"] is False
+    assert body["tier"] == "unverified"
+
+
+def test_malformed_token_is_vetoed():
+    r = _post(_CLEAN, token="v1.not-a-real-token.bad-sig")
+    assert r.json()["vetoed"] is True
+    assert r.json()["tier_ok"] is False
+
+
+def test_expired_token_is_vetoed():
+    # Minted ~2h in the past → exp elapsed; clean §6 verdict cannot save it.
+    expired = _token(mint_at=int(time.time()) - 7200)
+    r = _post(_CLEAN, token=expired)
+    assert r.json()["vetoed"] is True
+    assert r.json()["tier_ok"] is False
+
+
+def test_aid_mismatch_token_is_vetoed():
+    # A perfectly valid, fresh token — but for a DIFFERENT identity than the
+    # claimed proposer. Closes the confused-deputy path.
+    other = _token(aid=OTHER_UUID)
+    r = _post(_CLEAN, token=other)
+    assert r.json()["vetoed"] is True
+    assert r.json()["tier_ok"] is False
+
+
+def test_secret_unset_fails_closed():
+    # If the HMAC secret is missing in the gov-mcp process, NO token can verify
+    # → every effect fails closed (loudly blocked), never silently allowed.
+    valid = _token()
+    with patch.dict(os.environ, {}, clear=True):
+        r = _post(_CLEAN, token=valid)
+    assert r.json()["vetoed"] is True
+    assert r.json()["tier_ok"] is False
+
+
+# ── policy edges ──────────────────────────────────────────────────────────────
+
+def test_unknown_proposer_with_strong_token_fails_open():
+    # §6 fails open for a never-governed proposer — but only when §7 is
+    # satisfied. A strong, never-flagged identity may spawn.
+    r = _post(row=None)  # no governance state; default token is valid+strong
     assert r.status_code == 200
     body = r.json()
     assert body["vetoed"] is False
     assert body["reason"] == "no_governance_state"
+    assert body["tier_ok"] is True
+
+
+def test_unknown_proposer_without_token_is_vetoed():
+    # The hole §6 alone left open: an unknown proposer with no identity proof
+    # must NOT slip through. §7 closes it.
+    r = _post(row=None, token=None)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["vetoed"] is True
+    assert body["tier_ok"] is False
 
 
 def test_db_error_returns_503_so_caller_fails_closed():

--- a/tests/test_s1_continuity_token_narrow.py
+++ b/tests/test_s1_continuity_token_narrow.py
@@ -832,3 +832,76 @@ def test_handle_bind_session_s1c_rejection_wiring_present():
 def _b64url_decode(data: str) -> bytes:
     padding = "=" * (-len(data) % 4)
     return base64.urlsafe_b64decode(data + padding)
+
+
+# -----------------------------------------------------------------------------
+# §7 governed-effect strong-tier re-certification (recertify_strong_tier)
+# -----------------------------------------------------------------------------
+# Unit-level proof for the encapsulated §7 gate: "fresh HMAC AND aid == claimed
+# proposer." Single-sourced here so the invariant is tested as a function, not
+# only as an HTTP shape (see tests/test_http_api_effect_veto.py for the
+# endpoint-level proof).
+
+_S7_SECRET = {"UNITARES_CONTINUITY_TOKEN_SECRET": "test-secret-s7"}
+_S7_AID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+def test_recertify_strong_tier_accepts_fresh_matching_token():
+    from src.mcp_handlers.identity import session as session_mod
+
+    with patch.dict("os.environ", _S7_SECRET, clear=False):
+        token = session_mod.create_continuity_token(_S7_AID, "agent-aaa:claude")
+        assert session_mod.recertify_strong_tier(token, _S7_AID) is True
+
+
+def test_recertify_strong_tier_rejects_missing_token_or_proposer():
+    from src.mcp_handlers.identity import session as session_mod
+
+    with patch.dict("os.environ", _S7_SECRET, clear=False):
+        token = session_mod.create_continuity_token(_S7_AID, "agent-aaa:claude")
+        assert session_mod.recertify_strong_tier(None, _S7_AID) is False
+        assert session_mod.recertify_strong_tier("", _S7_AID) is False
+        assert session_mod.recertify_strong_tier(token, None) is False
+        assert session_mod.recertify_strong_tier(token, "") is False
+        # non-str inputs must not raise
+        assert session_mod.recertify_strong_tier(123, _S7_AID) is False
+        assert session_mod.recertify_strong_tier(token, 123) is False
+
+
+def test_recertify_strong_tier_rejects_aid_mismatch():
+    """A perfectly valid token for identity X cannot re-certify proposer Y."""
+    from src.mcp_handlers.identity import session as session_mod
+
+    with patch.dict("os.environ", _S7_SECRET, clear=False):
+        token = session_mod.create_continuity_token(_S7_AID, "agent-aaa:claude")
+        assert session_mod.recertify_strong_tier(token, "ffffffff-0000-0000-0000-000000000000") is False
+
+
+def test_recertify_strong_tier_rejects_expired_token():
+    """Freshness IS required (irreversible spawn) — an expired token is refused
+    even though its signature and aid are valid."""
+    from src.mcp_handlers.identity import session as session_mod
+
+    with patch.dict("os.environ", _S7_SECRET, clear=False):
+        with patch.object(session_mod.time, "time", return_value=int(time.time()) - 7200):
+            stale = session_mod.create_continuity_token(_S7_AID, "agent-aaa:claude")
+        assert session_mod.recertify_strong_tier(stale, _S7_AID) is False
+
+
+def test_recertify_strong_tier_rejects_tampered_signature():
+    from src.mcp_handlers.identity import session as session_mod
+
+    with patch.dict("os.environ", _S7_SECRET, clear=False):
+        token = session_mod.create_continuity_token(_S7_AID, "agent-aaa:claude")
+        tampered = token[:-4] + ("AAAA" if not token.endswith("AAAA") else "BBBB")
+        assert session_mod.recertify_strong_tier(tampered, _S7_AID) is False
+
+
+def test_recertify_strong_tier_fails_closed_without_secret():
+    from src.mcp_handlers.identity import session as session_mod
+
+    with patch.dict("os.environ", _S7_SECRET, clear=False):
+        token = session_mod.create_continuity_token(_S7_AID, "agent-aaa:claude")
+    # secret removed → no token can verify → fail closed
+    with patch.dict("os.environ", {}, clear=True):
+        assert session_mod.recertify_strong_tier(token, _S7_AID) is False


### PR DESCRIPTION
Extends the live §6 governance veto (#1073) with the contract **§2/§7** gate:
an `execute` agent_spawn commits only if the proposer's **identity tier
re-verifies as `strong`** — without trusting a self-asserted tier. Closes the
last gate deferred by #1067/#1073.

## Why a token, not a re-resolution
Tier is **not durable** (no column; computed per-request from the caller's live
proof). A `client_session_id` resolved fresh at gov-mcp is stamped
`server_inferred` → **weak** → would block every effect (the trap). The
transport-robust proof is the **continuity_token** (HMAC + `exp`, carries
`aid`): a verified, unexpired token whose `aid` matches the claimed proposer
resolves to source `continuity_token` → **strong**. We re-verify with the
canonical crypto primitives, never the resolution pipeline.

## Changes
- **`session.py`** — `recertify_strong_tier(token, proposer)`: single-sourced §7
  invariant (*fresh HMAC AND `aid==proposer`*); fails closed on any other input.
- **`http_api.py` `/v1/effect-veto`** — compute `tier_ok` **before any allow
  return** so §7 dominates every path, including the unknown-proposer branch §6
  fails open. `vetoed = §6 verdict/action OR not tier_ok`. New response fields
  `tier`, `tier_ok`.
- **lease plane** — carry `proposer.continuity_token` transiently (credential:
  never persisted/logged; kept out of `payload`, which `credential_shaped?`
  rejects). `GovernanceVetoClient` forwards it, **omitting the key when absent**
  (fail-closed, not an explicit `null`).

## Council (architect + reviewer + live-verifier), folded
- **Closed the fail-open hole**: the `row is None` early return bypassed the tier
  gate — an unknown proposer with no token now fails closed.
- **Intent**: §7 gates identity strength, §6 gates behavioral verdict. A strong,
  never-flagged identity may spawn; a weak/unverified one may not.
- **Encapsulated** the gate (not composed inline); **single proposer value**
  across veto/cert/spawn (no TOCTOU); documented **replay residual** + sanctioned
  token-refresh path.

## Proof-tests — no silent no-op
A clean-verdict proposer (safe/approve) with **no / expired / malformed /
aid-mismatched** token is provably **vetoed**; with a valid strong token,
**allowed**. Elixir: a forwarded token **never leaks** into the durable record;
the veto body omits the key when absent.
- Python: 19 new/updated green (`test_http_api_effect_veto`, `test_s1_continuity_token_narrow`); affected sweep 158 green; ruff clean.
- Elixir lease suite: **193 tests + 11 properties, 0 failures**.

## Deploy order
**gov-mcp first** (understands `proposer_continuity_token` + `tier_ok`), **then
lease plane** (starts forwarding). Fails closed in between — never open.

Design: `docs/proposals/governed-effect-s7-strong-tier-recert.md`.

https://claude.ai/code/session_015pJBaVkotW8Ds2d7vcuo9b