### PR TITLE
ci(elixir): run mix test for the Sentinel BEAM app

### DIFF
--- a/.github/workflows/elixir-tests.yml
+++ b/.github/workflows/elixir-tests.yml
@@ -1,0 +1,75 @@
+name: Elixir Tests
+
+# Closes the BEAM-vs-Python drift gap: the active Sentinel is the Elixir runtime
+# (com.unitares.sentinel-beam), but until this workflow nothing ran its test
+# suite in CI — so a regression in the BEAM forced-release poller (or any other
+# elixir/sentinel module) could merge unvalidated. This runs `mix test` for the
+# Sentinel app on every PR that touches it.
+#
+# Scope note: only elixir/sentinel runs here. Its test_helper.exs auto-detects
+# Postgres and EXCLUDES :db-tagged integration tests when the DB is unreachable,
+# so the pure-logic suite (incl. the cross-runtime fingerprint parity tests)
+# runs cleanly without a database service. elixir/lease_plane is intentionally
+# NOT included yet: its test_helper.exs raises without a live governance DB +
+# the lease_plane.* schema, which needs a Postgres service + migration load —
+# a follow-up once that harness exists.
+
+on:
+  push:
+    branches: [ master, main ]
+    paths:
+      - 'elixir/sentinel/**'
+      - '.github/workflows/elixir-tests.yml'
+  pull_request:
+    branches: [ master, main ]
+    paths:
+      - 'elixir/sentinel/**'
+      - '.github/workflows/elixir-tests.yml'
+
+# Least-privilege: this job only reads the repo and runs tests.
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Structured as a matrix so adding DB-free apps later is one line.
+        app: [ sentinel ]
+
+    defaults:
+      run:
+        working-directory: elixir/${{ matrix.app }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+      with:
+        persist-credentials: false
+
+    - name: Set up Elixir / OTP
+      uses: erlef/setup-beam@v1
+      with:
+        otp-version: '27'
+        elixir-version: '1.19'
+
+    - name: Cache deps and build
+      uses: actions/cache@v4
+      with:
+        path: |
+          elixir/${{ matrix.app }}/deps
+          elixir/${{ matrix.app }}/_build
+        key: ${{ runner.os }}-mix-${{ matrix.app }}-${{ hashFiles(format('elixir/{0}/mix.lock', matrix.app), format('elixir/{0}/mix.exs', matrix.app)) }}
+        restore-keys: |
+          ${{ runner.os }}-mix-${{ matrix.app }}-
+
+    - name: Install dependencies
+      run: mix deps.get
+
+    - name: Run tests
+      # No DB service: test_helper.exs excludes :db-tagged integration tests
+      # when Postgres is unreachable, so the pure-logic suite runs green.
+      run: mix test


### PR DESCRIPTION
## Why

The active Sentinel is the **Elixir runtime** (`com.unitares.sentinel-beam`), but no CI workflow ran its test suite — `.github/workflows/` had zero `mix`/Elixir jobs. So a regression in the BEAM forced-release poller (or any `elixir/sentinel` module) could merge unvalidated. This is the exact BEAM-vs-Python drift class behind the recent forced-release-alarm incident (#1102 / #1114): the Python path was patched and tested while the running BEAM path went unchecked.

## What

Adds `.github/workflows/elixir-tests.yml` — a `mix test` job that runs on PRs touching `elixir/sentinel/**`.

- **No DB service needed.** The Sentinel suite's `test_helper.exs` auto-detects Postgres and **excludes `:db`-tagged integration tests** when the DB is unreachable, so the pure-logic suite — including the cross-runtime fingerprint **parity contract** (`forced_release_poller_logic_*test.exs`) — runs green standalone.
- `erlef/setup-beam` with OTP 27 / Elixir 1.19 (matches `mix.exs` `~> 1.19`), deps+`_build` cached.
- Least-privilege `contents: read`.
- Structured as a **matrix** so adding more DB-free apps later is a one-line change.

## Scope / deferred

- **Only `elixir/sentinel`** runs here — the active agent and the gap that bit us.
- **`elixir/lease_plane` is intentionally deferred.** Its `test_helper.exs` *raises* without a live governance DB + the `lease_plane.*` schema, which would need a Postgres service container + a migration load step (and possibly AGE). That's a separate, more involved harness — worth doing, but not bundled here to keep this job reliable rather than flaky.
- `agent_orchestrator` / `wave3a_handlers` are DB-free and could be added to the matrix once each is confirmed green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BzBQCXUkx8NshtxPGSTPo1)_