### PR TITLE
[codex] Expose KG list scope params

### DIFF
--- a/src/mcp_handlers/schemas/knowledge.py
+++ b/src/mcp_handlers/schemas/knowledge.py
@@ -356,6 +356,8 @@ class KnowledgeParams(AgentIdentityMixin):
     # exposed on the unified tool (see test_knowledge_param_coverage backlog).
     include_archived: Optional[bool] = Field(None, description="Include archived discoveries in search results (default: excluded)")
     include_cold: Optional[bool] = Field(None, description="Include cold-storage (long-term) discoveries in search results (default: excluded)")
+    epoch_scope: Optional[Literal["current", "all"]] = Field(None, description="Stats/list scope: current epoch only or all epochs")
+    including_cold: Union[bool, str, None] = Field(None, description="Include cold-storage discoveries in action=list raw status aggregates")
     dry_run: Union[bool, str, None] = Field(None, description="Dry run mode (for action=cleanup, synthesize)")
     # Synthesis (action=synthesize): roll discoveries up into topic summaries.
     topic: Optional[str] = Field(None, description="Synthesize just this one tag/topic (for action=synthesize). Omit to sweep the densest topics.")
@@ -390,4 +392,6 @@ class KnowledgeParams(AgentIdentityMixin):
                 self.confidence = None
         if isinstance(self.include_response_chain, str):
             self.include_response_chain = self.include_response_chain.lower() in ('true', '1', 'yes')
+        if isinstance(self.including_cold, str):
+            self.including_cold = self.including_cold.lower() in ('true', '1', 'yes')
         return self

--- a/tests/test_knowledge_param_coverage.py
+++ b/tests/test_knowledge_param_coverage.py
@@ -64,8 +64,7 @@ INTERNAL_KEYS = {
 # it by declaring the real params on KnowledgeParams (then deleting them here),
 # not to grow it. Adding a NEW entry must be a deliberate, reviewed act.
 KNOWN_UNEXPOSED = {
-    "auto_link_related", "epoch_scope", "exclude_agent_labels",
-    "including_cold",
+    "auto_link_related", "exclude_agent_labels",
     "related_files", "resolve_question",
     "scope", "synthesize", "top_n",
     "use_model",
@@ -75,8 +74,9 @@ KNOWN_UNEXPOSED = {
 # min_similarity / operator followed on 2026-06-26 as handler-documented search
 # controls. offset / length / include_response_chain / max_chain_depth /
 # response_to followed as details/threading controls. confidence followed as a
-# store-path writer-authored quality signal. Shrinking this set is the goal;
-# growing it is the smell.
+# store-path writer-authored quality signal. epoch_scope / including_cold
+# followed as list/stats scope controls. Shrinking this set is the goal; growing
+# it is the smell.
 
 
 def _classify_undeclared() -> set[str]:
@@ -148,6 +148,15 @@ def test_store_confidence_signal_exposed():
     assert "confidence" in declared
     assert KnowledgeParams(action="store", summary="x", confidence="0.8").confidence == 0.8
     assert KnowledgeParams(action="store", summary="x", confidence="not-a-number").confidence is None
+
+
+def test_list_scope_controls_exposed():
+    """List/stats scope controls must be sendable through knowledge(action=list)."""
+    declared = set(KnowledgeParams.model_fields.keys())
+    assert {"epoch_scope", "including_cold"} <= declared
+    model = KnowledgeParams(action="list", epoch_scope="all", including_cold="true")
+    assert model.epoch_scope == "all"
+    assert model.including_cold is True
 
 
 def test_supersession_link_params_stay_declared():


### PR DESCRIPTION
## Summary
- Expose `epoch_scope` and `including_cold` on the unified `knowledge` schema for `knowledge(action="list")`.
- Remove those two keys from the #1001 known-unexposed backlog.
- Add a coverage test proving the list/stat scope controls are agent-sendable and `including_cold` string coercion works.

## Why
The list handler already documents and honors these scope controls, but the Pydantic schema stripped them from the unified tool surface. This closes another small piece of the silent-strip backlog from #1001 without bulk-expanding the schema.

## Validation
- `python3 -m pytest tests/test_knowledge_param_coverage.py tests/test_pydantic_schemas.py`
- `python3 -m pytest tests/test_lease_plane_deprecate_cli.py::test_deprecate_emits_lease_deprecation_marked_event` after one unrelated serialization-race failure in the full gate
- `./scripts/dev/test-cache.sh` (rerun): 10865 passed, 21 skipped
- pre-push smoke: 138 passed, 10101 deselected

Refs #1001