### PR TITLE
fix(grounding): run grounding pre-persist/response + shadow-compare (#1092 ordering)

### DIFF
--- a/config/governance_config.py
+++ b/config/governance_config.py
@@ -1057,6 +1057,32 @@ def basin_shadow_enabled() -> bool:
     return os.getenv("UNITARES_BASIN_SHADOW", "").strip().lower() in {"1", "true", "on", "yes"}
 
 
+def grounding_shadow_enabled() -> bool:
+    """Whether to shadow-compare grounded vs ungrounded canonical metrics each
+    check-in (UNITARES_GROUNDING_SHADOW). Default off.
+
+    Behavior-neutral measurement: computes what enrich_grounding would produce
+    for E/I/S/coherence (incl. s_source from any supplied logprobs) BEFORE the
+    persist/response stages, records the per-dimension divergence via the
+    'grounding_shadow' audit event, then reverts the live metrics unless
+    grounding_apply_enabled(). Lets the fleet-wide metric shift be measured
+    before activation — see [[project_logprob-entropy-grounding]].
+    """
+    return os.getenv("UNITARES_GROUNDING_SHADOW", "").strip().lower() in {"1", "true", "on", "yes"}
+
+
+def grounding_apply_enabled() -> bool:
+    """Whether grounded E/I/S/coherence actually replace the ODE/heuristic values
+    in the canonical metrics (UNITARES_GROUNDING_APPLY). Default off.
+
+    When on, grounding runs BEFORE persist + response-build (the #1092 ordering
+    fix — enrich_grounding previously ran after both consumers and was a no-op).
+    LIVE-AFFECTING: turning this on shifts coherence (manifold)/E/I/S fleet-wide,
+    which moves basin/verdict/risk. Validate via grounding_shadow first.
+    """
+    return os.getenv("UNITARES_GROUNDING_APPLY", "").strip().lower() in {"1", "true", "on", "yes"}
+
+
 def get_s_setpoint(agent_class: str = "default") -> float:
     """Per-class S decay target σ for the dynamics.
 

--- a/src/audit_log.py
+++ b/src/audit_log.py
@@ -150,6 +150,31 @@ class AuditLogger:
         )
         self._write_entry(entry)
 
+    def log_grounding_shadow(self, agent_id: str, ungrounded: dict, grounded: dict,
+                             sources: dict, applied: bool):
+        """Shadow-compare grounded vs ungrounded canonical metrics (E/I/S/coherence).
+
+        Records what enrich_grounding would change each dimension to, and which
+        tier produced it (s_source/coherence_source/...), before the persist and
+        response stages. `applied` says whether the grounded values were actually
+        kept this check-in (grounding_apply_enabled) or reverted (shadow only).
+        Lets the fleet-wide metric shift from activating grounding be measured.
+        """
+        dims = ("E", "I", "S", "coherence")
+        details = {"applied": bool(applied), "sources": sources or {}}
+        for d in dims:
+            u, g = ungrounded.get(d), grounded.get(d)
+            details[d] = {"ungrounded": u, "grounded": g,
+                          "delta": (g - u) if isinstance(u, (int, float)) and isinstance(g, (int, float)) else None}
+        entry = AuditEntry(
+            timestamp=datetime.now().isoformat(),
+            agent_id=agent_id,
+            event_type="grounding_shadow",
+            confidence=0.0,
+            details=details,
+        )
+        self._write_entry(entry)
+
     def log_pause_auto_expired(self, agent_id: str,
                                 original_paused_at: Optional[str],
                                 elapsed_seconds: float):

--- a/src/mcp_handlers/updates/enrichments.py
+++ b/src/mcp_handlers/updates/enrichments.py
@@ -1986,3 +1986,76 @@ async def enrich_grounding(ctx: UpdateContext) -> None:
     # Surface the calibration class so audit/broadcast can see what
     # class-conditional constants were applied to this check-in.
     metrics["agent_class"] = ctx.agent_class
+
+
+async def run_grounding_stage(ctx: UpdateContext) -> None:
+    """Run grounding BEFORE persist + response-build, shadow-logging the shift.
+
+    Fixes the #1092 ordering bug: ``enrich_grounding`` was registered in the
+    late enrichment pipeline, which runs *after* ``execute_post_update_effects``
+    (persist) and ``build_process_update_response_data`` (response) — so its
+    grounded E/I/S/coherence reached neither, making grounding a silent no-op
+    since it shipped.
+
+    This stage runs early, but is gated:
+      * neither flag set  -> no-op (current behavior; the late enrich_grounding
+        stays the existing discarded no-op).
+      * GROUNDING_SHADOW   -> compute grounded metrics, emit a 'grounding_shadow'
+        audit event with the per-dimension shift, then REVERT the live metrics
+        (behavior-neutral) unless APPLY is also set.
+      * GROUNDING_APPLY    -> keep the grounded values, so persist + response use
+        them. LIVE-AFFECTING (coherence/E/I/S shift fleet-wide).
+    """
+    from config.governance_config import (
+        grounding_shadow_enabled,
+        grounding_apply_enabled,
+    )
+    from src.audit_log import audit_logger
+
+    shadow = grounding_shadow_enabled()
+    apply = grounding_apply_enabled()
+    if not (shadow or apply):
+        return
+
+    result = ctx.result or {}
+    metrics = result.get("metrics")
+    if not isinstance(metrics, dict) or "E_legacy" in metrics:
+        return  # nothing to ground, or already grounded
+
+    dims = ("E", "I", "S", "coherence")
+    pre = {d: metrics.get(d) for d in dims}
+
+    try:
+        await enrich_grounding(ctx)  # mutates metrics in place: sets grounded + *_legacy + *_source
+    except Exception as exc:  # pragma: no cover - defensive, must never break check-in
+        logger.debug(f"run_grounding_stage failed — metrics untouched: {exc}")
+        return
+
+    if "s_source" not in metrics:
+        return  # enrich_grounding returned early (e.g. metrics not dict) — nothing applied
+
+    if shadow:
+        try:
+            audit_logger.log_grounding_shadow(
+                agent_id=getattr(ctx, "agent_id", None) or "unknown",
+                ungrounded=pre,
+                grounded={d: metrics.get(d) for d in dims},
+                sources={
+                    "E": metrics.get("e_source"),
+                    "I": metrics.get("i_source"),
+                    "S": metrics.get("s_source"),
+                    "coherence": metrics.get("coherence_source"),
+                },
+                applied=apply,
+            )
+        except Exception as exc:  # pragma: no cover
+            logger.debug(f"grounding_shadow audit failed: {exc}")
+
+    if not apply:
+        # Behavior-neutral: restore the ungrounded canonical values and drop the
+        # grounding bookkeeping so persist + response are byte-identical to today.
+        for d in dims:
+            metrics[d] = pre[d]
+        for k in ("E_legacy", "I_legacy", "S_legacy", "coherence_legacy",
+                  "e_source", "i_source", "s_source", "coherence_source", "agent_class"):
+            metrics.pop(k, None)

--- a/src/services/update_workflow_service.py
+++ b/src/services/update_workflow_service.py
@@ -29,6 +29,7 @@ async def run_process_update_workflow(ctx, *, serializer=None) -> Sequence[TextC
         transform_inputs,
     )
     from src.mcp_handlers.updates.pipeline import run_enrichment_pipeline
+    from src.mcp_handlers.updates.enrichments import run_grounding_stage
     from src.mcp_handlers.response_formatter import format_response
     from src.mcp_handlers.utils import error_response
 
@@ -122,6 +123,12 @@ async def run_process_update_workflow(ctx, *, serializer=None) -> Sequence[TextC
             )]
 
         # --- Everything below runs OUTSIDE the lock ---
+
+        # Grounding must run BEFORE persist + response-build read ctx.result.
+        # (enrich_grounding still runs in the late pipeline but is idempotent.)
+        # Flag-gated: no-op unless GROUNDING_SHADOW/APPLY set. See #1092 ordering fix.
+        await run_grounding_stage(ctx)
+        _tick("grounding")
 
         await execute_post_update_effects(ctx)
         _tick("post_update")

--- a/tests/test_grounding_stage.py
+++ b/tests/test_grounding_stage.py
@@ -1,0 +1,104 @@
+"""Tests for run_grounding_stage — the #1092 ordering fix.
+
+enrich_grounding previously ran AFTER persist + response-build, so its grounded
+E/I/S/coherence were silently discarded. run_grounding_stage runs grounding
+early, flag-gated, with a shadow-compare:
+
+  * no flags        -> no-op (metrics byte-identical to today)
+  * GROUNDING_SHADOW -> emit grounding_shadow audit + REVERT metrics (neutral)
+  * GROUNDING_APPLY  -> keep grounded values (S becomes logprob-derived, etc.)
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.mcp_handlers.updates.context import UpdateContext
+from src.mcp_handlers.updates.enrichments import run_grounding_stage
+from src import audit_log
+
+# a real-shaped logprobs payload (uncertain first token -> non-trivial entropy)
+LOGPROBS = [
+    {"top_logprobs": [{"logprob": -0.6875}, {"logprob": -0.7241}, {"logprob": -4.5567}]},
+    {"top_logprobs": [{"logprob": -0.0}, {"logprob": -10.72}, {"logprob": -12.3}]},
+]
+
+
+def _ctx(logprobs=None):
+    ctx = UpdateContext(arguments={"logprobs": logprobs} if logprobs else {})
+    ctx.result = {"metrics": {"E": 0.72, "I": 0.80, "S": 0.1415, "V": -0.02, "coherence": 0.49}}
+    ctx.meta = None
+    ctx.agent_id = "test-agent"
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_no_flags_is_noop(monkeypatch):
+    monkeypatch.delenv("UNITARES_GROUNDING_SHADOW", raising=False)
+    monkeypatch.delenv("UNITARES_GROUNDING_APPLY", raising=False)
+    spy = MagicMock()
+    monkeypatch.setattr(audit_log.audit_logger, "log_grounding_shadow", spy)
+
+    ctx = _ctx(LOGPROBS)
+    before = dict(ctx.result["metrics"])
+    await run_grounding_stage(ctx)
+
+    assert ctx.result["metrics"] == before  # untouched
+    assert "s_source" not in ctx.result["metrics"]
+    spy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_shadow_logs_but_reverts(monkeypatch):
+    monkeypatch.setenv("UNITARES_GROUNDING_SHADOW", "1")
+    monkeypatch.delenv("UNITARES_GROUNDING_APPLY", raising=False)
+    spy = MagicMock()
+    monkeypatch.setattr(audit_log.audit_logger, "log_grounding_shadow", spy)
+
+    ctx = _ctx(LOGPROBS)
+    before = dict(ctx.result["metrics"])
+    await run_grounding_stage(ctx)
+
+    # behavior-neutral: live metrics reverted, no grounding bookkeeping left
+    m = ctx.result["metrics"]
+    assert m == before
+    assert "s_source" not in m and "S_legacy" not in m
+
+    # but the shadow WAS recorded, with applied=False and a logprob S source
+    assert spy.call_count == 1
+    kw = spy.call_args.kwargs
+    assert kw["applied"] is False
+    assert kw["sources"]["S"] == "logprob"
+    assert kw["grounded"]["S"] != kw["ungrounded"]["S"]  # grounding would have moved S
+
+
+@pytest.mark.asyncio
+async def test_apply_grounds_live_metrics(monkeypatch):
+    monkeypatch.setenv("UNITARES_GROUNDING_APPLY", "1")
+    monkeypatch.delenv("UNITARES_GROUNDING_SHADOW", raising=False)
+    monkeypatch.setattr(audit_log.audit_logger, "log_grounding_shadow", MagicMock())
+
+    ctx = _ctx(LOGPROBS)
+    await run_grounding_stage(ctx)
+
+    m = ctx.result["metrics"]
+    # grounded values are now live and tagged
+    assert m["s_source"] == "logprob"
+    assert m["S_legacy"] == pytest.approx(0.1415)
+    assert m["S"] != pytest.approx(0.1415)  # S replaced by logprob entropy
+    assert 0.0 <= m["S"] <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_no_logprobs_falls_to_heuristic_under_apply(monkeypatch):
+    # Without logprobs, S grounding is heuristic == prior S (no change), but the
+    # stage still runs and stamps s_source=heuristic when applied.
+    monkeypatch.setenv("UNITARES_GROUNDING_APPLY", "1")
+    monkeypatch.setattr(audit_log.audit_logger, "log_grounding_shadow", MagicMock())
+
+    ctx = _ctx(logprobs=None)
+    await run_grounding_stage(ctx)
+    m = ctx.result["metrics"]
+    assert m.get("s_source") == "heuristic"
+    assert m["S"] == pytest.approx(0.1415)  # heuristic S == prior ODE S


### PR DESCRIPTION
## The bug

#1092's `enrich_grounding` is registered in the **late** enrichment pipeline. In `update_workflow_service.py` the order is:

```
126: execute_post_update_effects(ctx)   → record_agent_state PERSISTS (ungrounded)
129: build_process_update_response_data → RESPONSE built (ungrounded)
138: run_enrichment_pipeline(ctx)       → enrich_grounding runs — after both consumers
```

So grounded `E/I/S/coherence` (and `s_source`) reach **neither** the DB nor the response. **#1092's grounding has been a silent no-op since it shipped** — not for lack of logprobs.

**Verified live** (two real check-ins carrying logprobs against the deployed server): logprobs *do* reach `ctx.arguments` (transport works — confirmed in `mcp_server.log`), `compute_entropy`/`enrich_grounding` are correct *in isolation* (`s_source="logprob"`, `S=0.156`), but the live persisted/returned `S` == raw `ode.S` with no `s_source`. Cause: ordering.

## Why this lands behind flags (not a silent reorder)

Activating grounding is **fleet-wide consequential**: `compute_coherence` returns a *manifold* value and `free_energy`/`mutual_info` re-derive `E`/`I` for **every** agent, not just logprob ones — shifting `coherence/E/I/S` and therefore basin/verdict/risk. So this follows the basin-shadow pattern:

- **`run_grounding_stage(ctx)`** runs **before** persist + response-build:
  - **no flags** → no-op (byte-identical to today; the late `enrich_grounding` stays the existing discarded no-op).
  - **`UNITARES_GROUNDING_SHADOW`** → compute grounded metrics, emit a **`grounding_shadow`** audit event with the per-dimension shift + tier sources, then **revert** the live metrics. Behavior-neutral measurement of the fleet-wide shift.
  - **`UNITARES_GROUNDING_APPLY`** → keep grounded values so persist + response use them. **LIVE-AFFECTING** — validate via shadow first.
- The late `enrich_grounding` stays registered but is idempotent (`E_legacy` guard), so no double-application.

## Files
- `config/governance_config.py` — `grounding_shadow_enabled()` / `grounding_apply_enabled()` (both default off)
- `src/audit_log.py` — `log_grounding_shadow()` → `grounding_shadow` audit event
- `src/mcp_handlers/updates/enrichments.py` — `run_grounding_stage()`
- `src/services/update_workflow_service.py` — call it before `execute_post_update_effects`
- `tests/test_grounding_stage.py` — no-op / shadow-reverts / apply-grounds / heuristic-no-logprobs

## Safety
Grounding stays **OFF by default** — this PR changes nothing live until a flag is set. Full `test-cache.sh`: **10840 passed, 22 skipped**, coverage 81.8%. Existing grounding suites all still green.

## Rollout
1. Merge (inert).
2. `UNITARES_GROUNDING_SHADOW=1` → measure the grounded-vs-ungrounded shift fleet-wide (esp. coherence) + the `s_source` distribution, via `audit.events` `event_type='grounding_shadow'`.
3. If the shift is acceptable, `UNITARES_GROUNDING_APPLY=1` to activate.

Related: [#1092] (logprob-entropy grounding), #1089 (basin-shadow pattern this mirrors).

https://claude.ai/code/session_0148U7HfEUhwgXoRybnVw9Dx