### PR TITLE
fix(governance): risk-path decoupling — F1–F4 + pause-stage narrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ One layer of the **[CIRWEL stack](https://cirwel.github.io)** — runtime safety
 ## What you get after install
 
 - **A governance server for heterogeneous agents.** MCP on `/mcp/`, REST on `/v1/tools/call`, an optional dashboard on `/dashboard`, and an SDK for resident or scheduled agents.
-- **Online agent-state estimation.** Each process identity gets EISV state readings against its *own* baseline and recent history, so slow degradation surfaces while output still looks fine.
+- **Online agent-state estimation.** Each process identity gets EISV state readings against its *own* baseline and recent history, so slow degradation surfaces while output still looks fine. (During the baseline warmup the reading leans on self-reported signals and is not yet drift-discriminative — the payload flags this explicitly.)
 - **Outcome-grounded calibration.** Self-reported `confidence` is scored against real evidence — tests, exit codes, tool output, file ops, deployments, and task results — and that calibration feeds future state readings and policy actions.
 - **Governed shared memory.** A Postgres + pgvector + Apache AGE knowledge graph lets agents search and contribute durable discoveries, corrections, supersessions, and cross-agent relations with provenance. It is sediment, not a transcript dump.
 - **Dialectic review and durable constraints.** Disputed policy actions can be reviewed by authority-weighted peers; synthesized conditions persist and can gate that agent's future decisions.
@@ -115,6 +115,8 @@ Want to act on *why*, not just the policy action? Each check-in also returns fou
 | **I** · Integrity | do claims match results? | high confidence, low actual success |
 | **S** · Entropy / drift | drifting from its own normal? | erratic, divergent behavior |
 | **V** · Valence | derived: energy vs integrity | motion without coherence (or vice-versa) |
+
+The baseline takes ~30 check-ins to establish. Until then the verdict falls back to self-reported signals and fixed thresholds, so it is *not yet* discriminative of absolute drift magnitude — a worsening drift vector will not, on its own, move the verdict during warmup. After baselining, the per-agent behavioral assessment is combined into the verdict and can escalate it. A pause is enforced (the runtime boundary marks the agent `paused` and blocks further writes until recovery), not merely advisory.
 
 </details>
 

--- a/src/governance_monitor.py
+++ b/src/governance_monitor.py
@@ -909,7 +909,12 @@ class UNITARESMonitor:
     
     def update_lambda1(self) -> float:
         """Updates lambda1 using PI controller based on void frequency and coherence targets."""
-        return _update_lambda1(self.state)
+        result = _update_lambda1(self.state)
+        # Propagate the HCK gain-modulation flag so the surfaced
+        # hck.gains_modulated reflects whether ρ(t) actually modulated PI gains
+        # this cycle, rather than the always-False stub (F4).
+        self._gains_modulated = getattr(self.state, 'gains_modulated', False)
+        return result
     
     def estimate_risk(self, agent_state: Dict, score_result: Dict = None) -> float:
         """Estimate risk score using governance_core phi_objective and verdict_from_phi."""
@@ -1166,7 +1171,21 @@ class UNITARESMonitor:
 
         self._behavioral_state.update(beh_E_obs, beh_I_obs, beh_S_obs)
 
-        # Assess behavioral state with auxiliary signals
+        # ── ODE Dynamics (Diagnostic) ──
+        # The ODE engine runs in parallel but does NOT drive verdicts when
+        # BEHAVIORAL_VERDICT_ENABLED is True (default). Primary verdicts
+        # come from behavioral assessment (EMA + z-score deviations).
+        # ODE provides: phi objective, regime detection, historical continuity.
+        #
+        # Dynamics runs BEFORE the behavioral assessment so the assessment pairs
+        # THIS cycle's observations with THIS cycle's update coherence ρ(t) and
+        # continuity energy (both produced by update_dynamics). Previously the
+        # assessment read the prior cycle's ρ/CE, so an adversarial ρ spike could
+        # surface in hck.rho while adversarial_rho stayed 0.0 — the signal that
+        # detected the anomaly was decoupled from the verdict (F4).
+        self.update_dynamics(grounded_agent_state, dt=effective_dt)
+
+        # Assess behavioral state with auxiliary signals (now sees fresh ρ/CE).
         behavioral_assessment = assess_behavioral_state(
             state=self._behavioral_state,
             rho=getattr(self.state, 'current_rho', 0.0),
@@ -1174,13 +1193,6 @@ class UNITARESMonitor:
             agent_context={'task_type': task_type},
         )
         self._last_behavioral_verdict = behavioral_assessment.verdict
-
-        # ── ODE Dynamics (Diagnostic) ──
-        # The ODE engine runs in parallel but does NOT drive verdicts when
-        # BEHAVIORAL_VERDICT_ENABLED is True (default). Primary verdicts
-        # come from behavioral assessment (EMA + z-score deviations).
-        # ODE provides: phi objective, regime detection, historical continuity.
-        self.update_dynamics(grounded_agent_state, dt=effective_dt)
 
         # Step 1b: Confidence handling
         # When agent reports confidence, use it as-is — capping created calibration
@@ -1220,6 +1232,9 @@ class UNITARESMonitor:
         
         # Step 3: Update λ₁ (every N updates) - WITH CONFIDENCE GATING
         # Updated to every 5 cycles for faster adaptation (was 10)
+        # Reset the per-cycle gain-modulation flag: it is True only on a cycle
+        # where update_lambda1 actually ran AND ρ(t) reduced the PI gains (F4).
+        self._gains_modulated = False
         lambda1_skipped = False
         if self.state.update_count % 5 == 0:  # Update λ₁ every 5 cycles
             # Gate lambda1 updates based on confidence

--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -2035,6 +2035,7 @@ async def execute_post_update_effects(ctx: UpdateContext) -> None:
                         'prev_norm': tv['prev_norm'],
                         'current_norm': tv['current_norm'],
                         'norm_delta': tv['norm_delta'],
+                        'improvement': tv.get('improvement'),
                     },
                     # Quality computed server-side from ctx.result trajectory data.
                     verification_source='server_observation',

