### PR TITLE
Adopt lease plane for cleanup callers

### DIFF
--- a/agents/vigil_hygiene/agent.py
+++ b/agents/vigil_hygiene/agent.py
@@ -39,6 +39,8 @@ from agents.vigil_hygiene.clean_check import check_worktree_clean
 KEEPALIVE_BRANCH_NAMES = frozenset({"master", "main", "feat/branch-hygiene-automation"})
 NEWER_THAN_SECONDS = 24 * 60 * 60
 LOG_FILE = Path.home() / "Library" / "Logs" / "unitares-vigil-hygiene.log"
+LEASE_SURFACE_ID = "resident:/vigil_hygiene_sweep"
+LEASE_TTL_S = 900
 
 
 @dataclass
@@ -196,7 +198,22 @@ def _safe_status(repo_or_wt: Path) -> Optional[str]:
         return None
 
 
-def sweep(repo: Path, dry_run: bool = True) -> SweepReport:
+def sweep(repo: Path, dry_run: bool = True, *, lease_client: object | None = None) -> SweepReport:
+    """Run a branch-hygiene sweep under a Phase A lease-plane advisory scope."""
+    from unitares_sdk.lease_plane import advisory as lease_advisory
+
+    mode = "dry-run" if dry_run else "live"
+    with lease_advisory.lease_advisory_scope(
+        surface_id=LEASE_SURFACE_ID,
+        holder_agent_uuid=lease_advisory.new_holder_uuid(),
+        ttl_s=LEASE_TTL_S,
+        intent=f"vigil-hygiene {mode} branch/worktree sweep repo={repo}",
+        client=lease_client,
+    ):
+        return _sweep_inner(repo, dry_run=dry_run)
+
+
+def _sweep_inner(repo: Path, dry_run: bool = True) -> SweepReport:
     started = time.time()
     report = SweepReport(
         started_at=datetime.now(timezone.utc).isoformat(),

--- a/dashboard/redesign/app.html
+++ b/dashboard/redesign/app.html
@@ -38,6 +38,7 @@
     <a href="#dialectic" data-section="dialectic">Dialectic</a>
     <a href="#activity" data-section="activity">Activity</a>
     <a href="#eisv" data-section="eisv">EISV</a>
+    <a href="#research" data-section="research">Research</a>
     <a href="#metrics" data-section="metrics">Metrics</a>
     <a href="#residents" data-section="residents">Residents</a>
     <a href="#automations" data-section="automations">Automations</a>
@@ -100,6 +101,10 @@
       <h2 class="section-title">EISV</h2>
       <div id="eisv-mount"><div class="loading-skeleton"><div class="skeleton" style="width:35%"></div><div class="skeleton" style="width:88%"></div><div class="skeleton" style="width:72%"></div><div class="skeleton" style="width:80%"></div></div></div>
     </section>
+    <section class="section" data-pane="research" hidden>
+      <h2 class="section-title">Research</h2>
+      <div id="research-mount"><div class="loading-skeleton"><div class="skeleton" style="width:35%"></div><div class="skeleton" style="width:88%"></div><div class="skeleton" style="width:72%"></div><div class="skeleton" style="width:80%"></div></div></div>
+    </section>
     <section class="section" data-pane="metrics" hidden>
       <h2 class="section-title">Metrics</h2>
       <div id="met-mount"><div class="loading-skeleton"><div class="skeleton" style="width:35%"></div><div class="skeleton" style="width:88%"></div><div class="skeleton" style="width:72%"></div><div class="skeleton" style="width:80%"></div></div></div>
@@ -127,6 +132,7 @@
 <script src="./sections/dialectic.js"></script>
 <script src="./sections/activity.js"></script>
 <script src="./sections/eisv.js"></script>
+<script src="./sections/research.js"></script>
 <script src="./sections/metrics.js"></script>
 <script src="./sections/residents.js"></script>
 <script src="./sections/automations.js"></script>
@@ -179,6 +185,7 @@ function lazyLoad(id) {
   if (id === "dialectic" && window.Dialectic) { loaded[id] = true; window.Dialectic.load(); }
   if (id === "activity" && window.Activity) { loaded[id] = true; window.Activity.load(); }
   if (id === "eisv" && window.EISV) { loaded[id] = true; window.EISV.load(); }
+  if (id === "research" && window.Research) { loaded[id] = true; window.Research.load(); }
   if (id === "metrics" && window.Metrics) { loaded[id] = true; window.Metrics.load(); }
   if (id === "residents" && window.Residents) { loaded[id] = true; window.Residents.load(); }
   if (id === "automations" && window.Automations) { loaded[id] = true; window.Automations.load(); }

--- a/dashboard/redesign/data.js
+++ b/dashboard/redesign/data.js
@@ -270,6 +270,25 @@
       );
     },
 
