### PR TITLE
[codex] Smooth workflow rough edges

### DIFF
--- a/scripts/dev/workspace_closeout.py
+++ b/scripts/dev/workspace_closeout.py
@@ -58,6 +58,7 @@ class ProcessInfo:
     cwd: str
     command: str
     launch_label: str | None = None
+    expected_reason: str | None = None
 
 
 @dataclass
@@ -84,6 +85,7 @@ class CloseoutResult:
     stashed: bool
     stash_message: str | None
     repo_processes: list[ProcessInfo]
+    expected_repo_processes: list[ProcessInfo]
     stopped_processes: list[int]
     booted_out_labels: list[str]
     errors: list[str]
@@ -556,6 +558,65 @@ def repo_rooted_processes(
     return sorted(found, key=lambda item: item.pid)
 
 
+def expected_repo_process_reason(proc: ProcessInfo, root: Path) -> str | None:
+    """Classify known resident/control-plane processes.
+
+    These are still rendered for operator visibility, but they do not make
+    closeout fail. The goal is to distinguish normal UNITARES/Codex substrate
+    services from unexpected leftover task processes.
+    """
+    label = proc.launch_label or ""
+    if label.startswith("com.unitares."):
+        return f"launchd UNITARES service ({label})"
+
+    try:
+        relative_cwd = Path(proc.cwd).resolve().relative_to(root.resolve())
+        cwd_parts = relative_cwd.parts
+    except (OSError, ValueError):
+        cwd_parts = ()
+
+    if len(cwd_parts) >= 2 and cwd_parts[0] == "elixir":
+        service = cwd_parts[1]
+        if service in {"sentinel", "wave3a_handlers", "agent_orchestrator"}:
+            return f"UNITARES BEAM resident service ({service})"
+
+    command = proc.command
+    if "/Applications/Codex.app/" in command and "node_repl" in command:
+        return "Codex tool runtime helper"
+    if "date-context-mcp/src/mcp_server.py" in command:
+        return "Codex date-context MCP helper"
+    if "src/gateway_server.py --port 8768" in command:
+        return "UNITARES local gateway server"
+
+    raw_patterns = os.getenv("UNITARES_CLOSEOUT_EXPECTED_PROCESS_RE", "")
+    for raw in (part.strip() for part in raw_patterns.split("||")):
+        if not raw:
+            continue
+        try:
+            if re.search(raw, command) or re.search(raw, proc.cwd):
+                return f"operator-expected pattern ({raw})"
+        except re.error:
+            continue
+
+    return None
+
+
+def split_expected_processes(
+    processes: list[ProcessInfo],
+    root: Path,
+) -> tuple[list[ProcessInfo], list[ProcessInfo]]:
+    unexpected: list[ProcessInfo] = []
+    expected: list[ProcessInfo] = []
+    for proc in processes:
+        reason = expected_repo_process_reason(proc, root)
+        if reason:
+            proc.expected_reason = reason
+            expected.append(proc)
+        else:
+            unexpected.append(proc)
+    return unexpected, expected
+
+
 def stop_repo_processes(
     root: Path,
     processes: list[ProcessInfo],
@@ -652,6 +713,7 @@ def closeout(
             errors.append(str(exc))
 
     processes = repo_rooted_processes(root, baseline_keys=baseline_keys)
+    processes, expected_processes = split_expected_processes(processes, root)
     stopped: list[int] = []
     labels: list[str] = []
     if stop_processes and processes:
@@ -662,6 +724,7 @@ def closeout(
         )
         errors.extend(stop_errors)
         processes = repo_rooted_processes(root, baseline_keys=baseline_keys)
+        processes, expected_processes = split_expected_processes(processes, root)
 
     if branch_hygiene or branch_hygiene_live:
         try:
@@ -681,6 +744,7 @@ def closeout(
         stashed=stashed,
         stash_message=stash_message,
         repo_processes=processes,
+        expected_repo_processes=expected_processes,
         stopped_processes=stopped,
         booted_out_labels=labels,
         errors=errors,
@@ -719,6 +783,7 @@ def start_check(
             stashed=False,
             stash_message=None,
             repo_processes=[],
+            expected_repo_processes=[],
             stopped_processes=[],
             booted_out_labels=[],
             errors=[],
@@ -827,6 +892,18 @@ def render_text(result: CloseoutResult) -> str:
     else:
         lines.append("repo-rooted processes: none")
 
+    if result.expected_repo_processes:
+        lines.append(
+            f"expected repo-rooted processes: {len(result.expected_repo_processes)}"
+        )
+        for proc in result.expected_repo_processes:
+            label = f" label={proc.launch_label}" if proc.launch_label else ""
+            reason = proc.expected_reason or "expected"
+            lines.append(
+                f"  pid={proc.pid}{label} reason={reason} "
+                f"cwd={proc.cwd} cmd={proc.command}"
+            )
+
     if result.booted_out_labels:
         lines.append("booted out launch labels:")
         for label in result.booted_out_labels:
@@ -923,6 +1000,9 @@ def to_jsonable(result: CloseoutResult) -> dict[str, Any]:
         "stashed": result.stashed,
         "stash_message": result.stash_message,
         "repo_processes": [asdict(proc) for proc in result.repo_processes],
+        "expected_repo_processes": [
+            asdict(proc) for proc in result.expected_repo_processes
+        ],
         "stopped_processes": result.stopped_processes,
         "booted_out_labels": result.booted_out_labels,
         "errors": result.errors,

--- a/scripts/diagnostics/mcp_call.py
+++ b/scripts/diagnostics/mcp_call.py
@@ -17,13 +17,21 @@ Usage:
 """
 
 import argparse
+from datetime import datetime, timezone
 import json
+import os
 import sys
 import urllib.request
 import urllib.error
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 DEFAULT_URL = "http://127.0.0.1:8767"
+SESSION_CACHE_DIR = ".unitares"
+SESSION_CACHE_PREFIX = "session"
+SESSION_CACHE_SUFFIX = ".json"
+SESSION_CACHE_SKIP_TOOLS = {"onboard", "start_session"}
+AUTO_LINEAGE_TOOLS = {"process_agent_update", "sync_state"}
 
 
 def call_tool(
@@ -51,6 +59,205 @@ def call_tool(
         return {"error": f"Connection failed: {e.reason}"}
     except Exception as e:
         return {"error": str(e)}
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _session_cache_paths(workspace: Path) -> list[Path]:
+    cache_dir = workspace / SESSION_CACHE_DIR
+    if not cache_dir.is_dir():
+        return []
+    paths: list[Path] = []
+    for path in cache_dir.iterdir():
+        if not path.is_file():
+            continue
+        if path.name == f"{SESSION_CACHE_PREFIX}{SESSION_CACHE_SUFFIX}":
+            paths.append(path)
+        elif (
+            path.name.startswith(f"{SESSION_CACHE_PREFIX}-")
+            and path.name.endswith(SESSION_CACHE_SUFFIX)
+        ):
+            paths.append(path)
+    return paths
+
+
+def _parse_timestamp(raw: Any, fallback: float) -> tuple[float, float]:
+    if isinstance(raw, str) and raw:
+        try:
+            parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return parsed.timestamp(), fallback
+        except ValueError:
+            pass
+    return 0.0, fallback
+
+
+def latest_session_cache(workspace: Path) -> dict[str, Any] | None:
+    """Return the newest local v2-ish session cache entry, if any.
+
+    The diagnostics caller is stateless HTTP. Rehydrating the local
+    ``client_session_id`` into both the JSON arguments and ``X-Session-ID``
+    makes it behave like the normal adapter path without treating a legacy
+    continuity token as a cross-process credential.
+    """
+    candidates: list[tuple[tuple[float, float], dict[str, Any]]] = []
+    for path in _session_cache_paths(workspace):
+        payload = _read_json(path)
+        client_session_id = payload.get("client_session_id")
+        uuid = payload.get("uuid")
+        if not isinstance(client_session_id, str) or not client_session_id:
+            continue
+        if uuid is not None and not isinstance(uuid, str):
+            continue
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            mtime = 0.0
+        sort_key = _parse_timestamp(payload.get("updated_at"), mtime)
+        entry = dict(payload)
+        entry["_path"] = str(path)
+        candidates.append((sort_key, entry))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    return candidates[0][1]
+
+
+def write_session_cache(
+    workspace: Path,
+    *,
+    uuid: str,
+    client_session_id: str,
+    parent_agent_id: str | None = None,
+) -> None:
+    cache_dir = workspace / SESSION_CACHE_DIR
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    safe_slot = "".join(
+        c if c.isalnum() or c in ("-", "_") else "_" for c in client_session_id
+    )[:64]
+    path = cache_dir / f"{SESSION_CACHE_PREFIX}-{safe_slot}{SESSION_CACHE_SUFFIX}"
+    payload: dict[str, Any] = {
+        "schema_version": 2,
+        "uuid": uuid,
+        "client_session_id": client_session_id,
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    if parent_agent_id:
+        payload["parent_agent_id"] = parent_agent_id
+    data = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, data)
+        os.fchmod(fd, 0o600)
+    finally:
+        os.close(fd)
+
+
+def resolve_session_binding(
+    tool_name: str,
+    arguments: dict[str, Any],
+    explicit_session_id: str | None,
+    *,
+    workspace: Path,
+    use_cache: bool,
+) -> tuple[str | None, dict[str, Any] | None]:
+    """Resolve the session header and maybe inject ``client_session_id``.
+
+    Explicit CLI/session arguments win. A supplied ``client_session_id`` also
+    becomes the HTTP session header, which is the diagnostic-path gap this
+    helper closes.
+    """
+    if explicit_session_id:
+        return explicit_session_id, None
+
+    client_session_id = arguments.get("client_session_id")
+    if isinstance(client_session_id, str) and client_session_id:
+        return client_session_id, None
+
+    if not use_cache or tool_name in SESSION_CACHE_SKIP_TOOLS:
+        return None, None
+
+    entry = latest_session_cache(workspace)
+    if not entry:
+        return None, None
+    cached_session_id = entry.get("client_session_id")
+    if isinstance(cached_session_id, str) and cached_session_id:
+        arguments.setdefault("client_session_id", cached_session_id)
+        return cached_session_id, entry
+    return None, entry
+
+
+def is_identity_required(result: dict[str, Any]) -> bool:
+    payload = result.get("result")
+    if not isinstance(payload, dict):
+        return False
+    return payload.get("status") == "identity_required"
+
+
+def maybe_retry_with_lineage(
+    *,
+    base_url: str,
+    tool_name: str,
+    arguments: dict[str, Any],
+    workspace: Path,
+    cached_entry: dict[str, Any] | None,
+    result: dict[str, Any],
+    enabled: bool,
+) -> dict[str, Any]:
+    """Mint a fresh lineage identity for check-ins after context rollover.
+
+    This is intentionally limited to check-in tools. Arbitrary diagnostic calls
+    should not mint identities as a side effect.
+    """
+    if not enabled or tool_name not in AUTO_LINEAGE_TOOLS:
+        return result
+    if not is_identity_required(result):
+        return result
+
+    entry = cached_entry or latest_session_cache(workspace)
+    if not entry:
+        return result
+    parent_agent_id = entry.get("uuid") or entry.get("parent_agent_id")
+    if not isinstance(parent_agent_id, str) or not parent_agent_id:
+        return result
+
+    onboard_args = {
+        "force_new": True,
+        "parent_agent_id": parent_agent_id,
+        "spawn_reason": "new_session",
+        "response_mode": "minimal",
+    }
+    onboard_result = call_tool(base_url, "onboard", onboard_args)
+    onboard_payload = onboard_result.get("result")
+    if not isinstance(onboard_payload, dict) or not onboard_payload.get("success"):
+        return result
+
+    new_uuid = onboard_payload.get("uuid")
+    new_session_id = onboard_payload.get("client_session_id")
+    if not isinstance(new_uuid, str) or not isinstance(new_session_id, str):
+        return result
+
+    write_session_cache(
+        workspace,
+        uuid=new_uuid,
+        client_session_id=new_session_id,
+        parent_agent_id=parent_agent_id,
+    )
+    arguments["client_session_id"] = new_session_id
+    retried = call_tool(base_url, tool_name, arguments, session_id=new_session_id)
+    if isinstance(retried, dict):
+        retried["_mcp_call_auto_lineage"] = {
+            "parent_agent_id": parent_agent_id,
+            "client_session_id": new_session_id,
+        }
+    return retried
 
 
 def list_tools(base_url: str) -> None:
@@ -133,6 +340,24 @@ Examples:
     )
     parser.add_argument("--url", default=DEFAULT_URL, help="MCP server URL")
     parser.add_argument("--session", "-s", help="Session ID for X-Session-ID header")
+    parser.add_argument(
+        "--workspace",
+        default=".",
+        help="Workspace used for .unitares/session-*.json discovery",
+    )
+    parser.add_argument(
+        "--no-session-cache",
+        action="store_true",
+        help="Do not infer client_session_id/X-Session-ID from .unitares cache",
+    )
+    parser.add_argument(
+        "--no-auto-lineage",
+        action="store_true",
+        help=(
+            "Do not mint a fresh lineage identity when a cached check-in "
+            "returns identity_required"
+        ),
+    )
     parser.add_argument("--list", "-l", action="store_true", help="List available tools")
     parser.add_argument("--describe", "-d", metavar="TOOL", help="Describe a tool")
     parser.add_argument("--raw", "-r", action="store_true", help="Output raw JSON")
@@ -145,6 +370,8 @@ Examples:
         list_tools(args.url)
         return
 
+    workspace = Path(args.workspace).expanduser().resolve()
+
     if args.describe:
         describe_tool(args.url, args.describe, args.session)
         return
@@ -154,7 +381,23 @@ Examples:
         sys.exit(1)
 
     arguments = parse_arguments(args.args)
-    result = call_tool(args.url, args.tool, arguments, args.session)
+    session_id, cached_entry = resolve_session_binding(
+        args.tool,
+        arguments,
+        args.session,
+        workspace=workspace,
+        use_cache=not args.no_session_cache,
+    )
+    result = call_tool(args.url, args.tool, arguments, session_id)
+    result = maybe_retry_with_lineage(
+        base_url=args.url,
+        tool_name=args.tool,
+        arguments=arguments,
+        workspace=workspace,
+        cached_entry=cached_entry,
+        result=result,
+        enabled=not args.no_auto_lineage,
+    )
 
     if args.raw:
         print(json.dumps(result))

--- a/tests/test_autopilot_closeout.py
+++ b/tests/test_autopilot_closeout.py
@@ -47,6 +47,7 @@ def _closeout(module, state):
         stashed=False,
         stash_message=None,
         repo_processes=[],
+        expected_repo_processes=[],
         stopped_processes=[],
         booted_out_labels=[],
         errors=[],

--- a/tests/test_diagnostics_mcp_call.py
+++ b/tests/test_diagnostics_mcp_call.py
@@ -1,0 +1,116 @@
+"""Tests for scripts/diagnostics/mcp_call.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def mcp_call_module():
+    project_root = Path(__file__).resolve().parent.parent
+    module_path = project_root / "scripts" / "diagnostics" / "mcp_call.py"
+    spec = importlib.util.spec_from_file_location("diagnostics_mcp_call", module_path)
+    assert spec and spec.loader, f"could not load {module_path}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["diagnostics_mcp_call"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_resolve_session_binding_promotes_argument_to_header(mcp_call_module, tmp_path):
+    arguments = {"client_session_id": "agent-existing"}
+
+    session_id, cached = mcp_call_module.resolve_session_binding(
+        "process_agent_update",
+        arguments,
+        None,
+        workspace=tmp_path,
+        use_cache=True,
+    )
+
+    assert session_id == "agent-existing"
+    assert cached is None
+    assert arguments == {"client_session_id": "agent-existing"}
+
+
+def test_resolve_session_binding_uses_newest_cache_entry(mcp_call_module, tmp_path):
+    cache_dir = tmp_path / ".unitares"
+    cache_dir.mkdir()
+    (cache_dir / "session-agent-old.json").write_text(
+        '{"schema_version": 2, "uuid": "old", '
+        '"client_session_id": "agent-old", '
+        '"updated_at": "2026-01-01T00:00:00+00:00"}\n'
+    )
+    (cache_dir / "session-agent-new.json").write_text(
+        '{"schema_version": 2, "uuid": "new", '
+        '"client_session_id": "agent-new", '
+        '"updated_at": "2026-01-02T00:00:00+00:00"}\n'
+    )
+    arguments = {}
+
+    session_id, cached = mcp_call_module.resolve_session_binding(
+        "process_agent_update",
+        arguments,
+        None,
+        workspace=tmp_path,
+        use_cache=True,
+    )
+
+    assert session_id == "agent-new"
+    assert cached["uuid"] == "new"
+    assert arguments["client_session_id"] == "agent-new"
+
+
+def test_retry_with_lineage_mints_and_persists_fresh_session(
+    mcp_call_module, tmp_path, monkeypatch
+):
+    calls: list[tuple[str, dict, str | None]] = []
+
+    def fake_call_tool(base_url, tool_name, arguments, session_id=None):
+        calls.append((tool_name, dict(arguments), session_id))
+        if tool_name == "onboard":
+            return {
+                "result": {
+                    "success": True,
+                    "uuid": "child-uuid",
+                    "client_session_id": "agent-child",
+                }
+            }
+        return {"result": {"success": True, "status": "healthy"}}
+
+    monkeypatch.setattr(mcp_call_module, "call_tool", fake_call_tool)
+    result = mcp_call_module.maybe_retry_with_lineage(
+        base_url="http://example",
+        tool_name="process_agent_update",
+        arguments={"response_text": "work"},
+        workspace=tmp_path,
+        cached_entry={"uuid": "parent-uuid", "client_session_id": "agent-parent"},
+        result={"result": {"status": "identity_required"}},
+        enabled=True,
+    )
+
+    assert calls == [
+        (
+            "onboard",
+            {
+                "force_new": True,
+                "parent_agent_id": "parent-uuid",
+                "spawn_reason": "new_session",
+                "response_mode": "minimal",
+            },
+            None,
+        ),
+        (
+            "process_agent_update",
+            {"response_text": "work", "client_session_id": "agent-child"},
+            "agent-child",
+        ),
+    ]
+    assert result["_mcp_call_auto_lineage"]["parent_agent_id"] == "parent-uuid"
+    cache_payload = (tmp_path / ".unitares" / "session-agent-child.json").read_text()
+    assert '"uuid": "child-uuid"' in cache_payload
+    assert '"continuity_token"' not in cache_payload

--- a/tests/test_migration_027_lease_plane_deprecation.py
+++ b/tests/test_migration_027_lease_plane_deprecation.py
@@ -4,7 +4,7 @@ Phase A schema tests for surface-lease-plane migration 027.
 Migration 027 (per RFC v0.8 §7.11.1) adds two tables:
 
   1. lease_plane.surface_kind_catalog — canonical registry of allowed scheme prefixes.
-     Seeded with the 5 v0 schemes (file, dialectic, resident, capture, td).
+     Seeded with the canonical schemes (capture, dialectic, file, maintenance, resident, td).
   2. lease_plane.deprecated_schemes — first-class persistence substrate for
      §7.11 deprecation procedure. FK to surface_kind_catalog so deprecation
      can only target a registered kind.
@@ -39,7 +39,7 @@ if not can_connect_to_test_db():
 
 @pytest.mark.asyncio
 async def test_migration_027_surface_kind_catalog_seeded():
-    """Migration 027 creates surface_kind_catalog and seeds the 5 canonical schemes."""
+    """Migration 027 creates surface_kind_catalog and seeds canonical schemes."""
     await ensure_test_database_schema()
     conn = await asyncpg.connect(TEST_DB_URL)
     try:
@@ -47,8 +47,8 @@ async def test_migration_027_surface_kind_catalog_seeded():
             "SELECT surface_kind FROM lease_plane.surface_kind_catalog ORDER BY surface_kind"
         )
         kinds = [r["surface_kind"] for r in rows]
-        assert kinds == ["capture", "dialectic", "file", "resident", "td"], (
-            f"Expected 5 canonical schemes seeded, got {kinds}"
+        assert kinds == ["capture", "dialectic", "file", "maintenance", "resident", "td"], (
+            f"Expected canonical schemes seeded, got {kinds}"
         )
     finally:
         await conn.close()

--- a/tests/test_workspace_closeout.py
+++ b/tests/test_workspace_closeout.py
@@ -137,6 +137,62 @@ def test_process_baseline_filters_existing_processes(closeout_module, tmp_path):
     assert closeout_module.process_key(new_proc) not in keys
 
 
+def test_split_expected_processes_keeps_substrate_visible_but_nonblocking(
+    closeout_module, tmp_path
+):
+    root = tmp_path / "repo"
+    root.mkdir()
+    expected = closeout_module.ProcessInfo(
+        pid=10,
+        ppid=1,
+        cwd=str(root / "elixir" / "sentinel"),
+        command="/opt/homebrew/bin/mix run --no-halt",
+    )
+    unexpected = closeout_module.ProcessInfo(
+        pid=11,
+        ppid=1,
+        cwd=str(root),
+        command="python scratch_task.py",
+    )
+
+    unexpected_result, expected_result = closeout_module.split_expected_processes(
+        [expected, unexpected],
+        root,
+    )
+
+    assert unexpected_result == [unexpected]
+    assert expected_result == [expected]
+    assert expected.expected_reason == "UNITARES BEAM resident service (sentinel)"
+
+
+def test_closeout_expected_processes_do_not_make_result_dirty(
+    closeout_module, git_repo, monkeypatch
+):
+    expected = closeout_module.ProcessInfo(
+        pid=10,
+        ppid=1,
+        cwd=str(git_repo / "elixir" / "agent_orchestrator"),
+        command="/opt/homebrew/bin/mix run --no-halt",
+    )
+    monkeypatch.setattr(
+        closeout_module,
+        "repo_rooted_processes",
+        lambda *args, **kwargs: [expected],
+    )
+
+    result = closeout_module.closeout(git_repo)
+    rendered = closeout_module.render_text(result)
+    payload = closeout_module.to_jsonable(result)
+
+    assert result.repo_processes == []
+    assert result.expected_repo_processes == [expected]
+    assert closeout_module.result_has_issues(result) is False
+    assert "repo-rooted processes: none" in rendered
+    assert "expected repo-rooted processes: 1" in rendered
+    assert payload["clean"] is True
+    assert payload["expected_repo_processes"][0]["expected_reason"]
+
+
 def test_closeout_stashes_dirty_repo_when_requested(closeout_module, git_repo, monkeypatch):
     monkeypatch.setattr(closeout_module, "repo_rooted_processes", lambda *args, **kwargs: [])
     (git_repo / "seed.py").write_text("dirty\n")


### PR DESCRIPTION
## Summary
- make scripts/diagnostics/mcp_call.py rehydrate local session cache state, send client_session_id as X-Session-ID, and auto-mint a fresh lineage identity for check-ins that hit identity_required after a context rollover
- split closeout repo-rooted processes into unexpected blockers vs visible expected substrate helpers
- update closeout/autopilot coverage and align migration 027 catalog coverage with the maintenance surface kind

## Validation
- python3 -m py_compile scripts/diagnostics/mcp_call.py scripts/dev/workspace_closeout.py
- bash -n /Users/cirwel/.local/bin/git-prepr
- python3 -m pytest tests/test_migration_027_lease_plane_deprecation.py tests/test_diagnostics_mcp_call.py tests/test_workspace_closeout.py tests/test_autopilot_closeout.py
- ./scripts/dev/test-cache.sh
- ./scripts/dev/test-cache.sh --staged
- python3 scripts/dev/workspace_closeout.py --cwd /Users/cirwel/projects/unitares
- git prepr --scope "mcp_call closeout prepr"

## Notes
- The live installed /Users/cirwel/.local/bin/git-prepr helper was also patched locally to add an owner-qualified gh pr list --head <owner>:<branch> fallback. That helper is outside this repository, so it is not included in this PR diff.