--- a/src/monitor_calibration.py
+++ b/src/monitor_calibration.py
@@ -36,13 +36,19 @@ def run_calibration_recording(monitor, confidence: float, decision: Dict, drift_
     if (monitor._prev_verdict_action is not None
             and monitor._prev_drift_norm is not None
             and elapsed_since_prev > 10.0):
-        norm_delta = monitor._prev_drift_norm - current_norm  # positive = improved
+        # `improvement` is the trajectory-quality quantity: positive = drift
+        # dropped since the previous check-in (the intervention helped).
+        improvement = monitor._prev_drift_norm - current_norm
+        # `norm_delta` is the plain delta exposed in the payload and must follow
+        # the math convention current - prev (positive = norm rose). Keeping the
+        # two distinct prevents the field name from contradicting its sign (F3).
+        norm_delta = current_norm - monitor._prev_drift_norm
 
-        # Convert to [0, 1] quality signal via sigmoid
-        trajectory_quality = 1.0 / (1.0 + math.exp(-norm_delta * 10.0))
+        # Convert improvement to [0, 1] quality signal via sigmoid
+        trajectory_quality = 1.0 / (1.0 + math.exp(-improvement * 10.0))
 
         if (monitor._prev_verdict_action in ('proceed', 'pause')
-                and abs(norm_delta) > 0.03):
+                and abs(improvement) > 0.03):
             calibration_checker.record_tactical_decision(
                 confidence=monitor._prev_confidence,
                 decision=monitor._prev_verdict_action,
@@ -55,6 +61,7 @@ def run_calibration_recording(monitor, confidence: float, decision: Dict, drift_
             'prev_norm': monitor._prev_drift_norm,
             'current_norm': current_norm,
             'norm_delta': norm_delta,
+            'improvement': improvement,
         }
 
     # Store current verdict for next check-in's validation

--- a/src/monitor_decision.py
+++ b/src/monitor_decision.py
@@ -242,4 +242,46 @@ def make_decision(
         coherence_history=state.coherence_history,
     )
     decision['basin'] = basin
+
+    # F2 fast-trip: the gate above runs on the (possibly task-adjusted) risk_score.
+    # The latest *raw* risk observation can spike past the pause threshold while
+    # the adjusted/smoothed value still clears — a real spike then silently
+    # approves. Surface at least a guide so the latent spike is not invisible.
+    decision = _maybe_latest_risk_fast_trip(state, decision, risk_score)
+    return decision
+
+
+def _maybe_latest_risk_fast_trip(state, decision: Dict, gated_risk: float) -> Dict:
+    """Upgrade a clean 'approve' to 'guide' when the latest raw risk observation
+    crossed the pause (revise) threshold even though the gated risk cleared it.
+
+    Never weakens a decision: applies only when the action is already an
+    unqualified ``proceed``/``approve``. Pauses and existing guides are left
+    intact. This is the F2 fast-trip — it guarantees that a single check-in whose
+    latest risk reaches PAUSE raises at least a guide, regardless of whether the
+    gated value was task-adjusted or smoothed below threshold.
+    """
+    if decision.get('action') != 'proceed' or decision.get('sub_action') != 'approve':
+        return decision
+    if not state.risk_history:
+        return decision
+    latest_risk = float(state.risk_history[-1])
+    pause_threshold = get_effective_threshold(
+        "risk_revise_threshold", default=config.RISK_REVISE_THRESHOLD)
+    if latest_risk >= pause_threshold and latest_risk > gated_risk:
+        decision['sub_action'] = 'guide'
+        decision['reason'] = (
+            f'Latest risk spiked (risk_latest={latest_risk:.2f} >= '
+            f'{pause_threshold:.2f}) though gated risk cleared (risk={gated_risk:.2f})'
+        )
+        decision['guidance'] = (
+            'A recent observation crossed the pause threshold even though the '
+            'adjusted/smoothed risk did not. Reflect on whether the latest step '
+            'introduced real risk before continuing.'
+        )
+        decision['latest_risk_fast_trip'] = {
+            'latest_risk': round(latest_risk, 4),
+            'gated_risk': round(gated_risk, 4),
+            'threshold': round(pause_threshold, 4),
+        }
     return decision

--- a/src/monitor_lambda.py
+++ b/src/monitor_lambda.py
@@ -53,6 +53,11 @@ def update_lambda1(state) -> float:
     K_p_adj, K_i_adj = modulate_gains(base_K_p, base_K_i, rho)
 
     gains_modulated = (K_p_adj != base_K_p or K_i_adj != base_K_i)
+    # Surface the modulation so the monitor/result can report it honestly.
+    # Previously this flag stayed local and `_gains_modulated` was always False
+    # even when ρ(t) drove a real gain reduction — the HCK signal was decoupled
+    # from its own reported effect (F4).
+    state.gains_modulated = gains_modulated
 
     # PI calculation with modulated gains
     error_void = config.TARGET_VOID_FREQ - void_freq_current

--- a/src/monitor_result.py
+++ b/src/monitor_result.py
@@ -28,21 +28,31 @@ _POLICY_INPUT_FIELDS = (
 )
 
 
-def _build_policy_evaluation(decision: Dict, metrics: Dict) -> Dict:
+def _build_policy_evaluation(decision: Dict, metrics: Dict,
+                             latest_risk: float = None) -> Dict:
     """Describe the policy layer that consumed measurements.
 
     EISV/risk/coherence are instrument readings. ``monitor_decision`` is the
     policy layer that maps those readings to guidance/action. Keeping this
     envelope distinct from ``decision`` lets clients and operators inspect the
     policy without treating the measurement itself as the actuator.
+
+    ``risk_score`` here is the value the gate ran on; ``risk_score_latest`` is
+    the most-recent raw observation. Surfacing both makes the relationship
+    explicit so a reader can never conclude "the policy never sees the latest
+    value" (F2) — and the fast-trip below acts on it.
     """
     inputs = {
         "basin": decision.get("basin"),
         **{field: metrics.get(field) for field in _POLICY_INPUT_FIELDS},
+        "risk_score_latest": (
+            latest_risk if latest_risk is not None
+            else metrics.get("latest_risk_score")
+        ),
         "margin": decision.get("margin"),
         "nearest_edge": decision.get("nearest_edge"),
     }
-    return {
+    evaluation = {
         "policy_name": "monitor_decision",
         "policy_version": "v1",
         "action": decision.get("action"),
@@ -52,6 +62,9 @@ def _build_policy_evaluation(decision: Dict, metrics: Dict) -> Dict:
         "inputs": inputs,
         "measurement_role": "EISV/risk/coherence are policy inputs, not the actuator itself.",
     }
+    if decision.get("latest_risk_fast_trip"):
+        evaluation["latest_risk_fast_trip"] = decision["latest_risk_fast_trip"]
+    return evaluation
 
 
 def _build_enforcement_stub(decision: Dict) -> Dict:
@@ -64,7 +77,11 @@ def _build_enforcement_stub(decision: Dict) -> Dict:
         "actor": None,
         "effect": None,
         "note": (
-            "Policy requested enforcement; actuator state is applied by the caller/runtime boundary."
+            "Policy requested enforcement. This envelope is the pre-actuation "
+            "candidate; the authenticated update boundary applies it as a circuit "
+            "breaker (agent metadata -> status=paused, blocking later writes) and "
+            "overwrites this with applied=true. A non-actuating path (e.g. "
+            "simulate) leaves it unapplied."
             if requested else
             "No enforcement requested by policy."
         ),
@@ -76,6 +93,7 @@ def _build_risk_attribution(
     drift_vector,
     continuity_metrics,
     behavioral_assessment,
+    baseline_status: Dict = None,
 ) -> Dict:
     """Decompose the risk/verdict by signal provenance.
 
@@ -121,10 +139,13 @@ def _build_risk_attribution(
     behavioral: Dict = {
         "provenance": "measured",
         "description": (
-            "Independent text-risk model — the only non-self-attested signal. "
-            "Not yet weighted into the enforcement verdict (verification layer "
-            "reserved for v2); shown for comparison against the self-reported "
-            "drivers."
+            "Per-agent behavioral EISV assessment (EMA z-scores vs this agent's "
+            "own baseline, plus tool-outcome signals) — the least self-attested "
+            "input. It IS combined into the verdict once the behavioral state is "
+            "warm (confidence >= 0.3): the enforcement pair takes the more-severe "
+            "verdict and the max risk, so it can escalate but not erase Φ. Before "
+            "warmup it is telemetry-only. A stronger verification/adversarial "
+            "weighting (the real fix for drift-discriminability) is reserved for v2."
         ),
         "risk": (
             float(behavioral_assessment.risk)
@@ -138,16 +159,19 @@ def _build_risk_attribution(
         ),
     }
 
-    return {
+    attribution = {
         "risk_score": metrics.get("risk_score"),
         "verdict": metrics.get("verdict"),
         "primary_driver": "self_reported",
         "note": (
             "At current maturity this verdict is driven primarily by signals you "
             "reported (ethical_drift, complexity, confidence). An agent that "
-            "under-reports ethical_drift lowers this risk regardless of its "
-            "actual behavior. The behavioral signal is the only non-self-attested "
-            "input and does not yet carry enforcement weight."
+            "under-reports ethical_drift lowers Φ-based risk regardless of its "
+            "actual behavior. The per-agent behavioral signal is the least "
+            "self-attested input; once warm (confidence >= 0.3) it is combined "
+            "into the verdict and can escalate it (more-severe verdict, max risk), "
+            "but it cannot lower a worse Φ and is not yet the primary driver — "
+            "stronger verification-weighted behavioral scoring is reserved for v2."
         ),
         "sources": {
             "self_reported": self_reported,
@@ -155,6 +179,38 @@ def _build_risk_attribution(
             "behavioral": behavioral,
         },
     }
+
+    # F1(b): during behavioral bootstrap the phi-based risk keys on
+    # baseline-deviation terms that sit near zero, so risk_score is NOT
+    # discriminative of absolute drift magnitude — it does not move under a
+    # worsening drift vector. Flag it explicitly (mirroring restorative's
+    # `suppressed` pattern) rather than letting a reader treat a confident
+    # margin-to-PAUSE as meaningful in this window. The real fix is a
+    # baseline-independent drift floor + v2 behavioral weighting (F1a / v2).
+    if baseline_status is not None:
+        is_baselined = bool(baseline_status.get("is_baselined", False))
+        completed = baseline_status.get("updates_completed")
+        target = baseline_status.get("baseline_target")
+        until = None
+        if isinstance(completed, int) and isinstance(target, int):
+            until = max(0, target - completed)
+        attribution["discriminability"] = {
+            "baselined": is_baselined,
+            "non_discriminative": not is_baselined,
+            "updates_completed": completed,
+            "baseline_target": target,
+            "updates_until_baseline": until,
+            "note": (
+                None if is_baselined else
+                "Behavioral baseline not yet established — risk_score keys on "
+                "baseline-deviation terms that are ~0 during bootstrap and does "
+                "not track absolute drift magnitude. Treat risk_score (and any "
+                "margin-to-PAUSE derived from it) as non-discriminative until "
+                "baselined; rely on the reported ethical_drift norm directly."
+            ),
+        }
+
+    return attribution
 
 
 def _complexity_divergence_novel(monitor, cm) -> bool:
@@ -212,7 +268,14 @@ def build_result(
     result = {
         'status': status,
         'decision': decision,
-        'policy_evaluation': _build_policy_evaluation(decision, metrics),
+        'policy_evaluation': _build_policy_evaluation(
+            decision, metrics,
+            latest_risk=(
+                float(monitor.state.risk_history[-1])
+                if getattr(getattr(monitor, 'state', None), 'risk_history', None)
+                else None
+            ),
+        ),
         'enforcement': _build_enforcement_stub(decision),
         'metrics': metrics,
         'timestamp': datetime.now(timezone.utc).isoformat(),
@@ -229,11 +292,21 @@ def build_result(
 
     # Verdict provenance: decompose risk by signal source so a reader can see
     # how much of the verdict is self-attested vs measured (dogfood P0).
+    _beh = getattr(monitor, '_behavioral_state', None)
+    _baseline_status = None
+    if _beh is not None:
+        from src.behavioral_state import BASELINE_WARMUP_UPDATES
+        _baseline_status = {
+            "is_baselined": _beh.is_baselined,
+            "updates_completed": getattr(_beh, 'update_count', None),
+            "baseline_target": BASELINE_WARMUP_UPDATES,
+        }
     result['risk_attribution'] = _build_risk_attribution(
         metrics,
         monitor._last_drift_vector,
         monitor._last_continuity_metrics,
         behavioral_assessment,
+        baseline_status=_baseline_status,
     )
 
     if task_type_adjustment:

--- a/tests/test_agent_loop_enforcement.py
+++ b/tests/test_agent_loop_enforcement.py
@@ -15,7 +15,13 @@ def test_mark_circuit_breaker_enforcement_applied_preserves_policy_request():
             "mode": "circuit_breaker_candidate",
             "actor": None,
             "effect": None,
-            "note": "Policy requested enforcement; actuator state is applied by the caller/runtime boundary.",
+            "note": (
+                "Policy requested enforcement. This envelope is the pre-actuation "
+                "candidate; the authenticated update boundary applies it as a circuit "
+                "breaker (agent metadata -> status=paused, blocking later writes) and "
+                "overwrites this with applied=true. A non-actuating path (e.g. "
+                "simulate) leaves it unapplied."
+            ),
         },
     }
 

--- a/tests/test_hck_rho_coupling.py
+++ b/tests/test_hck_rho_coupling.py
@@ -1,0 +1,71 @@
+"""F4 regression tests: HCK ρ(t) must not fire into a void.
+
+Two decouplings the dogfood probe found (v2.13.0):
+  1. ``hck.gains_modulated`` was always False even when ρ(t) reduced the PI
+     gains — the local flag in update_lambda1 was never propagated.
+  2. The behavioral assessment read the *previous* cycle's ρ (and continuity
+     energy) because it ran before update_dynamics, so an adversarial ρ spike
+     surfaced in ``hck.rho`` while ``adversarial_rho`` stayed 0.0.
+"""
+
+import numpy as np
+from unittest.mock import patch
+
+import src.governance_monitor as gm
+from src.governance_monitor import UNITARESMonitor
+
+
+class TestGainsModulatedPropagation:
+    def test_low_rho_marks_gains_modulated(self):
+        mon = UNITARESMonitor("test-f4-gains-low", load_state=False)
+        mon.state.current_rho = -0.5  # below neutral → gain factor floors at 0.5
+        mon.update_lambda1()
+        assert mon._gains_modulated is True
+
+    def test_rho_one_leaves_gains_unmodulated(self):
+        mon = UNITARESMonitor("test-f4-gains-one", load_state=False)
+        mon.state.current_rho = 1.0  # factor 1.0 → gains unchanged
+        mon.update_lambda1()
+        assert mon._gains_modulated is False
+
+    def test_flag_resets_each_cycle(self):
+        # A cycle that does not run update_lambda1 must not carry a stale True.
+        mon = UNITARESMonitor("test-f4-gains-reset", load_state=False)
+        mon._gains_modulated = True  # simulate a prior modulated cycle
+        # update_count starts at 0; a check-in that skips lambda1 (low confidence
+        # on a non-multiple-of-5 cycle) should reset the flag to False.
+        mon.state.update_count = 3  # 3 % 5 != 0 → lambda1 block skipped
+        mon.process_update(
+            {"response_text": "x", "complexity": 0.3, "ethical_drift": [0.0, 0.0, 0.0]},
+            confidence=0.9,
+        )
+        assert mon._gains_modulated is False
+
+
+class TestBehavioralAssessmentSeesCurrentRho:
+    def test_assessment_consumes_current_cycle_rho(self):
+        """The ρ passed to the behavioral assessment on cycle N must equal the ρ
+        produced by cycle N's dynamics — i.e. dynamics runs first (reorder)."""
+        mon = UNITARESMonitor("test-f4-rho-order", load_state=False)
+        captured = {}
+        real = gm.assess_behavioral_state
+
+        def spy(*args, **kwargs):
+            captured["rho"] = kwargs.get("rho")
+            return real(*args, **kwargs)
+
+        # Distinct inputs per cycle so the ODE moves and ρ changes cycle-to-cycle.
+        with patch.object(gm, "assess_behavioral_state", side_effect=spy):
+            for i in range(4):
+                mon.process_update(
+                    {
+                        "parameters": (np.arange(10) * (i + 1) * 0.01).tolist(),
+                        "ethical_drift": [0.1 * (i + 1), 0.05, 0.02],
+                        "response_text": "varying input " * (i + 1),
+                        "complexity": 0.2 + 0.15 * i,
+                    },
+                    confidence=0.8,
+                )
+
+        # With dynamics-first, the consumed ρ is the freshly computed one.
+        assert captured["rho"] == mon.state.current_rho

--- a/tests/test_monitor_calibration_unit.py
+++ b/tests/test_monitor_calibration_unit.py
@@ -84,7 +84,11 @@ class TestTrajectoryValidationGating:
         assert result["prev_verdict"] == "proceed"
         assert result["prev_norm"] == 0.3
         assert result["current_norm"] == 0.1
-        assert result["norm_delta"] == pytest.approx(0.2)
+        # norm_delta follows the plain math convention current - prev; the norm
+        # dropped 0.3 -> 0.1, so the delta is negative (F3).
+        assert result["norm_delta"] == pytest.approx(-0.2)
+        # improvement is the trajectory-quality quantity (positive = drift dropped).
+        assert result["improvement"] == pytest.approx(0.2)
         assert 0.0 <= result["quality"] <= 1.0
         assert result["quality"] > 0.5  # improvement → quality above 0.5
 

--- a/tests/test_monitor_decision_fast_trip.py
+++ b/tests/test_monitor_decision_fast_trip.py
@@ -1,0 +1,82 @@
+"""Unit tests for the F2 latest-risk fast-trip in monitor_decision.
+
+The gate runs on the (possibly task-adjusted) risk_score. When the latest raw
+risk observation spiked past the pause threshold but the gated value cleared, a
+clean ``approve`` must be upgraded to ``guide`` so the spike is not silently
+approved. A genuine pause is never weakened.
+"""
+
+from types import SimpleNamespace
+
+from config.governance_config import config
+from src.monitor_decision import _maybe_latest_risk_fast_trip, make_decision
+
+
+def _healthy_state(risk_history):
+    return SimpleNamespace(
+        E=0.80, I=0.85, S=0.15, V=0.05,
+        coherence=0.90,
+        void_active=False,
+        coherence_history=[0.90, 0.90, 0.90],
+        risk_history=list(risk_history),
+    )
+
+
+class TestFastTripHelper:
+    def test_approve_upgraded_to_guide_on_latest_spike(self):
+        state = _healthy_state([0.10, 0.72])
+        decision = {"action": "proceed", "sub_action": "approve"}
+        out = _maybe_latest_risk_fast_trip(state, decision, gated_risk=0.20)
+        assert out["sub_action"] == "guide"
+        assert out["action"] == "proceed"
+        assert out["latest_risk_fast_trip"]["latest_risk"] == 0.72
+        assert out["latest_risk_fast_trip"]["gated_risk"] == 0.20
+
+    def test_no_trip_when_latest_below_threshold(self):
+        state = _healthy_state([0.10, 0.30])
+        decision = {"action": "proceed", "sub_action": "approve"}
+        out = _maybe_latest_risk_fast_trip(state, decision, gated_risk=0.20)
+        assert out["sub_action"] == "approve"
+        assert "latest_risk_fast_trip" not in out
+
+    def test_pause_never_weakened(self):
+        state = _healthy_state([0.10, 0.95])
+        decision = {"action": "pause", "sub_action": "risk_pause"}
+        out = _maybe_latest_risk_fast_trip(state, decision, gated_risk=0.20)
+        assert out["action"] == "pause"
+        assert out["sub_action"] == "risk_pause"
+
+    def test_existing_guide_left_intact(self):
+        state = _healthy_state([0.10, 0.72])
+        decision = {"action": "proceed", "sub_action": "guide", "reason": "orig"}
+        out = _maybe_latest_risk_fast_trip(state, decision, gated_risk=0.50)
+        # Already a guide — not re-stamped by the fast-trip.
+        assert out["sub_action"] == "guide"
+        assert out["reason"] == "orig"
+        assert "latest_risk_fast_trip" not in out
+
+    def test_no_trip_when_latest_equals_gated(self):
+        # When the gate already saw the latest value (no adjustment gap), the
+        # normal band logic owns the decision; the fast-trip must not double-fire.
+        state = _healthy_state([0.72])
+        decision = {"action": "proceed", "sub_action": "approve"}
+        out = _maybe_latest_risk_fast_trip(state, decision, gated_risk=0.72)
+        assert out["sub_action"] == "approve"
+
+
+class TestMakeDecisionIntegration:
+    def test_low_gated_risk_high_latest_yields_guide(self):
+        # gated risk well under the approve threshold -> config returns approve;
+        # latest raw observation is above the pause threshold -> fast-trip guides.
+        state = _healthy_state([0.10, 0.72])
+        decision = make_decision(state, risk_score=0.20, unitares_verdict="safe")
+        assert decision["action"] == "proceed"
+        assert decision["sub_action"] == "guide"
+        assert "latest_risk_fast_trip" in decision
+
+    def test_clean_low_risk_still_approves(self):
+        state = _healthy_state([0.10, 0.12])
+        decision = make_decision(state, risk_score=0.12, unitares_verdict="safe")
+        assert decision["action"] == "proceed"
+        assert decision["sub_action"] != "guide" or "latest_risk_fast_trip" not in decision
+        assert "latest_risk_fast_trip" not in decision

--- a/tests/test_monitor_result_novelty.py
+++ b/tests/test_monitor_result_novelty.py
@@ -151,6 +151,7 @@ def test_build_result_exposes_policy_and_unapplied_enforcement_layers():
             "nearest_edge": "coherence",
             "phi": 0.24,
             "risk_score": 0.72,
+            "risk_score_latest": None,
             "verdict": "high-risk",
             "void_active": False,
         },
