### PR TITLE
[codex] fix MCP OAuth 401 auth gate

### DIFF
--- a/docs/FLAGS.md
+++ b/docs/FLAGS.md
@@ -73,6 +73,7 @@ index; that one is the curated decision record.
 | `UNITARES_NX_FAIL_CLOSED` | `''` | read by _nx_fail_closed_enabled() | src/mcp_handlers/identity/persistence.py:44 |
 | `UNITARES_OAUTH_AUTO_APPROVE` | `'true'` | — | src/mcp_server.py:192 |
 | `UNITARES_OAUTH_ISSUER_URL` | `(required)` | — | src/mcp_server.py:182 |
+| `UNITARES_OAUTH_RESOURCE_URL` | `'<issuer>/mcp'` | Optional OAuth protected-resource URL override | src/mcp_server.py:194 |
 | `UNITARES_OAUTH_SECRET` | `(required)` | — | src/mcp_server.py:191 |
 | `UNITARES_OLLAMA_BASE` | `'http://localhost:11434'` | Native Ollama /api/chat endpoint (supports JSON-schema-constrained output via the `format` field) | src/mcp_handlers/support/llm_delegation.py:168 |
 | `UNITARES_OLLAMA_BASE_URL` | `'http://localhost:11434/v1'` | — | agents/dialectic_reviewer/reviewer.py:37 |

--- a/docs/integration/MCP_CLIENTS.md
+++ b/docs/integration/MCP_CLIENTS.md
@@ -109,7 +109,10 @@ tool runs:
      server then advertises Dynamic Client Registration, so a DCR-capable
      client (e.g. Claude.ai custom connector) leaves client_id/client_secret
      blank and self-registers. Note: client registrations are in-memory and
-     reset on restart. See `src/oauth_provider.py`.
+     reset on restart. The protected MCP resource defaults to
+     `<UNITARES_OAUTH_ISSUER_URL>/mcp`; set `UNITARES_OAUTH_RESOURCE_URL` only
+     if a reverse proxy exposes the MCP resource at a different public URL.
+     See `src/oauth_provider.py`.
 
 The Host allowlist applies regardless of the auth choice — set it even when
 using "none" locally is fine, but for a public host you need both the
@@ -120,7 +123,7 @@ outside:
 
 ```bash
 curl -i https://gov.example.org/mcp/ -H 'Accept: text/event-stream'
-# 403 gone -> Host gate open. 401 -> bearer gate is on (expected once a key is set).
+# 403 gone -> Host gate open. 401 -> auth gate is on (expected before the client sends a valid bearer/OAuth access token).
 ```
 
 ## Agent Identity

--- a/docs/manual/03-running-the-server.md
+++ b/docs/manual/03-running-the-server.md
@@ -89,13 +89,13 @@ python src/mcp_server.py --port 8767
    export UNITARES_MCP_BEARER_TOKENS="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
    ```
 
-   Comma-separated values rotate without a restart. For OAuth 2.1 with Dynamic Client Registration, set `UNITARES_OAUTH_ISSUER_URL` instead (see [`../integration/MCP_CLIENTS.md`](../integration/MCP_CLIENTS.md#remote-connectors-claudeai-perplexity-etc) and `src/oauth_provider.py`).
+   Comma-separated values rotate without a restart. For OAuth 2.1 with Dynamic Client Registration, set `UNITARES_OAUTH_ISSUER_URL` instead (see [`../integration/MCP_CLIENTS.md`](../integration/MCP_CLIENTS.md#remote-connectors-claudeai-perplexity-etc) and `src/oauth_provider.py`). OAuth protects the `/mcp` resource by default; use `UNITARES_OAUTH_RESOURCE_URL` only if a proxy exposes it at a different public URL.
 
 After changing any of these, restart and sanity-check from outside:
 
 ```bash
 curl -i https://gov.example.org/mcp/ -H 'Accept: text/event-stream'
