### PR TITLE
Runtime denial/error guidance: corrective refusals + error-envelope fixes

### DIFF
--- a/src/mcp_handlers/dialectic/handlers.py
+++ b/src/mcp_handlers/dialectic/handlers.py
@@ -608,8 +608,8 @@ async def handle_request_dialectic_review(arguments: Dict[str, Any]) -> Sequence
             error_code="SESSION_EXISTS",
             error_category="validation_error",
             recovery={
-                "action": "Use get_dialectic_session() to view the active session",
-                "related_tools": ["get_dialectic_session"]
+                "action": "Use dialectic(action='get') to view the active session",
+                "related_tools": ["dialectic"]
             },
             arguments=arguments
         )]
@@ -1031,7 +1031,7 @@ async def handle_list_dialectic_sessions(arguments: Dict[str, Any]) -> Sequence[
                     "status": status,
                     "limit": limit
                 },
-                "tip": "Use list_dialectic_sessions() with no filters to see all sessions"
+                "tip": "Use dialectic(action='list') with no filters to see all sessions"
             })
 
         return success_response({
@@ -1044,7 +1044,7 @@ async def handle_list_dialectic_sessions(arguments: Dict[str, Any]) -> Sequence[
                 "limit": limit,
                 "include_transcript": include_transcript
             },
-            "tip": "Use get_dialectic_session(session_id='...') for full details"
+            "tip": "Use dialectic(action='get', session_id='...') for full details"
         })
 
     except Exception as e:
@@ -1053,7 +1053,7 @@ async def handle_list_dialectic_sessions(arguments: Dict[str, Any]) -> Sequence[
             f"Error listing sessions: {str(e)}",
             recovery={
                 "action": "Try with different filters or check server logs",
-                "related_tools": ["get_dialectic_session", "health_check"]
+                "related_tools": ["dialectic", "health_check"]
             }
         )]
 
@@ -1547,7 +1547,7 @@ async def handle_submit_antithesis(arguments: Dict[str, Any]) -> Sequence[TextCo
                         "action": "Use the assigned reviewer or explicitly take over reviewer ownership",
                         "assigned_reviewer_id": session.reviewer_agent_id,
                         "assigned_reviewer_label": _agent_label(session.reviewer_agent_id),
-                        "related_tools": ["get_dialectic_session", "dialectic", "identity"],
+                        "related_tools": ["dialectic", "identity"],
                         "workflow": workflow,
                     },
                 )]

--- a/src/mcp_handlers/dialectic/responses.py
+++ b/src/mcp_handlers/dialectic/responses.py
@@ -13,7 +13,7 @@ def missing_session_id_recovery() -> Dict[str, Any]:
     """Recovery payload for submit handlers missing `session_id`."""
     return {
         "action": "Provide session_id",
-        "related_tools": ["get_dialectic_session", "identity"],
+        "related_tools": ["dialectic", "identity"],
     }
 
 
@@ -21,7 +21,7 @@ def session_not_found_recovery() -> Dict[str, Any]:
     """Recovery payload when a dialectic session cannot be loaded."""
     return {
         "action": "Session may have expired or been resolved",
-        "related_tools": ["get_dialectic_session", "request_dialectic_review"],
+        "related_tools": ["dialectic"],
     }
 
 
@@ -77,7 +77,7 @@ def get_reviewer_reassigned_recovery(
             f"New reviewer '{new_reviewer_id}' should submit antithesis",
             "Session phase and transcript are preserved",
         ],
-        "related_tools": ["get_dialectic_session", "submit_antithesis"],
+        "related_tools": ["dialectic"],
     }
 
 
@@ -90,10 +90,10 @@ def get_awaiting_facilitation_recovery(session_id: str) -> Dict[str, Any]:
         ),
         "what_you_can_do": [
             f"1. Use dialectic(action='reassign', session_id='{session_id}', new_reviewer_id='<agent_id>') to assign a reviewer manually",
-            "2. Use list_agents to find available agents",
+            "2. Use agent(action='list') to find available agents",
             "3. Or let your bound session answer directly with dialectic(action='antithesis', session_id='...', reasoning='...', take_over_if_requested=true)",
         ],