@@ -162,7 +163,13 @@ def test_build_result_exposes_policy_and_unapplied_enforcement_layers():
         "mode": "circuit_breaker_candidate",
         "actor": None,
         "effect": None,
-        "note": "Policy requested enforcement; actuator state is applied by the caller/runtime boundary.",
+        "note": (
+            "Policy requested enforcement. This envelope is the pre-actuation "
+            "candidate; the authenticated update boundary applies it as a circuit "
+            "breaker (agent metadata -> status=paused, blocking later writes) and "
+            "overwrites this with applied=true. A non-actuating path (e.g. "
+            "simulate) leaves it unapplied."
+        ),
     }
 
 

--- a/tests/test_risk_discriminability.py
+++ b/tests/test_risk_discriminability.py
@@ -1,0 +1,40 @@
+"""F1(b) tests: risk_score must be flagged non-discriminative during bootstrap.
+
+During behavioral bootstrap the phi-based risk keys on baseline-deviation terms
+that sit near zero, so risk_score does not track absolute drift magnitude. The
+payload must carry an explicit discriminability caveat rather than emitting a
+confident margin-to-PAUSE in that window.
+"""
+
+from src.monitor_result import _build_risk_attribution
+
+
+def _metrics():
+    return {"risk_score": 0.26, "verdict": "safe"}
+
+
+def test_no_baseline_status_omits_discriminability():
+    # Back-compat: callers that pass no baseline_status get no new key.
+    attr = _build_risk_attribution(_metrics(), None, None, None)
+    assert "discriminability" not in attr
+
+
+def test_bootstrap_flags_non_discriminative():
+    status = {"is_baselined": False, "updates_completed": 4, "baseline_target": 30}
+    attr = _build_risk_attribution(_metrics(), None, None, None, baseline_status=status)
+    disc = attr["discriminability"]
+    assert disc["baselined"] is False
+    assert disc["non_discriminative"] is True
+    assert disc["updates_until_baseline"] == 26
+    assert disc["note"] is not None
+    assert "non-discriminative" in disc["note"]
+
+
+def test_baselined_clears_caveat():
+    status = {"is_baselined": True, "updates_completed": 35, "baseline_target": 30}
+    attr = _build_risk_attribution(_metrics(), None, None, None, baseline_status=status)
+    disc = attr["discriminability"]
+    assert disc["baselined"] is True
+    assert disc["non_discriminative"] is False
+    assert disc["updates_until_baseline"] == 0
+    assert disc["note"] is None


