### PR TITLE
fix(identity): surface PG-layer session collision in ensure_agent_persisted

### DIFF
--- a/src/mcp_handlers/identity/persistence.py
+++ b/src/mcp_handlers/identity/persistence.py
@@ -602,12 +602,31 @@ async def ensure_agent_persisted(
                     existing = await db.get_session(session_key)
                     existing_uuid = getattr(existing, "agent_id", None) if existing else None
                     if existing_uuid and existing_uuid != agent_uuid:
+                        # The identifying UUIDs go to the structured broadcast
+                        # event (durable audit channel), NOT the clear-text log:
+                        # logging a DB-sourced identity value trips CodeQL
+                        # py/clear-text-logging-sensitive-data. The log stays
+                        # identifier-free; the detail rides the
+                        # pg_session_collision event, same pattern as
+                        # resident_fork_detected / identity_hijack_suspected.
                         logger.warning(
                             "[S21A_PG_SESSION_COLLISION] session_key already bound "
                             "to a different identity at the PG layer — refusing to "
-                            "overwrite (existing=%s... incoming=%s...)",
-                            existing_uuid[:8], agent_uuid[:8],
+                            "overwrite (detail in pg_session_collision event)"
                         )
+                        b = _broadcaster()
+                        if b is not None:
+                            try:
+                                await b.broadcast_event(
+                                    event_type="pg_session_collision",
+                                    agent_id=agent_uuid,
+                                    payload={
+                                        "existing_agent_id": existing_uuid,
+                                        "incoming_agent_id": agent_uuid,
+                                    },
+                                )
+                            except Exception as _be:
+                                logger.debug(f"pg_session_collision broadcast failed: {_be}")
                 except Exception as _e:
                     logger.debug(f"PG session collision check skipped: {_e}")
 

--- a/src/mcp_handlers/identity/persistence.py
+++ b/src/mcp_handlers/identity/persistence.py
@@ -580,13 +580,36 @@ async def ensure_agent_persisted(
             client_info = {"agent_id": agent_uuid, "agent_uuid": agent_uuid, "lazy_created": True}
             if public_agent_id and public_agent_id != agent_uuid:
                 client_info["public_agent_id"] = public_agent_id
-            await db.create_session(
+            created = await db.create_session(
                 session_id=session_key,
                 identity_id=identity.identity_id,
                 expires_at=datetime.now() + timedelta(hours=GovernanceConfig.SESSION_TTL_HOURS),
                 client_type="mcp",
                 client_info=client_info,
             )
+            # create_session uses ON CONFLICT (session_id) DO NOTHING, so a
+            # False return means a row for this session_key already existed.
+            # That is benign when it maps to the same identity (a re-persist),
+            # but a divergent identity is a PG-layer session collision — the
+            # S21-a ghost-fork shape at the durable layer. The Redis guard
+            # (_redis_slot_blocks_overwrite) caught this for the cache; the PG
+            # path was silent. Surface it (observability only — the agent_uuid
+            # was already decided upstream, so we do not change control flow here;
+            # the atomic guard in the Phase 1 session-binding mirror is where the
+            # block is enforced). See redis-retirement-phase-1-plan.md.
+            if not created:
+                try:
+                    existing = await db.get_session(session_key)
+                    existing_uuid = getattr(existing, "agent_id", None) if existing else None
+                    if existing_uuid and existing_uuid != agent_uuid:
+                        logger.warning(
+                            "[S21A_PG_SESSION_COLLISION] session_key already bound "
+                            "to a different identity at the PG layer — refusing to "
+                            "overwrite (existing=%s... incoming=%s...)",
+                            existing_uuid[:8], agent_uuid[:8],
+                        )
+                except Exception as _e:
+                    logger.debug(f"PG session collision check skipped: {_e}")
 
         logger.info(f"Lazy-persisted agent on first work: {agent_uuid[:8]}...")
         return True

--- a/tests/test_session_persist_pg_collision.py
+++ b/tests/test_session_persist_pg_collision.py
@@ -17,7 +17,7 @@ See docs/proposals/redis-retirement-phase-1-plan.md (prep fix).
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch, AsyncMock
+from unittest.mock import patch, AsyncMock, MagicMock
 
 import pytest
 
@@ -57,34 +57,52 @@ def _make_db(*, create_session_result: bool, existing_session_agent_id):
     return db
 
 
-async def _run(db):
+async def _run(db, broadcaster=None):
     # _redis_cache=False makes _get_redis() return None -> skips Redis hydration.
+    # _broadcaster patched so the collision detail goes to a mock event, not the
+    # real broadcaster — and so the identifiers never reach a clear-text log.
     with patch.object(persistence, "_redis_cache", False), \
-         patch.object(persistence, "get_db", return_value=db):
+         patch.object(persistence, "get_db", return_value=db), \
+         patch.object(persistence, "_broadcaster", return_value=broadcaster):
         return await persistence.ensure_agent_persisted(_AGENT_UUID, _SESSION_KEY)
 
 
 @pytest.mark.asyncio
-async def test_divergent_pg_session_logs_collision(caplog):
+async def test_divergent_pg_session_emits_event_and_clean_log(caplog):
     """create_session returns False AND the existing row maps to a different
-    UUID -> [S21A_PG_SESSION_COLLISION] warning fires."""
+    UUID -> identifier-free warning + structured pg_session_collision event."""
     db = _make_db(create_session_result=False, existing_session_agent_id=_OTHER_UUID)
+    bcast = MagicMock()
+    bcast.broadcast_event = AsyncMock()
     with caplog.at_level("WARNING"):
-        await _run(db)
+        await _run(db, broadcaster=bcast)
     db.get_session.assert_awaited_once_with(_SESSION_KEY)
-    assert any("S21A_PG_SESSION_COLLISION" in r.message for r in caplog.records), \
-        "divergent PG session binding must emit the collision warning"
+    # log fires with the tag...
+    collision_logs = [r for r in caplog.records if "S21A_PG_SESSION_COLLISION" in r.message]
+    assert collision_logs, "divergent binding must emit the collision warning"
+    # ...but must NOT leak either UUID into the clear-text log (CodeQL).
+    for r in collision_logs:
+        assert _OTHER_UUID not in r.getMessage() and _AGENT_UUID not in r.getMessage()
+    # the identifiers ride the structured event instead.
+    bcast.broadcast_event.assert_awaited_once()
+    kw = bcast.broadcast_event.call_args.kwargs
+    assert kw["event_type"] == "pg_session_collision"
+    assert kw["payload"]["existing_agent_id"] == _OTHER_UUID
+    assert kw["payload"]["incoming_agent_id"] == _AGENT_UUID
 
 
 @pytest.mark.asyncio
 async def test_same_identity_repersist_is_quiet(caplog):
     """create_session returns False but the existing row maps to the SAME
-    UUID -> benign re-persist, no warning."""
+    UUID -> benign re-persist, no warning, no event."""
     db = _make_db(create_session_result=False, existing_session_agent_id=_AGENT_UUID)
+    bcast = MagicMock()
+    bcast.broadcast_event = AsyncMock()
     with caplog.at_level("WARNING"):
-        await _run(db)
+        await _run(db, broadcaster=bcast)
     assert not any("S21A_PG_SESSION_COLLISION" in r.message for r in caplog.records), \
         "same-identity re-persist must not warn"
+    bcast.broadcast_event.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_session_persist_pg_collision.py
+++ b/tests/test_session_persist_pg_collision.py
@@ -1,0 +1,98 @@
+"""Regression tests for the PG-layer session-collision observability fix.
+
+`ensure_agent_persisted` calls `db.create_session`, which uses
+`ON CONFLICT (session_id) DO NOTHING` and returns False when a row for the
+session_key already exists. Previously the return value was ignored, so a
+session_key already bound to a *different* identity at the PG layer (the S21-a
+ghost-fork shape, durable layer) was silent.
+
+The fix surfaces that collision via an [S21A_PG_SESSION_COLLISION] warning
+(observability only — control flow is unchanged; the agent_uuid is decided
+upstream). These tests assert the warning fires on a divergent existing
+binding and stays quiet on a same-identity re-persist or a fresh insert.
+
+See docs/proposals/redis-retirement-phase-1-plan.md (prep fix).
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch, AsyncMock
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from src.mcp_handlers.identity import persistence
+
+
+_AGENT_UUID = "11111111-1111-4111-8111-111111111111"
+_OTHER_UUID = "22222222-2222-4222-8222-222222222222"
+_SESSION_KEY = "agent-111111111111"
+
+
+def _make_db(*, create_session_result: bool, existing_session_agent_id):
+    """DB mock that drives ensure_agent_persisted to the create_session call.
+
+    get_identity: first None (not-yet-persisted check), then the upserted row
+    so the create_session branch is reached.
+    """
+    db = AsyncMock()
+    db.get_identity = AsyncMock(side_effect=[
+        None,  # line ~474 not-yet-persisted check
+        SimpleNamespace(identity_id=42, metadata={}),  # line ~576 re-fetch
+    ])
+    db.get_agent = AsyncMock(return_value=None)
+    db.upsert_agent = AsyncMock()
+    db.upsert_identity = AsyncMock()
+    db.create_session = AsyncMock(return_value=create_session_result)
+    db.get_session = AsyncMock(
+        return_value=(
+            SimpleNamespace(agent_id=existing_session_agent_id)
+            if existing_session_agent_id is not None
+            else None
+        )
+    )
+    return db
+
+
+async def _run(db):
+    # _redis_cache=False makes _get_redis() return None -> skips Redis hydration.
+    with patch.object(persistence, "_redis_cache", False), \
+         patch.object(persistence, "get_db", return_value=db):
+        return await persistence.ensure_agent_persisted(_AGENT_UUID, _SESSION_KEY)
+
+
+@pytest.mark.asyncio
+async def test_divergent_pg_session_logs_collision(caplog):
+    """create_session returns False AND the existing row maps to a different
+    UUID -> [S21A_PG_SESSION_COLLISION] warning fires."""
+    db = _make_db(create_session_result=False, existing_session_agent_id=_OTHER_UUID)
+    with caplog.at_level("WARNING"):
+        await _run(db)
+    db.get_session.assert_awaited_once_with(_SESSION_KEY)
+    assert any("S21A_PG_SESSION_COLLISION" in r.message for r in caplog.records), \
+        "divergent PG session binding must emit the collision warning"
+
+
+@pytest.mark.asyncio
+async def test_same_identity_repersist_is_quiet(caplog):
+    """create_session returns False but the existing row maps to the SAME
+    UUID -> benign re-persist, no warning."""
+    db = _make_db(create_session_result=False, existing_session_agent_id=_AGENT_UUID)
+    with caplog.at_level("WARNING"):
+        await _run(db)
+    assert not any("S21A_PG_SESSION_COLLISION" in r.message for r in caplog.records), \
+        "same-identity re-persist must not warn"
+
+
+@pytest.mark.asyncio
+async def test_fresh_insert_skips_collision_check(caplog):
+    """create_session returns True (fresh insert) -> no get_session probe,
+    no warning."""
+    db = _make_db(create_session_result=True, existing_session_agent_id=None)
+    with caplog.at_level("WARNING"):
+        await _run(db)
+    db.get_session.assert_not_awaited()
+    assert not any("S21A_PG_SESSION_COLLISION" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

First implementation step of the Redis-retirement Phase 1 plan (PR #1115) — the one piece that's unambiguously safe and isolated. **Observability only, no control-flow change.**

`ensure_agent_persisted` calls `db.create_session`, which uses `ON CONFLICT (session_id) DO NOTHING` and returns `False` when a row for the `session_key` already exists (`persistence.py:583`). The return value was **ignored**, so a `session_key` already bound to a *different* identity at the PG layer — the S21-a ghost-fork shape at the durable layer — was silent. The Redis guard (`_redis_slot_blocks_overwrite`) caught this for the cache; the PG path did not.

This checks the return value and, on conflict, fetches the existing session and emits an `[S21A_PG_SESSION_COLLISION]` warning when it maps to a different `agent_uuid`. Control flow is unchanged (the `agent_uuid` is decided upstream); the *atomic block* is enforced later in the Phase 1 session-binding mirror. This is deliberately the minimal, zero-behavior-change slice.

## Tests
3 new (mock-based, `tests/test_session_persist_pg_collision.py`): divergent existing binding → warns; same-identity re-persist → quiet; fresh insert → no `get_session` probe. `test_identity_s21a` (19) + `test_identity_core` (63) green.

## CI note — one unrelated pre-existing flake
The full local gate flagged `test_postgres_backend_integration.py::test_list_identities_with_status_filter` (`assert len(active) == 1`, got 2). **Not caused by this change** — it passes in isolation; it's a test-isolation issue in the integration suite (absolute count assertions against the shared live `governance` DB, polluted by a concurrent `anon_*` identity). This diff only adds logging to `ensure_agent_persisted`, an orthogonal code path. Flagging for visibility, not fixing here (out of scope; it's a test-isolation defect, not a product bug).

Part of the Redis-retirement track; see docs/proposals/redis-retirement-phase-1-plan.md.