### PR TITLE
fix(watcher): suppress runtime-hygiene patterns (P001/P003/P011) on test files

### DIFF
--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -1434,6 +1434,23 @@ _PATTERN_FILE_PATH_CONSTRAINTS: dict[str, tuple[str, ...]] = {
     "P004": ("/src/mcp_handlers/",),
 }
 
+# File-path substrings that SUPPRESS a pattern when present in finding.file —
+# the inverse of the constraints above. The runtime-hygiene patterns listed
+# here encode invariants about LIVE runtime behavior (fire-and-forget task
+# cleanup, the monitor cache, persist-before-mutate ordering) that do not apply
+# to test code: tests legitimately spawn unreferenced tasks, construct isolated
+# transient monitors (`UNITARESMonitor(agent_id, load_state=False)`), and poke
+# in-memory state without persisting. Security patterns (P008 shell-injection,
+# P012 unsafe-deserialization) are deliberately NOT listed — they must still
+# fire on tests. False-positive class confirmed 2026-06-27: 156
+# `UNITARESMonitor(` call sites across 32 test files would all trip P003
+# (e.g. test_hck_rho_coupling.py:20/26/33/49).
+_PATTERN_FILE_PATH_EXCLUSIONS: dict[str, tuple[str, ...]] = {
+    "P001": ("/tests/",),
+    "P003": ("/tests/",),
+    "P011": ("/tests/",),
+}
+
 # Regex: `name = ...create_task(...)` on one line. If this matches the P001
 # flagged line, the task reference is stored — not fire-and-forget.
 _P001_TASK_ASSIGNMENT = re.compile(r"\b[a-zA-Z_]\w*\s*=\s*[^=].*create_task\(")
@@ -1816,6 +1833,20 @@ def _verify_finding_against_source(
             "warning",
         )
         return False
