### PR TITLE
grounding: tier-1 logprob entropy — consumer + transport (Stages 1+2)

### DIFF
--- a/src/grounding/entropy.py
+++ b/src/grounding/entropy.py
@@ -5,7 +5,8 @@ Three tiers in preference order:
   2. multisample — k-sample self-consistency over semantic equivalence classes
   3. heuristic — wraps the legacy [0,1] complexity/drift-driven S (degraded mode)
 """
-from typing import Any, Dict
+import math
+from typing import Any, Dict, List
 
 from src.grounding.types import GroundedValue
 
@@ -29,11 +30,70 @@ def compute_entropy(ctx: Any, metrics: Dict[str, Any]) -> GroundedValue:
     return _compute_heuristic(metrics)
 
 
+def _candidate_logprobs(entry: Any) -> List[float]:
+    """Extract one token position's top-k candidate logprobs as floats.
+
+    Accepts the canonical form (a list/tuple of logprob floats) and the richer
+    provider shapes: a dict carrying ``top_logprobs`` (list of floats, or list of
+    ``{"logprob": float}``), or a single ``{"logprob": float}`` (k=1 position).
+    """
+    if isinstance(entry, dict):
+        top = entry.get("top_logprobs")
+        if top is None and "logprob" in entry:
+            top = [entry]  # single-candidate position
+        entry = top
+    if not isinstance(entry, (list, tuple)):
+        raise ValueError("token entry is not a candidate list")
+    out: List[float] = []
+    for c in entry:
+        if isinstance(c, dict):
+            c = c.get("logprob")
+        if c is None:
+            continue
+        out.append(float(c))
+    return out
+
+
+def _token_entropy(logprobs: List[float]) -> float:
+    """Normalized Shannon entropy in [0,1] over one token's top-k candidates."""
+    k = len(logprobs)
+    if k <= 1:
+        return 0.0  # no representable uncertainty
+    probs = [math.exp(lp) for lp in logprobs]
+    total = sum(probs)
+    if total <= 0.0:
+        return 0.0
+    probs = [p / total for p in probs]
+    h = -sum(p * math.log(p) for p in probs if p > 0.0)
+    return max(0.0, min(1.0, h / math.log(k)))
+
+
 def _compute_from_logprobs(logprobs: list) -> GroundedValue:
-    raise NotImplementedError(
-        "tier-1 (logprob) entropy requires plugin-side logprob capture; "
-        "see spec §3.1 S 'Computation recipe' and Phase-1 out-of-scope items"
-    )
+    """Tier-1 S: mean per-token normalized entropy over returned top-k logprobs.
+
+    Normalization (the load-bearing modeling choice): each token's Shannon
+    entropy is divided by ``log(k)`` — the entropy of a uniform distribution over
+    the k candidates the provider returned — yielding a value in [0,1] regardless
+    of k. This is a *consistent proxy*, not absolute entropy: top-k truncation
+    omits the distribution's tail, so it under-estimates true response-
+    distribution entropy. Set ``top_logprobs`` as high as the provider allows to
+    tighten the estimate. Raises NotImplementedError when no usable per-token
+    candidates are present, so compute_entropy() falls through to the next tier.
+    """
+    if not isinstance(logprobs, (list, tuple)) or not logprobs:
+        raise NotImplementedError("no usable per-token logprobs supplied")
+    token_entropies: List[float] = []
+    for entry in logprobs:
+        try:
+            cands = _candidate_logprobs(entry)
+        except (ValueError, TypeError):
+            continue
+        if cands:
+            token_entropies.append(_token_entropy(cands))
+    if not token_entropies:
+        raise NotImplementedError("logprobs present but no parseable token candidates")
+    s = sum(token_entropies) / len(token_entropies)
+    return GroundedValue(value=max(0.0, min(1.0, s)), source="logprob")
 
 
 def _compute_from_samples(samples: list) -> GroundedValue:

--- a/src/mcp_handlers/schemas/core.py
+++ b/src/mcp_handlers/schemas/core.py
@@ -355,6 +355,17 @@ class ProcessAgentUpdateParams(AgentIdentityMixin):
     task_label: Optional[str] = Field(None, description="S22 H5 provenance: human-readable bounded task label")
     task_outcome: Optional[str] = Field(None, description="S22 H5 provenance: outcome label for the bounded task")
     memory_context: Optional[str] = Field(None, description="S22 provenance: memory/KG/transcript surfaces visible to the writer")
+    logprobs: Optional[list] = Field(
+        None,
+        description=(
+            "Optional per-token top-k output logprobs from the inference layer "
+            "(OpenAI top_logprobs / Ollama / local models). When present, grounds "
+            "S (entropy) at tier-1 ('logprob' source) instead of the heuristic. "
+            "Absent for Claude (no logprobs API). Substrate/proxy-supplied — send "
+            "a compact top-k per token, e.g. [[lp, lp, ...], ...] or "
+            "[{\"top_logprobs\": [{\"logprob\": lp}, ...]}, ...]."
+        ),
+    )
 
     @model_validator(mode='before')
     @classmethod

--- a/tests/test_grounding_entropy.py
+++ b/tests/test_grounding_entropy.py
@@ -30,11 +30,50 @@ def test_tier3_clamps_out_of_range_metric():
     assert compute_entropy(_mk_ctx(), metrics={"S": -0.05}).value == 0.0
 
 
-def test_tier1_logprobs_stub_falls_through_to_heuristic():
+def test_tier1_logprobs_computes_grounded_s():
     ctx = _mk_ctx(arguments={"logprobs": [[-0.1, -0.3, -0.8]]})
     result = compute_entropy(ctx, metrics={"S": 0.2})
