### PR TITLE
feat(sentinel-beam): emit boot build-stamp finding (git sha + version)

### DIFF
--- a/elixir/sentinel/lib/unitares_sentinel/application.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/application.ex
@@ -35,7 +35,28 @@ defmodule UnitaresSentinel.Application do
         fleet_state_children() ++
         websocket_children() ++ fleet_finding_emitter_children() ++ poller_children()
 
-    Supervisor.start_link(children, strategy: :one_for_one, name: UnitaresSentinel.Supervisor)
+    result =
+      Supervisor.start_link(children, strategy: :one_for_one, name: UnitaresSentinel.Supervisor)
+
+    maybe_emit_build_finding()
+    result
+  end
+
+  # Emit a one-shot build-info finding on boot so #alerts records exactly which
+  # commit the running node is on — makes "is the fix live?" answerable from the
+  # alert stream instead of an SSH-and-`git log` guess. Off the boot path (the
+  # findings POST is best-effort and Finch may still be warming), gated by the
+  # same :emit_findings flag the poller uses + Finch being enabled.
+  defp maybe_emit_build_finding do
+    info = UnitaresSentinel.BuildInfo.info()
+    Logger.info("BEAM Sentinel booted: #{info.summary}")
+
+    if Application.get_env(:unitares_sentinel, :emit_findings, true) and
+         Application.get_env(:unitares_sentinel, :start_finch, true) do
+      Task.start(fn -> UnitaresSentinel.Findings.post_build_info(info) end)
+    end
+
+    :ok
   end
 
   defp postgrex_children do

--- a/elixir/sentinel/lib/unitares_sentinel/build_info.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/build_info.ex
@@ -1,0 +1,102 @@
+defmodule UnitaresSentinel.BuildInfo do
+  @moduledoc """
+  Reports the git commit + app version the running BEAM Sentinel booted from.
+
+  Answers "is the merged fix actually live?" from the alert stream instead of
+  an SSH-and-`git log` guess — the running-process-vs-master-commit drift class
+  that has repeatedly masked deployed-but-not-running fixes (the lease-plane
+  #568 incident, the forced-release-alarm confusion this module follows from).
+
+  The SHA is read at RUNTIME (boot), not compile time, and on purpose: the
+  Sentinel runs via `mix run`, which recompiles changed modules on boot, but a
+  compile-time attribute in THIS module would only refresh when this file
+  itself changed — going stale whenever a commit touched other files. A runtime
+  `git rev-parse` in the node's working directory always reflects the actual
+  checkout being executed. Result is cached in `:persistent_term` after first
+  read (git is shelled out once per boot, never on a hot path).
+  """
+
+  @cache_key {__MODULE__, :info}
+
+  @type t :: %{
+          version: String.t(),
+          sha: String.t(),
+          dirty: boolean(),
+          summary: String.t()
+        }
+
+  @doc "Cached build info for this booted node."
+  @spec info() :: t()
+  def info do
+    case :persistent_term.get(@cache_key, nil) do
+      nil ->
+        detected = detect()
+        :persistent_term.put(@cache_key, detected)
+        detected
+
+      cached ->
+        cached
+    end
+  end
+
+  @spec version() :: String.t()
+  def version, do: info().version
+
+  @spec sha() :: String.t()
+  def sha, do: info().sha
+
+  @spec summary() :: String.t()
+  def summary, do: info().summary
+
+  @doc false
+  # Uncached probe — `info/0` is the caller-facing memoized entry point.
+  @spec detect() :: t()
+  def detect do
+    version = app_version()
+    sha = git_sha()
+    dirty = git_dirty?()
+    suffix = if dirty, do: " (dirty)", else: ""
+
+    %{
+      version: version,
+      sha: sha,
+      dirty: dirty,
+      summary: "unitares_sentinel #{version} @#{sha}#{suffix}"
+    }
+  end
+
+  defp app_version do
+    case Application.spec(:unitares_sentinel, :vsn) do
+      vsn when is_list(vsn) -> List.to_string(vsn)
+      _ -> "unknown"
+    end
+  end
+
+  defp git_sha do
+    case run_git(["rev-parse", "--short=12", "HEAD"]) do
+      {:ok, out} when out != "" -> out
+      _ -> "unknown"
+    end
+  end
+
+  defp git_dirty? do
+    case run_git(["status", "--porcelain"]) do
+      {:ok, ""} -> false
+      {:ok, _changes} -> true
+      :error -> false
+    end
+  end
+
+  # Best-effort: git missing from PATH, a non-repo cwd, or any error degrades to
+  # :error (→ "unknown" sha / not-dirty). Never raises into the boot path.
+  defp run_git(args) do
+    case System.cmd("git", args, stderr_to_stdout: true) do
+      {out, 0} -> {:ok, String.trim(out)}
+      _ -> :error
+    end
+  rescue
+    _ -> :error
+  catch
+    _, _ -> :error
+  end
+end