-        "related_tools": ["dialectic", "list_agents", "get_dialectic_session", "identity"],
+        "related_tools": ["dialectic", "agent", "identity"],
         "note": "Session is paused, not failed. It will auto-fail after 4 hours total if no reviewer is assigned.",
     }
 
@@ -102,7 +102,7 @@ def get_agent_not_found_recovery() -> Dict[str, Any]:
     """Recovery payload when querying sessions for an unknown agent."""
     return {
         "action": "Agent must be registered first",
-        "related_tools": ["get_agent_api_key", "list_agents"],
+        "related_tools": ["identity", "agent"],
     }
 
 
@@ -119,7 +119,7 @@ def missing_session_or_agent_recovery() -> Dict[str, Any]:
     """Recovery payload when neither session_id nor agent_id is provided."""
     return {
         "action": "Provide session_id or agent_id to inspect a dialectic session",
-        "related_tools": ["list_agents", "get_governance_metrics"],
+        "related_tools": ["agent", "get_governance_metrics"],
         "note": "Use get_governance_metrics for live state when you are not targeting a dialectic session.",
     }
 
@@ -128,7 +128,7 @@ def get_session_exception_recovery() -> Dict[str, Any]:
     """Recovery payload for unexpected get_dialectic_session errors."""
     return {
         "action": "Check session_id or agent_id and try again",
-        "related_tools": ["list_agents", "get_governance_metrics"],
+        "related_tools": ["agent", "get_governance_metrics"],
     }
 
 

