### PR TITLE
docs(registry): Theme 6 — shadow-gated surfaces with explicit wake conditions

### DIFF
--- a/docs/operations/dormant-capability-registry.md
+++ b/docs/operations/dormant-capability-registry.md
@@ -141,3 +141,33 @@ The adversarial pass confirmed these are live, correcting plausible "looks dead"
   not unwired surface.
 - **`retrieval.py` `rrf_fuse`/`apply_tag_boost`**, `find_similar`, `semantic_search`,
   `full_text_search`, `knowledge_graph_lifecycle` (daily task) — all live.
+
+---
+
+## Theme 6 — Shadow-gated validation surfaces (2026-06-26/27)
+
+Capabilities that run in **shadow** (measure, don't act) or are **flag-gated off**,
+each with an explicit **wake condition** — the test that separates deliberate dormancy
+from avoidance. The rule for this theme: *awaken the eyes (shadow), not the hands
+(apply), until the wake condition is met.* This theme exists because "built-but-unwired"
+caught one of its own as a silent no-op — #1092's grounding ran **after** its persist +
+response consumers and was discarded since it shipped (fixed by #1095, behind flags).
+
+| Capability | Flag / PR | Status | Wake condition |
+|---|---|---|---|
+| **EISV logprob-grounding** — tier-1 S from model output-distribution entropy | `#1092` Stages 1+2 shipped; Stage 3 (proxy supply) NOT built | KEEP-DORMANT | Build Stage 3 only if `grounding_shadow` shows `s_source="logprob"` S out-discriminates the heuristic **on outcomes**. Off-Claude only (Claude API exposes no logprobs — verified via claude-api skill). Depends on the grounding-apply path (#1095) working first. |
+| **Grounding apply** — grounded E/I/S/coherence replace ODE/heuristic in canonical metrics | `UNITARES_GROUNDING_APPLY` / `#1095` | KEEP-DORMANT (apply); shadow available | Run `UNITARES_GROUNDING_SHADOW=1` first → read `grounding_shadow` audit events → set APPLY only if the **fleet-wide** coherence/E/I/S shift (manifold coherence + re-derived E/I fire for *every* agent) causes no harmful verdict flips. LIVE-AFFECTING. |
+| **Behavioral-EISV basin** — kernel-split WS1 option b | `UNITARES_BASIN_SHADOW` / `#1089` | SHADOW-only | Feed `classify_basin` from behavioral EISV (and gate the 60–4500ms ODE off the check-in hot path) only when `basin_shadow` shows the behavioral basin tracks the ODE basin on the **broad** fleet. Current shadow (resident agents, small n): ~97% disagree, behavioral more conservative → **wake condition NOT met**; needs non-resident sampling + threshold recalibration. |
+| **Φ → telemetry-only** — behavioral verdict authoritative; Φ stops flooring risk | `UNITARES_PHI_TELEMETRY_ONLY` (default off) | DECIDE | A values call aligned with the design north-star (Φ = RLHF-shape → demote to predictor). No automated trigger: wake when making the behavioral/residual verdict fully authoritative is the intended posture. |
+
+**Counter-example (awakened, for contrast).** `UNITARES_GOVERNED_EFFECT_EXECUTE_AGENT_SPAWN=1`
+is a flag-gated capability that *was* deliberately awakened — operator flip 2026-06-25,
+a standing execute/RCE surface, persistent. That is what a met wake condition looks like:
+a named operator decision, not a default drift-on. Rollback = remove the plist key +
+bootout/bootstrap.
+
+**The test — apply to every `KEEP-DORMANT` entry, in this theme and above.** A dormancy
+with a written wake condition is discipline; a dormancy with none is avoidance wearing
+discipline's clothes — and becomes the looks-dead → deleted → rebuilt cycle this registry
+exists to stop. Treat dormancy as a **fermata, not a deletion**: a held note that resolves
+on its condition, not one held until the music stops.


### PR DESCRIPTION
Registers the session's flag-gated / shadow surfaces in `docs/operations/dormant-capability-registry.md`, each with an explicit **wake condition** — applying the "discipline vs avoidance" test rather than just cataloguing.

## Why
The discoverability audit found that #1089 (basin-shadow), #1092 (logprob-grounding), and #1095 (grounding) all shipped flag-gated capability **without** registering it — violating the registry's own rule 3 ("new capability should not merge unwired — add a `KEEP-DORMANT` entry"). And #1092's grounding turned out to be a **silent no-op since it shipped** (ran after its persist/response consumers) — the exact "built, never wired, looks dead" failure mode this registry exists to prevent. It wasn't in here.

## What
New **Theme 6** with a `Wake condition` column:
- **logprob-grounding** (#1092) — Stage 3 only if `grounding_shadow` shows logprob-S out-discriminates heuristic *on outcomes*; off-Claude only.
- **grounding apply** (#1095) — `SHADOW=1` → read divergence → `APPLY` only if the fleet-wide coherence/E/I/S shift is harmless.
- **behavioral-EISV basin** (#1089) — apply only when behavioral basin tracks ODE basin on the broad fleet (current shadow: ~97% disagree on residents → not met).
- **Φ→telemetry-only** — a values call per the north-star, no automated trigger.
- **governed-effect-execute** — the *awakened* counter-example (operator flip 2026-06-25) showing what a met wake condition looks like.

Plus the restated rule: dormancy with a written wake-condition is discipline; without one it's avoidance — a fermata, not a deletion.

Docs-only; no behavior change.

https://claude.ai/code/session_0148U7HfEUhwgXoRybnVw9Dx