### PR TITLE
feat(monitor): basin shadow-compare (kernel-split WS1 phase 0)

### DIFF
--- a/config/governance_config.py
+++ b/config/governance_config.py
@@ -1044,6 +1044,19 @@ def phi_telemetry_only() -> bool:
     return os.getenv("UNITARES_PHI_TELEMETRY_ONLY", "").strip().lower() in {"1", "true", "on", "yes"}
 
 
+def basin_shadow_enabled() -> bool:
+    """Whether to shadow-compare the behavioral-EISV basin against the live
+    ODE basin each warm check-in (UNITARES_BASIN_SHADOW). Default off.
+
+    Behavior-neutral measurement for kernel-split WS1 option b: it records
+    (via audit event 'basin_shadow') what classify_basin() would return if fed
+    the already-computed behavioral EISV instead of the ODE-evolved state, so
+    the swap can be validated before the ODE solve is gated off the check-in
+    critical path. Does NOT change any live decision.
+    """
+    return os.getenv("UNITARES_BASIN_SHADOW", "").strip().lower() in {"1", "true", "on", "yes"}
+
+
 def get_s_setpoint(agent_class: str = "default") -> float:
     """Per-class S decay target σ for the dynamics.
 

--- a/src/audit_log.py
+++ b/src/audit_log.py
@@ -124,7 +124,32 @@ class AuditLogger:
             }
         )
         self._write_entry(entry)
-    
+
+    def log_basin_shadow(self, agent_id: str, ode_basin: str, behavioral_basin: str,
+                         agree: bool, confidence: float, details: dict = None):
+        """Shadow-compare the live ODE-derived basin against a basin computed
+        from the (already-available) behavioral EISV.
+
+        Behavior-neutral: records what the decision basin *would* be if the
+        boundary/void/coherence inputs were fed from behavioral EISV instead of
+        the ODE-evolved state (kernel-split WS1 option b). It does NOT change the
+        live decision — it only measures divergence so the swap can be validated
+        before the ODE is gated off the check-in critical path.
+        """
+        entry = AuditEntry(
+            timestamp=datetime.now().isoformat(),
+            agent_id=agent_id,
+            event_type="basin_shadow",
+            confidence=float(confidence),
+            details={
+                "ode_basin": ode_basin,
+                "behavioral_basin": behavioral_basin,
+                "agree": bool(agree),
+                **(details or {}),
+            }
+        )
+        self._write_entry(entry)
+
     def log_pause_auto_expired(self, agent_id: str,
                                 original_paused_at: Optional[str],
                                 elapsed_seconds: float):

--- a/src/governance_monitor.py
+++ b/src/governance_monitor.py
@@ -1292,6 +1292,47 @@ class UNITARESMonitor:
             oscillation_state=oscillation_state
         )
 
+        # ── Basin shadow-compare (kernel-split WS1 option b, behavior-neutral) ──
+        # Record what classify_basin() would return if the boundary/void/coherence
+        # inputs were fed from the already-computed behavioral EISV instead of the
+        # ODE-evolved state. Warm agents only (the population that would skip the
+        # ODE). Coherence is a pure function of V — C(V,Θ) — so the behavioral
+        # coherence is just coherence_function(behavioral_V) on the same scale.
+        # This does NOT mutate `decision`; it only emits a 'basin_shadow' audit
+        # event so the swap can be validated before the ODE is gated off the hot
+        # path. Fully guarded — shadow measurement must never break the live path.
+        try:
+            from config.governance_config import basin_shadow_enabled, classify_basin
+            beh = self._behavioral_state
+            if (basin_shadow_enabled()
+                    and GovConfig.BEHAVIORAL_VERDICT_ENABLED
+                    and beh is not None
+                    and beh.confidence >= 0.3):
+                coh_beh = self.coherence_function(beh.V)
+                beh_basin = classify_basin(
+                    E=beh.E, I=beh.I, S=beh.S, V=beh.V,
+                    coherence=coh_beh, risk_score=risk_score,
+                )
+                ode_basin = decision.get('basin')
+                audit_logger.log_basin_shadow(
+                    agent_id=self.agent_id,
+                    ode_basin=ode_basin,
+                    behavioral_basin=beh_basin,
+                    agree=(ode_basin == beh_basin),
+                    confidence=beh.confidence,
+                    details={
+                        "ode_eisv": {"E": self.state.E, "I": self.state.I,
+                                     "S": self.state.S, "V": self.state.V,
+                                     "coherence": self.state.coherence},
+                        "behavioral_eisv": {"E": beh.E, "I": beh.I, "S": beh.S,
+                                            "V": beh.V, "coherence": coh_beh},
+                        "risk_score": risk_score,
+                        "sub_action": decision.get('sub_action'),
+                    },
+                )
+        except Exception as e:
+            logger.debug(f"basin_shadow skipped for {self.agent_id}: {e}")
+
         # Pre-flag gap-suppression so calibration, audit, and history can record
         # the *original* verdict truthfully — the actual decision mutation
         # happens after those recording paths so calibration doesn't learn from

--- a/tests/test_basin_shadow_compare.py
+++ b/tests/test_basin_shadow_compare.py
@@ -1,0 +1,88 @@
+"""Tests for the basin shadow-compare (kernel-split WS1 option b, Phase 0).
+
+The shadow path records what `classify_basin()` would return if fed the
+already-computed behavioral EISV (with coherence = C(behavioral_V)) instead of
+the ODE-evolved state. It is behavior-neutral measurement gated behind
+`UNITARES_BASIN_SHADOW` (default off), used to validate the behavioral-EISV
+basin against the live ODE basin before the ODE solve is gated off the
+check-in critical path.
+
+Guarantees under test:
+  1. Default off — no `basin_shadow` event, no behavior change.
+  2. When enabled, warm agents (behavioral confidence >= 0.3) emit a
+     `basin_shadow` event with a self-consistent `agree` flag.
+  3. Enabling the shadow does NOT perturb the live decision or metrics.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.governance_monitor import UNITARESMonitor
+from src import audit_log
+
+
+def _agent_state():
+    # 6 leading params + filler to the expected 128-wide parameter vector,
+    # mirroring tests/test_bug_fixes.py. Healthy, low-drift input.
+    params = [0.5, 0.5, 0.5, 0.5, 0.5, 0.5] + [0.01] * 122
+    return {
+        "parameters": params,
+        "ethical_drift": [0.1, 0.12, 0.1],
+        "response_text": "Test response",
+        "complexity": 0.4,
+    }
+
+
+def _run(monitor, n=6):
+    last = None
+    for _ in range(n):
+        last = monitor.process_update(_agent_state())
+    return last
+
+
+def test_basin_shadow_off_by_default(monkeypatch):
+    monkeypatch.delenv("UNITARES_BASIN_SHADOW", raising=False)
+    spy = MagicMock()
+    monkeypatch.setattr(audit_log.audit_logger, "log_basin_shadow", spy)
+
+    monitor = UNITARESMonitor(agent_id="shadow-default")
+    _run(monitor)
+
+    spy.assert_not_called()
+
+
+def test_basin_shadow_emits_when_enabled_and_warm(monkeypatch):
+    monkeypatch.setenv("UNITARES_BASIN_SHADOW", "1")
+    spy = MagicMock()
+    monkeypatch.setattr(audit_log.audit_logger, "log_basin_shadow", spy)
+
+    monitor = UNITARESMonitor(agent_id="shadow-warm")
+    _run(monitor, n=6)  # warms behavioral confidence past the 0.3 gate
+
+    assert spy.call_count >= 1, "warm agent should emit at least one basin_shadow event"
+    kw = spy.call_args.kwargs
+    assert kw["ode_basin"] in ("high", "low", "boundary")
+    assert kw["behavioral_basin"] in ("high", "low", "boundary")
+    # The agree flag must be self-consistent with the two basins it compares.
+    assert kw["agree"] == (kw["ode_basin"] == kw["behavioral_basin"])
+    assert kw["confidence"] >= 0.3
+
+
+def test_basin_shadow_is_behavior_neutral(monkeypatch):
+    # Same fresh state + identical inputs, shadow off vs on: the live decision
+    # and metrics must be byte-identical — the shadow only observes.
+    monkeypatch.delenv("UNITARES_BASIN_SHADOW", raising=False)
+    monkeypatch.setattr(audit_log.audit_logger, "log_basin_shadow", MagicMock())
+    off = _run(UNITARESMonitor(agent_id="neutral-off"))
+
+    monkeypatch.setenv("UNITARES_BASIN_SHADOW", "1")
+    monkeypatch.setattr(audit_log.audit_logger, "log_basin_shadow", MagicMock())
+    on = _run(UNITARESMonitor(agent_id="neutral-on"))
+
+    assert on["decision"]["action"] == off["decision"]["action"]
+    assert on["decision"].get("basin") == off["decision"].get("basin")
+    assert on["decision"].get("sub_action") == off["decision"].get("sub_action")
+    assert on["metrics"]["coherence"] == pytest.approx(off["metrics"]["coherence"])
+    assert on["metrics"]["E"] == pytest.approx(off["metrics"]["E"])
+    assert on["metrics"]["V"] == pytest.approx(off["metrics"]["V"])