-    assert result.source == "heuristic"
-    assert result.value == 0.2
+    assert result.source == "logprob"
+    # near-flat top-3 → high normalized entropy; legacy 0.2 is NOT used
+    assert result.value == pytest.approx(0.965, abs=0.01)
+
+
+def test_tier1_uniform_topk_is_max_entropy():
+    ctx = _mk_ctx(arguments={"logprobs": [[-0.5, -0.5, -0.5]]})
+    assert compute_entropy(ctx, metrics={"S": 0.2}).value == pytest.approx(1.0, abs=1e-9)
+
+
+def test_tier1_peaked_distribution_is_near_zero():
+    ctx = _mk_ctx(arguments={"logprobs": [[0.0, -20.0, -20.0]]})
+    result = compute_entropy(ctx, metrics={"S": 0.9})
+    assert result.source == "logprob"
+    assert result.value == pytest.approx(0.0, abs=1e-3)
+
+
+def test_tier1_single_candidate_is_zero_entropy():
+    ctx = _mk_ctx(arguments={"logprobs": [[-0.2]]})
+    assert compute_entropy(ctx, metrics={"S": 0.9}).value == 0.0
+
+
+def test_tier1_mean_over_tokens():
+    # token A uniform (→1.0), token B peaked (→~0) ⇒ mean ≈ 0.5
+    ctx = _mk_ctx(arguments={"logprobs": [[-0.5, -0.5, -0.5], [0.0, -20.0, -20.0]]})
+    assert compute_entropy(ctx, metrics={"S": 0.2}).value == pytest.approx(0.5, abs=1e-3)
+
+
+def test_tier1_accepts_openai_dict_shape():
+    # OpenAI-style: per-token entry carrying top_logprobs of {token, logprob}
+    entry = {"top_logprobs": [{"logprob": -0.5}, {"logprob": -0.5}, {"logprob": -0.5}]}
+    ctx = _mk_ctx(arguments={"logprobs": [entry]})
+    result = compute_entropy(ctx, metrics={"S": 0.2})
+    assert result.source == "logprob"
+    assert result.value == pytest.approx(1.0, abs=1e-9)
+
+
+def test_tier1_unparseable_logprobs_fall_through_to_heuristic():
+    # garbage / empty → NotImplementedError inside, compute_entropy degrades
+    assert compute_entropy(_mk_ctx({"logprobs": ["x"]}), {"S": 0.2}).source == "heuristic"
+    assert compute_entropy(_mk_ctx({"logprobs": []}), {"S": 0.2}).source == "heuristic"
 
 
 def test_tier2_samples_stub_falls_through_to_heuristic():

--- a/tests/test_pydantic_schemas.py
+++ b/tests/test_pydantic_schemas.py
@@ -23,6 +23,15 @@ class TestPydanticSchemas:
         # Explicit response_mode always wins over lite.
         assert ProcessAgentUpdateParams(lite=True, response_mode="full", response_text="T").response_mode == "full"
 
+    def test_logprobs_transport_field_accepted_and_roundtrips(self):
+        """tier-1 logprob-S transport: process_agent_update must accept an optional
+        `logprobs` field (defaults None) and carry it through so enrich_grounding's
+        compute_entropy can read it from ctx.arguments."""
+        from src.mcp_handlers.schemas.core import ProcessAgentUpdateParams
+        assert ProcessAgentUpdateParams(response_text="T").logprobs is None
+        lp = [[-0.1, -0.3, -0.8], [0.0, -20.0, -20.0]]
+        assert ProcessAgentUpdateParams(response_text="T", logprobs=lp).logprobs == lp
+
     def test_response_mode_aliases_are_canonicalized(self):
         from src.mcp_handlers.schemas.core import ProcessAgentUpdateParams
 


### PR DESCRIPTION
The **in-repo half** of logprob-grounded S (entropy) — two additive, inert-until-fed commits.

**Stage 1 — consumer (`src/grounding/entropy.py`).** Implements the dormant tier-1 stub `_compute_from_logprobs`: mean per-token Shannon entropy over renormalized top-k logprobs, normalized by `log(k)` → [0,1], `source="logprob"`. Accepts canonical `[[lp,...],...]` and OpenAI `{top_logprobs:[{logprob}]}` shapes; k=1 → 0; unusable input raises NotImplementedError so `compute_entropy` degrades to heuristic. The consumer chain was already live (`enrich_grounding` @ enrichments.py:1966 tags `s_source`) — it just always fell to heuristic for lack of data.

**Stage 2 — transport (`schemas/core.py`).** Adds an optional `logprobs` field to `ProcessAgentUpdateParams` (shared by sync_state). `ctx.arguments` is the raw check-in dict so a supplied value already reaches `compute_entropy`; this makes it a documented, typed slot that survives the MCP middleware path too.

**Normalization** is a top-k-truncated *consistent proxy* (under-estimates true entropy) — documented inline; higher `top_logprobs` tightens it.

**Zero live behavior change.** No agent supplies `logprobs` today, so S still resolves to heuristic fleet-wide. This only makes tier-1 *ready + reachable*.

**Not in this PR — Stage 3 (capture):** the OpenAI/Ollama proxy forwarding response logprobs via a post-response check-in (separate repo `unitares-host-adapter`, structural change). That's the point this stops being inert; held for an explicit go/no-go. Grounds S only on OpenAI/Ollama — **not Claude** (no logprobs API).

8 new tests; `test-cache.sh` full gate green (10834 passed).

https://claude.ai/code/session_019TLkNbrqefj5RvDNrcVD5L