-# 403 gone → Host gate open. 401 → bearer gate on (expected once a key is set).
+# 403 gone → Host gate open. 401 → auth gate on (expected before the client sends a valid bearer/OAuth access token).
 ```
 
 ## 3.6 Key environment variables
@@ -110,6 +110,7 @@ curl -i https://gov.example.org/mcp/ -H 'Accept: text/event-stream'
 | `UNITARES_MCP_ALLOWED_HOSTS` / `UNITARES_MCP_ALLOWED_ORIGINS` | Host/Origin allowlists |
 | `UNITARES_MCP_BEARER_TOKENS` | Bearer auth (comma-separated, hot-rotatable) |
 | `UNITARES_OAUTH_ISSUER_URL` | Enable OAuth 2.1 / DCR |
+| `UNITARES_OAUTH_RESOURCE_URL` | Optional OAuth protected-resource URL override (defaults to `<issuer>/mcp`) |
 | `UNITARES_HTTP_API_TOKEN` / `UNITARES_OPERATOR_TOKENS` | Dashboard read / operator-write tokens |
 | `UNITARES_RESIDENTS` | The named resident agent set (config, not hardcoded) |
 

--- a/src/mcp_listen_config.py
+++ b/src/mcp_listen_config.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import hmac
 import os
+import time
 from typing import List, Optional
 
 from mcp.server.transport_security import TransportSecuritySettings
@@ -125,14 +126,57 @@ def check_mcp_bearer(
         allow = mcp_bearer_tokens()
     if not allow:
         return True  # gate off — default posture
-    if not authorization_header:
-        return False
-    # RFC 7235: the auth scheme is case-insensitive. Accept "Bearer"/"bearer"/etc.
-    scheme, _, presented = authorization_header.partition(" ")
-    if scheme.lower() != "bearer":
-        return False
-    presented = presented.strip()
+    presented = bearer_token_from_authorization(authorization_header)
     if not presented:
         return False
     # Constant-time membership test over a small allowlist.
     return any(hmac.compare_digest(presented, tok) for tok in allow)
+
+
+def bearer_token_from_authorization(authorization_header: Optional[str]) -> Optional[str]:
+    """Return the bearer token from an Authorization header, if present."""
+    if not authorization_header:
+        return None
+    # RFC 7235: the auth scheme is case-insensitive. Accept "Bearer"/"bearer"/etc.
+    scheme, _, presented = authorization_header.partition(" ")
+    if scheme.lower() != "bearer":
+        return None
+    presented = presented.strip()
+    return presented or None
+
+
+async def check_oauth_bearer(
+    authorization_header: Optional[str],
+    provider,
+    required_scopes: Optional[List[str]] = None,
+) -> tuple[bool, Optional[str]]:
+    """Validate an OAuth bearer token against an MCP SDK auth provider.
+
+    Returns ``(allowed, client_id)``. OAuth is separate from the static hosted
+    bearer allowlist above: a DCR client presents a provider-minted access
+    token, not a value from ``UNITARES_MCP_BEARER_TOKENS``.
+    """
+    token = bearer_token_from_authorization(authorization_header)
+    if not token or provider is None:
+        return False, None
+
+    try:
+        access_token = await provider.load_access_token(token)
+    except Exception:
+        return False, None
+
+    if access_token is None:
+        return False, None
+
+    expires_at = getattr(access_token, "expires_at", None)
+    if expires_at and expires_at < int(time.time()):
+        return False, None
+
+    required = required_scopes or []
+    if required:
+        scopes = set(getattr(access_token, "scopes", None) or [])
+        if any(scope not in scopes for scope in required):
+            return False, None
+
+    client_id = getattr(access_token, "client_id", None)
+    return True, client_id if isinstance(client_id, str) else None

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -173,6 +173,7 @@ SERVER_VERSION = _load_version()
 from src.mcp_listen_config import (
     build_transport_security_settings,
     check_mcp_bearer,
+    check_oauth_bearer,
     cors_extra_origins,
     default_listen_host,
     mcp_bearer_tokens,
@@ -182,6 +183,7 @@ from src.mcp_listen_config import (
 _oauth_issuer_url = os.environ.get("UNITARES_OAUTH_ISSUER_URL")
 _oauth_provider = None
 _auth_settings = None
+_OAUTH_REQUIRED_SCOPES = ["mcp:tools"]
 
 if _oauth_issuer_url:
     try:
@@ -190,10 +192,15 @@ if _oauth_issuer_url:
 
         _oauth_secret = os.environ.get("UNITARES_OAUTH_SECRET")
         _auto_approve = os.environ.get("UNITARES_OAUTH_AUTO_APPROVE", "true").lower() in ("true", "1", "yes")
+        _oauth_resource_url = (
+            os.environ.get("UNITARES_OAUTH_RESOURCE_URL")
+            or f"{_oauth_issuer_url.rstrip('/')}/mcp"
+        )
         _oauth_provider = GovernanceOAuthProvider(secret=_oauth_secret, auto_approve=_auto_approve)
         _auth_settings = AuthSettings(
             issuer_url=_oauth_issuer_url,
-            resource_server_url=_oauth_issuer_url,
+            resource_server_url=_oauth_resource_url,
+            required_scopes=_OAUTH_REQUIRED_SCOPES,
             client_registration_options=ClientRegistrationOptions(
                 enabled=True,
                 valid_scopes=["mcp:tools"],
@@ -926,23 +933,55 @@ async def main():
                 if scope.get("type") != "http":
                     return
 
-                # Bearer gate (default-OFF; see src/mcp_listen_config). When
-                # UNITARES_MCP_BEARER_TOKENS is set, every /mcp request must
-                # present a matching `Authorization: Bearer <tok>`. No trusted-
-                # network bypass — a hosted endpoint authenticates every call.
-                # When unset, this is a no-op and localhost dev is unchanged.
-                # Fetch the allowlist once and pass it through, so "is the gate
-                # on" and "is this token valid" read the same snapshot.
+                # Auth gate (default-OFF unless bearer or OAuth is configured).
+                # UNITARES_MCP_BEARER_TOKENS accepts static operator-minted
+                # tokens. UNITARES_OAUTH_ISSUER_URL accepts provider-minted
+                # OAuth access tokens. No trusted-network bypass — a hosted
+                # endpoint authenticates every call. Fetch the static allowlist
+                # once and pass it through, so "is the gate on" and "is this
+                # token valid" read the same snapshot.
+                validated_oauth_client_id = None
                 _bearer_allow = mcp_bearer_tokens()
-                if _bearer_allow:
+                if _bearer_allow or _oauth_provider:
                     from starlette.datastructures import Headers as _BearerHeaders
                     _auth = _BearerHeaders(scope=scope).get("authorization")
-                    if not check_mcp_bearer(_auth, _bearer_allow):
+                    _static_bearer_ok = bool(_bearer_allow) and check_mcp_bearer(_auth, _bearer_allow)
+                    _oauth_bearer_ok = False
+                    if _oauth_provider:
+                        _oauth_bearer_ok, _oauth_client_id = await check_oauth_bearer(
+                            _auth,
+                            _oauth_provider,
+                            required_scopes=(
+                                _auth_settings.required_scopes
+                                if _auth_settings
+                                else _OAUTH_REQUIRED_SCOPES
+                            ),
+                        )
+                        if _oauth_client_id:
+                            validated_oauth_client_id = f"oauth:{_oauth_client_id}"
+
+                    if not (_static_bearer_ok or _oauth_bearer_ok):
+                        _www_authenticate = "Bearer"
+                        if _auth_settings and _auth_settings.resource_server_url:
+                            try:
+                                from mcp.server.auth.routes import build_resource_metadata_url
+                                _resource_metadata_url = build_resource_metadata_url(
+                                    _auth_settings.resource_server_url
+                                )
+                                _www_authenticate = (
+                                    f'Bearer resource_metadata="{_resource_metadata_url}"'
+                                )
+                            except Exception:
+                                pass
                         await JSONResponse(
                             {"error": "unauthorized",
-                             "detail": "valid bearer token required for /mcp"},
+                             "detail": (
+                                 "valid bearer token or OAuth access token required for /mcp"
+                                 if _oauth_provider
+                                 else "valid bearer token required for /mcp"
+                             )},
                             status_code=401,
-                            headers={"WWW-Authenticate": "Bearer"},
+                            headers={"WWW-Authenticate": _www_authenticate},
                         )(scope, receive, send)
                         return
 
@@ -971,17 +1010,9 @@ async def main():
                     x_session_id = headers.get("x-session-id")
                     x_client_id = headers.get("x-client-id") or headers.get("x-mcp-client-id")
 
-                    # Extract OAuth client identity from Bearer token
-                    oauth_client_id = None
-                    auth_header = headers.get("authorization", "")
-                    if auth_header.startswith("Bearer "):
-                        token = auth_header[7:]
-                        try:
-                            client_id = _oauth_provider.get_token_client_id(token) if _oauth_provider else None
-                            if client_id:
-                                oauth_client_id = f"oauth:{client_id}"
-                        except Exception:
-                            pass
+                    # OAuth client identity is set only after the auth gate has
+                    # validated the provider-minted access token.
+                    oauth_client_id = validated_oauth_client_id
 
                     detected_client = detect_client_from_user_agent(ua)
                     ip_ua_fp = f"{client_ip}:{ua_fingerprint}"

--- a/tests/test_mcp_bearer_gate.py
+++ b/tests/test_mcp_bearer_gate.py
@@ -10,8 +10,10 @@ on-path accept/reject rules — plus the deliberate no-trusted-bypass design.
 from __future__ import annotations
 
 import importlib
+import time
 
 import pytest
+from mcp.server.auth.provider import AccessToken
 
 import src.mcp_listen_config as cfg
 
@@ -62,6 +64,89 @@ def test_bearer_scheme_is_case_insensitive(monkeypatch, header):
     # RFC 7235: the auth scheme is case-insensitive. Real clients send "bearer".
     monkeypatch.setenv("UNITARES_MCP_BEARER_TOKENS", "s3cret")
     assert cfg.check_mcp_bearer(header) is True
+
+
+class _OAuthProvider:
+    def __init__(self, tokens):
+        self.tokens = tokens
+
+    async def load_access_token(self, token):
+        return self.tokens.get(token)
+
+
+@pytest.mark.asyncio
+async def test_oauth_bearer_accepts_provider_token():
+    provider = _OAuthProvider({
+        "oauth-token": AccessToken(
+            token="oauth-token",
+            client_id="client-1",
+            scopes=["mcp:tools"],
+            expires_at=int(time.time()) + 60,
+        )
+    })
+
+    ok, client_id = await cfg.check_oauth_bearer(
+        "Bearer oauth-token",
+        provider,
+        required_scopes=["mcp:tools"],
+    )
+
+    assert ok is True
+    assert client_id == "client-1"
+
+
+@pytest.mark.asyncio
+async def test_oauth_bearer_rejects_unknown_token():
+    ok, client_id = await cfg.check_oauth_bearer(
+        "Bearer missing",
+        _OAuthProvider({}),
+        required_scopes=["mcp:tools"],
+    )
+
+    assert ok is False
+    assert client_id is None
+
+
+@pytest.mark.asyncio
+async def test_oauth_bearer_rejects_missing_required_scope():
+    provider = _OAuthProvider({
+        "oauth-token": AccessToken(
+            token="oauth-token",
+            client_id="client-1",
+            scopes=["profile"],
+            expires_at=int(time.time()) + 60,
+        )
+    })
+
+    ok, client_id = await cfg.check_oauth_bearer(
+        "Bearer oauth-token",
+        provider,
+        required_scopes=["mcp:tools"],
+    )
+
+    assert ok is False
+    assert client_id is None
+
+
+@pytest.mark.asyncio
+async def test_oauth_bearer_rejects_expired_token():
+    provider = _OAuthProvider({
+        "oauth-token": AccessToken(
+            token="oauth-token",
+            client_id="client-1",
+            scopes=["mcp:tools"],
+            expires_at=int(time.time()) - 1,
+        )
+    })
+
+    ok, client_id = await cfg.check_oauth_bearer(
+        "Bearer oauth-token",
+        provider,
+        required_scopes=["mcp:tools"],
+    )
+
+    assert ok is False
+    assert client_id is None
 
 
 def test_token_rotation_accepts_any_listed(monkeypatch):


### PR DESCRIPTION
## Summary
- accept provider-minted OAuth access tokens in the custom /mcp ASGI auth gate
- require OAuth auth when UNITARES_OAUTH_ISSUER_URL is configured, instead of falling through open when no static bearer list exists
- advertise the /mcp protected-resource URL and document UNITARES_OAUTH_RESOURCE_URL for unusual proxy paths

## Root cause
The repo uses a custom /mcp mount that delegates directly to StreamableHTTPSessionManager. That bypasses the SDK's normal streamable_http_app auth middleware, so the local static bearer gate was the only enforcement point. OAuth access tokens were not accepted by that static gate, producing 401s for DCR/OAuth clients after connector registration.

## Validation
- python3 -m pytest tests/test_mcp_bearer_gate.py tests/test_oauth_provider.py tests/test_rest_auth_align.py
- python3 -m py_compile src/mcp_listen_config.py src/mcp_server.py
- ./scripts/dev/test-cache.sh --quick
- ./scripts/dev/test-cache.sh
- pre-push smoke: 138 passed