### PR TITLE
docs(readme): lead with stateful control-plane posture, not EISV-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The engine behind the verdict — what makes the decision *stateful* rather than
 - **Outcome-grounded calibration.** Self-reported `confidence` is scored against objective evidence — test exit codes, tool output, file ops — and the resulting calibration feeds back into future verdicts. The number is gameable; the success rate isn't.
 - **Dialectic peer review → runtime constraints.** A disputed verdict is reviewed by an authority-weighted peer agent from the fleet (self-review blocked; supermajority quorum on round exhaustion); the synthesized conditions *persist* and gate that agent's later verdicts — a runtime constraint, not debate text.
 - **Per-instance identity isolation.** Each process-instance is a distinct governed identity with its own state. Reads are open; writes are accountable to a bound caller. No cross-instance state bleed by default.
-- **Durable audit trail + shared knowledge.** Every confidence, evidence, verdict, drift, and recovery is recorded and queryable — the basis for "verify it yourself." The same store (Postgres + pgvector, with an Apache AGE graph view) also holds the fleet's shared knowledge graph, where agents contribute and search discoveries across instances.
+- **Durable audit trail + shared knowledge.** Every confidence, evidence, verdict, drift, and recovery is recorded — the basis for "verify it yourself." The same store (Postgres + pgvector, with an Apache AGE graph view) also holds the fleet's shared knowledge graph: agents contribute discoveries that are linked into a graph of cross-agent relations.
 
 <div align="center">
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 <img alt="UNITARES — runtime governance for AI-agent fleets" src="docs/assets/hero-v2.png" width="100%">
 
-### Catch an AI agent drifting — while it's still just numbers, not broken output.
+### A stateful governance runtime for fleets of autonomous AI agents.
 