+    async researchRuns() {
+      // Agent-network research-run registry: scenario, topology, population,
+      // interventions, grounding anchors, outcomes, and artifacts.
+      return withFallback(async () => {
+        const [runs, stats] = await Promise.all([
+          authFetch("/v1/research/runs?limit=200"),
+          authFetch("/v1/research/stats").catch(() => null),
+        ]);
+        if (!runs || !Array.isArray(runs.runs)) return null;
+        return {
+          runs: runs.runs,
+          count: runs.count,
+          totalMatched: runs.total_matched,
+          warnings: runs.warnings || [],
+          stats: stats && stats.stats ? stats.stats : {},
+        };
+      }, () => S().research || { runs: [], count: 0, totalMatched: 0, warnings: [], stats: { total: 0, by_status: {}, by_grounding: {}, by_research_area: {}, rigor_complete: 0, rigor_incomplete: 0 } });
+    },
+
     async metricsCatalog() {
       // Chronicler's registered metric series (fleet/project/infra). Each entry:
       // { name, description, unit, last_point_ts } — last_point_ts lets the view

--- a/dashboard/redesign/sections/research.js
+++ b/dashboard/redesign/sections/research.js
@@ -1,0 +1,136 @@
+/*
+ * Research section - agent-network research-run registry.
+ * Reads DATA.researchRuns() and renders the checklist that tells whether a run
+ * has the minimum research shape: scenario, topology, population, metrics,
+ * exogenous grounding, and artifacts.
+ */
+(function () {
+  "use strict";
+  const $ = (id) => document.getElementById(id);
+  const esc = (s) => String(s == null ? "" : s).replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+
+  let MODEL = { runs: [], stats: {}, warnings: [], source: "snapshot" };
+  let q = "", statusF = "all", groundingF = "all", areaF = "all";
+
+  function relTime(iso) {
+    if (!iso) return "-";
+    const ms = Date.now() - Date.parse(iso);
+    if (isNaN(ms)) return esc(iso);
+    const h = ms / 3.6e6;
+    return h < 1 ? Math.round(ms / 6e4) + "m ago" : h < 48 ? Math.round(h) + "h ago" : Math.round(h / 24) + "d ago";
+  }
+
+  function tag(text, cls) {
+    return `<span class="tag ${cls || ""}">${esc(text)}</span>`;
+  }
+
+  function groundingClass(value) {
+    if (value === "anchored") return "ok";
+    if (value === "missing") return "danger";
+    return "warn";
+  }
+
+  function checklistCell(run) {
+    const c = run.rigor_checklist || {};
+    const keys = ["scenario", "topology", "population", "metrics", "exogenous_grounding", "artifacts"];
+    return `<div style="display:flex;gap:4px;flex-wrap:wrap;max-width:280px">`
+      + keys.map((k) => tag(k.replace("exogenous_", ""), c[k] ? "ok" : "warn")).join("")
+      + `</div>`;
+  }
+
+  function visible() {
+    const needle = q.trim().toLowerCase();
+    return MODEL.runs.filter((r) => {
+      if (statusF !== "all" && r.status !== statusF) return false;
+      if (groundingF !== "all" && r.grounding_status !== groundingF) return false;
+      if (areaF !== "all" && !(r.research_areas || []).includes(areaF)) return false;
+      if (needle) {
+        const hay = [
+          r.run_id, r.title, r.status, r.scenario_id, r.scenario_name,
+          r.topology_kind, r.grounding_status, (r.research_areas || []).join(" "),
+          (r.tags || []).join(" "),
+        ].join(" ").toLowerCase();
+        if (!hay.includes(needle)) return false;
+      }
+      return true;
+    });
+  }
+
+  function render() {
+    const stats = MODEL.stats || {};
+    const rows = visible();
+    const statuses = ["all"].concat(Object.keys(stats.by_status || {}).sort());
+    const groundings = ["all"].concat(Object.keys(stats.by_grounding || {}).sort());
+    const areas = ["all"].concat(Object.keys(stats.by_research_area || {}).sort());
+    const sel = (id, value, items) => `<select id="${id}" class="theme-toggle">${items.map((x) => `<option value="${esc(x)}" ${x === value ? "selected" : ""}>${esc(x)}</option>`).join("")}</select>`;
+    const warn = (MODEL.warnings || []).map((w) =>
+      `<div class="attn-band calm" style="margin-bottom:var(--space-2)"><span class="glyph">-</span><span>${esc(w)}</span></div>`
+    ).join("");
+
+    $("research-mount").innerHTML =
+      warn
+      + `<div style="display:flex;align-items:center;gap:var(--space-4);flex-wrap:wrap;margin-bottom:var(--space-4);font-size:var(--text-xs);color:var(--muted)">
+           <span><b style="color:var(--ink)">${stats.total || MODEL.runs.length}</b> runs</span>
+           <span><b style="color:var(--ok)">${stats.rigor_complete || 0}</b> complete</span>
+           <span><b style="color:var(--warn)">${stats.rigor_incomplete || 0}</b> incomplete</span>
+           <span class="src-badge ${MODEL.source}">${MODEL.source}</span>
+         </div>`
+      + `<div style="display:flex;gap:var(--space-3);flex-wrap:wrap;align-items:center;margin-bottom:var(--space-4)">
+           <input id="research-q" placeholder="search run / scenario / tag" value="${esc(q)}"
+             style="flex:1;min-width:200px;padding:var(--space-2) var(--space-3);font-family:var(--font-sans);font-size:var(--text-sm);background:var(--surface);color:var(--ink);border:var(--hairline) solid var(--line-2);border-radius:var(--radius-sm)" />
+           ${sel("research-status", statusF, statuses)}
+           ${sel("research-grounding", groundingF, groundings)}
+           ${sel("research-area", areaF, areas)}
+           <button id="research-refresh" class="theme-toggle" title="Refresh">refresh</button>
+         </div>`
+      + (rows.length ? `<table class="tbl"><thead><tr>
+            <th>Run</th><th>Status</th><th>Scenario</th><th>Topology</th><th>Grounding</th><th>Checklist</th><th>Updated</th></tr></thead><tbody>`
+        + rows.map((r) => `<tr>
+              <td><div style="font-weight:500;color:var(--ink)">${esc(r.title || r.run_id)}</div>
+                  <div style="font-family:var(--font-mono);font-size:var(--text-xs);color:var(--faint);margin-top:2px">${esc(r.run_id)}</div>
+                  <div style="display:flex;gap:4px;flex-wrap:wrap;margin-top:4px">${(r.research_areas || []).slice(0, 4).map((a) => tag(a)).join("")}${(r.tags || []).slice(0, 3).map((t) => tag(t)).join("")}</div></td>
+              <td>${tag(r.status || "-", r.status === "completed" ? "ok" : r.status === "aborted" ? "danger" : "warn")}</td>
+              <td><div style="color:var(--ink-2)">${esc(r.scenario_name || r.scenario_id || "-")}</div>
+                  ${r.scenario_id ? `<div style="font-size:var(--text-xs);color:var(--faint)">${esc(r.scenario_id)}</div>` : ""}</td>
+              <td>${tag(r.topology_kind || "-")}${r.population_count != null ? `<div style="font-size:var(--text-xs);color:var(--muted);margin-top:3px">${r.population_count} agents/classes</div>` : ""}</td>
+              <td>${tag(r.grounding_status || "missing", groundingClass(r.grounding_status))}</td>
+              <td>${checklistCell(r)}</td>
+              <td style="font-size:var(--text-sm);color:var(--muted)" title="${esc(r.updated_at)}">${relTime(r.updated_at)}</td>
+            </tr>`).join("")
+        + `</tbody></table>`
+        : `<p class="empty">No research runs match the current filters.</p>`)
+      + `<div style="margin-top:var(--space-3);font-size:var(--text-xs);color:var(--faint)">showing ${rows.length} of ${MODEL.runs.length}</div>`;
+    wire();
+  }
+
+  function wire() {
+    const search = $("research-q");
+    if (search) {
+      search.oninput = () => {
+        const pos = search.selectionStart;
+        q = search.value;
+        render();
+        const next = $("research-q");
+        if (next) { next.focus(); if (pos != null) next.setSelectionRange(pos, pos); }
+      };
+    }
+    const status = $("research-status"); if (status) status.onchange = () => { statusF = status.value; render(); };
+    const grounding = $("research-grounding"); if (grounding) grounding.onchange = () => { groundingF = grounding.value; render(); };
+    const area = $("research-area"); if (area) area.onchange = () => { areaF = area.value; render(); };
+    const refresh = $("research-refresh"); if (refresh) refresh.onclick = load;
+  }
+
+  async function load() {
+    const r = await DATA.researchRuns();
+    const d = r.data || {};
+    MODEL = {
+      runs: d.runs || [],
+      stats: d.stats || {},
+      warnings: d.warnings || [],
+      source: r.source,
+    };
+    render();
+  }
+
+  window.Research = { load };
+})();

--- a/dashboard/redesign/snapshot.js
+++ b/dashboard/redesign/snapshot.js
@@ -131,6 +131,13 @@ window.SNAPSHOT = {
     health: { status:"healthy", version:"2.13.0", checks:{ healthy:12, warning:0, error:0 },
       breakers:{ governance:0, redis:0 }, calibration:"healthy", dbPool:{ size:8, idle:4, max:25 }, redis:true, continuity:"redis" },
   },
+  research: {
+    runs: [],
+    count: 0,
+    totalMatched: 0,
+    warnings: [],
+    stats: { total:0, by_status:{}, by_grounding:{}, by_research_area:{}, rigor_complete:0, rigor_incomplete:0 },
+  },
   // Fleet metrics (Chronicler) — /v1/metrics/catalog + /v1/metrics/series.
   metrics: {
     catalog: [

--- a/docs/README.md
+++ b/docs/README.md
@@ -79,6 +79,7 @@ How to run this in production. Most readers can skip these.
 - [`resident-validation-cohort.md`](operations/resident-validation-cohort.md) — experimental long-running resident validation tick contract
 - [`resident-validation-supervised-invocation.md`](operations/resident-validation-supervised-invocation.md) — local-only supervised canary invocation wrapper
 - [`dormant-capability-registry.md`](operations/dormant-capability-registry.md) — distinguishes built-but-unwired capability from genuine cruft, so cleanup is deliberate
+- [`research-registry.md`](operations/research-registry.md) — file-backed registry for agent-network research runs, rigor checklist, and REST/MCP query surfaces
 - [`kg-lineage-dashboard-handoff.md`](operations/kg-lineage-dashboard-handoff.md) — deferred implementation handoff for KG supersession/related-lineage dashboard exposure
 - [`test-suite-triage.md`](operations/test-suite-triage.md) — current state of the test gate and known-triaged suites
 - [`DATA_NOTES.md`](operations/DATA_NOTES.md) — operational data dictionary for the production governance database

--- a/docs/operations/research-registry.md
+++ b/docs/operations/research-registry.md
@@ -1,0 +1,71 @@
+# Research Registry
+
+The research registry records agent-network experiments in one queryable place.
+It is file-backed by design: no migration is required, and records can link out
+to KG discoveries, outcome events, findings, traces, or external artifacts.
+
+Default storage:
+
+```text
+~/.local/state/unitares/research-runs/*.json
+```
+
+Override with:
+
+```bash
+UNITARES_RESEARCH_REGISTRY_DIR=/path/to/research-runs
+```
+
+## MCP
+
+Read actions are available before onboarding:
+
+```text
+research_registry(action="query", research_area="science-of-agent-networks")
+research_registry(action="stats")
+research_registry(action="get", run_id="...")
+```
+
+Write action is identity-gated:
+
+```text
+research_registry(action="record", run={
+  "run_id": "agent-network-smoke-001",
+  "title": "Agent-network smoke run",
+  "status": "completed",
+  "scenario": {"id": "mixed-motive-routing", "name": "Mixed motive routing"},
+  "topology": {"kind": "small_world", "nodes": 4, "edges": 5},
+  "population": [{"agent_class": "planner", "count": 2}],
+  "metrics": [{"name": "task_success_rate", "source": "harness"}],
+  "exogenous_anchor": {"source": "harness", "outcome": "task_success_rate"},
+  "artifacts": [{"kind": "trace", "uri": "kg:disc-123"}],
+  "research_areas": ["science-of-agent-networks"],
+  "tags": ["grant", "network"]
+})
+```
+
+## REST
+
+```text
+GET /v1/research/runs
+GET /v1/research/runs?research_area=science-of-agent-networks&grounding=anchored
+GET /v1/research/runs/{run_id}
+GET /v1/research/stats
+```
+
+The dashboard exposes the same data under the `Research` tab.
+
+## Rigor Checklist
+
+Each record returns a derived `rigor_checklist`:
+
+- `scenario`
+- `topology`
+- `population`
+- `metrics`
+- `exogenous_grounding`
+- `artifacts`
+
+`grounding_status` is `anchored` when `exogenous_anchor` cites an external
+source/dataset/outcome, `linked` when only linked KG/outcome ids exist, and
+`missing` when neither is present.

--- a/scripts/dev/worktree_reaper.py
+++ b/scripts/dev/worktree_reaper.py
@@ -38,6 +38,8 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
+LEASE_SURFACE_ID = "resident:/worktree_reaper"
+LEASE_TTL_S = 900
 
 
 def _git(*args: str, cwd: Path = _REPO_ROOT) -> Tuple[int, str]:
@@ -138,16 +140,7 @@ def _idle_hours(path: str) -> Optional[float]:
     return max(0.0, (now - max(stamps)) / 3600.0)
 
 
-def main() -> int:
-    ap = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--apply", action="store_true",
-                    help="Actually remove eligible worktrees (default: dry-run).")
-    ap.add_argument("--min-idle-hours", type=float, default=12.0,
-                    help="Skip worktrees active more recently than this (default 12).")
-    ap.add_argument("--json", action="store_true", help="Emit JSON.")
-    args = ap.parse_args()
-
+def _run_reaper(args: argparse.Namespace) -> int:
     try:
         pr_states = _pr_states()
     except Exception as exc:
@@ -199,6 +192,32 @@ def main() -> int:
     else:
         print(f"\n(dry-run — re-run with --apply to remove the {len(elig)} eligible)")
     return 0
+
+
+def _lease_scope(*, apply: bool, min_idle_hours: float):
+    from unitares_sdk.lease_plane import advisory as lease_advisory
+
+    mode = "apply" if apply else "dry-run"
+    return lease_advisory.lease_advisory_scope(
+        surface_id=LEASE_SURFACE_ID,
+        holder_agent_uuid=lease_advisory.new_holder_uuid(),
+        ttl_s=LEASE_TTL_S,
+        intent=f"worktree reaper {mode} min_idle_hours={min_idle_hours:g}",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--apply", action="store_true",
+                    help="Actually remove eligible worktrees (default: dry-run).")
+    ap.add_argument("--min-idle-hours", type=float, default=12.0,
+                    help="Skip worktrees active more recently than this (default 12).")
+    ap.add_argument("--json", action="store_true", help="Emit JSON.")
+    args = ap.parse_args(argv)
+
+    with _lease_scope(apply=args.apply, min_idle_hours=args.min_idle_hours):
+        return _run_reaper(args)
 
 
 if __name__ == "__main__":

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -1247,6 +1247,79 @@ async def http_automations(request):
         return JSONResponse({"success": False, "error": str(exc)}, status_code=500)
 
 
+def _http_bool(value) -> bool:
+    return str(value or "").strip().lower() in ("1", "true", "yes")
+
+
+async def http_research_runs(request):
+    """GET /v1/research/runs - query registered agent-network research runs."""
+    http_api_token = os.getenv("UNITARES_HTTP_API_TOKEN")
+    if not _check_http_auth(request, http_api_token=http_api_token):
+        return _http_unauthorized()
+    try:
+        from src.research_registry import query_research_runs
+
+        params = request.query_params
+        try:
+            limit = int(params.get("limit", "50"))
+        except (TypeError, ValueError):
+            limit = 50
+        data = query_research_runs(
+            status=params.get("status"),
+            tag=params.get("tag"),
+            scenario_id=params.get("scenario_id"),
+            research_area=params.get("research_area"),
+            grounding=params.get("grounding"),
+            query=params.get("query"),
+            limit=limit,
+            include_details=_http_bool(params.get("include_details")),
+        )
+        data["success"] = True
+        return JSONResponse(data)
+    except Exception as exc:  # noqa: BLE001 - read-only endpoint, degrade visibly
+        return JSONResponse({"success": False, "error": str(exc)}, status_code=500)
+
+
+async def http_research_run(request):
+    """GET /v1/research/runs/{run_id} - return one research-run record."""
+    http_api_token = os.getenv("UNITARES_HTTP_API_TOKEN")
+    if not _check_http_auth(request, http_api_token=http_api_token):
+        return _http_unauthorized()
+    run_id = request.path_params.get("run_id", "")
+    try:
+        from src.research_registry import (
+            ResearchRunNotFound,
+            grounding_status,
+            load_research_run,
+            rigor_checklist,
+        )
+
+        record = load_research_run(run_id)
+        return JSONResponse({
+            "success": True,
+            "run": record,
+            "rigor_checklist": rigor_checklist(record),
+            "grounding_status": grounding_status(record),
+        })
+    except ResearchRunNotFound as exc:
+        return JSONResponse({"success": False, "error": str(exc)}, status_code=404)
+    except Exception as exc:  # noqa: BLE001 - read-only endpoint, degrade visibly
+        return JSONResponse({"success": False, "error": str(exc)}, status_code=500)
+
+
+async def http_research_stats(request):
+    """GET /v1/research/stats - aggregate research-run registry health."""
+    http_api_token = os.getenv("UNITARES_HTTP_API_TOKEN")
+    if not _check_http_auth(request, http_api_token=http_api_token):
+        return _http_unauthorized()
+    try:
+        from src.research_registry import research_registry_stats
+
+        return JSONResponse({"success": True, "stats": research_registry_stats()})
+    except Exception as exc:  # noqa: BLE001 - read-only endpoint, degrade visibly
+        return JSONResponse({"success": False, "error": str(exc)}, status_code=500)
+
+
 async def http_tier_distribution(request):
     """GET /v1/agents/tier_distribution — full-fleet trust-tier counts.
 
@@ -3254,6 +3327,9 @@ def register_http_routes(
     app.routes.append(Route("/v1/bootstrap/silent", http_bootstrap_silent, methods=["GET"]))
     app.routes.append(Route("/v1/sentinel/summary", http_sentinel_summary, methods=["GET"]))
     app.routes.append(Route("/v1/vigil/summary", http_vigil_summary, methods=["GET"]))
+    app.routes.append(Route("/v1/research/runs", http_research_runs, methods=["GET"]))
+    app.routes.append(Route("/v1/research/runs/{run_id}", http_research_run, methods=["GET"]))
+    app.routes.append(Route("/v1/research/stats", http_research_stats, methods=["GET"]))
     app.routes.append(Route("/v1/agents/tier_distribution", http_tier_distribution, methods=["GET"]))
     app.routes.append(Route("/v1/agents/{agent_id}/history", http_agent_history, methods=["GET"]))
     app.routes.append(Route("/api/automations", http_automations, methods=["GET"]))

--- a/src/mcp_handlers/__init__.py
+++ b/src/mcp_handlers/__init__.py
@@ -110,6 +110,8 @@ from .support.model_inference import handle_call_model
 from .observability.outcome_events import handle_outcome_event
 # Resident Progress - sentinel push-based pulse (Phase 1)
 from .resident_progress import handle_record_progress_pulse
+# Research-run registry
+from .research_registry import handle_research_registry
 # Consolidated tools - reduces cognitive load for agents (Jan 2026)
 from .consolidated import (
     handle_knowledge,

--- a/src/mcp_handlers/research_registry.py
+++ b/src/mcp_handlers/research_registry.py
@@ -1,0 +1,139 @@
+"""MCP handler for the file-backed research-run registry."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Sequence
+
+from mcp.types import TextContent
+
+from src.mcp_handlers.decorators import mcp_tool
+from src.mcp_handlers.utils import error_response, success_response
+from src.research_registry import (
+    ResearchRegistryError,
+    ResearchRunNotFound,
+    load_research_run,
+    query_research_runs,
+    record_research_run,
+    research_registry_stats,
+    rigor_checklist,
+    grounding_status,
+)
+
+
+_READ_ACTIONS = {"list", "query", "get", "stats", "export"}
+_RECORD_FIELDS = {
+    "run_id",
+    "title",
+    "status",
+    "scenario",
+    "topology",
+    "population",
+    "tools",
+    "memory",
+    "communication_channels",
+    "interventions",
+    "metrics",
+    "observations",
+    "outcomes",
+    "artifacts",
+    "linked_knowledge_ids",
+    "linked_outcome_ids",
+    "linked_finding_ids",
+    "research_areas",
+    "tags",
+    "exogenous_anchor",
+    "hypothesis",
+    "operator_question",
+    "notes",
+}
+
+
+def _record_payload(arguments: Dict[str, Any]) -> dict[str, Any]:
+    nested = arguments.get("run")
+    if nested is not None:
+        if not isinstance(nested, dict):
+            raise ResearchRegistryError("run must be an object")
+        payload = dict(nested)
+    else:
+        payload = {}
+    for key in _RECORD_FIELDS:
+        if key in arguments:
+            payload[key] = arguments[key]
+    return payload
+
+
+@mcp_tool(
+    "research_registry",
+    timeout=15.0,
+    description=(
+        "Register and query agent-network research runs: scenario, topology, "
+        "population, interventions, metrics, exogenous anchors, outcomes, and artifacts."
+    ),
+    pre_onboard_actions=_READ_ACTIONS,
+    default_action="list",
+)
+async def handle_research_registry(arguments: Dict[str, Any]) -> Sequence[TextContent]:
+    """Register and query agent-network research runs."""
+
+    action = str((arguments or {}).get("action") or "list").lower()
+
+    try:
+        if action in {"list", "query"}:
+            data = query_research_runs(
+                status=arguments.get("status"),
+                tag=arguments.get("tag"),
+                scenario_id=arguments.get("scenario_id"),
+                research_area=arguments.get("research_area"),
+                grounding=arguments.get("grounding"),
+                query=arguments.get("query"),
+                limit=arguments.get("limit", 50),
+                include_details=arguments.get("include_details") in (True, "true", "1", "yes"),
+            )
+            return success_response(data, arguments=arguments)
+
+        if action == "stats":
+            return success_response(
+                {"stats": research_registry_stats()},
+                arguments=arguments,
+            )
+
+        if action in {"get", "export"}:
+            run_id = arguments.get("run_id")
+            if not run_id:
+                return [error_response("run_id is required")]
+            record = load_research_run(str(run_id))
+            return success_response(
+                {
+                    "run": record,
+                    "rigor_checklist": rigor_checklist(record),
+                    "grounding_status": grounding_status(record),
+                },
+                arguments=arguments,
+            )
+
+        if action == "record":
+            payload = _record_payload(arguments)
+            record = record_research_run(payload)
+            return success_response(
+                {
+                    "run": record,
+                    "rigor_checklist": rigor_checklist(record),
+                    "grounding_status": grounding_status(record),
+                },
+                arguments=arguments,
+            )
+
+        return [error_response(
+            f"Unknown action: {action}",
+            recovery={
+                "valid_actions": sorted([*_READ_ACTIONS, "record"]),
+                "examples": [
+                    "research_registry(action='query', research_area='science-of-agent-networks')",
+                    "research_registry(action='record', run={...})",
+                ],
+            },
+        )]
+    except ResearchRunNotFound as exc:
+        return [error_response(str(exc))]
+    except ResearchRegistryError as exc:
+        return [error_response(str(exc))]

--- a/src/mcp_handlers/schemas/research.py
+++ b/src/mcp_handlers/schemas/research.py
@@ -1,0 +1,74 @@
+from typing import Any, Dict, List, Literal, Optional, Union
+
+from pydantic import Field, model_validator
+
+from .mixins import AgentIdentityMixin
+
+
+ResearchStatus = Literal["planned", "running", "completed", "aborted", "archived"]
+ResearchAction = Literal["list", "query", "get", "stats", "record", "export"]
+GroundingFilter = Literal["anchored", "linked", "missing"]
+
+
+class ResearchRegistryParams(AgentIdentityMixin):
+    """Register and query agent-network research runs."""
+
+    action: ResearchAction = Field(
+        default="list",
+        description="Operation to perform",
+    )
+    run_id: Optional[str] = Field(
+        default=None,
+        description="Stable run id for get/export/update",
+    )
+    run: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Full run payload for action=record",
+    )
+
+    # Query filters
+    query: Optional[str] = Field(default=None, description="Full-text substring query")
+    status: Optional[ResearchStatus] = Field(default=None, description="Filter by run status")
+    tag: Optional[str] = Field(default=None, description="Filter by exact tag")
+    scenario_id: Optional[str] = Field(default=None, description="Filter by scenario.id")
+    research_area: Optional[str] = Field(default=None, description="Filter by research area")
+    grounding: Optional[GroundingFilter] = Field(default=None, description="Filter by grounding status")
+    limit: Union[int, str, None] = Field(default=50, description="Max rows to return")
+    include_details: Union[bool, str, None] = Field(
+        default=False,
+        description="Return full records instead of summaries for list/query",
+    )
+
+    # Direct record fields (alternative to nested run={...})
+    title: Optional[str] = None
+    scenario: Optional[Dict[str, Any]] = None
+    topology: Optional[Dict[str, Any]] = None
+    population: Optional[List[Any]] = None
+    tools: Optional[List[Any]] = None
+    memory: Optional[List[Any]] = None
+    communication_channels: Optional[List[Any]] = None
+    interventions: Optional[List[Any]] = None
+    metrics: Optional[List[Any]] = None
+    observations: Optional[List[Any]] = None
+    outcomes: Optional[List[Any]] = None
+    artifacts: Optional[List[Any]] = None
+    linked_knowledge_ids: Optional[List[str]] = None
+    linked_outcome_ids: Optional[List[str]] = None
+    linked_finding_ids: Optional[List[str]] = None
+    research_areas: Optional[List[str]] = None
+    tags: Optional[List[str]] = None
+    exogenous_anchor: Optional[Dict[str, Any]] = None
+    hypothesis: Optional[str] = None
+    operator_question: Optional[str] = None
+    notes: Optional[str] = None
+
+    @model_validator(mode="after")
+    def coerce_flags(self):
+        if isinstance(self.limit, str):
+            try:
+                self.limit = int(self.limit)
+            except ValueError:
+                self.limit = 50
+        if isinstance(self.include_details, str):
+            self.include_details = self.include_details.lower() in ("true", "1", "yes")
+        return self

--- a/src/research_registry.py
+++ b/src/research_registry.py
@@ -1,0 +1,367 @@
+"""File-backed registry for agent-network research runs.
+
+The registry is intentionally thin: it gives operators and agents one durable,
+queryable place to describe a run without introducing a migration or coupling
+research bookkeeping to KG storage. KG/outcome/finding ids stay as links.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "unitares.research_run.v1"
+REGISTRY_ENV = "UNITARES_RESEARCH_REGISTRY_DIR"
+DEFAULT_REGISTRY_DIR = Path("~/.local/state/unitares/research-runs")
+
+VALID_STATUSES = frozenset({"planned", "running", "completed", "aborted", "archived"})
+_RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+
+_LIST_FIELDS = (
+    "population",
+    "tools",
+    "memory",
+    "communication_channels",
+    "interventions",
+    "metrics",
+    "observations",
+    "outcomes",
+    "artifacts",
+    "linked_knowledge_ids",
+    "linked_outcome_ids",
+    "linked_finding_ids",
+    "research_areas",
+    "tags",
+)
+
+_DICT_FIELDS = ("scenario", "topology", "exogenous_anchor")
+
+
+class ResearchRegistryError(ValueError):
+    """Raised when a research-run record is invalid."""
+
+
+class ResearchRunNotFound(FileNotFoundError):
+    """Raised when a requested run id is absent from the registry."""
+
+
+def registry_dir(root: str | Path | None = None) -> Path:
+    """Resolve the registry directory, honoring the env override."""
+
+    raw = root or os.getenv(REGISTRY_ENV) or DEFAULT_REGISTRY_DIR
+    return Path(raw).expanduser()
+
+
+def validate_run_id(run_id: str) -> str:
+    if not isinstance(run_id, str) or not _RUN_ID_RE.match(run_id):
+        raise ResearchRegistryError(
+            "run_id must start with an alphanumeric character and contain only "
+            "letters, numbers, '.', '_' or '-' (max 128 chars)"
+        )
+    return run_id
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _slug(text: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", text.strip().lower()).strip("-")
+    return slug or "research-run"
+
+
+def _generate_run_id(payload: dict[str, Any]) -> str:
+    base = payload.get("title")
+    if not isinstance(base, str) or not base.strip():
+        scenario = payload.get("scenario")
+        if isinstance(scenario, dict):
+            base = str(scenario.get("id") or scenario.get("name") or "research-run")
+        else:
+            base = "research-run"
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+    ).hexdigest()[:8]
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return validate_run_id(f"{stamp}-{_slug(base)[:48]}-{digest}")
+
+
+def _record_path(run_id: str, root: str | Path | None = None) -> Path:
+    run_id = validate_run_id(run_id)
+    return registry_dir(root) / f"{run_id}.json"
+
+
+def _coerce_dict(value: Any, field: str) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return dict(value)
+    raise ResearchRegistryError(f"{field} must be an object")
+
+
+def _coerce_list(value: Any, field: str) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return list(value)
+    if isinstance(value, tuple):
+        return list(value)
+    raise ResearchRegistryError(f"{field} must be an array")
+
+
+def _coerce_str_list(value: Any, field: str) -> list[str]:
+    return [str(v) for v in _coerce_list(value, field) if v is not None and str(v)]
+
+
+def _normalize_status(value: Any) -> str:
+    status = str(value or "planned").strip().lower()
+    if status not in VALID_STATUSES:
+        raise ResearchRegistryError(
+            f"status must be one of {', '.join(sorted(VALID_STATUSES))}"
+        )
+    return status
+
+
+def _require_shape(record: dict[str, Any]) -> None:
+    scenario = record["scenario"]
+    topology = record["topology"]
+    population = record["population"]
+    if not (scenario.get("id") or scenario.get("name")):
+        raise ResearchRegistryError("scenario.id or scenario.name is required")
+    if not topology:
+        raise ResearchRegistryError("topology is required")
+    if not population:
+        raise ResearchRegistryError("population must contain at least one agent or class")
+
+
+def normalize_research_run(
+    payload: dict[str, Any], *, existing: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Validate and normalize a run payload into the on-disk schema."""
+
+    if not isinstance(payload, dict):
+        raise ResearchRegistryError("research run payload must be an object")
+
+    now = _now_iso()
+    base = dict(existing or {})
+    base.update(payload)
+
+    run_id = validate_run_id(str(base.get("run_id") or _generate_run_id(base)))
+    status = _normalize_status(base.get("status"))
+    title = str(base.get("title") or "").strip()
+    if not title:
+        scenario = base.get("scenario") if isinstance(base.get("scenario"), dict) else {}
+        title = str(scenario.get("name") or scenario.get("id") or run_id)
+
+    record: dict[str, Any] = {
+        "schema": SCHEMA,
+        "run_id": run_id,
+        "title": title,
+        "status": status,
+        "created_at": existing.get("created_at") if existing else base.get("created_at"),
+        "updated_at": now,
+    }
+    if not record["created_at"]:
+        record["created_at"] = now
+
+    for field in _DICT_FIELDS:
+        record[field] = _coerce_dict(base.get(field), field)
+    for field in _LIST_FIELDS:
+        if field in {"tags", "research_areas", "linked_knowledge_ids", "linked_outcome_ids", "linked_finding_ids"}:
+            record[field] = _coerce_str_list(base.get(field), field)
+        else:
+            record[field] = _coerce_list(base.get(field), field)
+
+    for field in ("hypothesis", "operator_question", "notes"):
+        value = base.get(field)
+        if value is not None:
+            record[field] = str(value)
+
+    _require_shape(record)
+    return record
+
+
+def load_research_run(run_id: str, *, root: str | Path | None = None) -> dict[str, Any]:
+    path = _record_path(run_id, root)
+    if not path.exists():
+        raise ResearchRunNotFound(f"research run not found: {run_id}")
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, dict):
+        raise ResearchRegistryError(f"research run file is not an object: {run_id}")
+    return data
+
+
+def record_research_run(payload: dict[str, Any], *, root: str | Path | None = None) -> dict[str, Any]:
+    """Create or replace a run record, preserving created_at on updates."""
+
+    run_id = payload.get("run_id") if isinstance(payload, dict) else None
+    existing = None
+    if run_id:
+        try:
+            existing = load_research_run(str(run_id), root=root)
+        except ResearchRunNotFound:
+            existing = None
+
+    record = normalize_research_run(payload, existing=existing)
+    root_path = registry_dir(root)
+    root_path.mkdir(parents=True, exist_ok=True)
+    path = _record_path(record["run_id"], root_path)
+    tmp = path.with_suffix(".json.tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        json.dump(record, fh, ensure_ascii=False, indent=2, sort_keys=True)
+        fh.write("\n")
+    tmp.replace(path)
+    return record
+
+
+def _load_all(root: str | Path | None = None) -> tuple[list[dict[str, Any]], list[str]]:
+    root_path = registry_dir(root)
+    if not root_path.exists():
+        return [], []
+
+    runs: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    for path in sorted(root_path.glob("*.json")):
+        try:
+            with path.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            if isinstance(data, dict):
+                runs.append(data)
+            else:
+                warnings.append(f"{path.name}: expected object")
+        except Exception as exc:  # noqa: BLE001 - registry should keep serving valid rows
+            warnings.append(f"{path.name}: {exc}")
+    return runs, warnings
+
+
+def grounding_status(record: dict[str, Any]) -> str:
+    anchor = record.get("exogenous_anchor") or {}
+    if isinstance(anchor, dict) and (
+        anchor.get("source") or anchor.get("dataset") or anchor.get("outcome")
+    ):
+        return "anchored"
+    if record.get("linked_outcome_ids") or record.get("linked_knowledge_ids"):
+        return "linked"
+    return "missing"
+
+
+def rigor_checklist(record: dict[str, Any]) -> dict[str, bool]:
+    return {
+        "scenario": bool((record.get("scenario") or {}).get("id") or (record.get("scenario") or {}).get("name")),
+        "topology": bool(record.get("topology")),
+        "population": bool(record.get("population")),
+        "metrics": bool(record.get("metrics")),
+        "exogenous_grounding": grounding_status(record) == "anchored",
+        "artifacts": bool(record.get("artifacts")),
+    }
+
+
+def summarize_research_run(record: dict[str, Any]) -> dict[str, Any]:
+    scenario = record.get("scenario") if isinstance(record.get("scenario"), dict) else {}
+    topology = record.get("topology") if isinstance(record.get("topology"), dict) else {}
+    checklist = rigor_checklist(record)
+    return {
+        "run_id": record.get("run_id"),
+        "title": record.get("title"),
+        "status": record.get("status"),
+        "scenario_id": scenario.get("id"),
+        "scenario_name": scenario.get("name"),
+        "topology_kind": topology.get("kind"),
+        "population_count": len(record.get("population") or []),
+        "research_areas": record.get("research_areas") or [],
+        "tags": record.get("tags") or [],
+        "grounding_status": grounding_status(record),
+        "rigor_checklist": checklist,
+        "rigor_complete": all(checklist.values()),
+        "created_at": record.get("created_at"),
+        "updated_at": record.get("updated_at"),
+    }
+
+
+def _matches_text(record: dict[str, Any], query: str) -> bool:
+    needle = query.strip().lower()
+    if not needle:
+        return True
+    hay = json.dumps(record, sort_keys=True, default=str).lower()
+    return needle in hay
+
+
+def query_research_runs(
+    *,
+    status: str | None = None,
+    tag: str | None = None,
+    scenario_id: str | None = None,
+    research_area: str | None = None,
+    grounding: str | None = None,
+    query: str | None = None,
+    limit: int = 50,
+    include_details: bool = False,
+    root: str | Path | None = None,
+) -> dict[str, Any]:
+    runs, warnings = _load_all(root)
+
+    if status:
+        status = status.strip().lower()
+        runs = [r for r in runs if str(r.get("status", "")).lower() == status]
+    if tag:
+        runs = [r for r in runs if tag in (r.get("tags") or [])]
+    if scenario_id:
+        runs = [
+            r for r in runs
+            if isinstance(r.get("scenario"), dict) and r["scenario"].get("id") == scenario_id
+        ]
+    if research_area:
+        runs = [r for r in runs if research_area in (r.get("research_areas") or [])]
+    if grounding:
+        grounding = grounding.strip().lower()
+        runs = [r for r in runs if grounding_status(r) == grounding]
+    if query:
+        runs = [r for r in runs if _matches_text(r, query)]
+
+    runs.sort(key=lambda r: str(r.get("updated_at") or r.get("created_at") or ""), reverse=True)
+    try:
+        limit = max(1, min(int(limit), 500))
+    except (TypeError, ValueError):
+        limit = 50
+    selected = runs[:limit]
+    return {
+        "schema": SCHEMA,
+        "runs": selected if include_details else [summarize_research_run(r) for r in selected],
+        "count": len(selected),
+        "total_matched": len(runs),
+        "warnings": warnings,
+    }
+
+
+def research_registry_stats(*, root: str | Path | None = None) -> dict[str, Any]:
+    runs, warnings = _load_all(root)
+    by_status = Counter(str(r.get("status") or "unknown") for r in runs)
+    by_grounding = Counter(grounding_status(r) for r in runs)
+    by_scenario = Counter()
+    by_research_area = Counter()
+    for record in runs:
+        scenario = record.get("scenario") if isinstance(record.get("scenario"), dict) else {}
+        key = scenario.get("id") or scenario.get("name") or "unknown"
+        by_scenario[str(key)] += 1
+        for area in record.get("research_areas") or []:
+            by_research_area[str(area)] += 1
+    rigor_complete = sum(1 for record in runs if all(rigor_checklist(record).values()))
+    return {
+        "schema": SCHEMA,
+        "total": len(runs),
+        "by_status": dict(by_status),
+        "by_grounding": dict(by_grounding),
+        "by_scenario": dict(by_scenario),
+        "by_research_area": dict(by_research_area),
+        "rigor_complete": rigor_complete,
+        "rigor_incomplete": len(runs) - rigor_complete,
+        "registry_dir": str(registry_dir(root)),
+        "warnings": warnings,
+    }

--- a/src/tool_schemas.py
+++ b/src/tool_schemas.py
@@ -43,6 +43,7 @@ def _load_pydantic_schemas():
         "src.mcp_handlers.schemas.identity",
         "src.mcp_handlers.schemas.admin",
         "src.mcp_handlers.schemas.dashboard",
+        "src.mcp_handlers.schemas.research",
         "src.mcp_handlers.schemas.skills",  # S15-a
         *_EXTRA_SCHEMA_MODULES,
     ]
