### PR TITLE
docs(identity): restore mangled R2 doc reference in identity_payloads comment

### DIFF
--- a/src/services/identity_payloads.py
+++ b/src/services/identity_payloads.py
@@ -88,7 +88,7 @@ def build_identity_response_data(
         response_data["identity_resolution_outcome"] = identity_resolution_outcome
     # R2 PR 3: surface persisted lineage flag at top level so callers
     # don't need a follow-up read to detect provisional edges. See
- # .
+    # docs/ontology/r2-honest-memory-integration.md.
     response_data["provisional_lineage"] = bool(provisional_lineage)
     # R2 PR 3 council fix: surface response-facing lineage_state when
     # the caller has derived it (slow paths). Fast paths default to


### PR DESCRIPTION
Tiny cleanup spotted while wrapping up another thread.

`src/services/identity_payloads.py` had a `provisional_lineage` comment whose doc citation got mangled into ` # .` (a dangling "See" with botched indentation). The original (from #357, `ae0ca1df`) cited `docs/ontology/r2-honest-memory-integration.md` — which **exists** (verified against git history + the file). Restored it.

Comment-only; `py_compile` clean.