### PR DESCRIPTION
Addresses the v2.13.0 dogfood findings on the enforcement-weighted risk path, plus a doc/narrative reconciliation about the pause stage. Branched from `master` (independent of the in-flight dialectic-friction and README-positioning work).

## Findings fixed

**F3 — `norm_delta` sign inversion** (LOW). The internal "improvement" quantity (positive = drift dropped, feeds the trajectory-quality sigmoid) is split from the payload `norm_delta`, which now follows the plain convention `current − prev`. Adds an explicit `improvement` field.

**F2 — policy misses the latest spike** (HIGH). `monitor_decision` gains a fast-trip: a clean `approve` upgrades to `guide` when the latest raw risk observation crosses the pause threshold even though the gated (task-adjusted) value cleared. Never weakens a pause. `policy_evaluation.inputs` now surfaces `risk_score_latest` + a `latest_risk_fast_trip` marker, so the envelope shows what the gate ran on.

**F4 — HCK rho fires into a void** (MEDIUM).
1. `update_dynamics` now runs *before* the behavioral assessment, so cycle-N observations pair with cycle-N's ρ/CE. Previously an adversarial ρ spike surfaced in `hck.rho` while `adversarial_rho` stayed 0.0 (one-cycle lag).
2. The gain-modulation flag is propagated from `update_lambda1` to `monitor._gains_modulated` (it was initialized `False` and never set), with a per-cycle reset.

