### PR TITLE
Harden prospective validation dataset binding

### DIFF
--- a/scripts/analysis/outcome_inventory.py
+++ b/scripts/analysis/outcome_inventory.py
@@ -66,6 +66,7 @@ class InventoryBucket:
     n_total: int = 0
     n_bad: int = 0
     prediction_id_count: int = 0
+    registry_prediction_bound_count: int = 0
     prior_state_counts: dict[float, int] = field(default_factory=dict)
 
     @property
@@ -89,7 +90,9 @@ class OutcomeInventory:
     hard_exogenous_count: int
     eprocess_eligible_count: int
     total_prediction_id_count: int
+    registry_prediction_bound_count: int = 0
     eprocess_eligible_by_harness_lane: dict[str, int] = field(default_factory=dict)
+    registry_prediction_bound_by_harness_lane: dict[str, int] = field(default_factory=dict)
 
     @property
     def total_bad_rate(self) -> float | None:
@@ -191,6 +194,11 @@ def _has_prediction_id(detail: Mapping[str, Any]) -> bool:
     return prediction_id not in (None, "")
 
 
+def _is_registry_prediction_bound(detail: Mapping[str, Any]) -> bool:
+    """Return whether an outcome has a real prospective registry binding."""
+    return _has_prediction_id(detail) and _prediction_binding(detail) == "registry"
+
+
 def harness_lane_from_detail(detail: Mapping[str, Any] | str | None) -> str:
     """Return the analysis lane for a row's harness provenance.
 
@@ -222,6 +230,8 @@ def build_inventory(
     eprocess_eligible_count = 0
     eprocess_eligible_by_harness_lane: dict[str, int] = {}
     total_prediction_id_count = 0
+    registry_prediction_bound_count = 0
+    registry_prediction_bound_by_harness_lane: dict[str, int] = {}
 
     for row in rows:
         detail = _normalized_detail(row.detail)
@@ -272,6 +282,12 @@ def build_inventory(
         if _has_prediction_id(detail):
             bucket.prediction_id_count += 1
             total_prediction_id_count += 1
+        if _is_registry_prediction_bound(detail):
+            bucket.registry_prediction_bound_count += 1
+            registry_prediction_bound_count += 1
+            registry_prediction_bound_by_harness_lane[harness_lane] = (
+                registry_prediction_bound_by_harness_lane.get(harness_lane, 0) + 1
+            )
         for lead in leads:
             if bool(row.prior_state_by_lead.get(lead, False)):
                 bucket.prior_state_counts[lead] += 1
@@ -300,8 +316,12 @@ def build_inventory(
         hard_exogenous_count=hard_exogenous_count,
         eprocess_eligible_count=eprocess_eligible_count,
         total_prediction_id_count=total_prediction_id_count,
+        registry_prediction_bound_count=registry_prediction_bound_count,
         eprocess_eligible_by_harness_lane=dict(
             sorted(eprocess_eligible_by_harness_lane.items())
+        ),
+        registry_prediction_bound_by_harness_lane=dict(
+            sorted(registry_prediction_bound_by_harness_lane.items())
         ),
     )
 
@@ -338,6 +358,7 @@ def _harness_lane_summary_rows(
                 "task_scope_bad": 0,
                 "eprocess_eligible": 0,
                 "prediction_id": 0,
+                "registry_prediction_bound": 0,
                 "prior_state": {lead: 0 for lead in leads},
             },
         )
@@ -352,6 +373,7 @@ def _harness_lane_summary_rows(
         if bucket.eprocess_eligible:
             lane_summary["eprocess_eligible"] += bucket.n_total
         lane_summary["prediction_id"] += bucket.prediction_id_count
+        lane_summary["registry_prediction_bound"] += bucket.registry_prediction_bound_count
         for lead in leads:
             lane_summary["prior_state"][lead] += bucket.prior_state_counts.get(lead, 0)
 
@@ -370,6 +392,7 @@ def _harness_lane_summary_rows(
                 str(summary["task_scope_bad"]),
                 str(summary["eprocess_eligible"]),
                 str(summary["prediction_id"]),
+                str(summary["registry_prediction_bound"]),
                 *[f"{prior_state[lead]}/{outcomes}" for lead in leads],
             ]
         )
@@ -405,6 +428,13 @@ def format_inventory_report(
             )
         ],
         f"prediction_id_present: {inventory.total_prediction_id_count}",
+        f"registry_prediction_bound: {inventory.registry_prediction_bound_count}",
+        *[
+            f"registry_prediction_bound_{lane}: {count}"
+            for lane, count in sorted(
+                inventory.registry_prediction_bound_by_harness_lane.items()
+            )
+        ],
         "",
         "## Harness Lane Summary",
         "",
@@ -420,6 +450,7 @@ def format_inventory_report(
         "Task-scope bad",
         "E-process eligible",
         "Prediction IDs",
+        "Registry-bound predictions",
         *[f"Prior state {_format_lead(lead)}m" for lead in leads],
     ]
     lines.append("| " + " | ".join(summary_headers) + " |")

--- a/scripts/analysis/prospective_prediction_cohort.py
+++ b/scripts/analysis/prospective_prediction_cohort.py
@@ -61,6 +61,35 @@ class ProspectiveCohortSummary:
             else 0.0
         )
 
+    @property
+    def prediction_prior_state_coverage(self) -> float:
+        """Prior-state coverage within the registry-bound prediction cohort."""
+
+        return (
+            self.prediction_bound_prior_state / self.prediction_bound
+            if self.prediction_bound
+            else 0.0
+        )
+
+
+@dataclass(frozen=True)
+class ReadinessThresholds:
+    """Minimum bar for calling a prospective prediction cohort strong."""
+
+    min_prediction_bound: int = 100
+    min_prediction_bound_bad: int = 10
+    min_prediction_coverage: float = 0.05
+    min_prediction_prior_state_coverage: float = 0.8
+
+
+@dataclass(frozen=True)
+class ValidationReadiness:
+    """Readiness decision plus explicit unmet gates."""
+
+    status: str
+    reasons: tuple[str, ...]
+    thresholds: ReadinessThresholds
+
 
 def is_prospective_prediction_bound(row: OutcomeRow) -> bool:
     """True only for rows tied to a real registry prediction binding."""
@@ -101,8 +130,70 @@ def _fmt_lead(value: float) -> str:
     return f"{value:g}"
 
 
-def format_cohort_report(summary: ProspectiveCohortSummary) -> str:
+def evaluate_readiness(
+    summary: ProspectiveCohortSummary,
+    thresholds: ReadinessThresholds | None = None,
+) -> ValidationReadiness:
+    """Evaluate whether a prospective prediction cohort is strong enough.
+
+    This is a data-quality gate, not an EISV validation claim. It separates
+    registry-bound prospective volume, negative-class coverage, prediction
+    coverage, and prior-state coverage so weak datasets fail explicitly.
+    """
+
+    thresholds = thresholds or ReadinessThresholds()
+    reasons: list[str] = []
+    if summary.prediction_bound < thresholds.min_prediction_bound:
+        reasons.append(
+            f"prediction_bound {summary.prediction_bound} < {thresholds.min_prediction_bound}"
+        )
+    if summary.prediction_bound_bad < thresholds.min_prediction_bound_bad:
+        reasons.append(
+            "prediction_bound_bad "
+            f"{summary.prediction_bound_bad} < {thresholds.min_prediction_bound_bad}"
+        )
+    if summary.prediction_coverage < thresholds.min_prediction_coverage:
+        reasons.append(
+            "prediction_coverage "
+            f"{summary.prediction_coverage:.3f} < {thresholds.min_prediction_coverage:.3f}"
+        )
+    if summary.prediction_prior_state_coverage < thresholds.min_prediction_prior_state_coverage:
+        reasons.append(
+            "prediction_prior_state_coverage "
+            f"{summary.prediction_prior_state_coverage:.3f} < "
+            f"{thresholds.min_prediction_prior_state_coverage:.3f}"
+        )
+    return ValidationReadiness(
+        status="not_ready" if reasons else "strong",
+        reasons=tuple(reasons),
+        thresholds=thresholds,
+    )
+
+
+def format_cohort_report(
+    summary: ProspectiveCohortSummary,
+    *,
+    thresholds: ReadinessThresholds | None = None,
+) -> str:
     """Render a markdown summary for prospective holdout readiness."""
+
+    readiness = evaluate_readiness(summary, thresholds)
+    threshold_text = (
+        f"min_prediction_bound={readiness.thresholds.min_prediction_bound}, "
+        f"min_prediction_bound_bad={readiness.thresholds.min_prediction_bound_bad}, "
+        f"min_prediction_coverage={readiness.thresholds.min_prediction_coverage:.3f}, "
+        "min_prediction_prior_state_coverage="
+        f"{readiness.thresholds.min_prediction_prior_state_coverage:.3f}"
+    )
+    readiness_lines = [
+        f"readiness: {readiness.status}",
+        f"readiness_thresholds: {threshold_text}",
+    ]
+    if readiness.reasons:
+        readiness_lines.append("readiness_reasons:")
+        readiness_lines.extend(f"- {reason}" for reason in readiness.reasons)
+    else:
+        readiness_lines.append("readiness_reasons: none")
 
     lanes = ",".join(
         f"{lane}={count}" for lane, count in summary.by_harness_lane.items()
@@ -121,7 +212,10 @@ def format_cohort_report(summary: ProspectiveCohortSummary) -> str:
             f"prediction_bound_bad_rate: {summary.prediction_bound_bad_rate:.3f}",
             "prediction_bound_prior_state: "
             f"{summary.prediction_bound_prior_state}/{summary.prediction_bound}",
+            f"prediction_prior_state_coverage: {summary.prediction_prior_state_coverage:.3f}",
             f"harness_lanes: {lanes}",
+            "",
+            *readiness_lines,
             "",
             "Interpretation rule: this is prospective holdout plumbing only. "
             "It counts registry-bound predictions that existed before outcomes; "
@@ -162,6 +256,15 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--scope", choices=("strict", "task"), default="task")
     parser.add_argument("--window-days", type=int, default=90)
     parser.add_argument("--lead-minutes", type=float, default=30.0)
+    default_thresholds = ReadinessThresholds()
+    parser.add_argument("--min-prediction-bound", type=int, default=default_thresholds.min_prediction_bound)
+    parser.add_argument("--min-prediction-bound-bad", type=int, default=default_thresholds.min_prediction_bound_bad)
+    parser.add_argument("--min-prediction-coverage", type=float, default=default_thresholds.min_prediction_coverage)
+    parser.add_argument(
+        "--min-prediction-prior-state-coverage",
+        type=float,
+        default=default_thresholds.min_prediction_prior_state_coverage,
+    )
     parser.add_argument("--output", help="Optional markdown output path")
     return parser.parse_args(argv)
 
@@ -175,7 +278,13 @@ async def main_async(args: argparse.Namespace) -> int:
         window_days=args.window_days,
         lead_minutes=args.lead_minutes,
     )
-    report = format_cohort_report(summary)
+    thresholds = ReadinessThresholds(
+        min_prediction_bound=args.min_prediction_bound,
+        min_prediction_bound_bad=args.min_prediction_bound_bad,
+        min_prediction_coverage=args.min_prediction_coverage,
+        min_prediction_prior_state_coverage=args.min_prediction_prior_state_coverage,
+    )
+    report = format_cohort_report(summary, thresholds=thresholds)
     if args.output:
         path = Path(args.output)
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -238,6 +238,33 @@ def _derive_outcome(evidence: dict) -> tuple:
     return ("task_failed" if is_bad else "task_completed", is_bad)
 
 
+def _prediction_id_for_phase5_evidence(ctx: UpdateContext, evidence: dict) -> str | None:
+    """Return the prediction id to attach to one Phase-5 evidence row.
+
+    Caller-supplied evidence ids win. For unbound evidence rows, mint a fresh
+    tactical prediction from the current process_update confidence so each row
+    can resolve through outcome_event's one-shot registry path independently.
+    Reusing the process_update response's single prediction id would bind only
+    the first row; the rest would fall into missing/consumed fallback lanes.
+    """
+    explicit_prediction_id = evidence.get("prediction_id")
+    if explicit_prediction_id:
+        return explicit_prediction_id
+    if ctx.confidence is None:
+        return None
+    register_prediction = getattr(ctx.monitor, "register_tactical_prediction", None)
+    if not callable(register_prediction):
+        return None
+    decision = (ctx.result or {}).get("decision") or {}
+    decision_action = decision.get("action")
+    try:
+        minted = register_prediction(float(ctx.confidence), decision_action=decision_action)
+        return str(minted) if minted else None
+    except Exception as exc:
+        logger.debug("Phase-5 prediction id mint skipped: %s", exc, exc_info=True)
+        return None
+
+
 # Module-local strong-ref set for in-flight fire-and-forget persist tasks
 # (thread-identity, inferred-purpose). Without this, `asyncio.create_task(coro)`
 # returns a Task that CPython GC can collect mid-await — these persisters
@@ -2005,7 +2032,7 @@ async def execute_post_update_effects(ctx: UpdateContext) -> None:
                 await _record_outcome_event_inline({
                     "outcome_type": outcome_type,
                     "is_bad": is_bad,
-                    "prediction_id": evidence.get("prediction_id"),
+                    "prediction_id": _prediction_id_for_phase5_evidence(ctx, evidence),
                     "confidence": ctx.confidence,
                     "verification_source": "agent_reported_tool_result",
                     "detail": detail,

--- a/tests/test_outcome_inventory.py
+++ b/tests/test_outcome_inventory.py
@@ -102,6 +102,69 @@ def test_build_inventory_groups_by_scope_type_source_and_evidence_flags():
     assert inventory.total_outcomes == 4
     assert inventory.total_bad == 2
     assert inventory.total_prediction_id_count == 2
+    assert inventory.registry_prediction_bound_count == 2
+
+
+def test_build_inventory_counts_registry_prediction_bindings_separately_from_ids():
+    rows = [
+        OutcomeInventoryRow(
+            outcome_type="test_passed",
+            is_bad=False,
+            verification_source="server_observation",
+            detail={"prediction_id": "pred-reg", "prediction_binding": "registry"},
+            prior_state_by_lead={0.0: True},
+        ),
+        OutcomeInventoryRow(
+            outcome_type="test_failed",
+            is_bad=True,
+            verification_source="server_observation",
+            detail={"prediction_id": "pred-missing", "prediction_binding": "missing_prediction"},
+            prior_state_by_lead={0.0: True},
+        ),
+        OutcomeInventoryRow(
+            outcome_type="task_completed",
+            is_bad=False,
+            verification_source="agent_reported_tool_result",
+            detail={"prediction_binding": "argument_fallback"},
+            prior_state_by_lead={0.0: True},
+        ),
+    ]
+
+    inventory = build_inventory(rows, lead_minutes=(0.0,))
+
+    assert inventory.total_prediction_id_count == 2
+    assert inventory.registry_prediction_bound_count == 1
+    assert inventory.registry_prediction_bound_by_harness_lane == {"substrate": 1}
+
+
+def test_format_inventory_report_exposes_registry_bound_prediction_count():
+    rows = [
+        OutcomeInventoryRow(
+            outcome_type="test_passed",
+            is_bad=False,
+            verification_source="server_observation",
+            detail={"prediction_id": "pred-reg", "prediction_binding": "registry"},
+            prior_state_by_lead={0.0: True},
+        ),
+        OutcomeInventoryRow(
+            outcome_type="test_failed",
+            is_bad=True,
+            verification_source="server_observation",
+            detail={"prediction_id": "pred-missing", "prediction_binding": "missing_prediction"},
+            prior_state_by_lead={0.0: True},
+        ),
+    ]
+
+    inventory = build_inventory(rows, lead_minutes=(0.0,))
+    report = format_inventory_report(inventory, window_days=90, lead_minutes=(0.0,))
+
+    assert "prediction_id_present: 2" in report
+    assert "registry_prediction_bound: 1" in report
+    assert (
+        "| Lane | Outcomes | Bad | Strict outcomes | Strict bad | Task-scope outcomes | Task-scope bad | E-process eligible | Prediction IDs | Registry-bound predictions | Prior state 0m |"
+        in report
+    )
+    assert "| substrate | 2 | 1 | 2 | 1 | 2 | 1 | 0 | 2 | 1 | 2/2 |" in report
 
 
 def test_build_inventory_splits_beam_harness_from_substrate_lane():
@@ -186,11 +249,11 @@ def test_format_inventory_report_includes_harness_lane_summary():
 
     assert "## Harness Lane Summary" in report
     assert (
-        "| Lane | Outcomes | Bad | Strict outcomes | Strict bad | Task-scope outcomes | Task-scope bad | E-process eligible | Prediction IDs | Prior state 0m |"
+        "| Lane | Outcomes | Bad | Strict outcomes | Strict bad | Task-scope outcomes | Task-scope bad | E-process eligible | Prediction IDs | Registry-bound predictions | Prior state 0m |"
         in report
     )
-    assert "| beam | 2 | 1 | 0 | 0 | 2 | 1 | 2 | 0 | 0/2 |" in report
-    assert "| substrate | 2 | 1 | 1 | 0 | 2 | 1 | 1 | 1 | 2/2 |" in report
+    assert "| beam | 2 | 1 | 0 | 0 | 2 | 1 | 2 | 0 | 0 | 0/2 |" in report
+    assert "| substrate | 2 | 1 | 1 | 0 | 2 | 1 | 1 | 1 | 0 | 2/2 |" in report
 
 
 def test_format_inventory_report_exposes_zero_bad_strict_and_prior_coverage():

--- a/tests/test_phases_phase5_evidence.py
+++ b/tests/test_phases_phase5_evidence.py
@@ -252,6 +252,77 @@ async def test_evidence_iteration_enabled_calls_outcome_event(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_evidence_iteration_mints_prediction_ids_for_unbound_items(monkeypatch):
+    """Enabled Phase-5 evidence should bind each unbound item to a fresh prediction.
+
+    Reusing the process_update top-level prediction_id across several evidence
+    rows makes only the first row resolve as `registry`; later rows see a
+    consumed/missing id. The robust path is one freshly minted tactical
+    prediction per evidence row when the caller did not supply an explicit id.
+    """
+    monkeypatch.setenv("UNITARES_PHASE5_EVIDENCE_WRITE", "1")
+
+    outcome_event_mock = AsyncMock(return_value=[MagicMock(text='{"outcome_id":"eid"}')])
+    ctx = _make_ctx(
+        recent_tool_results=[
+            {"kind": "test", "tool": "pytest", "summary": "passed", "exit_code": 0},
+            {"kind": "lint", "tool": "ruff", "summary": "clean", "exit_code": 0},
+        ],
+        confidence=0.72,
+    )
+    assert ctx.monitor is not None
+    ctx.monitor.register_tactical_prediction = MagicMock(side_effect=["pred-phase5-1", "pred-phase5-2"])
+
+    with _make_patch_stack(ctx, outcome_event_mock=outcome_event_mock):
+        await execute_post_update_effects(ctx)
+
+    phase5_calls = [
+        c.args[0] for c in outcome_event_mock.call_args_list
+        if (c.args[0].get("detail") or {}).get("phase5_emitter") is True
+    ]
+    assert [args.get("prediction_id") for args in phase5_calls] == [
+        "pred-phase5-1",
+        "pred-phase5-2",
+    ]
+    assert ctx.monitor.register_tactical_prediction.call_count == 2
+    for call in ctx.monitor.register_tactical_prediction.call_args_list:
+        assert call.args == (0.72,)
+        assert call.kwargs == {"decision_action": "proceed"}
+
+
+@pytest.mark.asyncio
+async def test_evidence_iteration_preserves_explicit_prediction_id(monkeypatch):
+    """Explicit evidence prediction IDs are caller intent and must not be reminted."""
+    monkeypatch.setenv("UNITARES_PHASE5_EVIDENCE_WRITE", "1")
+
+    outcome_event_mock = AsyncMock(return_value=[MagicMock(text='{"outcome_id":"eid"}')])
+    ctx = _make_ctx(
+        recent_tool_results=[
+            {
+                "kind": "test",
+                "tool": "pytest",
+                "summary": "passed",
+                "exit_code": 0,
+                "prediction_id": "caller-prediction-id",
+            }
+        ]
+    )
+    assert ctx.monitor is not None
+    ctx.monitor.register_tactical_prediction = MagicMock(return_value="should-not-be-used")
+
+    with _make_patch_stack(ctx, outcome_event_mock=outcome_event_mock):
+        await execute_post_update_effects(ctx)
+
+    phase5_calls = [
+        c.args[0] for c in outcome_event_mock.call_args_list
+        if (c.args[0].get("detail") or {}).get("phase5_emitter") is True
+    ]
+    assert len(phase5_calls) == 1
+    assert phase5_calls[0].get("prediction_id") == "caller-prediction-id"
+    ctx.monitor.register_tactical_prediction.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_shadow_mode_sets_shadow_write_detail(monkeypatch):
     """UNITARES_PHASE5_EVIDENCE_WRITE=shadow → detail["shadow_write"]=True on each row."""
     monkeypatch.setenv("UNITARES_PHASE5_EVIDENCE_WRITE", "shadow")

--- a/tests/test_prospective_prediction_cohort.py
+++ b/tests/test_prospective_prediction_cohort.py
@@ -4,7 +4,9 @@ from datetime import datetime, timedelta, timezone
 
 from scripts.analysis.eisv_skeptic_report import OutcomeRow
 from scripts.analysis.prospective_prediction_cohort import (
+    ReadinessThresholds,
     build_cohort_summary,
+    evaluate_readiness,
     format_cohort_report,
 )
 
@@ -88,3 +90,69 @@ def test_format_cohort_report_keeps_holdout_language_and_lane_counts():
     assert "prediction_bound_prior_state: 1/2" in report
     assert "harness_lanes: beam=1,substrate=1" in report
     assert "prospective holdout" in report
+
+
+def test_evaluate_readiness_reports_strong_when_thresholds_are_met():
+    rows = [
+        _row(0, prediction_id="pred-1", binding="registry", prior_state=True),
+        _row(1, bad=True, prediction_id="pred-2", binding="registry", prior_state=True),
+        _row(2, prediction_id="pred-3", binding="registry", prior_state=False),
+        _row(3),
+    ]
+    summary = build_cohort_summary(rows, scope="task", window_days=90, lead_minutes=30)
+    thresholds = ReadinessThresholds(
+        min_prediction_bound=3,
+        min_prediction_bound_bad=1,
+        min_prediction_coverage=0.5,
+        min_prediction_prior_state_coverage=0.6,
+    )
+
+    readiness = evaluate_readiness(summary, thresholds)
+
+    assert readiness.status == "strong"
+    assert readiness.reasons == ()
+
+
+def test_evaluate_readiness_explains_weak_dataset_gaps():
+    rows = [
+        _row(0, prediction_id="pred-1", binding="registry", prior_state=False),
+        _row(1),
+        _row(2),
+        _row(3),
+    ]
+    summary = build_cohort_summary(rows, scope="task", window_days=90, lead_minutes=30)
+    thresholds = ReadinessThresholds(
+        min_prediction_bound=3,
+        min_prediction_bound_bad=1,
+        min_prediction_coverage=0.5,
+        min_prediction_prior_state_coverage=0.8,
+    )
+
+    readiness = evaluate_readiness(summary, thresholds)
+
+    assert readiness.status == "not_ready"
+    assert "prediction_bound 1 < 3" in readiness.reasons
+    assert "prediction_bound_bad 0 < 1" in readiness.reasons
+    assert "prediction_coverage 0.250 < 0.500" in readiness.reasons
+    assert "prediction_prior_state_coverage 0.000 < 0.800" in readiness.reasons
+
+
+def test_format_cohort_report_includes_readiness_gate():
+    rows = [
+        _row(0, prediction_id="pred-1", binding="registry", prior_state=False),
+        _row(1),
+    ]
+    summary = build_cohort_summary(rows, scope="task", window_days=90, lead_minutes=30)
+    thresholds = ReadinessThresholds(
+        min_prediction_bound=2,
+        min_prediction_bound_bad=1,
+        min_prediction_coverage=0.8,
+        min_prediction_prior_state_coverage=0.5,
+    )
+
+    report = format_cohort_report(summary, thresholds=thresholds)
+
+    assert "readiness: not_ready" in report
+    assert "readiness_reasons:" in report
+    assert "- prediction_bound 1 < 2" in report
+    assert "readiness_thresholds: min_prediction_bound=2" in report


### PR DESCRIPTION
## Summary
- mint per-evidence registry prediction IDs for Phase-5 recent_tool_results when callers omit prediction_id, while preserving explicit IDs
- separate raw prediction_id presence from registry-bound prospective predictions in outcome_inventory reports
- add prospective cohort readiness gates for registry-bound volume, bad-outcome coverage, prediction coverage, and prior-state coverage

## Verification
- PATH=/usr/local/bin:/Users/cirwel/.hermes/hermes-agent/venv/bin:/Users/cirwel/.hermes/hermes-agent/node_modules/.bin:/opt/homebrew/Cellar/node/25.9.0_2/bin:/opt/homebrew/opt/postgresql@17/bin:/Library/Frameworks/Python.framework/Versions/3.14/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/Users/cirwel/.cargo/bin:/Users/cirwel/.codex/tmp/arg0/codex-arg0rMEgfV:/Users/cirwel/projects/discord-dispatch/node_modules/.bin:/Users/cirwel/projects/node_modules/.bin:/Users/cirwel/node_modules/.bin:/Users/node_modules/.bin:/node_modules/.bin:/opt/homebrew/lib/node_modules/npm/node_modules/@npmcli/run-script/lib/node-gyp-bin:/usr/local/sbin UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 -m pytest tests/test_phases_phase5_evidence.py tests/test_outcome_inventory.py tests/test_prospective_prediction_cohort.py -q -o 'addopts='
- PATH=/usr/local/bin:/Users/cirwel/.hermes/hermes-agent/venv/bin:/Users/cirwel/.hermes/hermes-agent/node_modules/.bin:/opt/homebrew/Cellar/node/25.9.0_2/bin:/opt/homebrew/opt/postgresql@17/bin:/Library/Frameworks/Python.framework/Versions/3.14/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/Users/cirwel/.cargo/bin:/Users/cirwel/.codex/tmp/arg0/codex-arg0rMEgfV:/Users/cirwel/projects/discord-dispatch/node_modules/.bin:/Users/cirwel/projects/node_modules/.bin:/Users/cirwel/node_modules/.bin:/Users/node_modules/.bin:/node_modules/.bin:/opt/homebrew/lib/node_modules/npm/node_modules/@npmcli/run-script/lib/node-gyp-bin:/usr/local/sbin UNITARES_PYTHON=/usr/local/bin/python3 ./scripts/dev/test-cache.sh
- PATH=/usr/local/bin:/Users/cirwel/.hermes/hermes-agent/venv/bin:/Users/cirwel/.hermes/hermes-agent/node_modules/.bin:/opt/homebrew/Cellar/node/25.9.0_2/bin:/opt/homebrew/opt/postgresql@17/bin:/Library/Frameworks/Python.framework/Versions/3.14/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/Users/cirwel/.cargo/bin:/Users/cirwel/.codex/tmp/arg0/codex-arg0rMEgfV:/Users/cirwel/projects/discord-dispatch/node_modules/.bin:/Users/cirwel/projects/node_modules/.bin:/Users/cirwel/node_modules/.bin:/Users/node_modules/.bin:/node_modules/.bin:/opt/homebrew/lib/node_modules/npm/node_modules/@npmcli/run-script/lib/node-gyp-bin:/usr/local/sbin UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 scripts/analysis/outcome_inventory.py --window-days 90 --leads 0,5,30
- PATH=/usr/local/bin:/Users/cirwel/.hermes/hermes-agent/venv/bin:/Users/cirwel/.hermes/hermes-agent/node_modules/.bin:/opt/homebrew/Cellar/node/25.9.0_2/bin:/opt/homebrew/opt/postgresql@17/bin:/Library/Frameworks/Python.framework/Versions/3.14/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/Users/cirwel/.cargo/bin:/Users/cirwel/.codex/tmp/arg0/codex-arg0rMEgfV:/Users/cirwel/projects/discord-dispatch/node_modules/.bin:/Users/cirwel/projects/node_modules/.bin:/Users/cirwel/node_modules/.bin:/Users/node_modules/.bin:/node_modules/.bin:/opt/homebrew/lib/node_modules/npm/node_modules/@npmcli/run-script/lib/node-gyp-bin:/usr/local/sbin UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 scripts/analysis/prospective_prediction_cohort.py --scope task --window-days 90 --lead-minutes 30