--- a/elixir/sentinel/lib/unitares_sentinel/findings.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/findings.ex
@@ -44,6 +44,33 @@ defmodule UnitaresSentinel.Findings do
     |> post_json(opts)
   end
 
+  @doc """
+  POST a one-shot build-info finding (`sentinel_build_finding`, severity info)
+  so the alert stream records exactly which commit the running node booted from
+  — the queryable answer to "is the merged fix actually live?".
+
+  The fingerprint includes the sha, so a boot onto NEW code emits a fresh
+  finding while a reboot onto the SAME code dedups (no per-restart spam).
+  Takes a `UnitaresSentinel.BuildInfo.t()` map.
+  """
+  @spec post_build_info(map(), keyword()) :: boolean()
+  def post_build_info(info, opts \\ []) when is_map(info) do
+    sha = Map.get(info, :sha, "unknown")
+
+    %{
+      "type" => "sentinel_build_finding",
+      "severity" => "info",
+      "message" => "BEAM Sentinel booted: " <> Map.get(info, :summary, sha),
+      "agent_id" => agent_id(opts),
+      "agent_name" => agent_name(opts),
+      "fingerprint" => compute_fingerprint(["sentinel", "build", sha]),
+      "git_sha" => sha,
+      "version" => Map.get(info, :version, "unknown"),
+      "dirty" => Map.get(info, :dirty, false)
+    }
+    |> post_json(opts)
+  end
+
   @doc false
   @spec alarm_body(UnitaresSentinel.ForcedReleasePoller.Logic.alarm(), keyword()) :: map()
   def alarm_body(alarm, opts \\ []) when is_map(alarm) do

