### PR TITLE
docs: align ablation reports with state-estimation framing

### DIFF
--- a/docs/operations/ablation-initiates-finding-2026-06-16.md
+++ b/docs/operations/ablation-initiates-finding-2026-06-16.md
@@ -100,17 +100,17 @@ All 30-day task slices remain skeptical.
   row, classified its provenance, bound it to a prediction, incorporated it into
   the matrix, and the watchdog noticed the delta. Targeted tests still pass
   (16 passed).
-- **Diagnostic signal — weak / interesting.** One strict slice now beats baseline,
-  but strict n=1 bad is too fragile to read as lift.
+- **Online state-estimation signal — weak / interesting.** One strict slice now
+  beats baseline, but strict n=1 bad is too fragile to read as lift.
 - **Governance policy — not proven.** The row's `decision_action = proceed`.
 - **Enforcement / prevention — not shown.** Nothing here blocked, paused,
   rejected, or reverted an adverse effect; this is a captured negative-label row.
 
 The most interesting angle: this is an **overconfidence case** — high reported
 confidence (~0.915) while a hard external test failed and the decision was
-`proceed`. That is a clean label for "confidence was high, outcome was bad," which
-is exactly the failure mode UNITARES cares about — captured as calibration
-evidence, not caught-and-stopped.
+`proceed`. That is a clean label for "confidence was high, outcome was bad,"
+which is exactly the state-estimation failure mode UNITARES cares about —
+captured as calibration evidence, not caught-and-stopped.
 
 ## Evidence discipline — what would move this forward
 

--- a/scripts/analysis/eisv_ablation_matrix.py
+++ b/scripts/analysis/eisv_ablation_matrix.py
@@ -442,8 +442,8 @@ def format_matrix_report(
     lines.extend(
         [
             "",
-            "Interpretation rule: this matrix does not validate EISV as ontology. `Bad` means rows labeled `is_bad=true` by external/rubric evidence; it is not a moral verdict or a count of prevented outcomes.",
-            "It only checks whether EISV/prior-state fields add measurable predictive signal over a simple previous-outcome baseline across slices; it does not make EISV the bad-verdict authority.",
+            "Interpretation rule: this matrix evaluates online agent-state estimation, not bad-action prevention. `Bad` means rows labeled `is_bad=true` by external/rubric evidence; it is not a moral verdict or a count of prevented outcomes.",
+            "It only checks whether EISV/prior-state fields add measurable predictive signal over a simple previous-outcome baseline across slices; it does not make EISV an outcome oracle, bad-verdict authority, or bad-agent detector.",
         ]
     )
     return "\n".join(lines)

--- a/scripts/analysis/eisv_skeptic_report.py
+++ b/scripts/analysis/eisv_skeptic_report.py
@@ -1037,8 +1037,8 @@ def build_report(
     a(conclusion)
     a("")
     a(
-        "Interpretation rule: EISV is proprioceptive telemetry, not an "
-        "outcome oracle or bad-verdict dispenser."
+        "Interpretation rule: EISV is online agent-state estimation "
+        "(agent proprioception), not an outcome oracle or bad-verdict dispenser."
     )
     a("Outcome labels come from external evidence/rubrics; this report only checks")
     a("whether EISV/prior-state fields add measurable predictive signal over simpler")

--- a/scripts/analysis/outcome_inventory.py
+++ b/scripts/analysis/outcome_inventory.py
@@ -439,7 +439,7 @@ def format_inventory_report(
         "## Interpretation rule",
         "",
         "`bad` is an outcome-label class (`is_bad=true`), not a moral verdict or a prevented outcome. CI/test failure is task-negative evidence; strict governance-bad claims require external outcome evidence for contract, authority, or harm boundaries.",
-        "EISV is proprioceptive telemetry and policy input, not a bad-verdict dispenser, outcome-truth source, or enforcement evidence.",
+        "EISV is online agent-state estimation (agent proprioception) and policy input, not a bad-verdict dispenser, outcome-truth source, or enforcement evidence.",
         "",
         "## Harness Lane Summary",
         "",

--- a/scripts/analysis/prospective_prediction_cohort.py
+++ b/scripts/analysis/prospective_prediction_cohort.py
@@ -218,8 +218,8 @@ def format_cohort_report(
             *readiness_lines,
             "",
             "Interpretation rule: this is registry-bound prediction coverage for future holdout scoring (prospective holdout), not a grand jury. "
-            "It counts predictions that existed before outcomes; EISV remains proprioceptive telemetry, "
-            "not an outcome oracle or bad-verdict dispenser, unless a frozen holdout later beats boring baselines with external labels.",
+            "It counts predictions that existed before outcomes; EISV remains online agent-state estimation (agent proprioception), "
+            "not an outcome oracle or bad-verdict dispenser. A frozen holdout can support predictive-signal claims; external labels still own outcome truth.",
         ]
     )
 

--- a/tests/test_eisv_ablation_matrix.py
+++ b/tests/test_eisv_ablation_matrix.py
@@ -277,9 +277,13 @@ def test_format_matrix_report_contains_skeptical_ablation_table():
     assert "[0.010, 0.050]" in report
     assert "[0.0020, 0.0200]" in report
     assert "0.040" in report
+    assert "online agent-state estimation" in report
+    assert "not bad-action prevention" in report
     assert "`Bad` means rows labeled `is_bad=true`" in report
     assert "not a moral verdict or a count of prevented outcomes" in report
+    assert "outcome oracle" in report
     assert "bad-verdict authority" in report
+    assert "bad-agent detector" in report
     assert "prior_risk_binned" in report
     assert "KEEP TESTING" in report
 

--- a/tests/test_eisv_semantic_contract.py
+++ b/tests/test_eisv_semantic_contract.py
@@ -88,6 +88,8 @@ def test_reports_preserve_proprioception_and_outcome_oracle_boundary():
         train_fraction=0.7,
         generated_at=rows[0].ts + timedelta(days=1),
     )
+    assert "online agent-state estimation" in skeptic_report
+    assert "agent proprioception" in skeptic_report
     assert "not an outcome oracle or bad-verdict dispenser" in skeptic_report
     assert "Outcome labels come from external evidence/rubrics" in skeptic_report
 
@@ -110,6 +112,7 @@ def test_reports_preserve_proprioception_and_outcome_oracle_boundary():
     )
     assert "`bad` is an outcome-label class (`is_bad=true`)" in inventory_report
     assert "not a moral verdict or a prevented outcome" in inventory_report