### PR DESCRIPTION
## What

Behavior-neutral measurement for **kernel-split WS1** (moving the heavy EISV ODE off the check-in critical path). Behind `UNITARES_BASIN_SHADOW` (**default off**), each warm check-in records what `classify_basin()` *would* return if fed the already-computed **behavioral EISV** — with coherence = `C(behavioral_V)`, a pure function of V — instead of the ODE-evolved state, as a `basin_shadow` audit event.

It does **not** change any live decision. It only measures divergence so WS1 **option (b)** — preserve the boundary-`guide` nudge by feeding `classify_basin()` from behavioral EISV rather than the ODE — can be validated before the ODE solve is gated off the hot path.

## Why (measured, 30d, 27,084 real check-ins)

- The ODE solve (`governance_monitor.py` `update_dynamics`) is the check-in tax: 60–4500ms, inside the agent lock, >60% of `process_agent_update` p99.
- `_make_decision` (`src/monitor_decision.py`) reads ODE-evolved `state.coherence`/`state.void_active`/`classify_basin(E,I,S,V)` — so the ODE state *does* gate pauses (corrects a prior "ODE doesn't gate" KG note).
- But every ODE-state-only pause (void/coherence/basin) in 30d fired on **cold** agents (which keep the ODE under a confidence gate). The **sole** warm-traffic effect of dropping the ODE is ~21% of warm check-ins losing a boundary `guide` nudge (4,101 `safe`+`guide` vs 68 `caution`+`guide`).
- Option (b) preserves that nudge by computing basin from behavioral EISV. This PR validates that the behavioral basin tracks the ODE basin closely enough before any gate flips.