--- a/elixir/sentinel/test/unitares_sentinel/build_info_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/build_info_test.exs
@@ -1,0 +1,89 @@
+defmodule UnitaresSentinel.BuildInfoTest do
+  @moduledoc """
+  Pure tests for the boot build-stamp: BuildInfo shape/caching and the
+  `Findings.post_build_info/2` payload. No DB or network — the findings POST
+  is exercised through an injected `:http_post`.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias UnitaresSentinel.{BuildInfo, Findings}
+
+  describe "BuildInfo.info/0" do
+    test "returns version, sha, dirty, summary with expected shapes" do
+      info = BuildInfo.info()
+
+      assert is_binary(info.version)
+      assert is_binary(info.sha)
+      assert is_boolean(info.dirty)
+      assert is_binary(info.summary)
+      # Summary is self-describing: app name + version + sha marker.
+      assert info.summary =~ "unitares_sentinel"
+      assert info.summary =~ info.version
+      assert info.summary =~ "@"
+    end
+
+    test "is cached — repeat calls return the identical map" do
+      assert BuildInfo.info() == BuildInfo.info()
+    end
+
+    test "convenience accessors agree with info/0" do
+      info = BuildInfo.info()
+      assert BuildInfo.version() == info.version
+      assert BuildInfo.sha() == info.sha
+      assert BuildInfo.summary() == info.summary
+    end
+  end
+
+  describe "Findings.post_build_info/2" do
+    test "posts a sentinel_build_finding with the sha in body + fingerprint" do
+      parent = self()
+
+      http_post = fn _url, body, _headers, _timeout ->
+        send(parent, {:posted, body})
+        {:ok, 200, ~s({"success": true})}
+      end
+
+      info = %{
+        version: "0.1.0",
+        sha: "abc123def456",
+        dirty: false,
+        summary: "unitares_sentinel 0.1.0 @abc123def456"
+      }
+
+      assert Findings.post_build_info(info, http_post: http_post) == true
+
+      assert_receive {:posted, body}
+      # Gateway requires the `_finding` suffix on the event type.
+      assert body["type"] == "sentinel_build_finding"
+      assert body["severity"] == "info"
+      assert body["git_sha"] == "abc123def456"
+      assert body["version"] == "0.1.0"
+      assert body["dirty"] == false
+      assert body["message"] =~ "abc123def456"
+      # Fingerprint keys on the sha → new code = fresh finding, same code dedups.
+      assert body["fingerprint"] == Findings.compute_fingerprint(["sentinel", "build", "abc123def456"])
+    end
+
+    test "a different sha yields a different fingerprint (dedup distinctness)" do
+      capture = fn ->
+        parent = self()
+
+        http_post = fn _url, body, _headers, _timeout ->
+          send(parent, {:fp, body["fingerprint"]})
+          {:ok, 200, ~s({"success": true})}
+        end
+
+        &Findings.post_build_info(&1, http_post: http_post)
+      end
+
+      poster = capture.()
+      poster.(%{version: "0.1.0", sha: "aaaaaaaaaaaa", dirty: false, summary: "s @aaaaaaaaaaaa"})
+      poster.(%{version: "0.1.0", sha: "bbbbbbbbbbbb", dirty: false, summary: "s @bbbbbbbbbbbb"})
+
+      assert_receive {:fp, fp_a}
+      assert_receive {:fp, fp_b}
+      assert fp_a != fp_b
+    end
+  end
+end


### PR DESCRIPTION
## Why

Today's debugging — "the forced-release fix is merged, but Sentinel *still* alerts" — came down to the running BEAM node executing **pre-merge code**, with **no way to tell from the alert stream which commit emitted a finding**. Answering "is the fix live?" required SSHing the Mac and `git log`-ing the checkout. That's the running-process-vs-master-commit drift class, and it keeps recurring (lease-plane #568, the :8788 outage, this).

This makes it queryable: the alert stream itself records what code is running.

## What

- **`UnitaresSentinel.BuildInfo`** — reads the booted checkout's **git SHA + app version at runtime**, cached in `:persistent_term`. Runtime (not compile-time) on purpose: the Sentinel runs via `mix run`, which recompiles changed modules on boot — a compile-time attribute in this module would go stale whenever a commit touched *other* files. A `git rev-parse` in the node's cwd always reflects the actual running checkout. Degrades to `"unknown"` if git is unavailable; never raises into boot.
- **Boot emit** — on startup the Application posts a one-shot `sentinel_build_finding` (severity `info`): *"BEAM Sentinel booted: unitares_sentinel \<vsn\> @\<sha\>"*. Best-effort, off the boot path, gated by the existing `:emit_findings` flag.
- **Dedup-friendly fingerprint** — keyed on the SHA: a boot onto **new** code emits a fresh finding; a same-code reboot dedups (no per-restart spam).

## Result

After any restart, `#alerts` shows exactly which commit the Sentinel is on. Next time "merged but still alerting" happens, the build finding answers it instantly — and you can compare the SHA against `origin/master` without leaving the alert feed.

## Tests

Pure, DB-free (run under the new `Elixir Tests` CI from #1116): `BuildInfo` shape + caching + accessors, and `Findings.post_build_info/2` payload via an injected `http_post` (asserts type/severity/git_sha/message and SHA-keyed fingerprint distinctness).

## Note

This is a diagnostics/observability improvement — it does **not** change forced-release alarm behavior (that's #1102/#1114, already merged). It pairs with restarting `com.unitares.sentinel-beam` to load those fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BzBQCXUkx8NshtxPGSTPo1)_