### PR TITLE
perf(kg): batch-fetch nodes in semantic search (substrate-tax mitigation)

### DIFF
--- a/src/db/mixins/knowledge_graph.py
+++ b/src/db/mixins/knowledge_graph.py
@@ -296,6 +296,26 @@ class KnowledgeGraphMixin:
 
             return d
 
+    async def kg_get_discoveries_by_ids(
+        self, discovery_ids: List[str]
+    ) -> Dict[str, Dict[str, Any]]:
+        """Batch variant of kg_get_discovery: fetch many discoveries in ONE query.
+
+        Returns an id -> discovery-dict map. Unlike the singular path this omits
+        the per-row backlinks (``responses_from``) — search/ranking callers don't
+        read them, and the whole point of the batch is to avoid the per-id round
+        trips that the in-handler anyio<->asyncpg amplification turns into a
+        multi-second N+1 (see "Substrate Tax" in CLAUDE.md).
+        """
+        if not discovery_ids:
+            return {}
+        async with self.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT * FROM knowledge.discoveries WHERE id = ANY($1::text[])",
+                discovery_ids,
+            )
+        return {row["id"]: self._row_to_discovery_dict(row) for row in rows}
+
     async def kg_stats(self, including_cold: bool = False) -> Dict[str, Any]:
         """Discovery-level aggregates straight from knowledge.discoveries.
 

--- a/src/storage/knowledge_graph_age.py
+++ b/src/storage/knowledge_graph_age.py
@@ -2256,15 +2256,43 @@ class KnowledgeGraphAGE:
             )
             
             if scored_ids:
-                # Fetch full discovery nodes
+                # Fetch full discovery nodes in ONE batched query rather than an
+                # await-per-id loop. Each in-handler DB await pays the anyio<->
+                # asyncpg amplification tax, so a ~limit-long sequential
+                # get_discovery loop dominated the fast-path latency; collapsing
+                # it to a single fetch is the biggest in-handler win short of the
+                # substrate migration. SQL is the source of truth (get_discovery
+                # itself falls back to it), so this returns the same nodes; any id
+                # present only as an AGE node (rare) is picked up by the per-id
+                # fallback below.
+                db = await self._get_db()
+                ordered_ids = [did for did, _ in scored_ids]
+                dict_by_id = await db.kg_get_discoveries_by_ids(ordered_ids)
+                by_id = {}
+                for did in ordered_ids:
+                    d = dict_by_id.get(did)
+                    node = self._dict_to_discovery(d) if d else None
+                    if node is not None:
+                        by_id[did] = node
+                missing = [did for did in ordered_ids if did not in by_id]
+                if missing:
+                    fetched = await asyncio.gather(
+                        *(self.get_discovery(m) for m in missing),
+                        return_exceptions=True,
+                    )
+                    for m, node in zip(missing, fetched):
+                        if node and not isinstance(node, Exception):
+                            by_id[m] = node
+
                 raw_results = []
                 for discovery_id, similarity in scored_ids:
-                    discovery = await self.get_discovery(discovery_id)
-                    if discovery:
-                        # Apply agent filter if needed (pgvector doesn't filter by agent)
-                        if agent_id and discovery.agent_id != agent_id:
-                            continue
-                        raw_results.append((discovery, similarity))
+                    discovery = by_id.get(discovery_id)
+                    if not discovery:
+                        continue
+                    # Apply agent filter if needed (pgvector doesn't filter by agent)
+                    if agent_id and discovery.agent_id != agent_id:
+                        continue
+                    raw_results.append((discovery, similarity))
 
                 if raw_results:
                     # Blend with connectivity scores

--- a/tests/test_knowledge_graph_age.py
+++ b/tests/test_knowledge_graph_age.py
@@ -2118,6 +2118,8 @@ class TestSemanticSearch:
         kg._pgvector_search = AsyncMock(return_value=[("d1", 0.9)])
 
         d1 = make_discovery(discovery_id="d1")
+        # Batch fetch returns nothing → code falls back to per-id get_discovery.
+        mock_db.kg_get_discoveries_by_ids = AsyncMock(return_value={})
         kg.get_discovery = AsyncMock(return_value=d1)
 
         kg._blend_with_connectivity = AsyncMock(return_value=[(d1, 0.85)])
@@ -2144,6 +2146,8 @@ class TestSemanticSearch:
 
         # Discovery belongs to wrong agent
         d1 = make_discovery(discovery_id="d1", agent_id="other-agent")
+        # Batch fetch returns nothing → code falls back to per-id get_discovery.
+        mock_db.kg_get_discoveries_by_ids = AsyncMock(return_value={})
         kg.get_discovery = AsyncMock(return_value=d1)
 
         with patch.dict("sys.modules", {"src.embeddings": mock_module}):

--- a/tests/test_knowledge_graph_postgres_unit.py
+++ b/tests/test_knowledge_graph_postgres_unit.py
@@ -101,6 +101,37 @@ def test_row_to_discovery_dict_decodes_provenance_chain_json():
 
 
 @pytest.mark.asyncio
+async def test_kg_get_discoveries_by_ids_batches_in_one_query():
+    """Batch fetch collapses the per-id get_discovery N+1 (the loop that the
+    in-handler anyio<->asyncpg await tax turned into a multi-second cost) into a
+    single query: one fetch, id->dict map, empty input short-circuits with no DB
+    round-trip."""
+    calls = {"fetch": 0}
+
+    async def fake_fetch(query, *args):
+        calls["fetch"] += 1
+        assert "id = ANY" in query  # single batched query, not per-id
+        now = datetime.now(timezone.utc)
+        return [
+            {"id": "d-1", "agent_id": "a", "type": "note", "summary": "one", "created_at": now},
+            {"id": "d-2", "agent_id": "a", "type": "note", "summary": "two", "created_at": now},
+        ]
+
+    conn = MagicMock()
+    conn.fetch = AsyncMock(side_effect=fake_fetch)
+    backend = _FakeKgBackend(conn)
+
+    out = await backend.kg_get_discoveries_by_ids(["d-1", "d-2"])
+    assert calls["fetch"] == 1
+    assert set(out) == {"d-1", "d-2"}
+    assert out["d-1"]["summary"] == "one"
+
+    # Empty input must not touch the DB.
+    assert await backend.kg_get_discoveries_by_ids([]) == {}
+    assert calls["fetch"] == 1
+
+
+@pytest.mark.asyncio
 class TestUpdateDiscoveryTimestampCoercion:
     async def _make_backend(self, captured: list):
         """KnowledgeGraphPostgres with a mocked pool that records fetchval args."""


### PR DESCRIPTION
**Mitigation for the 15s KG search timeout** (follow-up to #1099, which fixed the crash + stopped the catastrophic in-memory fallback).

**Diagnosis (measured).** Locally nothing is 15s — `semantic_search` is sub-second even forcing the in-memory path. The 15s is the **anyio↔asyncpg in-handler amplification** (CLAUDE.md "Substrate Tax"), which is paid **per await**. The pgvector fast path then fetched full nodes with an **await-per-id loop** (up to ~`limit` sequential `get_discovery` calls) — that N+1 dominated the in-handler wall-clock.

**Change.** Collapse the N+1 into **one** query:
- New `kg_get_discoveries_by_ids` (`WHERE id = ANY($1::text[])`) on the relational source-of-truth that `get_discovery` already falls back to, reconstructed via the same `_row_to_discovery_dict`.
- `semantic_search` uses it; any id present only as an AGE node (rare) is picked up by a gathered per-id fallback. Order + agent filter preserved.

**Verified against the live DB:** identical nodes (0 missing / 0 extra / 0 field-diffs vs per-id), 5.6× faster locally (107→19ms) — but the real win is **50 awaits → 1** on a per-await tax.

**Honest scope.** This is a *mitigation*, not a cure for the class. I can't measure the in-handler magnitude from here (needs a post-deploy timing). The structural elimination of the class is the substrate question — which is justified by **coordination/aliveness, not latency** (operator gate 2026-06-24), so this query should be fixed in Python, not by a migration. Remaining levers if more is needed: broader ExecutorPool coverage, caching hot reads.

Tests: new unit test for the batch method; the two pgvector `TestSemanticSearch` mocks updated. Full `test-cache` gate green (10843 passed).

https://claude.ai/code/session_019TLkNbrqefj5RvDNrcVD5L
