### PR TITLE
Frame EISV as proprioceptive telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ One layer of the **[CIRWEL stack](https://cirwel.github.io)** — runtime safety
 
 - **Drift surfaces while the output still looks fine.** Each agent is graded against its *own* baseline, so slow degradation shows up as integrity slipping and entropy rising before the work visibly breaks.
 - **Confidence is checked against results.** Self-reported `confidence` is scored against real evidence — tests, exit codes, tool output. An agent can inflate the number; it can't inflate its success rate.
-- **Agents get a state signal they can act on.** Each check-in returns one plain verdict — `proceed`, `guide`, `pause`, or `reject` — plus the agent's full health signals (the `EISV` state vector) for finer policies. Humans can watch the same fleet through the optional dashboard.
+- **Agents get a proprioceptive state signal they can act on.** Each check-in returns one plain policy action — `proceed`, `guide`, `pause`, or `reject` — plus the agent's full health signals (the `EISV` state vector) for finer policies. Humans can watch the same fleet through the optional dashboard.
 
 ## Use UNITARES if
 
@@ -36,7 +36,7 @@ One layer of the **[CIRWEL stack](https://cirwel.github.io)** — runtime safety
 - you need agents to check their own state before continuing; and
 - you want an audit trail of confidence, evidence, drift, and recovery.
 
-UNITARES is **not** an output validator, sandbox, or hosted agent platform. It is the runtime state layer between evals and guardrails.
+UNITARES is **not** an output validator, sandbox, hosted agent platform, or grand jury. EISV is **not an outcome oracle**; it is proprioceptive telemetry for the running agent. External outcome evidence and policy/review layers own labels such as task-negative, contract violation, or authority/harm.
 
 ## Try the demo locally
 
@@ -64,10 +64,10 @@ UNITARES runs **alongside** your evals and guardrails — it doesn't replace eit
 ## How it works
 
 <div align="center">
-  <img src="docs/assets/flow.png" width="100%" alt="agent acts → checks in (sync_state) → graded vs its own baseline → state + verdict → self-regulates → durable audit trail"/>
+  <img src="docs/assets/flow.png" width="100%" alt="agent acts → checks in (sync_state) → graded vs its own baseline → state + action → self-regulates → durable audit trail"/>
 </div>
 
-After each unit of work, the agent checks in with `sync_state()` — passing its self-reported confidence plus verifiable evidence (test results, exit codes, tool output). It gets back one plain verdict:
+After each unit of work, the agent checks in with `sync_state()` — passing its self-reported confidence plus verifiable evidence (test results, exit codes, tool output). It gets back one plain policy action:
 
 <div align="center">
 
@@ -75,14 +75,14 @@ After each unit of work, the agent checks in with `sync_state()` — passing its
 
 </div>
 
-That's the whole contract: the agent reads the verdict and course-corrects *before* an external guardrail has to fire. No new vocabulary required to use it.
+That's the whole contract: the agent reads the policy action and course-corrects *before* an external guardrail has to fire. No new vocabulary required to use it.
 
 <details>
-<summary><strong>The four numbers behind the verdict (EISV)</strong></summary>
+<summary><strong>The four numbers behind the policy action (EISV)</strong></summary>
 
 <br/>
 
-Want to act on *why*, not just the verdict? Each check-in also returns four scores per agent, each graded against that agent's *own* ~30-check-in baseline — so slow drift surfaces even while output still looks fine:
+Want to act on *why*, not just the policy action? Each check-in also returns four scores per agent, each graded against that agent's *own* ~30-check-in baseline — so slow drift surfaces even while output still looks fine:
 
 | | | Goes wrong when… |
 |---|---|---|
@@ -95,7 +95,7 @@ Want to act on *why*, not just the verdict? Each check-in also returns four scor
 
 <div align="center">
 
-[How EISV is computed](docs/EISV_COMPUTATION.md) · [Architecture](docs/UNIFIED_ARCHITECTURE.md) · [Who it's for & threat model](docs/SCOPE_AND_THREAT_MODEL.md)
+[EISV proprioception contract](docs/ontology/eisv-proprioception-contract.md) · [How EISV is computed](docs/EISV_COMPUTATION.md) · [Architecture](docs/UNIFIED_ARCHITECTURE.md) · [Who it's for & threat model](docs/SCOPE_AND_THREAT_MODEL.md)
 
 </div>
 
@@ -150,9 +150,9 @@ For long-running or scheduled agents, the [SDK](agents/sdk/README.md) handles co
 
 ## Don't trust this README — verify it
 
-**Evaluating with an agent?** Don't take the prose. On a fresh clone, the [falsifiability harness](docs/REVIEWER_GUIDE.md#falsifiability-grade-eisv-yourself-dont-trust-this-doc) scores EISV against a deliberately dumb baseline (AUC, Brier) and self-labels each slice `INCONCLUSIVE` / `SKEPTICAL` / `WEAK SIGNAL` / `KEEP TESTING` rather than asserting. The harness is the part you run yourself.
+**Evaluating with an agent?** Don't take the prose. On a fresh clone, the [falsifiability harness](docs/REVIEWER_GUIDE.md#falsifiability-grade-eisv-yourself-dont-trust-this-doc) scores EISV/prior-state telemetry against a deliberately dumb baseline (AUC, Brier) using external outcome labels, and self-labels each slice `INCONCLUSIVE` / `SKEPTICAL` / `WEAK SIGNAL` / `KEEP TESTING` rather than asserting. The harness is the part you run yourself.
 
-**Honest about what fires.** Verdicts come from an auditable behavioral model ([`behavioral_assessment.py`](src/behavioral_assessment.py)), not a black box — the information-theoretic / free-energy formulation is the research *target*, not the live verdict path ([Paper v6](https://github.com/cirwel/unitares-paper-v6) · [how EISV is computed](docs/EISV_COMPUTATION.md)).
+**Honest about what fires.** Policy actions come from an auditable behavioral model ([`behavioral_assessment.py`](src/behavioral_assessment.py)), not a black box — the information-theoretic / free-energy formulation is the research *target*, not the live policy-action path ([Paper v6](https://github.com/cirwel/unitares-paper-v6) · [how EISV is computed](docs/EISV_COMPUTATION.md)).
 
 Human evaluators start with the [Reviewer Guide](docs/REVIEWER_GUIDE.md).
 

--- a/docs/EVALUATION_INDEX.md
+++ b/docs/EVALUATION_INDEX.md
@@ -10,6 +10,16 @@ name only are **~**. Freshness flags call out scripts that **won't run as-is** (
 backends, missing source symlinks). Hermes-agent's ablation/dogfood lives in its own
 repo (automation-side) and is intentionally *not* consolidated here.
 
+## Semantic guardrail: EISV is proprioception, not verdict authority
+
+Read [`docs/ontology/eisv-proprioception-contract.md`](ontology/eisv-proprioception-contract.md)
+before interpreting these reports. EISV/prior-state analysis asks whether
+proprioceptive telemetry adds signal over baselines. It does **not** let EISV
+supply its own outcome labels, and it does not treat ordinary CI/test failures as
+moral badness. Human-facing labels should distinguish task-negative evidence,
+contract/process violations, authority/harm events, synthetic red-team fixtures,
+and unknown/unmeasured outcomes.
+
 ## ⚠ Start here: the two scripts that already answer "does EISV discriminate?"
 
 Don't rebuild discrimination analysis — these exist and are current:

--- a/docs/REVIEWER_GUIDE.md
+++ b/docs/REVIEWER_GUIDE.md
@@ -1,7 +1,7 @@
 # UNITARES Reviewer Guide
 
 **Created:** May 23, 2026  
-**Last Updated:** June 16, 2026  
+**Last Updated:** June 26, 2026
 **Status:** Active
 
 ---
@@ -10,12 +10,13 @@ This guide is for a cold evaluator deciding whether UNITARES is real, what layer
 
 ## One-sentence read
 
-UNITARES is runtime state telemetry for long-lived AI-agent fleets: agents check in after units of work, UNITARES grades drift and calibration against each agent's own baseline, and the agent receives a verdict it can act on before failures become visible incidents.
+UNITARES is proprioceptive runtime state telemetry for long-lived AI-agent fleets: agents check in after units of work, UNITARES reads drift and calibration against each agent's own baseline, and policy/enforcement layers can use that signal before failures become visible incidents.
 
 ## What this is
 
 - A governance MCP + HTTP server for agent runtime state.
 - A continuous check-in loop: `onboard` -> `process_agent_update` -> `outcome_event` -> `get_governance_metrics`.
+- A proprioceptive signal layer for agent strain/coherence/overload, documented in [`docs/ontology/eisv-proprioception-contract.md`](ontology/eisv-proprioception-contract.md).
 - A calibration layer that combines self-reported confidence with exogenous outcomes such as tests, exit codes, and tool results.
 - A continuity and audit layer for long-running and repeated agent process-instances.
 - A research implementation backed by a public paper, DOI, reproducibility kit, and deployment-derived datasets.
@@ -24,6 +25,7 @@ UNITARES is runtime state telemetry for long-lived AI-agent fleets: agents check
 
 - Not an output filter or guardrail classifier.
 - Not a sandbox or permission system.
+- Not an outcome oracle or grand jury. EISV can report strain; external outcome evidence and policy/review layers decide task-negative, contract, authority/harm, or synthetic labels.
 - Not a universal ethics oracle. "No ethics classifier" means no hand-labeled ethics model — not that the system is value-free; drift is a salience flag, not a verdict, and Integrity is anchored to outcomes rather than to the agent's own history.
 - Not hardened against a motivated adversary gaming the EISV proxy. The design is adversarial-aware — outcomes can't be faked, baselines are self-relative — but enforcement leans lenient by intent and there has been no red-team. See [README → Scope and threat model](../README.md#scope-and-threat-model).
 - Not a claim of broad external adoption yet; the public deployment metrics describe a single-operator stress test.
@@ -71,7 +73,7 @@ The first integration is deliberately small:
 
 1. Give each process-instance an identity with `onboard`.
 2. Send one `process_agent_update` after each meaningful unit of work.
-3. Send `outcome_event` when a hard result exists: test passed/failed, tool rejected, task completed/failed, CI signal, or external observation.
+3. Send `outcome_event` when a hard result exists: test passed/failed, tool rejected, task completed/failed, CI signal, or external observation. Treat ordinary CI/test failures as task-negative evidence unless a separate contract, authority, or harm boundary was crossed.
 4. Let the agent read the returned state and verdict before deciding whether to proceed, narrow scope, ask for review, or pause.
 
 This complements evals, guardrails, and sandboxes. Evals ask whether a model should be deployed. Guardrails and sandboxes constrain actions. UNITARES asks what the already-running agent is doing now, whether it is still calibrated to its own baseline, and whether it should self-regulate.

--- a/docs/guides/START_HERE.md
+++ b/docs/guides/START_HERE.md
@@ -60,11 +60,14 @@ Important current semantics:
 - `response_text` is the primary check-in input
 - `complexity` and `confidence` are optional reflective inputs, not the sole substrate
 - Behavioral EISV is the primary measurement source for governance policy when its confidence is sufficient
+- EISV is proprioceptive telemetry: it can indicate strain, drift, overload, or incoherence; it is not an outcome oracle, moral classifier, or grand jury
 - ODE state is diagnostic/fallback, not the main verdict source
 - Governance responses separate measurement (`primary_eisv`, `behavioral_eisv`, `ode_eisv`), policy evaluation (`policy_evaluation`), and actuator state (`enforcement`)
+- External outcome evidence — tests, CI, tool rejection, human review, red-team fixtures, or harm/authority signals — owns the label that later validation scores
 
 ## Read Next
 
+- [EISV Proprioception Contract](../ontology/eisv-proprioception-contract.md): measurement/diagnosis/policy/enforcement split and outcome-label taxonomy
 - [README.md](../../README.md): top-level overview and quick start
 - [UNIFIED_ARCHITECTURE.md](../UNIFIED_ARCHITECTURE.md): current architecture summary
 - [CANONICAL_SOURCES.md](../dev/CANONICAL_SOURCES.md): authority ordering and source-of-truth map
@@ -72,7 +75,6 @@ Important current semantics:
 - [TROUBLESHOOTING.md](TROUBLESHOOTING.md): common issues and fixes
 
 ## Why This File Is Short
-
 This file used to be a larger onboarding guide from an earlier MCP/tooling phase. It is intentionally kept small now to avoid duplicated explanations drifting out of sync with the runtime.
 
-**Last Updated:** 2026-06-18 (identity contract simplified for normal agent workflows)
+**Last Updated:** 2026-06-26 (EISV proprioception/outcome-oracle boundary added)

--- a/docs/ontology/README.md
+++ b/docs/ontology/README.md
@@ -27,6 +27,7 @@ So `r1-verify-lineage-claim.md` resolves row R1 in `plan.md`; `s1-continuity-tok
 ## Index by category
 
 **Conceptual entries** (read these for the model):
+- [`eisv-proprioception-contract.md`](eisv-proprioception-contract.md) — EISV as proprioceptive telemetry, not an outcome oracle; separates measurement, diagnosis, policy, enforcement, and external labels
 - [`identity.md`](identity.md) — v2 ontology
 - [`paper-positioning.md`](paper-positioning.md) — Q3, ontology ↔ paper relationship
 - [`harness-substrate-plurality.md`](harness-substrate-plurality.md) — R6, identity across variable harness/model/transport

--- a/docs/ontology/eisv-proprioception-contract.md
+++ b/docs/ontology/eisv-proprioception-contract.md
@@ -1,0 +1,101 @@
+# EISV Proprioception Contract
+
+**Created:** June 26, 2026
+**Last Updated:** June 26, 2026
+**Status:** Active
+
+---
+
+## Contract
+
+**EISV is proprioception**: runtime self-state telemetry about agent strain,
+coherence, entropy, integrity, and imbalance. It is the system saying "my balance
+is changing" or "this process is running hot," not a court deciding whether a
+worker was morally bad.
+
+EISV is **not an outcome oracle** and **not a grand jury**. It does not decide
+whether harm occurred, whether the user was wronged, or whether an agent is
+"guilty." Those judgments require external outcome evidence, policy, and review
+surfaces that are separate from the measurement vector.
+
+## Layer separation
+
+The canonical stack is:
+
+```text
+measurement → diagnosis → policy → enforcement → external outcome evidence
+```
+
+| Layer | Owns | Must not pretend to own |
+|---|---|---|
+| Measurement | EISV, confidence, coherence, risk, phi, provenance | Outcome truth or punishment |
+| Diagnosis | Interpretations such as strained, scattered, brittle, running hot | The authority to pause by itself |
+| Policy | Rules mapping measured/diagnosed state to advice, review, or circuit-breaker candidates | Raw measurement truth |
+| Enforcement | Actual pause/block/review/allow effects, with actor and mode | The reason an outcome was good or bad |
+| External outcome evidence | Test/CI/tool/user/harm/verifier results, with provenance | Retrospective EISV self-justification |
+
+A thermometer can inform a safety protocol; it does not itself pause the body.
+Likewise, EISV can inform governance policy, but pause authority belongs to a
+policy/enforcement layer.
+
+## Outcome taxonomy
+
+The word `bad` in storage and reports is a compact label class, not a moral
+verdict. Human-facing docs should name the class whenever possible:
+
+| Class | Examples | Validation use |
+|---|---|---|
+| `task-negative` | CI failed, test failed, command exit nonzero, answer was corrected | Useful for calibration and rework prediction; not automatically governance-bad |
+| `contract/process violation` | Claimed tests passed without running them, hid uncertainty, ignored explicit constraints, fabricated output | Stronger governance signal because it breaks the work contract |
+| `authority/harm` | Deleted data, leaked secrets, bypassed ask-first boundaries, charged money, spammed or impersonated a user | Strict governance-bad / escalation class when externally verified |
+| `synthetic red-team fixture` | Known-safe adversarial cases, negative controls, containment probes | Validates plumbing and containment only; never production trust by itself |
+| `unknown/unmeasured` | No verifier, no rubric, no external signal | Exclude from strict validation |
+
+A normal mistake is usually task-negative feedback. It becomes governance-bad
+only when it is tied to a contract violation, authority overreach, concealment,
+or user harm.
+
+## Validation rule
+
+Never validate EISV by letting EISV create its own labels. A prospective claim
+needs all of the following to be meaningful:
+
+1. a prediction or prior-state snapshot recorded before the outcome;
+2. an external label source or pre-registered rubric;
+3. enough negative-class coverage for the lane being scored;
+4. comparison against boring baselines such as previous outcome, task type,
+   confidence, recency, and harness lane;
+5. language that distinguishes internal signal, predictive lift, policy effect,
+   and enforcement effect.
+
+Red-team data is useful, but only if labeled as red-team data. It answers "can
+we detect this frozen failure mode?" It does not answer "does EISV generally
+judge agents correctly in production?"
+
+## Preferred wording
+
+Use:
+
+- "EISV/prior-state telemetry"
+- "proprioceptive signal"
+- "agent strain / incoherence / overload"
+- "policy input"
+- "task-negative / contract / authority-harm outcome label"
+- "external outcome evidence"
+
+Avoid:
+
+- "EISV decided this was bad"
+- "EISV prevented harm" unless an enforcement path actually did
+- "bad outcome" without naming the label source/class
+- "validated EISV" from synthetic fixtures, single-class strict scope, or
+  retrospective self-labels
+
+## What ablations should say
+
+Ablations should ask whether EISV/prior-state telemetry adds predictive signal or
+useful policy steering over baselines. They should not imply EISV is the judge of
+badness. The skeptical report, inventory, and prospective cohort reports should
+make weak data obvious: sparse bad labels, synthetic fixtures, unbound prediction
+IDs, missing prior-state coverage, and harness-lane contamination are data-quality
+limits, not philosophical failures of proprioception.

--- a/docs/ontology/glossary.md
+++ b/docs/ontology/glossary.md
@@ -182,7 +182,9 @@ against a baseline.
 | Term | Question it answers | Canonical source |
 |---|---|---|
 | `process-instance` | Which live subject is speaking right now? | `identity.md`, `harness-substrate-plurality.md` |
-| `registry` (identity layer) | Which governance record is this claim bound to? (the UUID) | `harness-substrate-plurality.md` |
+| `EISV` | What proprioceptive state vector says how this agent is running right now? | `eisv-proprioception-contract.md`; runtime `primary_eisv` / `behavioral_eisv` / `ode_eisv` fields |
+| `outcome label` | What external evidence/rubric classified a result as task-negative, contract/process violation, authority/harm, synthetic fixture, or unknown? | `eisv-proprioception-contract.md`; `audit.outcome_events.is_bad` is the compact storage label, not a moral verdict |
+| `registry` (identity layer) | Which governance record is this claim bound to? (the UUID) | `harness-substrate-plurality.md`, `identity.md` |
 | `transport` | Through what channel does the process act? (CLI, MCP-http, Discord, cron) | `harness-substrate-plurality.md` |
 | `lease` | What time-bounded claim to a surface is live, with what proof obligation and expiry? | `beam-coordination-kernel.md` |
 | `handoff` | How is custody of a lease (or of work) transferred without TTL expiry or ghost claims? | `beam-coordination-kernel.md`, `identity.md` |

--- a/docs/operations/ablation-negative-controls.md
+++ b/docs/operations/ablation-negative-controls.md
@@ -1,7 +1,7 @@
 # Ablation Negative Controls
 
 **Created:** June 14, 2026
-**Last Updated:** June 14, 2026
+**Last Updated:** June 26, 2026
 **Status:** Experimental
 
 ---
@@ -10,9 +10,9 @@
 
 Ablation tests need negative controls. If every resident, dogfood probe, and
 outcome row is well-behaved, the analysis pipeline only proves the happy path.
-`ablation_negative_controls.py` creates known-safe synthetic bad outcomes so the
-EISV/outcome inventory path can prove it sees, counts, labels, and refuses to
-overinterpret adverse fixtures.
+`ablation_negative_controls.py` creates known-safe synthetic negative-class task
+outcomes so the EISV/outcome inventory path can prove it sees, counts, labels,
+and refuses to overinterpret adverse fixtures.
 
 These rows are **not** real failures. They are fixture data for local smoke tests
 and red-team checks.
@@ -36,10 +36,12 @@ Every serialized row carries:
 
 ## What the fixture proves
 
-The fixture includes strict bad outcomes (`test_failed`, `tool_rejected`) with
-high prior risk and strict good outcomes (`test_passed`) with low prior risk.
-That proves the local analysis path can observe a bad class and detect a
-predictive synthetic prior without claiming live validation.
+The fixture includes strict negative-class task outcomes (`test_failed`,
+`tool_rejected`) with high prior risk and strict good outcomes (`test_passed`)
+with low prior risk. That proves the local analysis path can observe a negative
+class and detect a predictive synthetic prior without claiming live validation.
+It does not prove EISV is an outcome oracle; it proves the plumbing preserves a
+known-safe label.
 
 Use this to test containment and instrumentation, not agent obedience.
 
@@ -64,7 +66,7 @@ The output JSONL is local fixture material. It is safe to delete after the smoke
 
 Good language:
 
-> Synthetic negative controls show the analysis path can observe a bad class and
+> Synthetic negative controls show the analysis path can observe a negative class and
 > route fixture evidence without contaminating production state.
 
 Bad language:

--- a/scripts/analysis/eisv_skeptic_report.py
+++ b/scripts/analysis/eisv_skeptic_report.py
@@ -1036,9 +1036,10 @@ def build_report(
     a("")
     a(conclusion)
     a("")
-    a("Interpretation rule: this report does not validate EISV as ontology. It only")
-    a("checks whether EISV/prior-state fields add measurable predictive signal over")
-    a("simpler baselines in this data slice.")
+    a("Interpretation rule: EISV is proprioceptive telemetry, not an outcome oracle.")
+    a("Outcome labels come from external evidence/rubrics; this report only checks")
+    a("whether EISV/prior-state fields add measurable predictive signal over simpler")
+    a("baselines in this data slice.")
     return "\n".join(lines)
 
 

--- a/scripts/analysis/outcome_inventory.py
+++ b/scripts/analysis/outcome_inventory.py
@@ -436,6 +436,11 @@ def format_inventory_report(
             )
         ],
         "",
+        "## Interpretation rule",
+        "",
+        "`bad` is an outcome-label class, not a moral verdict. CI/test failure is task-negative evidence; strict governance-bad claims require external outcome evidence for contract, authority, or harm boundaries.",
+        "EISV is proprioceptive telemetry and policy input, not the source of outcome truth.",
+        "",
         "## Harness Lane Summary",
         "",
     ]

--- a/scripts/analysis/prospective_prediction_cohort.py
+++ b/scripts/analysis/prospective_prediction_cohort.py
@@ -217,9 +217,9 @@ def format_cohort_report(
             "",
             *readiness_lines,
             "",
-            "Interpretation rule: this is prospective holdout plumbing only. "
-            "It counts registry-bound predictions that existed before outcomes; "
-            "it does not validate EISV unless a frozen holdout later beats boring baselines.",
+            "Interpretation rule: this is registry-bound prediction coverage for future holdout scoring (prospective holdout), not a grand jury. "
+            "It counts predictions that existed before outcomes; EISV remains proprioceptive telemetry, "
+            "not an outcome oracle, unless a frozen holdout later beats boring baselines with external labels.",
         ]
     )
 

--- a/tests/test_eisv_semantic_contract.py
+++ b/tests/test_eisv_semantic_contract.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from scripts.analysis.eisv_skeptic_report import OutcomeRow, build_report
+from scripts.analysis.outcome_inventory import (
+    OutcomeInventoryRow,
+    build_inventory,
+    format_inventory_report,
+)
+from scripts.analysis.prospective_prediction_cohort import (
+    build_cohort_summary,
+    format_cohort_report,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _outcome_row(idx: int, *, bad: bool, risk: float | None = None) -> OutcomeRow:
+    risk = risk if risk is not None else (0.9 if bad else 0.1)
+    return OutcomeRow(
+        ts=datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(minutes=idx),
+        agent_id=f"agent-{idx % 6}",
+        outcome_type="task_failed" if bad else "task_completed",
+        is_bad=bad,
+        outcome_score=0.0 if bad else 1.0,
+        verification_source="server_observation",
+        reported_confidence=None,
+        reported_complexity=None,
+        detail={"prediction_binding": "registry", "prediction_id": f"pred-{idx}"},
+        prior_state_age_seconds=30.0,
+        prior_risk=risk,
+        prior_phi=1.0 - risk,
+        prior_verdict="high-risk" if risk > 0.7 else "safe",
+        prior_coherence=0.5,
+        prior_e=0.7,
+        prior_i=0.7,
+        prior_s=0.2,
+        prior_v=0.0,
+        snapshot_verdict=None,
+        snapshot_e=None,
+        snapshot_i=None,
+        snapshot_s=None,
+        snapshot_v=None,
+        snapshot_phi=None,
+        snapshot_coherence=None,
+    )
+
+
+def test_canonical_eisv_contract_doc_names_proprioception_not_grand_jury():
+    doc = ROOT / "docs" / "ontology" / "eisv-proprioception-contract.md"
+
+    text = doc.read_text()
+
+    assert "EISV is proprioception" in text
+    assert "not an outcome oracle" in text
+    assert "not a grand jury" in text
+    assert "measurement → diagnosis → policy → enforcement" in text
+    assert "external outcome evidence" in text
+    assert "task-negative" in text
+    assert "authority/harm" in text
+
+
+def test_landing_docs_link_the_proprioception_contract():
+    readme = (ROOT / "README.md").read_text()
+    start_here = (ROOT / "docs" / "guides" / "START_HERE.md").read_text()
+    evaluation_index = (ROOT / "docs" / "EVALUATION_INDEX.md").read_text()
+
+    for text in (readme, start_here, evaluation_index):
+        assert "eisv-proprioception-contract.md" in text
+    assert "not an outcome oracle" in readme
+    assert "grand jury" in readme
+    assert "task-negative" in evaluation_index
+
+
+def test_reports_preserve_proprioception_and_outcome_oracle_boundary():
+    rows = [_outcome_row(idx, bad=idx >= 96) for idx in range(120)]
+
+    skeptic_report = build_report(
+        rows,
+        scope="task",
+        window_days=90,
+        lead_minutes=30,
+        train_fraction=0.7,
+        generated_at=rows[0].ts + timedelta(days=1),
+    )
+    assert "EISV is proprioceptive telemetry, not an outcome oracle." in skeptic_report
+    assert "Outcome labels come from external evidence/rubrics" in skeptic_report
+
+    inventory = build_inventory(
+        [
+            OutcomeInventoryRow(
+                outcome_type="test_failed",
+                is_bad=True,
+                verification_source="server_observation",
+                detail={"prediction_binding": "registry", "prediction_id": "pred-1"},
+                prior_state_by_lead={0.0: True},
+            )
+        ],
+        lead_minutes=(0.0,),
+    )
+    inventory_report = format_inventory_report(
+        inventory,
+        window_days=90,
+        lead_minutes=(0.0,),
+    )
+    assert "`bad` is an outcome-label class, not a moral verdict" in inventory_report
+    assert "CI/test failure is task-negative evidence" in inventory_report
+
+    cohort_summary = build_cohort_summary(
+        rows[:10], scope="task", window_days=90, lead_minutes=30
+    )
+    cohort_report = format_cohort_report(cohort_summary)
+    assert "not a grand jury" in cohort_report
+    assert "registry-bound prediction coverage for future holdout scoring" in cohort_report


### PR DESCRIPTION
## Summary
- add a canonical EISV proprioception contract that separates measurement, diagnosis, policy, enforcement, and external outcome evidence
- update README/reviewer/start/evaluation docs and ablation wording away from outcome-oracle / grand-jury framing
- update analysis report interpretation text so `bad`/negative labels are described as external outcome labels, not moral verdicts
- add regression tests that lock the ontology into landing docs and generated reports

## Verification
- `git diff --check`
- `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 -m pytest tests/test_eisv_semantic_contract.py tests/test_doc_health_dead_refs.py tests/test_doc_drift.py -q -o 'addopts='` → 40 passed
- `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 -m pytest tests/test_eisv_semantic_contract.py tests/test_eisv_skeptic_report.py tests/test_outcome_inventory.py tests/test_prospective_prediction_cohort.py tests/test_doc_health_dead_refs.py tests/test_doc_drift.py -q -o 'addopts='` → 65 passed
- report smoke generation for outcome inventory, prospective cohort, and skeptic report semantic lines
- `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 ./scripts/dev/test-cache.sh` → 10830 passed, 21 skipped, 4 warnings, coverage 81.75%
