### PR TITLE
feat(db): session-binding + onboard-pin mirror tables (Redis-retirement Phase 1A)

### DIFF
--- a/db/postgres/migrations/051_session_mirror_tables.sql
+++ b/db/postgres/migrations/051_session_mirror_tables.sql
@@ -1,0 +1,74 @@
+-- 051_session_mirror_tables.sql
+--
+-- Redis-retirement Phase 1A (docs/proposals/redis-retirement-phase-1-plan.md):
+-- durable PostgreSQL mirror for session/identity state that today lives only in
+-- Redis. ADDITIVE and INERT: nothing writes here yet. The dual-write wiring
+-- (modifying _cache_session / set_onboard_pin / resolution.py) is a separate,
+-- flag-gated PR; this migration only lands the tables the DB methods target.
+--
+-- Two tables:
+--   * core.onboard_pins      — durable mirror of Redis recent_onboard:* keys.
+--     The IP:UA-fallback session-routing anchor (Claude Desktop, REST clients
+--     without client_session_id). Phase 1A — needed regardless.
+--   * core.session_bindings  — FK-less mirror of the Redis session: payload.
+--     Phase 1B — built as instrumented shadow; kept only if a soak measurement
+--     shows material cold-mints not covered by an onboard pin.
+--
+-- Design notes (from the v1.1 council review):
+--   * NO foreign keys (cf. the 043/044 shadow replicas). The Redis session:
+--     payload stores an agent_uuid *string* with no core.identities row for the
+--     ephemeral persist=False majority; a FK would force eager identity
+--     persistence, polluting the agent population. These are write-only
+--     resolution mirrors, not referential targets.
+--   * agent_uuid carries a CHECK enforcing UUID shape, so the "this column holds
+--     the UUID-proof, never a display label" identity invariant is enforced at
+--     the schema layer, not just by discipline.
+--   * Column set verified against 865 live Redis session: payloads — includes
+--     public_agent_id (59.8% of payloads) and api_key_hash (40.2%, legacy
+--     sessions) which an earlier draft omitted.
+--   * IF NOT EXISTS throughout so the migration is safe to re-run.
+--   * Reaping: get_session_binding / lookup_onboard_pin_pg filter expires_at, so
+--     expired rows are already invisible. Physical cleanup (extending
+--     core.cleanup_expired_sessions) lands with the dual-write wiring PR, when
+--     there is actually something to reap.
+
+CREATE TABLE IF NOT EXISTS core.onboard_pins (
+    fingerprint        TEXT PRIMARY KEY,   -- full suffix after "recent_onboard:" e.g. "ua:<hash>|<transport>|<model>" (1-3 pipe segments)
+    agent_uuid         TEXT NOT NULL CHECK (agent_uuid ~ '^[0-9a-fA-F-]{36}$'),
+    client_session_id  TEXT NOT NULL,
+    expires_at         TIMESTAMPTZ NOT NULL   -- 30-min TTL (PIN_TTL=1800) in the Redis original
+);
+
+CREATE INDEX IF NOT EXISTS idx_onboard_pins_expires ON core.onboard_pins(expires_at);
+
+CREATE TABLE IF NOT EXISTS core.session_bindings (
+    session_key         TEXT PRIMARY KEY,
+    agent_uuid          TEXT NOT NULL CHECK (agent_uuid ~ '^[0-9a-fA-F-]{36}$'),  -- maps from Redis JSON "agent_id"
+    public_agent_id     TEXT NULL,
+    display_agent_id    TEXT NULL,
+    api_key_hash        TEXT NULL,
+    spawn_reason        TEXT NULL,
+    bind_ip_ua          TEXT NULL,   -- consumed by the PATH 2 fingerprint hijack check
+    trajectory_required BOOLEAN NOT NULL DEFAULT FALSE,
+    bind_count          INTEGER NOT NULL DEFAULT 1,
+    bound_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at          TIMESTAMPTZ NULL   -- NULL = permanent (Redis TTL=-1)
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_bindings_expires ON core.session_bindings(expires_at);
+CREATE INDEX IF NOT EXISTS idx_session_bindings_uuid    ON core.session_bindings(agent_uuid);
+
+COMMENT ON TABLE core.onboard_pins IS
+    'Redis-retirement Phase 1A: durable mirror of recent_onboard:* — the IP:UA-'
+    'fallback session-routing anchor. Inert until the dual-write wiring PR.';
+
+COMMENT ON TABLE core.session_bindings IS
+    'Redis-retirement Phase 1B: FK-less mirror of the Redis session: payload '
+    '(session_key -> agent_uuid + rich fields). Inert; kept only if a shadow '
+    'soak shows material cold-mints not covered by an onboard pin. Distinct from '
+    'coordination.session_resolution_sagas (Wave 3 saga state).';
+
+-- Register migration
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (51, 'session_mirror_tables', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/src/db/mixins/session.py
+++ b/src/db/mixins/session.py
@@ -145,3 +145,182 @@ class SessionMixin:
             client_info=json.loads(row["client_info"]) if isinstance(row["client_info"], str) else row["client_info"],
             metadata=json.loads(row["metadata"]) if isinstance(row["metadata"], str) else row["metadata"],
         )
+
+    # ------------------------------------------------------------------
+    # Session-binding mirror (Redis-retirement Phase 1)
+    #
+    # FK-less durable mirror of the Redis session: payload, keyed by
+    # session_key. INERT — nothing in production calls these yet; the
+    # dual-write/read wiring is a separate flag-gated PR. See
+    # docs/proposals/redis-retirement-phase-1-plan.md.
+    # ------------------------------------------------------------------
+
+    async def upsert_session_binding(
+        self,
+        session_key: str,
+        agent_uuid: str,
+        *,
+        public_agent_id: Optional[str] = None,
+        display_agent_id: Optional[str] = None,
+        api_key_hash: Optional[str] = None,
+        spawn_reason: Optional[str] = None,
+        bind_ip_ua: Optional[str] = None,
+        trajectory_required: bool = False,
+        expires_at=None,
+        mint_guard: bool = False,
+    ) -> str:
+        """Upsert a session_key -> agent_uuid binding into core.session_bindings.
+
+        Returns one of:
+          - "inserted": a new row was created
+          - "updated":  an existing row for the same agent_uuid was refreshed
+          - "blocked":  mint_guard=True and an existing row binds a *different*
+                        agent_uuid — the S21-a collision case; the write is
+                        refused (atomic, via the ON CONFLICT ... WHERE guard).
+
+        The (xmax = 0) RETURNING idiom distinguishes insert (xmax=0) from update
+        (xmax<>0); when mint_guard blocks, the conditional UPDATE matches no row
+        and RETURNING yields nothing -> "blocked".
+        """
+        guard_clause = (
+            "WHERE core.session_bindings.agent_uuid = EXCLUDED.agent_uuid"
+            if mint_guard else ""
+        )
+        sql = f"""
+            INSERT INTO core.session_bindings (
+                session_key, agent_uuid, public_agent_id, display_agent_id,
+                api_key_hash, spawn_reason, bind_ip_ua, trajectory_required,
+                bound_at, expires_at
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now(), $9)
+            ON CONFLICT (session_key) DO UPDATE SET
+                agent_uuid          = EXCLUDED.agent_uuid,
+                public_agent_id     = EXCLUDED.public_agent_id,
+                display_agent_id    = EXCLUDED.display_agent_id,
+                api_key_hash        = EXCLUDED.api_key_hash,
+                spawn_reason        = COALESCE(EXCLUDED.spawn_reason, core.session_bindings.spawn_reason),
+                bind_ip_ua          = COALESCE(EXCLUDED.bind_ip_ua, core.session_bindings.bind_ip_ua),
+                trajectory_required = EXCLUDED.trajectory_required,
+                bind_count          = core.session_bindings.bind_count + 1,
+                expires_at          = EXCLUDED.expires_at
+            {guard_clause}
+            RETURNING (xmax = 0) AS inserted
+        """
+        async with self.acquire() as conn:
+            row = await conn.fetchrow(
+                sql,
+                session_key, agent_uuid, public_agent_id, display_agent_id,
+                api_key_hash, spawn_reason, bind_ip_ua, trajectory_required,
+                expires_at,
+            )
+        if row is None:
+            return "blocked"
+        return "inserted" if row["inserted"] else "updated"
+
+    async def get_session_binding(self, session_key: str) -> Optional[Dict[str, Any]]:
+        """Read a live (unexpired) session binding as a plain dict, or None.
+
+        Returns a dict (not a dataclass) so callers like the PATH 2 fingerprint
+        hijack check can do binding.get("bind_ip_ua") uniformly. Expired rows
+        (expires_at <= now) are treated as absent — Redis enforced this via TTL;
+        PG must filter explicitly. expires_at IS NULL means permanent.
+        """
+        async with self.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT session_key, agent_uuid, public_agent_id, display_agent_id,
+                       api_key_hash, spawn_reason, bind_ip_ua, trajectory_required,
+                       bind_count, bound_at, expires_at
+                FROM core.session_bindings
+                WHERE session_key = $1
+                  AND (expires_at IS NULL OR expires_at > now())
+                """,
+                session_key,
+            )
+            return dict(row) if row else None
+
+    async def delete_session_binding(self, session_key: str) -> bool:
+        """Remove a session binding (e.g. on force_new). True if a row was removed."""
+        async with self.acquire() as conn:
+            result = await conn.execute(
+                "DELETE FROM core.session_bindings WHERE session_key = $1",
+                session_key,
+            )
+            return "DELETE 1" in result
+
+    # ------------------------------------------------------------------
+    # Onboard pins (Redis-retirement Phase 1A) — durable recent_onboard:* mirror
+    # ------------------------------------------------------------------
+
+    async def set_onboard_pin_pg(
+        self,
+        fingerprint: str,
+        agent_uuid: str,
+        client_session_id: str,
+        *,
+        ttl_seconds: int = 1800,
+        if_absent: bool = False,
+    ) -> bool:
+        """Write an onboard pin (fingerprint -> client_session_id) with a TTL.
+
+        if_absent=True implements the NX-claim semantics (a subagent must not
+        displace the driver's pin): INSERT ... ON CONFLICT DO NOTHING, returning
+        True only when this call actually claimed the slot. if_absent=False
+        upserts unconditionally and always returns True.
+        """
+        async with self.acquire() as conn:
+            if if_absent:
+                result = await conn.execute(
+                    """
+                    INSERT INTO core.onboard_pins (fingerprint, agent_uuid, client_session_id, expires_at)
+                    VALUES ($1, $2, $3, now() + ($4 * interval '1 second'))
+                    ON CONFLICT (fingerprint) DO NOTHING
+                    """,
+                    fingerprint, agent_uuid, client_session_id, ttl_seconds,
+                )
+                return "INSERT 0 1" in result
+            await conn.execute(
+                """
+                INSERT INTO core.onboard_pins (fingerprint, agent_uuid, client_session_id, expires_at)
+                VALUES ($1, $2, $3, now() + ($4 * interval '1 second'))
+                ON CONFLICT (fingerprint) DO UPDATE SET
+                    agent_uuid        = EXCLUDED.agent_uuid,
+                    client_session_id = EXCLUDED.client_session_id,
+                    expires_at        = EXCLUDED.expires_at
+                """,
+                fingerprint, agent_uuid, client_session_id, ttl_seconds,
+            )
+            return True
+
+    async def lookup_onboard_pin_pg(
+        self,
+        fingerprint: str,
+        *,
+        refresh_ttl: bool = False,
+        ttl_seconds: int = 1800,
+    ) -> Optional[str]:
+        """Return the pinned client_session_id for a fingerprint, or None.
+
+        Expired pins are treated as absent. refresh_ttl extends the pin's TTL on
+        a hit (mirrors the Redis expire-on-read behavior).
+        """
+        async with self.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT client_session_id
+                FROM core.onboard_pins
+                WHERE fingerprint = $1 AND expires_at > now()
+                """,
+                fingerprint,
+            )
+            if not row:
+                return None
+            if refresh_ttl:
+                await conn.execute(
+                    """
+                    UPDATE core.onboard_pins
+                    SET expires_at = now() + ($2 * interval '1 second')
+                    WHERE fingerprint = $1
+                    """,
+                    fingerprint, ttl_seconds,
+                )
+            return row["client_session_id"]

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -153,6 +153,10 @@ async def ensure_test_database_schema() -> None:
         # (extends the 026/042 grammar CHECK). Applied after 042 here because
         # it supersedes the same surface_id_grammar constraint.
         await _execute_sql_file(conn, "db/postgres/migrations/050_lease_plane_maintenance_scheme.sql")
+        # Migration 051: Redis-retirement Phase 1 session-binding + onboard-pin
+        # mirror tables (FK-less; additive/inert). Depends only on the core
+        # schema. See docs/proposals/redis-retirement-phase-1-plan.md.
+        await _execute_sql_file(conn, "db/postgres/migrations/051_session_mirror_tables.sql")
 
         # Ensure partitioned audit tables can accept inserts for current month.
         await _execute_sql_file(conn, "db/postgres/partitions.sql")
@@ -183,6 +187,8 @@ TRUNCATE_TABLES = [
     "core.agent_state",
     "core.agent_sessions",
     "core.agent_baselines",
+    "core.session_bindings",
+    "core.onboard_pins",
     "core.sessions",
     "core.identities",
     "core.agents",

--- a/tests/test_session_mirror_tables.py
+++ b/tests/test_session_mirror_tables.py
@@ -1,0 +1,193 @@
+"""Integration tests for the Redis-retirement Phase 1 session-binding +
+onboard-pin mirror tables (migration 051) and their DB mixin methods.
+
+Runs against governance_test; skips if unavailable. The methods are inert in
+production (nothing wires them yet) — these tests exercise them directly against
+a real PostgreSQL so the durable mirror is proven before the dual-write PR.
+
+See docs/proposals/redis-retirement-phase-1-plan.md.
+"""
+
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+try:
+    import asyncpg  # noqa: F401
+except ImportError:
+    pytest.skip("asyncpg not installed", allow_module_level=True)
+
+from tests.test_db_utils import can_connect_to_test_db
+
+if not can_connect_to_test_db():
+    pytest.skip("governance_test database not available", allow_module_level=True)
+
+
+@pytest_asyncio.fixture
+async def backend(live_postgres_backend):
+    """Alias for the conftest live_postgres_backend fixture (governance_test)."""
+    return live_postgres_backend
+
+
+def _uuid() -> str:
+    return str(uuid.uuid4())
+
+
+def _future(seconds: int = 3600) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(seconds=seconds)
+
+
+def _past(seconds: int = 3600) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(seconds=seconds)
+
+
+# ---------------------------------------------------------------------------
+# session_bindings
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_insert_then_get_roundtrips_rich_fields(backend):
+    sk, au = "agent-" + _uuid()[:12], _uuid()
+    outcome = await backend.upsert_session_binding(
+        sk, au,
+        public_agent_id="Claude_Code_20260628",
+        display_agent_id="Claude_Code_20260628",
+        api_key_hash="hash-abc",
+        spawn_reason="new_session",
+        bind_ip_ua="127.0.0.1:deadbe",
+        trajectory_required=True,
+        expires_at=_future(),
+    )
+    assert outcome == "inserted"
+
+    row = await backend.get_session_binding(sk)
+    assert row is not None
+    assert isinstance(row, dict)  # B2: callers do row.get("bind_ip_ua")
+    assert row["agent_uuid"] == au
+    assert row["public_agent_id"] == "Claude_Code_20260628"
+    assert row["api_key_hash"] == "hash-abc"
+    assert row["spawn_reason"] == "new_session"
+    assert row["bind_ip_ua"] == "127.0.0.1:deadbe"
+    assert row["trajectory_required"] is True
+    assert row["bind_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_same_uuid_reupsert_updates_and_bumps_bind_count(backend):
+    sk, au = "agent-" + _uuid()[:12], _uuid()
+    await backend.upsert_session_binding(sk, au, expires_at=_future())
+    outcome = await backend.upsert_session_binding(sk, au, expires_at=_future())
+    assert outcome == "updated"
+    row = await backend.get_session_binding(sk)
+    assert row["bind_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_mint_guard_blocks_divergent_uuid(backend):
+    """S21-a: mint_guard must refuse to overwrite a binding for a different uuid."""
+    sk, au1, au2 = "agent-" + _uuid()[:12], _uuid(), _uuid()
+    assert await backend.upsert_session_binding(sk, au1, expires_at=_future()) == "inserted"
+
+    outcome = await backend.upsert_session_binding(sk, au2, mint_guard=True, expires_at=_future())
+    assert outcome == "blocked"
+
+    row = await backend.get_session_binding(sk)
+    assert row["agent_uuid"] == au1  # original binding intact
+
+
+@pytest.mark.asyncio
+async def test_corrective_write_overwrites_divergent_uuid(backend):
+    """Without mint_guard, a corrective write may overwrite (authoritative source)."""
+    sk, au1, au2 = "agent-" + _uuid()[:12], _uuid(), _uuid()
+    await backend.upsert_session_binding(sk, au1, expires_at=_future())
+    outcome = await backend.upsert_session_binding(sk, au2, mint_guard=False, expires_at=_future())
+    assert outcome == "updated"
+    row = await backend.get_session_binding(sk)
+    assert row["agent_uuid"] == au2
+
+
+@pytest.mark.asyncio
+async def test_expired_binding_is_invisible(backend):
+    sk, au = "agent-" + _uuid()[:12], _uuid()
+    await backend.upsert_session_binding(sk, au, expires_at=_past())
+    assert await backend.get_session_binding(sk) is None
+
+
+@pytest.mark.asyncio
+async def test_permanent_binding_null_expiry_visible(backend):
+    sk, au = "agent-" + _uuid()[:12], _uuid()
+    await backend.upsert_session_binding(sk, au, expires_at=None)
+    row = await backend.get_session_binding(sk)
+    assert row is not None and row["expires_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_missing_binding_returns_none(backend):
+    assert await backend.get_session_binding("agent-" + _uuid()[:12]) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_session_binding(backend):
+    sk, au = "agent-" + _uuid()[:12], _uuid()
+    await backend.upsert_session_binding(sk, au, expires_at=_future())
+    assert await backend.delete_session_binding(sk) is True
+    assert await backend.get_session_binding(sk) is None
+    assert await backend.delete_session_binding(sk) is False  # already gone
+
+
+@pytest.mark.asyncio
+async def test_uuid_check_rejects_display_label(backend):
+    """The agent_uuid CHECK enforces 'proof not label' at the schema layer."""
+    sk = "agent-" + _uuid()[:12]
+    with pytest.raises(Exception):  # asyncpg.CheckViolationError
+        await backend.upsert_session_binding(sk, "Claude_Code_20260628", expires_at=_future())
+
+
+# ---------------------------------------------------------------------------
+# onboard_pins
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_set_and_lookup_onboard_pin(backend):
+    fp, au, csid = f"ua:{_uuid()[:6]}|unknown|claude", _uuid(), "agent-" + _uuid()[:12]
+    assert await backend.set_onboard_pin_pg(fp, au, csid) is True
+    assert await backend.lookup_onboard_pin_pg(fp) == csid
+
+
+@pytest.mark.asyncio
+async def test_onboard_pin_if_absent_nx_semantics(backend):
+    """if_absent must not displace an existing pin (subagent NX-claim)."""
+    fp = f"ua:{_uuid()[:6]}|unknown"
+    csid1, csid2 = "agent-" + _uuid()[:12], "agent-" + _uuid()[:12]
+    assert await backend.set_onboard_pin_pg(fp, _uuid(), csid1, if_absent=True) is True
+    assert await backend.set_onboard_pin_pg(fp, _uuid(), csid2, if_absent=True) is False
+    assert await backend.lookup_onboard_pin_pg(fp) == csid1  # first claim wins
+
+
+@pytest.mark.asyncio
+async def test_onboard_pin_upsert_overwrites(backend):
+    fp = f"ua:{_uuid()[:6]}|claude"
+    csid1, csid2 = "agent-" + _uuid()[:12], "agent-" + _uuid()[:12]
+    await backend.set_onboard_pin_pg(fp, _uuid(), csid1)
+    await backend.set_onboard_pin_pg(fp, _uuid(), csid2)  # default upsert
+    assert await backend.lookup_onboard_pin_pg(fp) == csid2
+
+
+@pytest.mark.asyncio
+async def test_expired_onboard_pin_is_invisible(backend):
+    fp, au, csid = f"ua:{_uuid()[:6]}", _uuid(), "agent-" + _uuid()[:12]
+    # negative TTL -> already expired
+    await backend.set_onboard_pin_pg(fp, au, csid, ttl_seconds=-10)
+    assert await backend.lookup_onboard_pin_pg(fp) is None
+
+
+@pytest.mark.asyncio
+async def test_lookup_missing_onboard_pin_returns_none(backend):
+    assert await backend.lookup_onboard_pin_pg(f"ua:{_uuid()[:6]}") is None


### PR DESCRIPTION
## Summary

Phase 1A groundwork for Redis retirement (plan: PR #1115). **Additive and INERT** — nothing in production calls these yet. Lands the durable PG mirror the dual-write will target, so the later wiring PR is a code-only change against an existing schema (same pattern as the Wave 3 saga migration #049).

## What's here
- **Migration 051** (`db/postgres/migrations/051_session_mirror_tables.sql`):
  - `core.session_bindings` — FK-less mirror of the Redis `session:` payload (`session_key → agent_uuid` + rich fields). Column set verified against 865 live payloads — includes `public_agent_id` and `api_key_hash` (the two an earlier draft missed). `agent_uuid` CHECK enforces "proof not label" at the schema layer.
  - `core.onboard_pins` — durable mirror of `recent_onboard:*`, the IP:UA-fallback routing anchor (Claude Desktop / REST without `client_session_id`).
  - No FKs (cf. 043/044 shadow replicas): the ephemeral `persist=False` majority has no `core.identities` row, so a FK would force eager identity persistence.
- **SessionMixin methods** (`src/db/mixins/session.py`):
  - `upsert_session_binding` — atomic S21-a `mint_guard` via `ON CONFLICT … WHERE agent_uuid = EXCLUDED.agent_uuid` + `(xmax = 0) RETURNING` → returns `inserted`/`updated`/`blocked` (strictly stronger than the old non-atomic Redis `get`+`setex`).
  - `get_session_binding` — returns a **plain dict** (so the PATH 2 hijack check can `.get("bind_ip_ua")`), filters `expires_at`.
  - `delete_session_binding`, `set_onboard_pin_pg` (`if_absent` NX-claim for subagents), `lookup_onboard_pin_pg` (expiry-filtered, refresh-on-read).
- **Test harness:** bootstrap applies 051; the two tables added to `TRUNCATE_TABLES`.
- **14 integration tests** (`governance_test`): roundtrip incl. rich fields, `mint_guard` block vs corrective overwrite, expiry invisibility, UUID-CHECK rejection of a display label, onboard-pin NX semantics. All green; full `test_postgres_backend_integration` (123 tests) green.

## Notes
- **Migration is MANUAL** — apply on deploy. `unitares_doctor.py` will report `missing 51:session_mirror_tables` against any DB where it hasn't been applied yet; that's the expected pending-migration state, not drift.
- Slot 51 coordination-checked (no open migration PRs; top slot was 050).
- Distinct from `coordination.session_resolution_sagas` (#049, Wave 3 saga state) — disambiguated in the table COMMENT.

Next in the track: the flag-gated dual-write/read wiring (load-bearing — modifies `_cache_session` / `resolution.py` / `set_onboard_pin`), per the Phase 1A build order.