-**Runtime governance & self-telemetry for fleets of autonomous AI agents.**<br/>
-UNITARES watches each agent while it works and tells you — and the agent itself — the moment one starts to drift, while it's still just numbers moving and not yet broken output.
+**Each agent is judged against its own history and calibration — not a fixed per-action rule — and gets back a verdict it can act on, mid-run.**<br/>
+Most controls are stateless: they check one action against one rule. UNITARES carries each agent's trajectory, calibration, and recent verdicts into the next decision — so an agent *drifting* surfaces while its output still looks fine, and it self-corrects (`proceed` / `guide` / `pause` / `reject`) before an external guardrail has to fire.
 
 [![Tests](https://github.com/cirwel/unitares/actions/workflows/tests.yml/badge.svg)](https://github.com/cirwel/unitares/actions/workflows/tests.yml)
 [![Python](https://img.shields.io/badge/python-3.12+-2f7d72?style=flat-square&labelColor=0f171f)](https://www.python.org/downloads/)
@@ -25,9 +25,10 @@ One layer of the **[CIRWEL stack](https://cirwel.github.io)** — runtime safety
 
 ---
 
-- **Drift surfaces while the output still looks fine.** Each agent is graded against its *own* baseline, so slow degradation shows up as integrity slipping and entropy rising before the work visibly breaks.
-- **Confidence is checked against results.** Self-reported `confidence` is scored against real evidence — tests, exit codes, tool output. An agent can inflate the number; it can't inflate its success rate.
-- **Agents get a proprioceptive state signal they can act on.** Each check-in returns one plain policy action — `proceed`, `guide`, `pause`, or `reject` — plus the agent's full health signals (the `EISV` state vector) for finer policies. Humans can watch the same fleet through the optional dashboard.
+- **Stateful, state-aware verdicts.** Each agent is judged against its *own* ~30-check-in baseline and recent history — not a fixed per-action rule — so slow degradation surfaces while the output still looks fine, and the verdict reflects context, not just the current action.
+- **Confidence grounded in results.** Self-reported `confidence` is scored against real evidence — test exit codes, tool output, file ops. An agent can inflate the number; it can't inflate its success rate, and that calibration feeds back into future verdicts.
+- **Peer review that becomes a runtime constraint.** On a disputed verdict, an authority-weighted peer agent from the fleet reviews (self-review blocked); the synthesized conditions *persist* and gate that agent's future decisions — a runtime constraint, not just debate text.
+- **One signal the agent acts on.** Every check-in returns a plain verdict — `proceed` / `guide` / `pause` / `reject` — plus the agent's full health vector (`EISV`) for finer per-dimension policies. Humans watch the same fleet through the optional dashboard.
 
 ## Use UNITARES if
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,22 @@ UNITARES runs **alongside** your evals and guardrails — it doesn't replace eit
 | **Guardrails** | Is this *action* allowed right now? | per action |
 | **UNITARES** | Is this agent *still healthy* as it works? | continuously, mid-run |
 
+## Mechanisms
+
+The engine behind the verdict — what makes the decision *stateful* rather than a per-action rule:
+
+- **State-aware verdict engine.** Each verdict is a function of the agent's own baseline, calibration, and recent verdict history — not the current action in isolation. Auditable behavioral model, not a black box ([`behavioral_assessment.py`](src/behavioral_assessment.py)).
+- **Outcome-grounded calibration.** Self-reported `confidence` is scored against objective evidence — test exit codes, tool output, file ops — and the resulting calibration feeds back into future verdicts. The number is gameable; the success rate isn't.
+- **Dialectic peer review → runtime constraints.** A disputed verdict is reviewed by an authority-weighted peer agent from the fleet (self-review blocked; supermajority quorum on round exhaustion); the synthesized conditions *persist* and gate that agent's later verdicts — a runtime constraint, not debate text.
+- **Per-instance identity isolation.** Each process-instance is a distinct governed identity with its own state. Reads are open; writes are accountable to a bound caller. No cross-instance state bleed by default.
+- **Durable audit trail.** Every confidence, evidence, verdict, drift, and recovery is recorded and queryable — the basis for "verify it yourself," not a dashboard afterthought.
+
+<div align="center">
+
+[Architecture](docs/UNIFIED_ARCHITECTURE.md) · [Scope & threat model](docs/SCOPE_AND_THREAT_MODEL.md)
+
+</div>
+
 ## How it works
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The engine behind the verdict — what makes the decision *stateful* rather than
 - **Outcome-grounded calibration.** Self-reported `confidence` is scored against objective evidence — test exit codes, tool output, file ops — and the resulting calibration feeds back into future verdicts. The number is gameable; the success rate isn't.
 - **Dialectic peer review → runtime constraints.** A disputed verdict is reviewed by an authority-weighted peer agent from the fleet (self-review blocked; supermajority quorum on round exhaustion); the synthesized conditions *persist* and gate that agent's later verdicts — a runtime constraint, not debate text.
 - **Per-instance identity isolation.** Each process-instance is a distinct governed identity with its own state. Reads are open; writes are accountable to a bound caller. No cross-instance state bleed by default.
-- **Durable audit trail.** Every confidence, evidence, verdict, drift, and recovery is recorded and queryable — the basis for "verify it yourself," not a dashboard afterthought.
+- **Durable audit trail + shared knowledge.** Every confidence, evidence, verdict, drift, and recovery is recorded and queryable — the basis for "verify it yourself." The same store (Postgres + pgvector, with an Apache AGE graph view) also holds the fleet's shared knowledge graph, where agents contribute and search discoveries across instances.
 
 <div align="center">
 


### PR DESCRIPTION
Positioning revamp of the README per the "show the engine, not just EISV; don't over-apologize" correction. Two commits:

**1. Reframe the lead (hero + opening bullets).**
- **Hero** leads with the architectural posture — a stateful governance runtime; each agent judged against its own history + calibration, not a fixed per-action rule — with the stateless-vs-stateful contrast as the differentiator. Drift stays the concrete payoff, not the headline.
- **Opening bullets** reframed to the defensible triad: stateful state-aware verdicts; confidence grounded in verified outcomes + fed back into future verdicts; dialectic peer conditions that *persist as runtime constraints* (authority-weighted, self-review blocked — not "recalibrates the fleet"); the graded verdict primitive.
- **EISV demoted** from a lead to the per-dimension health readout behind the verdict.

**2. Add a `## Mechanisms` section** (between "Where it fits" and "How it works") naming the governed engine: state-aware verdict engine · outcome-grounded calibration · dialectic peer review → runtime constraints · per-instance identity isolation · durable audit trail. Architectural posture, grounded (behavioral model is auditable), no commodity items, no overclaim.

**Held to the discipline:** no new claims, no commodity items (heterogeneous-fleet / MCP-native) promoted to differentiators, no adoption overclaim, and the honesty spine — "research target, not the live verdict path" + the falsifiability harness — untouched.

Docs-only; pre-commit (scope guard + markdown) clean.

https://claude.ai/code/session_019TLkNbrqefj5RvDNrcVD5L