@@ -138,6 +139,7 @@ TOOL_ORDER = [
     "bind_session",
     "debug_request_context",
     "knowledge",
+    "research_registry",
     "agent",
     "calibration",
     "cirs_protocol",

--- a/tests/test_research_registry.py
+++ b/tests/test_research_registry.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from src.research_registry import (
+    ResearchRegistryError,
+    grounding_status,
+    query_research_runs,
+    record_research_run,
+    research_registry_stats,
+    rigor_checklist,
+)
+
+
+def _sample_run(**overrides):
+    run = {
+        "run_id": "coop-agent-networks-smoke",
+        "title": "Cooperative agent-network smoke run",
+        "status": "completed",
+        "scenario": {"id": "mixed-motive-routing", "name": "Mixed motive routing"},
+        "topology": {"kind": "small_world", "nodes": 4, "edges": 5},
+        "population": [
+            {"agent_class": "planner", "count": 2},
+            {"agent_class": "skeptic", "count": 1},
+        ],
+        "metrics": [{"name": "task_success_rate", "source": "harness"}],
+        "artifacts": [{"kind": "trace", "uri": "kg:disc-1"}],
+        "exogenous_anchor": {"source": "harness", "outcome": "task_success_rate"},
+        "research_areas": ["science-of-agent-networks"],
+        "tags": ["grant", "network"],
+    }
+    run.update(overrides)
+    return run
+
+
+def _parse_tool_result(result):
+    return json.loads(result[0].text)
+
+
+def test_record_and_query_research_runs(tmp_path):
+    record = record_research_run(_sample_run(), root=tmp_path)
+
+    assert record["run_id"] == "coop-agent-networks-smoke"
+    assert grounding_status(record) == "anchored"
+    assert all(rigor_checklist(record).values())
+
+    result = query_research_runs(
+        research_area="science-of-agent-networks",
+        tag="grant",
+        root=tmp_path,
+    )
+    assert result["count"] == 1
+    assert result["runs"][0]["run_id"] == "coop-agent-networks-smoke"
+    assert result["runs"][0]["rigor_complete"] is True
+
+
+def test_record_requires_core_research_shape(tmp_path):
+    with pytest.raises(ResearchRegistryError, match="population"):
+        record_research_run(
+            {
+                "scenario": {"id": "missing-population"},
+                "topology": {"kind": "line"},
+            },
+            root=tmp_path,
+        )
+
+
+def test_stats_group_grounding_and_research_area(tmp_path):
+    record_research_run(_sample_run(run_id="anchored"), root=tmp_path)
+    record_research_run(
+        _sample_run(
+            run_id="linked",
+            exogenous_anchor={},
+            linked_knowledge_ids=["disc-1"],
+            artifacts=[],
+        ),
+        root=tmp_path,
+    )
+
+    stats = research_registry_stats(root=tmp_path)
+    assert stats["total"] == 2
+    assert stats["by_grounding"] == {"anchored": 1, "linked": 1}
+    assert stats["by_research_area"]["science-of-agent-networks"] == 2
+    assert stats["rigor_complete"] == 1
+    assert stats["rigor_incomplete"] == 1
+
+
+@pytest.mark.asyncio
+async def test_research_registry_mcp_record_and_query(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNITARES_RESEARCH_REGISTRY_DIR", str(tmp_path))
+    from src.mcp_handlers.research_registry import handle_research_registry
+
+    recorded = _parse_tool_result(
+        await handle_research_registry({"action": "record", "run": _sample_run()})
+    )
+    assert recorded["success"] is True
+    assert recorded["grounding_status"] == "anchored"
+
+    queried = _parse_tool_result(
+        await handle_research_registry({
+            "action": "query",
+            "research_area": "science-of-agent-networks",
+        })
+    )
+    assert queried["count"] == 1
+    assert queried["runs"][0]["run_id"] == "coop-agent-networks-smoke"
+
+
+@pytest.mark.asyncio
+async def test_research_registry_http_reads(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNITARES_RESEARCH_REGISTRY_DIR", str(tmp_path))
+    record_research_run(_sample_run(), root=tmp_path)
+
+    from src import http_api
+
+    monkeypatch.setattr(
+        http_api,
+        "_check_http_auth",
+        lambda request, *, http_api_token: True,
+    )
+
+    list_req = SimpleNamespace(
+        headers={},
+        query_params={"tag": "grant", "limit": "10"},
+        path_params={},
+    )
+    list_resp = await http_api.http_research_runs(list_req)
+    list_body = json.loads(list_resp.body)
+    assert list_body["success"] is True
+    assert list_body["count"] == 1
+
+    get_req = SimpleNamespace(
+        headers={},
+        query_params={},
+        path_params={"run_id": "coop-agent-networks-smoke"},
+    )
+    get_resp = await http_api.http_research_run(get_req)
+    get_body = json.loads(get_resp.body)
+    assert get_body["success"] is True
+    assert get_body["run"]["scenario"]["id"] == "mixed-motive-routing"
+
+    stats_resp = await http_api.http_research_stats(list_req)
+    stats_body = json.loads(stats_resp.body)
+    assert stats_body["stats"]["total"] == 1
+
+
+def test_research_registry_schema_is_advertised():
+    from src.tool_schemas import get_pydantic_schemas
+
+    schema_model = get_pydantic_schemas()["research_registry"]
+    props = schema_model.model_json_schema()["properties"]
+    assert "research_area" in props
+    assert "exogenous_anchor" in props

--- a/tests/test_vigil_hygiene_sweep.py
+++ b/tests/test_vigil_hygiene_sweep.py
@@ -3,6 +3,7 @@ ephemeral local git repo. Avoids network by stubbing list_open_pr_branches.
 """
 from __future__ import annotations
 
+import contextlib
 import os
 import subprocess
 from pathlib import Path
@@ -77,6 +78,33 @@ class TestKeepaliveLogic:
 
 
 class TestSweepDryRun:
+    def test_sweep_invokes_lease_advisory_with_expected_surface(
+        self, fake_repo: Path, monkeypatch
+    ):
+        from unitares_sdk.lease_plane import advisory as advisory_module
+
+        captured: dict = {}
+        events: list[str] = []
+
+        @contextlib.contextmanager
+        def fake_scope(**kwargs):
+            captured.update(kwargs)
+            events.append("enter")
+            yield ("held_by_other", None)
+            events.append("exit")
+
+        monkeypatch.setattr(advisory_module, "lease_advisory_scope", fake_scope)
+        monkeypatch.setattr(agent_mod, "list_open_pr_branches", lambda repo: set())
+
+        report = sweep(fake_repo, dry_run=True)
+
+        assert report.dry_run is True
+        assert events == ["enter", "exit"]
+        assert captured["surface_id"] == "resident:/vigil_hygiene_sweep"
+        assert captured["ttl_s"] == 900
+        assert "dry-run branch/worktree sweep" in captured["intent"]
+        assert str(fake_repo) in captured["intent"]
+
     def test_dry_run_does_not_delete_worktree(self, fake_repo: Path, monkeypatch):
         wt_dir = fake_repo / ".worktrees" / "wt1"
         _git(fake_repo, "worktree", "add", "-b", "feature/x", str(wt_dir))

--- a/tests/test_worktree_reaper.py
+++ b/tests/test_worktree_reaper.py
@@ -4,6 +4,7 @@ The reaper exists because a naive "0 commits ahead" rule deleted a freshly-
 created worktree another session had just opened. These tests pin the safety
 invariants: merged authorizes, liveness/dirtiness vetoes.
 """
+import contextlib
 import importlib.util
 from pathlib import Path
 
@@ -57,3 +58,31 @@ def test_idle_floor_is_inclusive_boundary():
     # Exactly at the floor counts as idle-enough (>= floor removes).
     assert decide("MERGED", False, 12.0, 12.0)[0] == "remove"
     assert decide("MERGED", False, 11.99, 12.0)[0] == "skip"
+
+
+def test_main_invokes_lease_advisory_with_expected_surface(monkeypatch, capsys):
+    from unitares_sdk.lease_plane import advisory as advisory_module
+
+    captured = {}
+    events = []
+
+    @contextlib.contextmanager
+    def fake_scope(**kwargs):
+        captured.update(kwargs)
+        events.append("enter")
+        yield ("held_by_other", None)
+        events.append("exit")
+
+    monkeypatch.setattr(advisory_module, "lease_advisory_scope", fake_scope)
+    monkeypatch.setattr(reaper, "_pr_states", lambda: {})
+    monkeypatch.setattr(reaper, "_worktrees", lambda: [])
+
+    rc = reaper.main(["--json", "--min-idle-hours", "24"])
+
+    assert rc == 0
+    assert events == ["enter", "exit"]
+    assert captured["surface_id"] == "resident:/worktree_reaper"
+    assert captured["ttl_s"] == 900
+    assert "worktree reaper dry-run" in captured["intent"]
+    assert "min_idle_hours=24" in captured["intent"]
+    assert '"plan": []' in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- wrap vigil-hygiene sweeps in advisory lease scope resident:/vigil_hygiene_sweep
- wrap worktree_reaper CLI path in advisory lease scope resident:/worktree_reaper
- add tests that pin lease surface IDs, TTLs, and Phase A non-blocking behavior

## Tests
- python3 -m pytest tests/test_vigil_hygiene_sweep.py tests/test_worktree_reaper.py -q
- UNITARES_HTTP_API_TOKEN= ./scripts/dev/test-cache.sh (elevated for loopback socket integration tests)

Note: initial test-cache without the explicit empty UNITARES_HTTP_API_TOKEN failed in the local auth environment at tests/test_http_api_effect_veto.py::test_high_risk_verdict_is_vetoed with HTTP 401; the same test passes when the token is explicitly empty.