### PR TITLE
fix(kg): expose store confidence on knowledge tool

### DIFF
--- a/src/mcp_handlers/schemas/knowledge.py
+++ b/src/mcp_handlers/schemas/knowledge.py
@@ -319,6 +319,13 @@ class KnowledgeParams(AgentIdentityMixin):
     response_to: Optional[dict] = Field(None, description="Typed response link {discovery_id, response_type} for threaded store/note writes")
     tags: Optional[List[str]] = Field(None, description="Tags for discovery (for action=store, search, note)")
     severity: Optional[str] = Field(None, description="Severity: low, medium, high, critical (for action=store)")
+    confidence: Union[float, str, None] = Field(
+        None,
+        description=(
+            "Writer confidence for action=store, clamped to 0-1 and "
+            "cross-checked against agent coherence"
+        ),
+    )
     discovery_id: Optional[str] = Field(None, description="Discovery ID (for action=get/details, update; the NEW discovery for action=supersede)")
     status: Optional[str] = Field(None, description="Status filter/update value (open, resolved, archived, superseded)")
     resolution_notes: Optional[str] = Field(None, description="Rationale to append when closing or updating a discovery")
@@ -376,6 +383,11 @@ class KnowledgeParams(AgentIdentityMixin):
                 self.min_similarity = float(self.min_similarity)
             except ValueError:
                 self.min_similarity = None
+        if isinstance(self.confidence, str):
+            try:
+                self.confidence = float(self.confidence)
+            except ValueError:
+                self.confidence = None
         if isinstance(self.include_response_chain, str):
             self.include_response_chain = self.include_response_chain.lower() in ('true', '1', 'yes')
         return self

--- a/tests/test_http_api_effect_veto.py
+++ b/tests/test_http_api_effect_veto.py
@@ -36,11 +36,23 @@ TEST_SECRET = "test-continuity-secret-0123456789abcdef"
 
 
 @pytest.fixture(autouse=True)
-def _continuity_secret_env():
+def _effect_veto_env():
     """The HMAC secret must be present for BOTH mint and server-side verify —
     `_get_continuity_secret()` reads env on each call. Without it
-    `resolve_continuity_token` returns None and every token looks invalid."""
-    with patch.dict(os.environ, {"UNITARES_CONTINUITY_TOKEN_SECRET": TEST_SECRET}):
+    `resolve_continuity_token` returns None and every token looks invalid.
+
+    Bearer auth for the REST surface is covered separately by
+    tests/test_rest_auth_align.py. Clear ambient operator/deploy bearer env so
+    this unit remains focused on the §6/§7 effect-veto gates.
+    """
+    with patch.dict(
+        os.environ,
+        {
+            "UNITARES_CONTINUITY_TOKEN_SECRET": TEST_SECRET,
+            "UNITARES_MCP_BEARER_TOKENS": "",
+            "UNITARES_HTTP_API_TOKEN": "",
+        },
+    ):
         yield
 
 

--- a/tests/test_knowledge_param_coverage.py
+++ b/tests/test_knowledge_param_coverage.py
@@ -64,7 +64,7 @@ INTERNAL_KEYS = {
 # it by declaring the real params on KnowledgeParams (then deleting them here),
 # not to grow it. Adding a NEW entry must be a deliberate, reviewed act.
 KNOWN_UNEXPOSED = {
-    "auto_link_related", "confidence", "epoch_scope", "exclude_agent_labels",
+    "auto_link_related", "epoch_scope", "exclude_agent_labels",
     "including_cold",
     "related_files", "resolve_question",
     "scope", "synthesize", "top_n",
@@ -74,8 +74,9 @@ KNOWN_UNEXPOSED = {
 # recall-recovery levers. include_provenance / search_mode / semantic /
 # min_similarity / operator followed on 2026-06-26 as handler-documented search
 # controls. offset / length / include_response_chain / max_chain_depth /
-# response_to followed as details/threading controls. Shrinking this set is the
-# goal; growing it is the smell.
+# response_to followed as details/threading controls. confidence followed as a
+# store-path writer-authored quality signal. Shrinking this set is the goal;
+# growing it is the smell.
 
 
 def _classify_undeclared() -> set[str]:
@@ -139,6 +140,14 @@ def test_details_and_threading_controls_exposed():
         "max_chain_depth",
         "response_to",
     } <= declared
+
+
+def test_store_confidence_signal_exposed():
+    """Store-path confidence is a writer-authored signal, not internal plumbing."""
+    declared = set(KnowledgeParams.model_fields.keys())
+    assert "confidence" in declared
+    assert KnowledgeParams(action="store", summary="x", confidence="0.8").confidence == 0.8
+    assert KnowledgeParams(action="store", summary="x", confidence="not-a-number").confidence is None
 
 
 def test_supersession_link_params_stay_declared():


### PR DESCRIPTION
## Summary
- expose confidence on unified knowledge(action=store) params so the existing store handler can persist the writer-authored quality signal instead of having Pydantic strip it
- shrink the #1001 known-unexposed backlog and add coverage that confidence stays sendable
- isolate effect-veto tests from ambient REST bearer env so veto tests exercise the effect gates instead of local deploy auth state

## Tests
- python3 -m pytest tests/test_knowledge_param_coverage.py tests/test_kg_store.py tests/test_http_api_effect_veto.py -q
- ./scripts/dev/test-cache.sh
- git diff --check

Refs #1001