+    assert "online agent-state estimation (agent proprioception)" in inventory_report
     assert "not a bad-verdict dispenser" in inventory_report
     assert "CI/test failure is task-negative evidence" in inventory_report
 
@@ -118,5 +121,7 @@ def test_reports_preserve_proprioception_and_outcome_oracle_boundary():
     )
     cohort_report = format_cohort_report(cohort_summary)
     assert "not a grand jury" in cohort_report
+    assert "online agent-state estimation (agent proprioception)" in cohort_report
     assert "not an outcome oracle or bad-verdict dispenser" in cohort_report
+    assert "external labels still own outcome truth" in cohort_report
     assert "registry-bound prediction coverage for future holdout scoring" in cohort_report

--- a/tests/test_outcome_inventory.py
+++ b/tests/test_outcome_inventory.py
@@ -285,6 +285,7 @@ def test_format_inventory_report_exposes_zero_bad_strict_and_prior_coverage():
     assert "strict_bad_gap_to_min: 10" in report
     assert "`bad` is an outcome-label class (`is_bad=true`)" in report
     assert "not a moral verdict or a prevented outcome" in report
+    assert "online agent-state estimation (agent proprioception)" in report
     assert "not a bad-verdict dispenser" in report
     assert "task_failed" in report
     assert "prior_state_5m" in report

--- a/tests/test_prospective_prediction_cohort.py
+++ b/tests/test_prospective_prediction_cohort.py
@@ -90,7 +90,9 @@ def test_format_cohort_report_keeps_holdout_language_and_lane_counts():
     assert "prediction_bound_prior_state: 1/2" in report
     assert "harness_lanes: beam=1,substrate=1" in report
     assert "prospective holdout" in report
+    assert "online agent-state estimation (agent proprioception)" in report
     assert "not an outcome oracle or bad-verdict dispenser" in report
+    assert "external labels still own outcome truth" in report
 
 
 def test_evaluate_readiness_reports_strong_when_thresholds_are_met():


### PR DESCRIPTION
## Summary
- Aligns ablation/inventory/generated report language with the merged online agent-state estimation framing.
- Makes ablation reports explicitly say they evaluate state-estimation signal, not bad-action prevention or bad-agent detection.
- Keeps external labels as outcome truth and updates regression assertions for generated reports.

## Verification
- `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 -m pytest tests/test_eisv_ablation_matrix.py tests/test_outcome_inventory.py tests/test_eisv_semantic_contract.py tests/test_prospective_prediction_cohort.py -q -o 'addopts='` → 25 passed
- `git diff --check` → passed
- `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 scripts/diagnostics/check_doc_drift.py` → Doc drift check passed
- analysis CLI help smoke for ablation/inventory/skeptic/prospective scripts → passed
- `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 ./scripts/dev/test-cache.sh` → 10865 passed, 21 skipped