## Changes

- `config/governance_config.py`: `basin_shadow_enabled()` reading `UNITARES_BASIN_SHADOW` (default off).
- `src/audit_log.py`: `log_basin_shadow()` → `basin_shadow` row in `audit.events`.
- `src/governance_monitor.py`: guarded shadow block after `make_decision` (warm agents only; fully try/except-wrapped — measurement must never break the live path).
- `tests/test_basin_shadow_compare.py`: default-off, warm-emission + self-consistent `agree`, and behavior-neutrality (live decision/metrics byte-identical on vs off).

## How to read the data once enabled

Set `UNITARES_BASIN_SHADOW=1`, let it run, then:
```sql
SELECT (payload->'details'->>'agree')::bool AS agree, count(*)
FROM audit.events WHERE event_type='basin_shadow'
GROUP BY 1;
```
High agreement → option (b) is safe; the boundary-`guide` divergence rows show exactly where behavioral basin and ODE basin differ.

## Tests / gate

`test-cache.sh`: 6590 passed, 17 skipped, 1 failure — `test_migration_027_lease_plane_deprecation` — which is **pre-existing on clean master** (verified by stashing this diff) and unrelated (live surface_kind catalog drift; this diff touches no migrations/lease code).

## Related

Adjacent to the verdict-blending proposal in #1088 (smoothing the behavioral↔Φ *risk* blend) — orthogonal mechanism, same owner-space.

https://claude.ai/code/session_0148U7HfEUhwgXoRybnVw9Dx