### PR TITLE
fix(kg): guard None min_similarity in semantic search (crash fix)

### DIFF
--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -1323,7 +1323,8 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
                 )
             if hybrid_path:
                 import asyncio as _asyncio
-                min_similarity = arguments.get("min_similarity", 0.3)
+                _ms = arguments.get("min_similarity")
+                min_similarity = 0.3 if _ms is None else _ms
                 hybrid_fetch_limit = max(first_stage_limit, 50)
                 sem_task = graph.semantic_search(
                     str(query_text), limit=hybrid_fetch_limit, min_similarity=min_similarity
@@ -1413,7 +1414,8 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
             elif use_semantic:
                 # Semantic search using vector embeddings
                 # Default 0.3 for precision; auto-fallback to 0.2 catches edge cases
-                min_similarity = arguments.get("min_similarity", 0.3)
+                _ms = arguments.get("min_similarity")
+                min_similarity = 0.3 if _ms is None else _ms
                 semantic_results = await graph.semantic_search(
                     str(query_text),
                     limit=first_stage_limit,  # wider pool when reranker is on

--- a/src/storage/knowledge_graph_age.py
+++ b/src/storage/knowledge_graph_age.py
@@ -2215,6 +2215,12 @@ class KnowledgeGraphAGE:
             Callers should check: if isinstance(result, tuple) and len(result) == 2
             and isinstance(result[1], dict), it's a degraded response.
         """
+        # Defensive: callers (notably the search handler reading an Optional
+        # schema field) can pass min_similarity=None; without this the later
+        # `similarity < min_similarity` comparison raises TypeError. Coalesce to
+        # the documented default, preserving an explicit 0.0 ("accept all").
+        if min_similarity is None:
+            min_similarity = 0.3
         try:
             from src.embeddings import get_embeddings_service, embeddings_available
         except ImportError:

--- a/tests/test_kg_search.py
+++ b/tests/test_kg_search.py
@@ -161,6 +161,34 @@ class TestSearchKnowledgeGraph:
         assert data["search_mode_used"] == "indexed_filters"
 
     @pytest.mark.asyncio
+    async def test_search_coalesces_none_min_similarity(self, patch_common):
+        """Regression (dogfood 2026-06-27): the knowledge schema defaults
+        min_similarity to None, so arguments.get('min_similarity', 0.3) returned
+        None (key present, not absent) and semantic_search crashed at
+        `similarity < min_similarity` with "'<' not supported between instances of
+        'float' and 'NoneType'". The handler must coalesce None -> 0.3 before
+        calling semantic_search."""
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+        mock_graph.semantic_search = AsyncMock(return_value=[])
+        mock_graph.full_text_search = AsyncMock(return_value=[])
+
+        # arguments as the validated schema produces them when the caller does not
+        # set a threshold: the key is present with value None.
+        result = await handle_search_knowledge_graph(
+            {"query": "MagicDNS", "limit": 3, "min_similarity": None,
+             "search_mode": "semantic"}
+        )
+
+        assert parse_result(result)["success"] is True
+        assert mock_graph.semantic_search.await_count >= 1
+        for call in mock_graph.semantic_search.await_args_list:
+            passed = call.kwargs.get("min_similarity")
+            assert passed is not None, "handler must not pass min_similarity=None down"
+            assert passed == 0.3
+
+    @pytest.mark.asyncio
     async def test_superseded_result_is_flagged(self, patch_common):
         """Agent-facing trust flag (2026-06-21): a superseded result is marked
         superseded + carries the replacement id, so an agent doesn't cite stale


### PR DESCRIPTION
**Crash fix surfaced by dogfooding the KG (2026-06-27).** `knowledge(action=search)` threw `'<' not supported between instances of 'float' and 'NoneType'` on any query that didn't set a similarity threshold — i.e. the common case. That makes `search-before-write` error out.

**Root cause (two-part):**
1. `schemas/knowledge.py` defaults `min_similarity` to `None`.
2. `knowledge/handlers.py` resolved it with `arguments.get("min_similarity", 0.3)` — which returns `None` when the key is *present with a None value* (the classic `.get` footgun), not the `0.3` default. The `None` flowed into `semantic_search` and crashed at `similarity < min_similarity`.

**Fix (two layers):**
- Both handler call sites coalesce `None → 0.3`, **preserving an explicit `0.0`** ("accept all").
- Defensive guard at `semantic_search` entry so no future caller can push `None` into the comparison again (covers `_pgvector_search` too).

**Test:** regression in `tests/test_kg_search.py` asserts the handler never passes `min_similarity=None` down — **verified failing before the fix** (AssertionError, None passed), passing after. Full `test-cache` gate green (10842 passed).

**Why it matters (corrected framing).** Not "near-zero KG adoption" — that was wrong: the KG is heavily used (1,111 discoveries / 364 agents; 7,172 check-ins/14d). The accurate metric (`adoption_kpi.py`) is **voluntary KG retrieval = 0 calls by 0 agents in 14d** — agents contribute to the KG but don't spontaneously *search* it. A broken/erroring search path is a coherent (not proven) cause of zero voluntary retrieval.

**Scope:** fixes the **crash** only. The *other* dogfood finding — semantic search **timing out at 15s** (AGE/embedding amplification, the documented substrate-tax) — is a separate, harder problem and is **not** addressed here.

KG discovery for this finding: `2026-06-27T06:07:56` (open, with corrected adoption framing).

https://claude.ai/code/session_019TLkNbrqefj5RvDNrcVD5L
