### PR TITLE
[codex] Fix KG retrieval eval serving path

### DIFF
--- a/scripts/eval/retrieval_eval.py
+++ b/scripts/eval/retrieval_eval.py
@@ -15,6 +15,7 @@ Requires live Postgres + embeddings backend.
 
 import argparse
 import asyncio
+from contextlib import contextmanager
 import json
 import os
 import statistics
@@ -26,11 +27,63 @@ from typing import Any, Dict, List
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 from scripts.eval.metrics import dcg, mrr, ndcg_at_k, recall_at_k  # noqa: F401  (dcg re-exported for callers)
-from src.knowledge_graph import get_knowledge_graph
+from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+
+def _parse_handler_response(result: Any) -> Dict[str, Any]:
+    """Parse a handler TextContent response into a JSON dict."""
+    if isinstance(result, (list, tuple)):
+        result = result[0]
+    return json.loads(result.text)
+
+
+@contextmanager
+def _temporary_env(overrides: Dict[str, str]):
+    """Temporarily apply env flags so CLI knobs hit the serving handler path."""
+    previous = {key: os.environ.get(key) for key in overrides}
+    os.environ.update(overrides)
+    try:
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+async def _serving_search(
+    query: str,
+    limit: int,
+    *,
+    rerank: bool = False,
+    hybrid: bool = False,
+    graph_expand: bool = False,
+) -> Dict[str, Any]:
+    """Run the same search handler used by knowledge(action='search')."""
+    arguments: Dict[str, Any] = {
+        "query": query,
+        "limit": limit,
+    }
+    env: Dict[str, str] = {}
+
+    if hybrid or graph_expand:
+        arguments["search_mode"] = "hybrid"
+        env["UNITARES_ENABLE_HYBRID"] = "1"
+    if graph_expand:
+        env["UNITARES_ENABLE_GRAPH_EXPANSION"] = "1"
+    if rerank:
+        env["UNITARES_ENABLE_RERANKER"] = "1"
+
+    with _temporary_env(env):
+        payload = _parse_handler_response(await handle_search_knowledge_graph(arguments))
+
+    if not payload.get("success"):
+        raise RuntimeError(payload.get("error") or payload.get("message") or "knowledge search failed")
+    return payload
 
 
 async def run_query(
-    graph,
     query: str,
     top_k: int,
     rerank: bool = False,
@@ -38,67 +91,45 @@ async def run_query(
     hybrid: bool = False,
     graph_expand: bool = False,
 ) -> tuple[List[str], List[float], float]:
-    """Run a single query against the current retrieval stack.
+    """Run a single query against the current serving retrieval stack.
 
     Returns (ids, scores, latency_ms). Supports:
-    - `hybrid=True`: fan out semantic + FTS, fuse via RRF (k=60). Phase 4.
-    - `graph_expand=True` (requires hybrid): pull 1-hop typed-edge neighbors
-      from top seeds into the pool at a discounted RRF score. Phase 5.
-    - `rerank=True`: apply cross-encoder to top `rerank_pool_size` candidates. Phase 3.
-    - Combined: hybrid fuse → graph expand → rerank the fused/expanded pool.
+    - default: live knowledge(action='search') routing for the active backend.
+    - `hybrid=True`: force the handler's hybrid mode.
+    - `graph_expand=True` (requires hybrid): enable the serving graph-expansion flag.
+    - `rerank=True`: enable the serving reranker flag.
     """
-    import asyncio as _asyncio
     t0 = time.perf_counter()
 
-    # First-stage retrieval
-    if hybrid:
-        from src.retrieval import rrf_fuse, expand_with_neighbors
-        fetch = max(top_k, rerank_pool_size if rerank else 50)
-        sem_task = graph.semantic_search(query, limit=fetch, min_similarity=0.0)
-        fts_task = graph.full_text_search(query, limit=fetch)
-        sem_res, fts_res = await _asyncio.gather(sem_task, fts_task)
-        sem_ids = [d.id for d, _ in sem_res]
-        fts_ids = [d.id for d in fts_res]
-        fused = rrf_fuse([sem_ids, fts_ids], k=60)
-        pool = {d.id: d for d, _ in sem_res}
-        for d in fts_res:
-            pool.setdefault(d.id, d)
-        if graph_expand:
-            seed_neighbors: Dict[str, set] = {}
-            for seed_id, _ in fused[:10]:
-                seed_doc = pool.get(seed_id)
-                if seed_doc is None:
-                    continue
-                nbrs: set = set()
-                nbrs.update(seed_doc.related_to or [])
-                nbrs.update(getattr(seed_doc, "responses_from", None) or [])
-                if seed_doc.response_to:
-                    nbrs.add(seed_doc.response_to.discovery_id)
-                nbrs.discard(seed_id)
-                seed_neighbors[seed_id] = nbrs
-            fused = expand_with_neighbors(
-                fused, seed_neighbors, edge_weight=0.5, max_seeds=10,
-            )
-        fused_docs = [pool[did] for did, _ in fused if did in pool]
-    else:
-        pool_size = max(top_k, rerank_pool_size) if rerank else top_k
-        first_stage = await graph.semantic_search(query, limit=pool_size, min_similarity=0.0)
-        fused_docs = [d for d, _ in first_stage]
-        fused = [(d.id, s) for d, s in first_stage]
+    # The old eval called graph.semantic_search() directly, which only exists
+    # on the AGE backend. The default backend is PostgreSQL FTS, and the live
+    # tool surface routes through handle_search_knowledge_graph(), so the eval
+    # must measure that path instead of a backend-private method.
+    payload = await _serving_search(
+        query,
+        limit=max(top_k, rerank_pool_size if rerank else top_k),
+        rerank=rerank,
+        hybrid=hybrid,
+        graph_expand=graph_expand,
+    )
+    ranked_ids = [
+        str(discovery["id"])
+        for discovery in payload.get("discoveries", [])[:top_k]
+        if discovery.get("id") is not None
+    ]
 
-    # Optional rerank on the first-stage top
-    if rerank and fused_docs:
-        from src.reranker import rerank as _rerank
-        pairs = [
-            (d.id, f"{d.summary}\n{(d.details or '')[:2000]}")
-            for d in fused_docs
-        ]
-        reranked = await _rerank(query, pairs, top_k=top_k, max_rerank_size=rerank_pool_size)
-        ranked_ids = [doc_id for doc_id, _ in reranked]
-        scores = [float(score) for _, score in reranked]
-    else:
-        ranked_ids = [did for did, _ in fused[:top_k]]
-        scores = [float(s) for _, s in fused[:top_k]]
+    score_map = (
+        payload.get("rerank_scores")
+        or payload.get("rrf_scores")
+        or payload.get("similarity_scores")
+        or {}
+    )
+    # PostgreSQL FTS does not expose a calibrated score through the handler.
+    # Metrics use rank only, so use reciprocal rank as a display placeholder.
+    scores = [
+        float(score_map.get(doc_id, 1.0 / (idx + 1)))
+        for idx, doc_id in enumerate(ranked_ids)
+    ]
 
     dt_ms = (time.perf_counter() - t0) * 1000.0
     return ranked_ids, scores, dt_ms
@@ -122,8 +153,6 @@ async def evaluate(
     if limit_queries:
         pairs = pairs[:limit_queries]
 
-    graph = await get_knowledge_graph()
-
     per_query: List[Dict[str, Any]] = []
     ndcgs, recalls, mrrs, latencies = [], [], [], []
 
@@ -131,7 +160,6 @@ async def evaluate(
         query = pair["query"]
         relevant = set(pair["relevant_ids"])
         ranked, scores, dt_ms = await run_query(
-            graph,
             query,
             max(top_k_fetch, recall_k),
             rerank=rerank,

--- a/src/mcp_handlers/schemas/knowledge.py
+++ b/src/mcp_handlers/schemas/knowledge.py
@@ -316,6 +316,7 @@ class KnowledgeParams(AgentIdentityMixin):
     details: Optional[str] = Field(None, description="Extended details for discovery (for action=store). Alias: content")
     summary: Optional[str] = Field(None, description="Discovery summary (for action=store)")
     discovery_type: Optional[str] = Field(None, description="Type: bug_found, insight, pattern, question, note, etc. (for action=store)")
+    response_to: Optional[dict] = Field(None, description="Typed response link {discovery_id, response_type} for threaded store/note writes")
     tags: Optional[List[str]] = Field(None, description="Tags for discovery (for action=store, search, note)")
     severity: Optional[str] = Field(None, description="Severity: low, medium, high, critical (for action=store)")
     discovery_id: Optional[str] = Field(None, description="Discovery ID (for action=details, update; the NEW discovery for action=supersede)")
@@ -338,6 +339,10 @@ class KnowledgeParams(AgentIdentityMixin):
     semantic: Union[bool, str, None] = Field(None, description="Legacy action=search toggle to force or skip semantic retrieval when supported")
     min_similarity: Union[float, str, None] = Field(None, description="Minimum cosine similarity for semantic retrieval modes")
     operator: Optional[Literal["AND", "OR"]] = Field(None, description="Boolean operator for multi-term FTS queries")
+    offset: Optional[int] = Field(None, description="Character offset for action=details pagination")
+    length: Optional[int] = Field(None, description="Maximum details characters returned for action=details")
+    include_response_chain: Union[bool, str, None] = Field(None, description="Include typed response chain for action=details")
+    max_chain_depth: Optional[int] = Field(None, description="Maximum response-chain traversal depth for action=details")
     # Recall-recovery levers for action=search. Default search excludes archived
     # and cold-storage notes; pass these to reach them when an active-tier search
     # comes up empty. The handler already honors both — they were just never
@@ -371,4 +376,6 @@ class KnowledgeParams(AgentIdentityMixin):
                 self.min_similarity = float(self.min_similarity)
             except ValueError:
                 self.min_similarity = None
+        if isinstance(self.include_response_chain, str):
+            self.include_response_chain = self.include_response_chain.lower() in ('true', '1', 'yes')
         return self

--- a/src/mcp_handlers/schemas/knowledge.py
+++ b/src/mcp_handlers/schemas/knowledge.py
@@ -330,6 +330,14 @@ class KnowledgeParams(AgentIdentityMixin):
     agent_id: Optional[str] = Field(None, description="Filter by agent (for action=get, search)")
     limit: Optional[int] = Field(None, description="Max results")
     include_details: Optional[bool] = Field(None, description="Include full details inline (for action=search/get)")
+    include_provenance: Union[bool, str, None] = Field(None, description="Include provenance and lineage chain fields in search/details results")
+    search_mode: Optional[Literal["auto", "fts", "semantic", "hybrid"]] = Field(
+        None,
+        description="Force retrieval mode for action=search. 'semantic' and 'hybrid' fail honestly when unsupported by the active backend.",
+    )
+    semantic: Union[bool, str, None] = Field(None, description="Legacy action=search toggle to force or skip semantic retrieval when supported")
+    min_similarity: Union[float, str, None] = Field(None, description="Minimum cosine similarity for semantic retrieval modes")
+    operator: Optional[Literal["AND", "OR"]] = Field(None, description="Boolean operator for multi-term FTS queries")
     # Recall-recovery levers for action=search. Default search excludes archived
     # and cold-storage notes; pass these to reach them when an active-tier search
     # comes up empty. The handler already honors both — they were just never
@@ -354,4 +362,13 @@ class KnowledgeParams(AgentIdentityMixin):
             self.dry_run = self.dry_run.lower() in ('true', '1', 'yes')
         if isinstance(self.use_llm, str):
             self.use_llm = self.use_llm.lower() in ('true', '1', 'yes')
+        if isinstance(self.include_provenance, str):
+            self.include_provenance = self.include_provenance.lower() in ('true', '1', 'yes')
+        if isinstance(self.semantic, str):
+            self.semantic = self.semantic.lower() in ('true', '1', 'yes')
+        if isinstance(self.min_similarity, str):
+            try:
+                self.min_similarity = float(self.min_similarity)
+            except ValueError:
+                self.min_similarity = None
         return self

--- a/tests/test_knowledge_param_coverage.py
+++ b/tests/test_knowledge_param_coverage.py
@@ -65,15 +65,15 @@ INTERNAL_KEYS = {
 # not to grow it. Adding a NEW entry must be a deliberate, reviewed act.
 KNOWN_UNEXPOSED = {
     "auto_link_related", "confidence", "epoch_scope", "exclude_agent_labels",
-    "include_provenance",
     "include_response_chain", "including_cold", "length", "max_chain_depth",
-    "min_similarity", "offset", "operator", "related_files", "resolve_question",
-    "response_to", "scope", "search_mode", "semantic", "synthesize", "top_n",
+    "offset", "related_files", "resolve_question",
+    "response_to", "scope", "synthesize", "top_n",
     "use_model",
 }
 # include_archived / include_cold were exposed on KnowledgeParams (2026-06-22) as
-# recall-recovery levers — removed from the backlog above. Shrinking this set is
-# the goal; growing it is the smell.
+# recall-recovery levers. include_provenance / search_mode / semantic /
+# min_similarity / operator followed on 2026-06-26 as handler-documented search
+# controls. Shrinking this set is the goal; growing it is the smell.
 
 
 def _classify_undeclared() -> set[str]:
@@ -113,6 +113,18 @@ def test_archived_cold_recall_levers_exposed():
     """include_archived / include_cold must be agent-sendable (recall recovery)."""
     declared = set(KnowledgeParams.model_fields.keys())
     assert {"include_archived", "include_cold"} <= declared
+
+
+def test_search_routing_controls_exposed():
+    """Handler-documented search knobs must be agent-sendable on knowledge()."""
+    declared = set(KnowledgeParams.model_fields.keys())
+    assert {
+        "include_provenance",
+        "search_mode",
+        "semantic",
+        "min_similarity",
+        "operator",
+    } <= declared
 
 
 def test_supersession_link_params_stay_declared():

--- a/tests/test_knowledge_param_coverage.py
+++ b/tests/test_knowledge_param_coverage.py
@@ -65,15 +65,17 @@ INTERNAL_KEYS = {
 # not to grow it. Adding a NEW entry must be a deliberate, reviewed act.
 KNOWN_UNEXPOSED = {
     "auto_link_related", "confidence", "epoch_scope", "exclude_agent_labels",
-    "include_response_chain", "including_cold", "length", "max_chain_depth",
-    "offset", "related_files", "resolve_question",
-    "response_to", "scope", "synthesize", "top_n",
+    "including_cold",
+    "related_files", "resolve_question",
+    "scope", "synthesize", "top_n",
     "use_model",
 }
 # include_archived / include_cold were exposed on KnowledgeParams (2026-06-22) as
 # recall-recovery levers. include_provenance / search_mode / semantic /
 # min_similarity / operator followed on 2026-06-26 as handler-documented search
-# controls. Shrinking this set is the goal; growing it is the smell.
+# controls. offset / length / include_response_chain / max_chain_depth /
+# response_to followed as details/threading controls. Shrinking this set is the
+# goal; growing it is the smell.
 
 
 def _classify_undeclared() -> set[str]:
@@ -124,6 +126,18 @@ def test_search_routing_controls_exposed():
         "semantic",
         "min_similarity",
         "operator",
+    } <= declared
+
+
+def test_details_and_threading_controls_exposed():
+    """Handler-documented details/threading knobs must be agent-sendable."""
+    declared = set(KnowledgeParams.model_fields.keys())
+    assert {
+        "offset",
+        "length",
+        "include_response_chain",
+        "max_chain_depth",
+        "response_to",
     } <= declared
 
 

--- a/tests/test_retrieval_eval_serving_path.py
+++ b/tests/test_retrieval_eval_serving_path.py
@@ -1,0 +1,89 @@
+import json
+import os
+
+import pytest
+from mcp.types import TextContent
+
+from scripts.eval import retrieval_eval
+
+
+def _text_payload(payload: dict):
+    return [TextContent(type="text", text=json.dumps(payload))]
+
+
+@pytest.mark.asyncio
+async def test_run_query_uses_serving_search_handler(monkeypatch):
+    calls = []
+
+    async def fake_search(arguments):
+        calls.append(dict(arguments))
+        return _text_payload({
+            "success": True,
+            "discoveries": [{"id": "disc-a"}, {"id": "disc-b"}],
+            "similarity_scores": {"disc-a": 0.72},
+        })
+
+    monkeypatch.setattr(retrieval_eval, "handle_search_knowledge_graph", fake_search)
+
+    ranked, scores, dt_ms = await retrieval_eval.run_query("identity bug", top_k=2)
+
+    assert calls == [{"query": "identity bug", "limit": 2}]
+    assert ranked == ["disc-a", "disc-b"]
+    assert scores == [0.72, 0.5]
+    assert dt_ms >= 0.0
+
+
+@pytest.mark.asyncio
+async def test_run_query_maps_cli_flags_to_serving_handler(monkeypatch):
+    observed = {}
+
+    async def fake_search(arguments):
+        observed["arguments"] = dict(arguments)
+        observed["env"] = {
+            "UNITARES_ENABLE_HYBRID": os.environ.get("UNITARES_ENABLE_HYBRID"),
+            "UNITARES_ENABLE_GRAPH_EXPANSION": os.environ.get("UNITARES_ENABLE_GRAPH_EXPANSION"),
+            "UNITARES_ENABLE_RERANKER": os.environ.get("UNITARES_ENABLE_RERANKER"),
+        }
+        return _text_payload({
+            "success": True,
+            "discoveries": [{"id": "disc-a"}],
+            "rrf_scores": {"disc-a": 0.0312},
+        })
+
+    monkeypatch.setattr(retrieval_eval, "handle_search_knowledge_graph", fake_search)
+
+    ranked, scores, _ = await retrieval_eval.run_query(
+        "retrieval eval",
+        top_k=1,
+        rerank=True,
+        hybrid=True,
+        graph_expand=True,
+    )
+
+    assert observed["arguments"] == {
+        "query": "retrieval eval",
+        "limit": 50,
+        "search_mode": "hybrid",
+    }
+    assert observed["env"] == {
+        "UNITARES_ENABLE_HYBRID": "1",
+        "UNITARES_ENABLE_GRAPH_EXPANSION": "1",
+        "UNITARES_ENABLE_RERANKER": "1",
+    }
+    assert ranked == ["disc-a"]
+    assert scores == [0.0312]
+
+
+@pytest.mark.asyncio
+async def test_run_query_restores_existing_env(monkeypatch):
+    monkeypatch.setenv("UNITARES_ENABLE_HYBRID", "operator-value")
+
+    async def fake_search(arguments):
+        assert os.environ["UNITARES_ENABLE_HYBRID"] == "1"
+        return _text_payload({"success": True, "discoveries": []})
+
+    monkeypatch.setattr(retrieval_eval, "handle_search_knowledge_graph", fake_search)
+
+    await retrieval_eval.run_query("retrieval eval", top_k=1, hybrid=True)
+
+    assert os.environ["UNITARES_ENABLE_HYBRID"] == "operator-value"


### PR DESCRIPTION
## Summary
- route scripts/eval/retrieval_eval.py through the live knowledge search handler instead of backend-only semantic_search
- add serving-path unit coverage for retrieval_eval
- expose handler-documented KG search controls plus details/threading controls on the unified knowledge schema
- shrink the #1001 silent-strip backlog with coverage that keeps those KG params declared

## Root Cause
The retrieval eval called graph.semantic_search() directly, but the default PostgreSQL KG backend does not implement that AGE-only method. The live knowledge(action=search) path already routes through handle_search_knowledge_graph(), so the eval was measuring the wrong API surface and failed on the default backend.

Separately, several handler-documented KG controls were accepted by the implementation but absent from KnowledgeParams, so schema validation silently stripped them before the handler could see them.

## Validation
- python3 -m pytest tests/test_retrieval_eval_serving_path.py tests/test_retrieval_eval_metrics.py
- python3 scripts/eval/retrieval_eval.py --limit-queries 1 --json
- python3 -m pytest tests/test_knowledge_param_coverage.py tests/test_kg_search.py tests/test_consolidated_handlers.py tests/test_retrieval_eval_serving_path.py tests/test_retrieval_eval_metrics.py
- ./scripts/dev/test-cache.sh
- python3 -m pytest tests/test_knowledge_param_coverage.py tests/test_retrieval_eval_serving_path.py
- python3 -m pytest tests/test_knowledge_param_coverage.py tests/test_pydantic_schemas.py tests/test_tool_schema_validation.py
- ./scripts/dev/test-cache.sh --staged

Closes #1050
Refs #1001