+    # Path-exclusion: runtime-hygiene patterns do not apply to test code.
+    # Normalize with a leading "/" so a "/tests/" segment matches both absolute
+    # finding paths (/Users/…/tests/x.py) and relative ones (tests/x.py), while
+    # still NOT matching unrelated dirs like src/subtests/ (→ /src/subtests/).
+    path_exclusions = _PATTERN_FILE_PATH_EXCLUSIONS.get(finding.pattern)
+    if path_exclusions:
+        norm_file = "/" + finding.file.lstrip("/")
+        if any(seg in norm_file for seg in path_exclusions):
+            log(
+                f"drop {finding.pattern} {finding.file}:{finding.line} — file under "
+                f"excluded path segments {path_exclusions!r} (runtime-hygiene rule N/A to tests)",
+                "warning",
+            )
+            return False
     src_line = snippet_lines_by_num.get(finding.line, "")
     if not src_line:
         log(

--- a/agents/watcher/patterns.md
+++ b/agents/watcher/patterns.md
@@ -24,6 +24,10 @@ storing the task reference for later cancellation or cleanup.
 **Seen in:** `background_tasks.py` stuck_agent_recovery_task (2026-04-10 incident,
 1.1GB RSS runaway)
 
+**Test-file exclusion:** suppressed under `/tests/` (`_PATTERN_FILE_PATH_EXCLUSIONS`
+in `agent.py`) — this is a live-runtime invariant; tests legitimately spawn
+unreferenced tasks.
+
 **SAFE — DO NOT FLAG:**
 ```python
 # Pattern A: task ref stored in a set with done-callback cleanup
@@ -100,6 +104,13 @@ not a transient call site. False-positive sweep 2026-04-17: flagged
 `agent_lifecycle.py:26` (the `monitor = UNITARESMonitor(agent_id)` line
 that the cache uses to populate itself). See
 `_is_inside_get_or_create_monitor` in `agent.py`.
+
+**Test-file exclusion:** suppressed under `/tests/` (`_PATTERN_FILE_PATH_EXCLUSIONS`
+in `agent.py`). The init-storm concern is a live-runtime invariant; tests
+legitimately construct isolated transient monitors
+(`UNITARESMonitor(agent_id, load_state=False)`) and would otherwise generate a
+large false-positive class (156 call sites across 32 test files, confirmed
+2026-06-27 — e.g. `test_hck_rho_coupling.py:20/26/33/49`).
 
 **Hint template:** `transient monitor — use get_or_create_monitor`
 
@@ -238,6 +249,10 @@ test. This is a standing rule for this project — see
 
 Mutating in-memory state BEFORE (or WITHOUT) the corresponding DB persistence
 call. The temporal ordering matters: **persist must come first**, then mutate.
+
+**Test-file exclusion:** suppressed under `/tests/` (`_PATTERN_FILE_PATH_EXCLUSIONS`
+in `agent.py`) — a live-runtime persistence invariant; tests deliberately poke
+in-memory state without persisting.
 
 **BAD (flag this):**
 ```python

--- a/tests/test_watcher_tests_path_exclusion.py
+++ b/tests/test_watcher_tests_path_exclusion.py
@@ -1,0 +1,71 @@
+"""Tests for runtime-hygiene pattern suppression on test files.
+
+P001 (fire-and-forget task), P003 (transient monitor), and P011
+(mutate-then-persist) encode invariants about LIVE runtime behavior. Test
+code legitimately violates them — tests spawn unreferenced tasks, build
+isolated transient monitors (`UNITARESMonitor(agent_id, load_state=False)`),
+and poke in-memory state without persisting. Findings under `/tests/` for
+these patterns are false positives and must drop.
+
+False-positive class confirmed 2026-06-27: 156 `UNITARESMonitor(` call sites
+across 32 test files would trip P003 (e.g. test_hck_rho_coupling.py:20/26/33/49).
+
+Security patterns (P008 shell-injection, P012 unsafe-deserialization) are NOT
+excluded — they must still fire on tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agents.watcher.agent import _verify_finding_against_source
+from agents.watcher.findings import Finding
+
+
+def _make(pattern: str, file: str, line: int = 1) -> Finding:
+    return Finding(
+        pattern=pattern,
+        file=file,
+        line=line,
+        hint="x",
+        severity="high",
+        detected_at="2026-06-27T00:00:00Z",
+        model_used="test",
+    )
+
+
+class TestRuntimeHygieneSuppressedInTests:
+    """P001/P003/P011 must drop when the file lives under /tests/."""
+
+    def test_p003_transient_monitor_in_tests_dropped(self):
+        snippet = {20: '        mon = UNITARESMonitor("test-f4-gains-low", load_state=False)'}
+        finding = _make("P003", "/Users/x/projects/unitares/tests/test_hck_rho_coupling.py", 20)
+        assert _verify_finding_against_source(finding, "", snippet) is False
+
+    def test_p001_create_task_in_tests_dropped(self):
+        snippet = {5: "        asyncio.create_task(do_thing())"}
+        finding = _make("P001", "tests/test_something.py", 5)
+        assert _verify_finding_against_source(finding, "", snippet) is False
+
+    def test_p011_mutate_then_persist_in_tests_dropped(self):
+        snippet = {7: "    mon.state.update_count = 3"}
+        finding = _make("P011", "tests/test_state.py", 7)
+        assert _verify_finding_against_source(finding, "", snippet) is False
+
+
+class TestRuntimeHygieneStillFiresInRuntime:
+    """The same patterns must survive in non-test (runtime) code."""
+
+    def test_p003_transient_monitor_in_runtime_survives(self):
+        snippet = {175: "    monitor = UNITARESMonitor(agent_id)"}
+        finding = _make("P003", "src/lifecycle/stuck.py", 175)
+        assert _verify_finding_against_source(finding, "", snippet) is True
+
+
+class TestSecurityPatternsNotExcludedInTests:
+    """Security patterns must keep firing even under /tests/."""
+
+    def test_p008_shell_injection_in_tests_survives(self):
+        snippet = {3: '    subprocess.run(cmd, shell=True)'}
+        finding = _make("P008", "tests/test_helper.py", 3)
+        assert _verify_finding_against_source(finding, "", snippet) is True


### PR DESCRIPTION
## Problem

The Watcher flagged 4 HIGH P003 findings on `tests/test_hck_rho_coupling.py:20/26/33/49` — `UNITARESMonitor(...)` constructors in unit tests. P003's rationale (`patterns.md`) is about **production init storms** (the `stuck.py` 2026-04-10 incident: throwaway monitors that never enter `mcp_server.monitors`). That invariant does not apply to test code — tests *need* `UNITARESMonitor(agent_id, load_state=False)` for isolated, deterministic instances they poke directly; using `get_or_create_monitor()` (shared cache) in tests would be actively wrong.

It's a latent FP **class**, not a one-off: **156 `UNITARESMonitor(` call sites across 32 test files** would all trip P003. Only 4 surfaced because the Watcher is PostToolUse-scoped (re-scans edited files). The same applies to the other live-runtime-hygiene rules.

## Fix

Add `_PATTERN_FILE_PATH_EXCLUSIONS` (the inverse of the existing `_PATTERN_FILE_PATH_CONSTRAINTS`), checked in `_verify_finding_against_source`, suppressing **P001** (fire-and-forget task), **P003** (transient monitor), **P011** (mutate-then-persist) under `/tests/`. These three encode live-runtime invariants that test code legitimately violates.

- **Security patterns (P008 shell-injection, P012 unsafe-deserialization) are deliberately NOT excluded** — they must still fire on tests.
- **P004** is already path-gated to `/src/mcp_handlers/`, so it can't hit tests (left as-is).
- Path match is normalized with a leading `/` so `/tests/` matches both absolute (`/Users/…/tests/x.py`) and relative (`tests/x.py`) finding paths, while NOT matching unrelated dirs like `src/subtests/`.

## Tests

`tests/test_watcher_tests_path_exclusion.py`: P001/P003/P011 drop under `/tests/`; P003 still fires in `src/` (runtime); P008 still fires under `/tests/`. Full watcher suite: **126 passed, 7 skipped**.

## Follow-up

The 4 live findings (`86badf9d`/`bff1fa82`/`5d3b407f`/`99416c87`) are dismissed as false positives.

https://claude.ai/code/session_01T7UB6D97mxbAZDRE5oJTwP