### PR TITLE
fix(onboard): make minimal-mode credential guidance transport-aware

### DIFF
--- a/src/services/identity_payloads.py
+++ b/src/services/identity_payloads.py
@@ -324,6 +324,21 @@ def build_onboard_response_data(
     # not inflate the tier (the binding genuinely is unproven until the agent
     # echoes the token) — we relabel it honestly and make the path actionable.
     _fresh_mint = bool(is_new or force_new)
+    # Transport-aware clarifier (#604 follow-up / dogfood false-positive fix):
+    # continuity_token is the universal ownership proof, but on session-maintaining
+    # clients (Claude Code/Desktop, Cursor) an echoed client_session_id alone also
+    # reaches strong. Spelling that out stops the dogfood probe from reading the
+    # token recommendation as a wrapper/nested contradiction and re-filing it each
+    # run — the guidance was correct, only its single-credential framing was not.
+    _session_maintaining = (client_hint or "").lower() in {
+        "claude_code", "claude_desktop", "cursor"
+    }
+    _csid_also_ok = (
+        " On this client (session-maintaining) an echoed client_session_id alone "
+        "also reaches strong."
+        if _session_maintaining
+        else ""
+    )
     _assurance = identity_context.get("identity_assurance")
     if _fresh_mint and isinstance(_assurance, dict) and _assurance.get("tier") != "strong":
         _assurance["baseline"] = "fresh_identity"
@@ -336,7 +351,7 @@ def build_onboard_response_data(
             _assurance["how_to_strengthen"] = (
                 "echo the continuity_token from this onboard response on your next "
                 "call to reach strong (works on stateless and session-maintaining "
-                "transports alike)"
+                "transports alike)" + _csid_also_ok
             )
         else:
             _assurance["baseline_note"] = (
@@ -358,7 +373,7 @@ def build_onboard_response_data(
             "Call process_agent_update with response_text describing your work — "
             "echo the continuity_token from this response as your ownership proof "
             "to reach 'strong' (it resolves on stateless and session-maintaining "
-            "transports alike)."
+            "transports alike)." + _csid_also_ok
         )
     else:
         ownership_proof = {"client_session_id": stable_session_id}


### PR DESCRIPTION
## What

The onboard/`start_session` minimal-mode guidance recommended `continuity_token` as the **sole** ownership proof. That's correct on stateless transports (#604 — an echoed `client_session_id` there resolves to a fresh per-call identity), but on **session-maintaining** clients (Claude Code/Desktop, Cursor) where `client_session_id` alone already reaches `strong`, it reads as a wrapper-vs-nested *contradiction*.

The UNITARES dogfood pulse (`hermes:ea2e3655cee4`) kept re-filing that apparent contradiction as friction every run (finding fingerprint `a405ae91637d67c1`, route `issue_surface`). The probe is stateless — it re-derives the observation each run — so the only durable fix is to remove what it misreads, not to patch the probe.

## Change

`src/services/identity_payloads.py` — append a transport-aware clarifier to `how_to_strengthen` and `next_step` when `client_hint ∈ {claude_code, claude_desktop, cursor}`:

> "an echoed client_session_id alone also reaches strong."

`continuity_token` stays the universal proof. Stateless / unknown transports are unchanged, so the #604 fix is preserved.

## Verification

- `tests/test_identity_payloads.py` + `tests/test_response_formatter.py` — 149/149 pass.
- Runtime check: clarifier present for `claude_code`/`cursor`, absent for `chatgpt`/`unknown`.

## Notes

- Closes the **root cause** of the dogfood false positive (guidance only *reads* as a contradiction), not the symptom.
- The already-logged finding row will stop incrementing once deployed; no server-side "mark by-design" retraction mechanism was found, so the existing row persists.