### PR TITLE
fix(sentinel): stop alarming on force-release contract test fixtures

### DIFF
--- a/agents/sentinel/forced_release_alarm.py
+++ b/agents/sentinel/forced_release_alarm.py
@@ -38,6 +38,24 @@ except ImportError:  # pragma: no cover — surfaces at first call site
     asyncpg = None  # type: ignore
 
 
+# Surfaces minted under this namespace are reserved for destructive integration
+# tests — e.g. tests/test_lease_plane_force_release_contract.py, which performs
+# a REAL force-release against the live router to exercise the §9 auth contract.
+# Those events land in lease_plane_events like any other, but they are test
+# fixtures, not operator-typed force-releases. Sentinel advances its cursor past
+# them WITHOUT emitting an alarm, so a normal `pytest` run against a live lease
+# plane does not page on every invocation. Tests that intentionally drive the
+# live force-release / conflict paths MUST mint surfaces under this prefix.
+RESERVED_TEST_SURFACE_PREFIX = "td:/test/"
+
+
+def _is_reserved_test_surface(surface_id: Any) -> bool:
+    """True if `surface_id` is in the reserved test namespace (see prefix doc)."""
+    return isinstance(surface_id, str) and surface_id.startswith(
+        RESERVED_TEST_SURFACE_PREFIX
+    )
+
+
 @dataclass
 class ForcedReleaseAlarm:
     """One alarm produced by `poll_forced_release_alarms`.
@@ -104,6 +122,13 @@ async def _poll_inner(
             ad_hoc_query.format(ts_filter="AND ts > $1"), last_event_ts,
         )
     for row in rows:
+        if _is_reserved_test_surface(row["surface_id"]):
+            # Reserved test-surface event: advance the cursor past it so it
+            # isn't re-scanned, but do NOT alarm — it is a test fixture, not an
+            # operator force-release.
+            if max_ts is None or row["ts"] > max_ts:
+                max_ts = row["ts"]
+            continue
         alarms.append(_ad_hoc_alarm(row))
         if max_ts is None or row["ts"] > max_ts:
             max_ts = row["ts"]
@@ -161,6 +186,11 @@ async def _poll_inner(
             conflict_query.format(ts_filter="AND ts > $1"), last_event_ts,
         )
     for row in rows:
+        if _is_reserved_test_surface(row["surface_id"]):
+            # Reserved test-surface conflict burst: advance the cursor, no alarm.
+            if max_ts is None or row["last_ts"] > max_ts:
+                max_ts = row["last_ts"]
+            continue
         alarms.append(_conflict_alarm(row))
         if max_ts is None or row["last_ts"] > max_ts:
             max_ts = row["last_ts"]

--- a/tests/test_lease_plane_force_release_contract.py
+++ b/tests/test_lease_plane_force_release_contract.py
@@ -30,6 +30,16 @@ from pathlib import Path
 
 import pytest
 
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+# Reserved test namespace: surfaces minted here are excluded from Sentinel's
+# forced-release alarm so this destructive contract test doesn't page the
+# operator on every `pytest` run (see forced_release_alarm.RESERVED_TEST_SURFACE_PREFIX).
+from agents.sentinel.forced_release_alarm import (  # noqa: E402
+    RESERVED_TEST_SURFACE_PREFIX,
+)
+
 # ---------- skip predicate ----------
 
 _ROUTER_HOST = "127.0.0.1"
@@ -118,7 +128,7 @@ def _post_json(path: str, body: dict, *, authorization: str | None = None) -> tu
 def _acquire_lease(bearer_token: str) -> str:
     """Acquire a td:/ lease and return its lease_id string."""
     body = {
-        "surface_id": f"td:/force-release-contract-test-{uuid.uuid4()}",
+        "surface_id": f"{RESERVED_TEST_SURFACE_PREFIX}force-release-contract-{uuid.uuid4()}",
         "holder_agent_uuid": str(uuid.uuid4()),
         "holder_class": "process_instance",
         "holder_kind": "local_beam",

--- a/tests/test_sentinel_forced_release_alarm.py
+++ b/tests/test_sentinel_forced_release_alarm.py
@@ -53,6 +53,10 @@ async def _cleanup(conn):
     await conn.execute(
         "DELETE FROM lease_plane.surface_leases WHERE intent LIKE 'pr3b-test%'"
     )
+    # Reserved test-namespace events (force-release contract test fixtures).
+    await conn.execute(
+        "DELETE FROM lease_plane.lease_plane_events WHERE surface_id LIKE 'td:/test/%'"
+    )
 
 
 async def _emit_event(
@@ -300,6 +304,52 @@ async def test_phase_zero_acquire_race_blocked():
             "WHERE marked_by_session_id = 'test-pr3b-race'"
         )
         assert count == 1
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+# ---------- reserved test-surface exclusion ----------
+
+
+@pytest.mark.asyncio
+async def test_sentinel_reserved_test_surface_excluded_from_alarms():
+    """Forced + conflict events on the reserved test namespace
+    (RESERVED_TEST_SURFACE_PREFIX) advance the cursor but emit NO alarms.
+
+    The force-release contract test does a REAL force-release against the live
+    router on every run; without this exclusion Sentinel paged a fresh
+    high-severity alarm each `pytest` invocation. The cursor must still advance
+    past the event so it isn't re-scanned indefinitely.
+    """
+    from agents.sentinel.forced_release_alarm import (
+        RESERVED_TEST_SURFACE_PREFIX,
+        poll_forced_release_alarms,
+    )
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        forced_surface = f"{RESERVED_TEST_SURFACE_PREFIX}force-release-contract-{uuid.uuid4()}"
+        conflict_surface = f"{RESERVED_TEST_SURFACE_PREFIX}conflict-{uuid.uuid4()}"
+        await _emit_event(conn, event_type="forced", surface_id=forced_surface)
+        await _emit_event(
+            conn, event_type="conflict_held_by_other", surface_id=conflict_surface,
+        )
+
+        alarms, new_cursor = await poll_forced_release_alarms(
+            db_url=TEST_DB_URL, last_event_ts=None,
+        )
+        reserved = [
+            a for a in alarms
+            if str(a.extra.get("surface_id", "")).startswith(RESERVED_TEST_SURFACE_PREFIX)
+        ]
+        assert reserved == [], (
+            f"reserved test-surface events must not alarm; got {reserved}"
+        )
+        # Cursor advanced past the events so they aren't re-scanned forever.
+        assert new_cursor is not None
     finally:
         await _cleanup(conn)
         await conn.close()

--- a/tests/test_sentinel_forced_release_fingerprint_parity.py
+++ b/tests/test_sentinel_forced_release_fingerprint_parity.py
@@ -30,12 +30,25 @@ project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
 from agents.sentinel.forced_release_alarm import (  # noqa: E402
+    RESERVED_TEST_SURFACE_PREFIX,
     _ad_hoc_alarm,
     _batch_alarm,
     _conflict_alarm,
+    _is_reserved_test_surface,
 )
 
 UTC = timezone.utc
+
+
+def test_reserved_test_surface_predicate():
+    # Pins the reserved namespace so the contract test and the alarm poller
+    # cannot drift apart. Events on this prefix are test fixtures, not operator
+    # force-releases, and must be excluded from alarms.
+    assert RESERVED_TEST_SURFACE_PREFIX == "td:/test/"
+    assert _is_reserved_test_surface("td:/test/force-release-contract-abc")
+    assert not _is_reserved_test_surface("td:/pr3b_a")
+    assert not _is_reserved_test_surface("dialectic:/x")
+    assert not _is_reserved_test_surface(None)
 
 
 def test_ad_hoc_fingerprint_is_event_id_only():


### PR DESCRIPTION
## What

Every local `pytest` run that has the live BEAM router + elevated token present was producing a fresh high-severity Sentinel alarm: `forced release: td:/force-release-contract-test-… `.

## Why

It's a **test-hygiene bug**, not a defect in the alarm logic:

1. `tests/test_lease_plane_force_release_contract.py::test_force_release_rejects_governance_token` (sub-assertion 3) performs a **real** `POST /v1/lease/force-release` against the live router to verify the §9 auth contract.
2. That writes a real `event_type='forced'` row into `lease_plane.lease_plane_events` (no cleanup; the governance DB forbids DELETE).
3. `forced_release_alarm.poll_forced_release_alarms` correctly treats every `forced` event as a per-event `ad_hoc` alarm (the intended RFC §7.10 "alarm on every operator force-release" semantic) — it had no way to tell the test fixture apart from a genuine operator force-release.
4. Each run mints a fresh `uuid` surface → a new event past the cursor → a new alarm every time.

## Fix

Reserve a test surface namespace `RESERVED_TEST_SURFACE_PREFIX = "td:/test/"`:

- The poller skips reserved-namespace surfaces in both the `ad_hoc` (forced) and `conflict_batch` paths, while **still advancing its cursor** past the events so they aren't re-scanned indefinitely.
- The contract test mints surfaces under that prefix instead of a bare `td:/…` surface, so it keeps its full end-to-end coverage without paging the operator.

## Tests

- `test_reserved_test_surface_predicate` — pins the namespace value + predicate (no DB needed).
- `test_sentinel_reserved_test_surface_excluded_from_alarms` — DB-backed: forced + conflict events on the reserved prefix produce zero alarms but still advance the cursor.
- Extended the alarm-suite `_cleanup` to tidy reserved-namespace rows.

Parity tests pass locally; the DB-backed and live-router tests skip cleanly when those dependencies are absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BzBQCXUkx8NshtxPGSTPo1)_