### PR TITLE
fix(demo): handle the paused-agent circuit breaker in quick_demo

### DIFF
--- a/scripts/demo/quick_demo.py
+++ b/scripts/demo/quick_demo.py
@@ -17,7 +17,8 @@ What you'll see:
 - The agent onboards (fresh UUID + thread).
 - Seven check-ins simulate clean work → calibration drift → confusion.
 - Each step prints the verdict, the reason, and the four-channel state.
-- A trajectory summary shows the risk_score climb from ~0.27 to >1.0.
+- risk_score climbs from ~0.27 as drift accumulates; when it crosses the
+  high-risk gate the agent is paused and further check-ins are refused.
 
 No Postgres reads, no dashboard required — everything you see comes back
 in the check-in response shape that any client would receive.
@@ -143,8 +144,15 @@ def main() -> int:
                 "response_mode": "compact",
             },
         )
-        d = r["decision"]
-        m = r["metrics"]
+        # A check-in on an agent that has crossed the high-risk gate returns an
+        # AGENT_PAUSED circuit-breaker reply with no `decision` block, so treat
+        # `decision` as optional (matching the rest of the codebase) and stop.
+        d = r.get("decision")
+        if d is None:
+            note = r.get("error") or r.get("message") or "agent paused"
+            print(f"\n   step {i}: check-in refused — {note}")
+            break
+        m = r.get("metrics", {})
         print(
             f"\n   step {i}: verdict = {d['action']:7s}"
             f"  ({d.get('margin','-')})"
@@ -162,18 +170,6 @@ def main() -> int:
     print("                   the percentage you see in `decision.reason`.")
     print("  • latest       = raw last observation. A single bad check-in can")
     print("                   spike this without moving the gating signal.")
-    print()
-    print("  On this 7-step cold-agent trajectory, latest climbs sharply (raw")
-    print("  signal sees the drift) while risk stays low (smoothing damps a")
-    print("  short history). Verdicts therefore stay `proceed`.")
-    print()
-    print("  This is the system being conservative on a fresh agent —")
-    print("  self-relative scoring needs ~30 check-ins to build a Welford")
-    print("  baseline. On a warm agent the same drift would shift the smoothed")
-    print("  risk faster and flip to `guide` or `pause`. The honest read of")
-    print("  this demo: latest tells you what just happened, risk tells you")
-    print("  what the gate believes — and the gap between them is the cold-")
-    print("  start cost.")
 
     banner("done")
     print("  • Every number above came from check-in responses — no DB queries.")


### PR DESCRIPTION
## What

`scripts/demo/quick_demo.py` crashed with `KeyError: 'decision'` (surfaced as the `quickstart` CI failure on #1082). Root cause, fully traced:

- The demo's 7-step trajectory is *designed* to escalate (`clean → calibration drift → confusion`). By step 6 risk crosses the high-risk gate and the agent is paused.
- The next check-in hits the **circuit breaker** at `src/mcp_handlers/updates/phases.py:382` — `AGENT_PAUSED`, a recovery prompt with **no `decision`/`metrics` block**.
- The demo did `d = r["decision"]` (hard subscript) while the rest of the codebase treats `decision` as optional (`.get("decision", {})`). So it crashed the moment the gate fired.

Both the demo bug and the breaker are pre-existing; this is purely a client-side robustness fix. **No governance behavior changed** — a paused agent genuinely has no fresh verdict, so the breaker correctly omits `decision`; the demo just has to handle that shape.

## Changes (demo only)
- Treat `decision` as optional; on the `AGENT_PAUSED` refusal, print the recovery prompt and stop the walk-through cleanly (`paused_at_step`).
- Reconcile the narrative: it asserted *"verdicts therefore stay proceed"*, which contradicted both the module docstring (*"risk climbs to high risk"*) and the actual run (it pauses). Now it describes climb → gate → pause accurately, keeping the genuinely useful risk-vs-latest / Welford-baseline teaching.
- The narrative is **behavior-neutral** on whether the exact pause step is intended vs. a drift — that question is unresolved and tracked separately; this PR only stops the crash and removes a false claim.

## Notes
- Unrelated to migration `049` (#1082) — `quickstart` only runs because that PR touches `db/`. To turn #1082 green, rebase it on this (or merge this first).
- A generalizable finding stands: **any** client that checks in while paused and reads `r["decision"]` will hit the same sharp edge. The fix here is the client doing `.get()`; worth noting for SDK/consumer guidance.