### PR TITLE
docs: reinforce EISV proprioception boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ One layer of the **[CIRWEL stack](https://cirwel.github.io)** — runtime safety
 - you need agents to check their own state before continuing; and
 - you want an audit trail of confidence, evidence, drift, and recovery.
 
-UNITARES is **not** an output validator, sandbox, hosted agent platform, or grand jury. EISV is **not an outcome oracle**; it is proprioceptive telemetry for the running agent. External outcome evidence and policy/review layers own labels such as task-negative, contract violation, or authority/harm.
+UNITARES is **not** an output validator, sandbox, hosted agent platform, or grand jury. EISV is **not an outcome oracle** or bad-verdict dispenser; it is proprioceptive telemetry for the running agent. External outcome evidence and policy/review layers own labels such as task-negative, contract violation, or authority/harm.
 
 ## Try the demo locally
 

--- a/docs/EVALUATION_INDEX.md
+++ b/docs/EVALUATION_INDEX.md
@@ -15,10 +15,10 @@ repo (automation-side) and is intentionally *not* consolidated here.
 Read [`docs/ontology/eisv-proprioception-contract.md`](ontology/eisv-proprioception-contract.md)
 before interpreting these reports. EISV/prior-state analysis asks whether
 proprioceptive telemetry adds signal over baselines. It does **not** let EISV
-supply its own outcome labels, and it does not treat ordinary CI/test failures as
-moral badness. Human-facing labels should distinguish task-negative evidence,
-contract/process violations, authority/harm events, synthetic red-team fixtures,
-and unknown/unmeasured outcomes.
+supply its own outcome labels, hand down bad verdicts, or treat ordinary CI/test
+failures as moral badness. Human-facing labels should distinguish task-negative
+evidence, contract/process violations, authority/harm events, synthetic red-team
+fixtures, and unknown/unmeasured outcomes.
 
 ### Outcome-label vocabulary
 
@@ -26,7 +26,7 @@ Use `bad` only as a data label, never as an undefined success/failure slogan:
 
 | Term | Meaning |
 |---|---|
-| `is_bad=true` / `bad` | An outcome row labeled negative by its recorded type or rubric. It is an analysis label, not a moral category. |
+| `is_bad=true` / `bad` | An outcome row labeled negative by its recorded type or rubric. It is an analysis label, not a moral category or an EISV bad verdict. |
 | `task-negative` | A failed test/tool/task result such as `test_failed`, `tool_rejected`, or `task_failed`. |
 | `strict_bad` | A strict-scope negative row with stronger provenance requirements; useful for validation only after enough rows exist. |
 | `prevented` | Only valid when a policy/actuator actually blocked, paused, rejected, or reverted an adverse effect. A counted `bad` row by itself is observed evidence, not prevention. |

--- a/docs/guides/START_HERE.md
+++ b/docs/guides/START_HERE.md
@@ -60,7 +60,7 @@ Important current semantics:
 - `response_text` is the primary check-in input
 - `complexity` and `confidence` are optional reflective inputs, not the sole substrate
 - Behavioral EISV is the primary measurement source for governance policy when its confidence is sufficient
-- EISV is proprioceptive telemetry: it can indicate strain, drift, overload, or incoherence; it is not an outcome oracle, moral classifier, or grand jury
+- EISV is proprioceptive telemetry: it can indicate strain, drift, overload, or incoherence; it is not an outcome oracle, moral classifier, bad-verdict dispenser, or grand jury
 - ODE state is diagnostic/fallback, not the main verdict source
 - Governance responses separate measurement (`primary_eisv`, `behavioral_eisv`, `ode_eisv`), policy evaluation (`policy_evaluation`), and actuator state (`enforcement`)
 - External outcome evidence — tests, CI, tool rejection, human review, red-team fixtures, or harm/authority signals — owns the label that later validation scores
@@ -77,4 +77,4 @@ Important current semantics:
 ## Why This File Is Short
 This file used to be a larger onboarding guide from an earlier MCP/tooling phase. It is intentionally kept small now to avoid duplicated explanations drifting out of sync with the runtime.
 
-**Last Updated:** 2026-06-26 (EISV proprioception/outcome-oracle boundary added)
+**Last Updated:** 2026-06-27 (EISV proprioception/outcome-oracle boundary reinforced)

--- a/docs/ontology/eisv-proprioception-contract.md
+++ b/docs/ontology/eisv-proprioception-contract.md
@@ -1,7 +1,7 @@
 # EISV Proprioception Contract
 
 **Created:** June 26, 2026
-**Last Updated:** June 26, 2026
+**Last Updated:** June 27, 2026
 **Status:** Active
 
 ---
@@ -13,10 +13,11 @@ coherence, entropy, integrity, and imbalance. It is the system saying "my balanc
 is changing" or "this process is running hot," not a court deciding whether a
 worker was morally bad.
 
-EISV is **not an outcome oracle** and **not a grand jury**. It does not decide
-whether harm occurred, whether the user was wronged, or whether an agent is
-"guilty." Those judgments require external outcome evidence, policy, and review
-surfaces that are separate from the measurement vector.
+EISV is **not an outcome oracle**, **not a grand jury**, and **not a
+bad-verdict dispenser**. It does not decide whether harm occurred, whether the
+user was wronged, or whether an agent is "guilty." Those judgments require
+external outcome evidence, policy, and review surfaces that are separate from
+the measurement vector.
 
 ## Layer separation
 
@@ -28,7 +29,7 @@ measurement → diagnosis → policy → enforcement → external outcome eviden
 
 | Layer | Owns | Must not pretend to own |
 |---|---|---|
-| Measurement | EISV, confidence, coherence, risk, phi, provenance | Outcome truth or punishment |
+| Measurement | EISV, confidence, coherence, risk, phi, provenance | Outcome truth, blame, or punishment |
 | Diagnosis | Interpretations such as strained, scattered, brittle, running hot | The authority to pause by itself |
 | Policy | Rules mapping measured/diagnosed state to advice, review, or circuit-breaker candidates | Raw measurement truth |
 | Enforcement | Actual pause/block/review/allow effects, with actor and mode | The reason an outcome was good or bad |
@@ -95,7 +96,8 @@ Avoid:
 
 Ablations should ask whether EISV/prior-state telemetry adds predictive signal or
 useful policy steering over baselines. They should not imply EISV is the judge of
-badness. The skeptical report, inventory, and prospective cohort reports should
-make weak data obvious: sparse bad labels, synthetic fixtures, unbound prediction
-IDs, missing prior-state coverage, and harness-lane contamination are data-quality
-limits, not philosophical failures of proprioception.
+badness or the component handing down bad verdicts. The skeptical report,
+inventory, and prospective cohort reports should make weak data obvious: sparse
+bad labels, synthetic fixtures, unbound prediction IDs, missing prior-state
+coverage, and harness-lane contamination are data-quality limits, not
+philosophical failures of proprioception.

--- a/scripts/analysis/eisv_ablation_matrix.py
+++ b/scripts/analysis/eisv_ablation_matrix.py
@@ -443,7 +443,7 @@ def format_matrix_report(
         [
             "",
             "Interpretation rule: this matrix does not validate EISV as ontology. `Bad` means rows labeled `is_bad=true` by external/rubric evidence; it is not a moral verdict or a count of prevented outcomes.",
-            "It only checks whether EISV/prior-state fields add measurable predictive signal over a simple previous-outcome baseline across slices.",
+            "It only checks whether EISV/prior-state fields add measurable predictive signal over a simple previous-outcome baseline across slices; it does not make EISV the bad-verdict authority.",
         ]
     )
     return "\n".join(lines)

--- a/scripts/analysis/eisv_skeptic_report.py
+++ b/scripts/analysis/eisv_skeptic_report.py
@@ -1036,7 +1036,10 @@ def build_report(
     a("")
     a(conclusion)
     a("")
-    a("Interpretation rule: EISV is proprioceptive telemetry, not an outcome oracle.")
+    a(
+        "Interpretation rule: EISV is proprioceptive telemetry, not an "
+        "outcome oracle or bad-verdict dispenser."
+    )
     a("Outcome labels come from external evidence/rubrics; this report only checks")
     a("whether EISV/prior-state fields add measurable predictive signal over simpler")
     a("baselines in this data slice.")

--- a/scripts/analysis/outcome_inventory.py
+++ b/scripts/analysis/outcome_inventory.py
@@ -439,7 +439,7 @@ def format_inventory_report(
         "## Interpretation rule",
         "",
         "`bad` is an outcome-label class (`is_bad=true`), not a moral verdict or a prevented outcome. CI/test failure is task-negative evidence; strict governance-bad claims require external outcome evidence for contract, authority, or harm boundaries.",
-        "EISV is proprioceptive telemetry and policy input, not the source of outcome truth or enforcement evidence.",
+        "EISV is proprioceptive telemetry and policy input, not a bad-verdict dispenser, outcome-truth source, or enforcement evidence.",
         "",
         "## Harness Lane Summary",
         "",

--- a/scripts/analysis/prospective_prediction_cohort.py
+++ b/scripts/analysis/prospective_prediction_cohort.py
@@ -219,7 +219,7 @@ def format_cohort_report(
             "",
             "Interpretation rule: this is registry-bound prediction coverage for future holdout scoring (prospective holdout), not a grand jury. "
             "It counts predictions that existed before outcomes; EISV remains proprioceptive telemetry, "
-            "not an outcome oracle, unless a frozen holdout later beats boring baselines with external labels.",
+            "not an outcome oracle or bad-verdict dispenser, unless a frozen holdout later beats boring baselines with external labels.",
         ]
     )
 

--- a/tests/test_eisv_ablation_matrix.py
+++ b/tests/test_eisv_ablation_matrix.py
@@ -279,6 +279,7 @@ def test_format_matrix_report_contains_skeptical_ablation_table():
     assert "0.040" in report
     assert "`Bad` means rows labeled `is_bad=true`" in report
     assert "not a moral verdict or a count of prevented outcomes" in report
+    assert "bad-verdict authority" in report
     assert "prior_risk_binned" in report
     assert "KEEP TESTING" in report
 

--- a/tests/test_eisv_semantic_contract.py
+++ b/tests/test_eisv_semantic_contract.py
@@ -56,6 +56,7 @@ def test_canonical_eisv_contract_doc_names_proprioception_not_grand_jury():
     assert "EISV is proprioception" in text
     assert "not an outcome oracle" in text
     assert "not a grand jury" in text
+    assert "bad-verdict dispenser" in text
     assert "measurement → diagnosis → policy → enforcement" in text
     assert "external outcome evidence" in text
     assert "task-negative" in text
@@ -71,7 +72,9 @@ def test_landing_docs_link_the_proprioception_contract():
         assert "eisv-proprioception-contract.md" in text
     assert "not an outcome oracle" in readme
     assert "grand jury" in readme
+    assert "bad-verdict dispenser" in readme
     assert "task-negative" in evaluation_index
+    assert "hand down bad verdicts" in evaluation_index
 
 
 def test_reports_preserve_proprioception_and_outcome_oracle_boundary():
@@ -85,7 +88,7 @@ def test_reports_preserve_proprioception_and_outcome_oracle_boundary():
         train_fraction=0.7,
         generated_at=rows[0].ts + timedelta(days=1),
     )
-    assert "EISV is proprioceptive telemetry, not an outcome oracle." in skeptic_report
+    assert "not an outcome oracle or bad-verdict dispenser" in skeptic_report
     assert "Outcome labels come from external evidence/rubrics" in skeptic_report
 
     inventory = build_inventory(
@@ -107,6 +110,7 @@ def test_reports_preserve_proprioception_and_outcome_oracle_boundary():
     )
     assert "`bad` is an outcome-label class (`is_bad=true`)" in inventory_report
     assert "not a moral verdict or a prevented outcome" in inventory_report
+    assert "not a bad-verdict dispenser" in inventory_report
     assert "CI/test failure is task-negative evidence" in inventory_report
 
     cohort_summary = build_cohort_summary(
@@ -114,4 +118,5 @@ def test_reports_preserve_proprioception_and_outcome_oracle_boundary():
     )
     cohort_report = format_cohort_report(cohort_summary)
     assert "not a grand jury" in cohort_report
+    assert "not an outcome oracle or bad-verdict dispenser" in cohort_report
     assert "registry-bound prediction coverage for future holdout scoring" in cohort_report

--- a/tests/test_outcome_inventory.py
+++ b/tests/test_outcome_inventory.py
@@ -285,6 +285,7 @@ def test_format_inventory_report_exposes_zero_bad_strict_and_prior_coverage():
     assert "strict_bad_gap_to_min: 10" in report
     assert "`bad` is an outcome-label class (`is_bad=true`)" in report
     assert "not a moral verdict or a prevented outcome" in report
+    assert "not a bad-verdict dispenser" in report
     assert "task_failed" in report
     assert "prior_state_5m" in report
     assert "agent_reported_tool_result" in report

--- a/tests/test_prospective_prediction_cohort.py
+++ b/tests/test_prospective_prediction_cohort.py
@@ -90,6 +90,7 @@ def test_format_cohort_report_keeps_holdout_language_and_lane_counts():
     assert "prediction_bound_prior_state: 1/2" in report
     assert "harness_lanes: beam=1,substrate=1" in report
     assert "prospective holdout" in report
+    assert "not an outcome oracle or bad-verdict dispenser" in report
 
 
 def test_evaluate_readiness_reports_strong_when_thresholds_are_met():


### PR DESCRIPTION
## Summary
- Reinforces the EISV semantic boundary: EISV is proprioceptive telemetry, not a bad-verdict dispenser or outcome oracle.
- Updates README/START_HERE/EVALUATION_INDEX and the canonical EISV proprioception contract with the measurement → diagnosis → policy → enforcement split.
- Carries the same wording into analysis reports: outcome inventory, ablation matrix, skeptic report, and prospective cohort.
- Adds/updates regression assertions so generated reports keep the proprioception-vs-verdict boundary.

## Verification
- `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 -m pytest tests/test_eisv_ablation_matrix.py tests/test_outcome_inventory.py tests/test_eisv_semantic_contract.py tests/test_prospective_prediction_cohort.py -q -o 'addopts='` → 25 passed
- `git diff --check` → passed
- `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 scripts/diagnostics/check_doc_drift.py` → Doc drift check passed
- analysis CLI `--help` smoke for the four touched report scripts → passed
- `./scripts/dev/test-cache.sh` → 10865 passed, 21 skipped, coverage 81.81%

## Context
Follow-up to #1112 after it merged; this addresses the additional wording point that EISV is proprioception rather than bad-verdict handing.