--- a/src/mcp_handlers/error_handling.py
+++ b/src/mcp_handlers/error_handling.py
@@ -21,7 +21,7 @@ def _infer_error_code_and_category(message: str) -> Tuple[Optional[str], Optiona
     error_patterns = [
         # Validation errors
         (["not found", "does not exist", "doesn't exist"], "NOT_FOUND", "validation_error"),
-        (["missing required", "required parameter", "must provide"], "MISSING_REQUIRED", "validation_error"),
+        (["missing required", "required parameter", "must provide", "is required"], "MISSING_REQUIRED", "validation_error"),
         (["invalid", "must be", "should be"], "INVALID_PARAM", "validation_error"),
         (["already exists", "duplicate"], "ALREADY_EXISTS", "validation_error"),
         (["too long", "exceeds maximum", "too large"], "VALUE_TOO_LARGE", "validation_error"),
@@ -32,6 +32,9 @@ def _infer_error_code_and_category(message: str) -> Tuple[Optional[str], Optiona
         # Keep these after validation so explicit parameter problems still win,
         # but before broad auth patterns like "session"; otherwise tool names
         # such as list_dialectic_sessions make timeout failures look like auth.
+        # Note: the "is required" validation pattern above must stay ahead of the
+        # "session" auth pattern below, so "session_id is required" classifies as
+        # a missing-parameter validation_error, not an auth_error.
         (["timeout", "timed out"], "TIMEOUT", "system_error"),
 
         # Auth errors

--- a/src/mcp_handlers/identity_bootstrap.py
+++ b/src/mcp_handlers/identity_bootstrap.py
@@ -34,6 +34,30 @@ _DEFAULT_REFUSAL_HINT = (
     "an exited session, pass parent_agent_id to declare lineage; otherwise "
     "pass force_new=true for a fresh identity."
 )
+_DEFAULT_REFUSAL_NEXT_STEP = (
+    "Call onboard(force_new=true) to mint a fresh process identity, or pass "
+    "parent_agent_id only for a real handoff from an exited predecessor."
+)
+_DEFAULT_REFUSAL_SAFE_OPTIONS = (
+    {
+        "action": "start_fresh",
+        "call": "onboard(force_new=true)",
+        "when": "This is a new process-instance with no causal predecessor.",
+    },
+    {
+        "action": "declare_lineage",
+        "call": "onboard(force_new=true, parent_agent_id=<prior UUID>, spawn_reason='new_session')",
+        "when": "A finished predecessor explicitly handed this work to you.",
+    },
+    {
+        "action": "stay_read_only",
+        "call": "get_governance_metrics() or list_tools()",
+        "when": "You do not yet have caller-proven identity for a write.",
+    },
+)
+_DEFAULT_REFUSAL_DO_NOT = (
+    "Do not retry bare identity(agent_uuid=..., resume=true); UUID alone is not ownership proof.",
+)
 
 
 def strict_identity_refusal_payload(
@@ -41,6 +65,11 @@ def strict_identity_refusal_payload(
     *,
     status: str = "identity_required",
     hint: str | None = None,
+    next_step: str | None = None,
+    safe_options: list[dict] | tuple[dict, ...] | None = None,
+    do_not: list[str] | tuple[str, ...] | None = None,
+    identity_assurance: dict | None = None,
+    surface_context: dict | None = None,
 ) -> dict:
     """The #425 typed-refusal shape, single-sourced.
 
@@ -59,11 +88,23 @@ def strict_identity_refusal_payload(
     A structured success-shape, not an error: error responses invite
     retry-with-mint catch paths and would reintroduce the ghost leak.
     """
-    return {
+    payload = {
         "status": status,
         "tool": tool_name,
         "tool_class": "required",
         "hint": hint if hint is not None else _DEFAULT_REFUSAL_HINT,
+        "next_step": next_step if next_step is not None else _DEFAULT_REFUSAL_NEXT_STEP,
+        "safe_options": [
+            dict(option) for option in (
+                safe_options if safe_options is not None else _DEFAULT_REFUSAL_SAFE_OPTIONS
+            )
+        ],
+        "do_not": list(do_not if do_not is not None else _DEFAULT_REFUSAL_DO_NOT),
         "ontology_ref": "CLAUDE.md \"STRICT_IDENTITY_REQUIRED (#425 staged rollout)\"",
         "rollout_flag": "STRICT_IDENTITY_REQUIRED",
     }
+    if identity_assurance is not None:
+        payload["identity_assurance"] = dict(identity_assurance)
+    if surface_context is not None:
+        payload["surface_context"] = dict(surface_context)
+    return payload

--- a/src/mcp_handlers/middleware/identity_step.py
+++ b/src/mcp_handlers/middleware/identity_step.py
@@ -824,7 +824,17 @@ async def resolve_identity(name: str, arguments: Dict[str, Any], ctx) -> Any:
                     # Single-sourced payload — the REST gate returns the
                     # same dict, so the two transports cannot drift
                     # (stage-1 burn-in fold, 2026-06-11).
-                    return success_response(strict_identity_refusal_payload(name))
+                    return success_response(strict_identity_refusal_payload(
+                        name,
+                        surface_context={
+                            "transport_surface": "mcp_dispatch",
+                            "lifecycle_automation": "not_confirmed",
+                            "note": (
+                                "Direct MCP dispatch refusal; tool exposure does "
+                                "not prove client lifecycle-hook automation."
+                            ),
+                        },
+                    ))
                 logger.info(
                     "[DISPATCH] session_resolve_miss for %s... — minting "
                     "ephemeral dispatch identity (S21-a, spawn_reason="

--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -377,9 +377,40 @@ async def resolve_identity_and_guards(ctx: UpdateContext) -> Optional[Sequence[T
                     hint=(
                         "This write resolved your identity by transport fingerprint, "
                         "not by a proof you supplied — under strict identity, writes "
-                        "require a caller-proven binding. Echo the client_session_id "
-                        "your onboard() returned (or pass continuity_token)."
+                        "require a caller-proven binding. Echo the continuity_token "
+                        "from your onboard() response as ownership proof; a "
+                        "session-maintaining client may instead pass an explicit "
+                        "client_session_id."
                     ),
+                    next_step=(
+                        "Retry process_agent_update with the continuity_token from "
+                        "your onboard()/identity() response; use client_session_id "
+                        "only when this client maintains a proven session binding."
+                    ),
+                    safe_options=[
+                        {
+                            "action": "retry_with_ownership_proof",
+                            "call": "process_agent_update(..., continuity_token=<onboard token>)",
+                            "when": "You have the ownership proof from this live process.",
+                        },
+                        {
+                            "action": "retry_with_session_binding",
+                            "call": "process_agent_update(..., client_session_id=<active session id>)",
+                            "when": "A session-maintaining client has a caller-proven active binding.",
+                        },
+                        {
+                            "action": "stay_read_only",
+                            "call": "get_governance_metrics()",
+                            "when": "You cannot present caller-proven identity yet.",
+                        },
+                    ],
+                    identity_assurance=ctx.identity_assurance,
+                    surface_context={
+                        "transport_surface": "process_agent_update",
+                        "session_resolution_source": ctx.session_resolution_source,
+                        "proof_origin": ctx.identity_assurance.get("proof_origin"),
+                        "lifecycle_automation": "not_confirmed",
+                    },
                 ))
 
     if ctx.arguments.get("require_strong_identity"):

--- a/src/services/http_tool_service.py
+++ b/src/services/http_tool_service.py
@@ -189,7 +189,17 @@ def _strict_identity_refusal_or_none(
         "typed refusal (no auto-mint)",
         tool_name,
     )
-    return strict_identity_refusal_payload(tool_name)
+    return strict_identity_refusal_payload(
+        tool_name,
+        surface_context={
+            "transport_surface": "rest_tool_call",
+            "lifecycle_automation": "not_confirmed",
+            "note": (
+                "REST /v1/tools/call refusal; direct tool reachability does "
+                "not prove client lifecycle-hook automation."
+            ),
+        },
+    )
 
 
 async def execute_http_tool(tool_name: str, arguments: Dict[str, Any]) -> Any:

--- a/tests/test_dialectic_recovery_pointers.py
+++ b/tests/test_dialectic_recovery_pointers.py
@@ -1,0 +1,54 @@
+"""Guard: dialectic recovery payloads point at the current tool surface.
+
+The dialectic handlers were consolidated (`get_dialectic_session`,
+`list_dialectic_sessions`, `submit_antithesis`, `list_agents`,
+`get_agent_api_key`, ... → `dialectic` / `agent` / `identity`). Recovery
+payloads must not hand an agent a `related_tools` pointer it cannot see in its
+tool list, or the error's own remediation is a dead end. This test pins the
+specific stale names that drifted, so a future regression is caught here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.mcp_handlers.dialectic import responses
+
+# Consolidated old names that are no longer exposed as standalone tools.
+# `request_dialectic_review` is deliberately excluded — it was restored as an
+# active tool (tool_stability: BETA), so it is a valid pointer.
+STALE_TOOL_NAMES = {
+    "get_dialectic_session",
+    "list_dialectic_sessions",
+    "submit_thesis",
+    "submit_antithesis",
+    "list_agents",
+    "get_agent_api_key",
+}
+
+# Recovery builders that emit a `related_tools` list, with call args.
+RECOVERY_BUILDERS = [
+    lambda: responses.missing_session_id_recovery(),
+    lambda: responses.session_not_found_recovery(),
+    lambda: responses.get_reviewer_reassigned_recovery(None, "reviewer-x"),
+    lambda: responses.get_awaiting_facilitation_recovery("sess-123"),
+    lambda: responses.get_agent_not_found_recovery(),
+    lambda: responses.no_sessions_found_recovery(),
+    lambda: responses.missing_session_or_agent_recovery(),
+    lambda: responses.get_session_exception_recovery(),
+    lambda: responses.get_session_timeout_recovery("timed out"),
+    lambda: responses.get_reviewer_stuck_recovery("reviewer-x"),
+    lambda: responses.llm_unavailable_recovery(),
+    lambda: responses.llm_failed_recovery(),
+]
+
+
+@pytest.mark.parametrize("builder", RECOVERY_BUILDERS)
+def test_recovery_related_tools_are_current_surface(builder):
+    payload = builder()
+    related = payload.get("related_tools", [])
+    stale = STALE_TOOL_NAMES.intersection(related)
+    assert not stale, (
+        f"recovery payload points at consolidated tool name(s) {stale}; "
+        f"use the current surface (dialectic / agent / identity)"
+    )

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -65,6 +65,16 @@ class TestInferErrorCode:
         assert code == "INVALID_PARAM"
         assert category == "validation_error"
 
+    def test_is_required_classifies_as_validation_not_auth(self):
+        # Regression: "session_id is required" is a missing-parameter error, but
+        # the message contains the substring 'session', which would fall through
+        # to the broad SESSION/auth pattern unless "is required" is caught as a
+        # MISSING_REQUIRED validation error first. The "X is required" phrasing
+        # (used by the dialectic submit handlers) must not look like an auth error.
+        code, category = _infer_error_code_and_category("session_id is required")
+        assert code == "MISSING_REQUIRED"
+        assert category == "validation_error"
+
 
 # --------------------------------------------------------------------------- #
 # _sanitize_error_message

--- a/tests/test_rest_strict_identity_gate.py
+++ b/tests/test_rest_strict_identity_gate.py
@@ -53,8 +53,24 @@ def test_refusal_payload_carries_the_425_contract_shape():
     assert p["status"] == "identity_required"
     assert p["tool"] == "knowledge"
     assert p["rollout_flag"] == "STRICT_IDENTITY_REQUIRED"
-    for key in ("hint", "ontology_ref", "tool_class"):
+    for key in ("hint", "ontology_ref", "tool_class", "next_step", "safe_options", "do_not"):
         assert p[key]
+    assert any("force_new=true" in option["call"] for option in p["safe_options"])
+    assert any("bare identity" in warning for warning in p["do_not"])
+
+
+def test_refusal_payload_accepts_surface_context():
+    p = strict_identity_refusal_payload(
+        "knowledge",
+        surface_context={
+            "transport_surface": "rest_tool_call",
+            "lifecycle_automation": "not_confirmed",
+        },
+    )
+    assert p["surface_context"] == {
+        "transport_surface": "rest_tool_call",
+        "lifecycle_automation": "not_confirmed",
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -75,7 +91,10 @@ def test_gate_exempts_pre_onboard_tools(strict_on, unbound_context):
 
 def test_gate_refuses_unbound_required_tool(strict_on, unbound_context):
     refusal = _strict_identity_refusal_or_none("knowledge", {"action": "store"})
-    assert refusal == strict_identity_refusal_payload("knowledge")
+    assert refusal is not None
+    assert refusal["status"] == "identity_required"
+    assert refusal["surface_context"]["transport_surface"] == "rest_tool_call"
+    assert refusal["surface_context"]["lifecycle_automation"] == "not_confirmed"
 
 
 def test_gate_fail_closed_for_unknown_tools(strict_on, unbound_context):
@@ -176,6 +195,9 @@ async def test_execute_refuses_with_transport_injected_session(strict_on, unboun
         )
 
     assert result["status"] == "identity_required"
+    assert result["next_step"]
+    assert result["surface_context"]["transport_surface"] == "rest_tool_call"
+    assert result["surface_context"]["lifecycle_automation"] == "not_confirmed"
     fallback.assert_not_awaited()
 
 

--- a/tests/test_strict_proof_origin.py
+++ b/tests/test_strict_proof_origin.py
@@ -105,6 +105,13 @@ def _is_refusal(result):
         return False
 
 
+def _refusal_payload(result):
+    if not result:
+        return {}
+    text = "".join(getattr(item, "text", "") or "" for item in result)
+    return json.loads(text)
+
+
 def _new_ctx():
     ctx = UpdateContext(arguments={})
     ctx.mcp_server = MagicMock()
@@ -132,6 +139,31 @@ async def test_strict_refuses_injected_csid_write(monkeypatch):
     _patch_db(monkeypatch, earned=False)
     result = await resolve_identity_and_guards(_new_ctx())
     assert _is_refusal(result)
+
+
+@pytest.mark.asyncio
+async def test_strict_refusal_payload_leads_with_continuity_token(monkeypatch):
+    """A denied write teaches the same credential order as success paths:
+    continuity_token first, client_session_id only as the session-maintaining
+    alternative. It also carries structured state instead of prose only."""
+    monkeypatch.setattr(ib, "is_strict_identity_required", lambda: True)
+    _patch_ctx(monkeypatch, agent_uuid="sibling-uuid",
+               source="explicit_client_session_id", proof_origin="server_inferred")
+    _patch_db(monkeypatch, earned=False)
+
+    result = await resolve_identity_and_guards(_new_ctx())
+    payload = _refusal_payload(result)
+
+    assert payload["status"] == "identity_required"
+    hint = payload["hint"]
+    assert "continuity_token" in hint
+    assert "client_session_id" in hint
+    assert hint.index("continuity_token") < hint.index("client_session_id")
+    assert "bare identity" in " ".join(payload["do_not"])
+    assert "continuity_token" in payload["next_step"]
+    assert payload["identity_assurance"]["proof_origin"] == "server_inferred"
+    assert payload["surface_context"]["session_resolution_source"] == "explicit_client_session_id"
+    assert payload["surface_context"]["proof_origin"] == "server_inferred"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Two commits, separately reviewable, both from one investigation into how the governance runtime orients confused agents at the moment of action.

## Commit 1 — corrective strict-identity write denials (`feat(identity)`)
*(implemented in the Codex/Hermes session)*

Strict-identity refusals now **teach the safe next move** instead of only diagnosing. The single-sourced refusal payload gains:
- `next_step`, structured `safe_options` (start_fresh / declare_lineage / stay_read_only), and a `do_not` warning against bare `identity()` retries
- the live `identity_assurance` block
- `surface_context` flagging that tool reachability (MCP dispatch / REST / `process_agent_update`) does **not** prove client lifecycle-hook automation

Strong-write denials lead with `continuity_token` and demote `client_session_id` to the session-maintaining alternative. MCP and REST transports return the same payload so they can't drift.

> ⚠️ Touches the strict-identity gate (writer-locked, deploy-sensitive area). Changes are **additive** — they add fields to refusal payloads and change no gating decision; no migration. Worth a focused look at `phases.py` reading `ctx.identity_assurance.get("proof_origin")` on the reached path.

## Commit 2 — error-envelope defects found by ground-truthing (`fix(errors)`)

Two bugs surfaced by probing the live server:
1. **Miscategorization** — `"<param> is required"` errors were tagged `auth_error` because the message contains `"session"`, falling through the validation patterns to the broad SESSION auth heuristic. A missing parameter is a `validation_error`; the mislabel sends agents chasing a phantom identity problem. Fix: add `"is required"` to the `MISSING_REQUIRED` pattern (precedes the auth pattern).
2. **Stale remediation pointers** — dialectic recovery payloads pointed at consolidated tool names (`get_dialectic_session`, `list_agents`, …) no longer on the exposed surface, so the error's own help was a dead end. Repointed `related_tools`/`action`/`tip` at `dialectic` / `agent` / `identity` per the `tool_stability` alias map.

## Verification
- `test_error_handling` + `test_dialectic_recovery_pointers` (new) + Hermes's strict-identity suite: **155 passed**
- Dialectic suite: **569 passed, 2 skipped**
- `ruff` clean; no stale `related_tools` remain (grep-confirmed)
- New tests: regression for the `is required` classification + a guard that every dialectic recovery builder emits only current-surface tool names

Draft — operator is the merge gate. The two commits are independent; either can be dropped without affecting the other.

https://claude.ai/code/session_0179i5zU32iD5jjJWLDMvpDb