**F1(b) — interim honesty** (CRITICAL; 1a/v2 deferred). `risk_attribution` gains a `discriminability` block flagging `risk_score` as non-discriminative during behavioral bootstrap (`updates_until_baseline` + caveat), mirroring `restorative.suppressed`. The real fix (baseline-independent drift floor + v2 behavioral weighting) is left to F1a/v2 as the finding noted.

## Pause-stage narrative reconciliation

Investigated whether the docs oversell the pause stage. Conclusion: pause **is** enforced (circuit breaker at `agent_loop_detection.py` flips a check-in pause into `meta.status=paused`, blocks later writes, sets `enforcement.applied=true`) — the docs underspecified that and oversold drift-sensitivity during warmup.

- **README**: warmup caveat (verdict leans on self-reported signals until baselined; a worsening drift vector won't move the verdict during warmup; pause is enforced, not advisory).
- **`risk_attribution` behavioral note**: corrected the stale "not yet weighted into the enforcement verdict (reserved for v2)" — the per-agent behavioral signal *is* combined via `resolve_verdict_risk` once `confidence ≥ 0.3` (escalate-only, can't erase Φ); v2 = stronger verification weighting.
- **Enforcement-stub note**: sharpened to describe circuit-breaker actuation at the authenticated boundary.

## Tests

Adds `test_monitor_decision_fast_trip`, `test_hck_rho_coupling`, `test_risk_discriminability`; updates calibration/result/enforcement tests for the corrected semantics. Full suite green locally (10878 passed) on the codex base; 377 focused tests green on this master base. CI is the final full gate.

## Notes

- F2's fast-trip is a live enforcement-path behavior change (latent-spike `approve`→`guide`, never a pause). Negligible for steady agents. Can be flag-gated if preferred during the maths revamp.
- No overlap with the in-flight EISV maths-revamp branches (verified none touch these files).

https://claude.ai/code/session_01VsXq3pJjFtzdy7GCeJ4PBq