### PR TITLE
feat(identity): shadow dual-write session bindings + onboard pins (Redis-retirement Phase 1A)

### DIFF
--- a/config/governance_config.py
+++ b/config/governance_config.py
@@ -1083,6 +1083,30 @@ def grounding_apply_enabled() -> bool:
     return os.getenv("UNITARES_GROUNDING_APPLY", "").strip().lower() in {"1", "true", "on", "yes"}
 
 
+def session_mirror_shadow_enabled() -> bool:
+    """Whether to dual-write session/identity bindings into the PostgreSQL mirror
+    tables (core.session_bindings, core.onboard_pins) alongside the Redis writes
+    (UNITARES_SESSION_MIRROR_SHADOW). Default off.
+
+    Behavior-neutral: Redis stays the authoritative read source; the PG writes
+    are best-effort (failures swallowed) and nothing reads the mirror yet. Lets
+    the durable mirror be populated and its write-path parity measured before the
+    read flip. Redis-retirement Phase 1A — see
+    docs/proposals/redis-retirement-phase-1-plan.md.
+    """
+    return os.getenv("UNITARES_SESSION_MIRROR_SHADOW", "").strip().lower() in {"1", "true", "on", "yes"}
+
+
+def session_mirror_apply_enabled() -> bool:
+    """Whether the resolver READS the PostgreSQL session mirror as a source of
+    truth (UNITARES_SESSION_MIRROR_APPLY). Default off. LIVE-AFFECTING when on:
+    PATH 2 resolves from core.session_bindings and pin lookup reads
+    core.onboard_pins. Only flip after session_mirror_shadow parity is proven.
+    Not wired in this PR — the read flip is a separate change.
+    """
+    return os.getenv("UNITARES_SESSION_MIRROR_APPLY", "").strip().lower() in {"1", "true", "on", "yes"}
+
+
 def get_s_setpoint(agent_class: str = "default") -> float:
     """Per-class S decay target σ for the dynamics.
 

--- a/db/postgres/migrations/051_session_mirror_tables.sql
+++ b/db/postgres/migrations/051_session_mirror_tables.sql
@@ -1,0 +1,74 @@
+-- 051_session_mirror_tables.sql
+--
+-- Redis-retirement Phase 1A (docs/proposals/redis-retirement-phase-1-plan.md):
+-- durable PostgreSQL mirror for session/identity state that today lives only in
+-- Redis. ADDITIVE and INERT: nothing writes here yet. The dual-write wiring
+-- (modifying _cache_session / set_onboard_pin / resolution.py) is a separate,
+-- flag-gated PR; this migration only lands the tables the DB methods target.
+--
+-- Two tables:
+--   * core.onboard_pins      — durable mirror of Redis recent_onboard:* keys.
+--     The IP:UA-fallback session-routing anchor (Claude Desktop, REST clients
+--     without client_session_id). Phase 1A — needed regardless.
+--   * core.session_bindings  — FK-less mirror of the Redis session: payload.
+--     Phase 1B — built as instrumented shadow; kept only if a soak measurement
+--     shows material cold-mints not covered by an onboard pin.
+--
+-- Design notes (from the v1.1 council review):
+--   * NO foreign keys (cf. the 043/044 shadow replicas). The Redis session:
+--     payload stores an agent_uuid *string* with no core.identities row for the
+--     ephemeral persist=False majority; a FK would force eager identity
+--     persistence, polluting the agent population. These are write-only
+--     resolution mirrors, not referential targets.
+--   * agent_uuid carries a CHECK enforcing UUID shape, so the "this column holds
+--     the UUID-proof, never a display label" identity invariant is enforced at
+--     the schema layer, not just by discipline.
+--   * Column set verified against 865 live Redis session: payloads — includes
+--     public_agent_id (59.8% of payloads) and api_key_hash (40.2%, legacy
+--     sessions) which an earlier draft omitted.
+--   * IF NOT EXISTS throughout so the migration is safe to re-run.
+--   * Reaping: get_session_binding / lookup_onboard_pin_pg filter expires_at, so
+--     expired rows are already invisible. Physical cleanup (extending
+--     core.cleanup_expired_sessions) lands with the dual-write wiring PR, when
+--     there is actually something to reap.
+
+CREATE TABLE IF NOT EXISTS core.onboard_pins (
+    fingerprint        TEXT PRIMARY KEY,   -- full suffix after "recent_onboard:" e.g. "ua:<hash>|<transport>|<model>" (1-3 pipe segments)
+    agent_uuid         TEXT NOT NULL CHECK (agent_uuid ~ '^[0-9a-fA-F-]{36}$'),
+    client_session_id  TEXT NOT NULL,
+    expires_at         TIMESTAMPTZ NOT NULL   -- 30-min TTL (PIN_TTL=1800) in the Redis original
+);
+
+CREATE INDEX IF NOT EXISTS idx_onboard_pins_expires ON core.onboard_pins(expires_at);
+
+CREATE TABLE IF NOT EXISTS core.session_bindings (
+    session_key         TEXT PRIMARY KEY,
+    agent_uuid          TEXT NOT NULL CHECK (agent_uuid ~ '^[0-9a-fA-F-]{36}$'),  -- maps from Redis JSON "agent_id"
+    public_agent_id     TEXT NULL,
+    display_agent_id    TEXT NULL,
+    api_key_hash        TEXT NULL,
+    spawn_reason        TEXT NULL,
+    bind_ip_ua          TEXT NULL,   -- consumed by the PATH 2 fingerprint hijack check
+    trajectory_required BOOLEAN NOT NULL DEFAULT FALSE,
+    bind_count          INTEGER NOT NULL DEFAULT 1,
+    bound_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at          TIMESTAMPTZ NULL   -- NULL = permanent (Redis TTL=-1)
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_bindings_expires ON core.session_bindings(expires_at);
+CREATE INDEX IF NOT EXISTS idx_session_bindings_uuid    ON core.session_bindings(agent_uuid);
+
+COMMENT ON TABLE core.onboard_pins IS
+    'Redis-retirement Phase 1A: durable mirror of recent_onboard:* — the IP:UA-'
+    'fallback session-routing anchor. Inert until the dual-write wiring PR.';
+
+COMMENT ON TABLE core.session_bindings IS
+    'Redis-retirement Phase 1B: FK-less mirror of the Redis session: payload '
+    '(session_key -> agent_uuid + rich fields). Inert; kept only if a shadow '
+    'soak shows material cold-mints not covered by an onboard pin. Distinct from '
+    'coordination.session_resolution_sagas (Wave 3 saga state).';
+
+-- Register migration
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (51, 'session_mirror_tables', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/src/db/mixins/session.py
+++ b/src/db/mixins/session.py
@@ -145,3 +145,182 @@ class SessionMixin:
             client_info=json.loads(row["client_info"]) if isinstance(row["client_info"], str) else row["client_info"],
             metadata=json.loads(row["metadata"]) if isinstance(row["metadata"], str) else row["metadata"],
         )
+
+    # ------------------------------------------------------------------
+    # Session-binding mirror (Redis-retirement Phase 1)
+    #
+    # FK-less durable mirror of the Redis session: payload, keyed by
+    # session_key. INERT — nothing in production calls these yet; the
+    # dual-write/read wiring is a separate flag-gated PR. See
+    # docs/proposals/redis-retirement-phase-1-plan.md.
+    # ------------------------------------------------------------------
+
+    async def upsert_session_binding(
+        self,
+        session_key: str,
+        agent_uuid: str,
+        *,
+        public_agent_id: Optional[str] = None,
+        display_agent_id: Optional[str] = None,
+        api_key_hash: Optional[str] = None,
+        spawn_reason: Optional[str] = None,
+        bind_ip_ua: Optional[str] = None,
+        trajectory_required: bool = False,
+        expires_at=None,
+        mint_guard: bool = False,
+    ) -> str:
+        """Upsert a session_key -> agent_uuid binding into core.session_bindings.
+
+        Returns one of:
+          - "inserted": a new row was created
+          - "updated":  an existing row for the same agent_uuid was refreshed
+          - "blocked":  mint_guard=True and an existing row binds a *different*
+                        agent_uuid — the S21-a collision case; the write is
+                        refused (atomic, via the ON CONFLICT ... WHERE guard).
+
+        The (xmax = 0) RETURNING idiom distinguishes insert (xmax=0) from update
+        (xmax<>0); when mint_guard blocks, the conditional UPDATE matches no row
+        and RETURNING yields nothing -> "blocked".
+        """
+        guard_clause = (
+            "WHERE core.session_bindings.agent_uuid = EXCLUDED.agent_uuid"
+            if mint_guard else ""
+        )
+        sql = f"""
+            INSERT INTO core.session_bindings (
+                session_key, agent_uuid, public_agent_id, display_agent_id,
+                api_key_hash, spawn_reason, bind_ip_ua, trajectory_required,
+                bound_at, expires_at
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now(), $9)
+            ON CONFLICT (session_key) DO UPDATE SET
+                agent_uuid          = EXCLUDED.agent_uuid,
+                public_agent_id     = EXCLUDED.public_agent_id,
+                display_agent_id    = EXCLUDED.display_agent_id,
+                api_key_hash        = EXCLUDED.api_key_hash,
+                spawn_reason        = COALESCE(EXCLUDED.spawn_reason, core.session_bindings.spawn_reason),
+                bind_ip_ua          = COALESCE(EXCLUDED.bind_ip_ua, core.session_bindings.bind_ip_ua),
+                trajectory_required = EXCLUDED.trajectory_required,
+                bind_count          = core.session_bindings.bind_count + 1,
+                expires_at          = EXCLUDED.expires_at
+            {guard_clause}
+            RETURNING (xmax = 0) AS inserted
+        """
+        async with self.acquire() as conn:
+            row = await conn.fetchrow(
+                sql,
+                session_key, agent_uuid, public_agent_id, display_agent_id,
+                api_key_hash, spawn_reason, bind_ip_ua, trajectory_required,
+                expires_at,
+            )
+        if row is None:
+            return "blocked"
+        return "inserted" if row["inserted"] else "updated"
+
+    async def get_session_binding(self, session_key: str) -> Optional[Dict[str, Any]]:
+        """Read a live (unexpired) session binding as a plain dict, or None.
+
+        Returns a dict (not a dataclass) so callers like the PATH 2 fingerprint
+        hijack check can do binding.get("bind_ip_ua") uniformly. Expired rows
+        (expires_at <= now) are treated as absent — Redis enforced this via TTL;
+        PG must filter explicitly. expires_at IS NULL means permanent.
+        """
+        async with self.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT session_key, agent_uuid, public_agent_id, display_agent_id,
+                       api_key_hash, spawn_reason, bind_ip_ua, trajectory_required,
+                       bind_count, bound_at, expires_at
+                FROM core.session_bindings
+                WHERE session_key = $1
+                  AND (expires_at IS NULL OR expires_at > now())
+                """,
+                session_key,
+            )
+            return dict(row) if row else None
+
+    async def delete_session_binding(self, session_key: str) -> bool:
+        """Remove a session binding (e.g. on force_new). True if a row was removed."""
+        async with self.acquire() as conn:
+            result = await conn.execute(
+                "DELETE FROM core.session_bindings WHERE session_key = $1",
+                session_key,
+            )
+            return "DELETE 1" in result
+
+    # ------------------------------------------------------------------
+    # Onboard pins (Redis-retirement Phase 1A) — durable recent_onboard:* mirror
+    # ------------------------------------------------------------------
+
+    async def set_onboard_pin_pg(
+        self,
+        fingerprint: str,
+        agent_uuid: str,
+        client_session_id: str,
+        *,
+        ttl_seconds: int = 1800,
+        if_absent: bool = False,
+    ) -> bool:
+        """Write an onboard pin (fingerprint -> client_session_id) with a TTL.
+
+        if_absent=True implements the NX-claim semantics (a subagent must not
+        displace the driver's pin): INSERT ... ON CONFLICT DO NOTHING, returning
+        True only when this call actually claimed the slot. if_absent=False
+        upserts unconditionally and always returns True.
+        """
+        async with self.acquire() as conn:
+            if if_absent:
+                result = await conn.execute(
+                    """
+                    INSERT INTO core.onboard_pins (fingerprint, agent_uuid, client_session_id, expires_at)
+                    VALUES ($1, $2, $3, now() + ($4 * interval '1 second'))
+                    ON CONFLICT (fingerprint) DO NOTHING
+                    """,
+                    fingerprint, agent_uuid, client_session_id, ttl_seconds,
+                )
+                return "INSERT 0 1" in result
+            await conn.execute(
+                """
+                INSERT INTO core.onboard_pins (fingerprint, agent_uuid, client_session_id, expires_at)
+                VALUES ($1, $2, $3, now() + ($4 * interval '1 second'))
+                ON CONFLICT (fingerprint) DO UPDATE SET
+                    agent_uuid        = EXCLUDED.agent_uuid,
+                    client_session_id = EXCLUDED.client_session_id,
+                    expires_at        = EXCLUDED.expires_at
+                """,
+                fingerprint, agent_uuid, client_session_id, ttl_seconds,
+            )
+            return True
+
+    async def lookup_onboard_pin_pg(
+        self,
+        fingerprint: str,
+        *,
+        refresh_ttl: bool = False,
+        ttl_seconds: int = 1800,
+    ) -> Optional[str]:
+        """Return the pinned client_session_id for a fingerprint, or None.
+
+        Expired pins are treated as absent. refresh_ttl extends the pin's TTL on
+        a hit (mirrors the Redis expire-on-read behavior).
+        """
+        async with self.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT client_session_id
+                FROM core.onboard_pins
+                WHERE fingerprint = $1 AND expires_at > now()
+                """,
+                fingerprint,
+            )
+            if not row:
+                return None
+            if refresh_ttl:
+                await conn.execute(
+                    """
+                    UPDATE core.onboard_pins
+                    SET expires_at = now() + ($2 * interval '1 second')
+                    WHERE fingerprint = $1
+                    """,
+                    fingerprint, ttl_seconds,
+                )
+            return row["client_session_id"]

--- a/src/mcp_handlers/identity/persistence.py
+++ b/src/mcp_handlers/identity/persistence.py
@@ -202,6 +202,90 @@ async def _cache_session(
             # WARNING level (v2.5.7): Cache failures can cause identity loss
             logger.warning(f"Redis cache write failed for session binding: {e}")
 
+    # Redis-retirement Phase 1A: dual-write the binding into the PostgreSQL
+    # mirror (core.session_bindings) when the shadow flag is on. Best-effort and
+    # behavior-neutral — Redis stays authoritative for reads, nothing reads the
+    # mirror yet, and a mirror failure never affects the live path. Runs even
+    # when Redis is unavailable so the mirror is populated regardless.
+    #
+    # Latency-bounded with the same _REDIS_WRITE_TIMEOUT budget as the Redis
+    # write above: get_db() is ExecutorPool-wrapped (no anyio deadlock), but the
+    # pool's own acquire() can block up to 10s when saturated. A best-effort
+    # shadow write must never hold the onboard path that long — on timeout we
+    # skip the mirror, exactly as we skip the Redis write on its timeout.
+    try:
+        await asyncio.wait_for(
+            _shadow_mirror_session_binding(
+                session_key,
+                agent_uuid,
+                display_agent_id=display_agent_id,
+                spawn_reason=spawn_reason,
+                bind_ip_ua=bind_ip_ua,
+                trajectory_required=trajectory_required,
+                mint_guard=mint_guard,
+            ),
+            timeout=_REDIS_WRITE_TIMEOUT,
+        )
+    except asyncio.TimeoutError:
+        logger.debug(
+            "[IDENTITY] session-binding shadow mirror timed out after %ss — skipped",
+            _REDIS_WRITE_TIMEOUT,
+        )
+
+
+async def _shadow_mirror_session_binding(
+    session_key: str,
+    agent_uuid: str,
+    *,
+    display_agent_id: Optional[str] = None,
+    spawn_reason: Optional[str] = None,
+    bind_ip_ua: Optional[str] = None,
+    trajectory_required: bool = False,
+    mint_guard: bool = False,
+) -> None:
+    """Best-effort dual-write of a session binding to core.session_bindings.
+
+    Gated on session_mirror_shadow_enabled(); no-op when off. Failures are
+    swallowed (logged at debug) so the durable mirror can never break the live
+    identity path. Uses get_db() (ExecutorPool-wrapped — safe to await directly
+    on the handler path, no anyio guard needed; the caller bounds latency with
+    asyncio.wait_for). Redis-retirement Phase 1A.
+
+    KNOWN GAP (close before the Phase 1B read flip): api_key_hash is not written
+    here — _cache_session does not carry it — so legacy sessions (≈40% of live
+    Redis payloads) mirror with api_key_hash=NULL. Harmless while the mirror is
+    write-only; must be plumbed before the mirror is read as authoritative.
+    """
+    try:
+        from config.governance_config import session_mirror_shadow_enabled
+        if not session_mirror_shadow_enabled():
+            return
+    except Exception:
+        return
+    try:
+        db = get_db()
+        expires_at = datetime.now(timezone.utc) + timedelta(
+            seconds=GovernanceConfig.SESSION_TTL_SECONDS
+        )
+        outcome = await db.upsert_session_binding(
+            session_key,
+            agent_uuid,
+            public_agent_id=display_agent_id,
+            display_agent_id=display_agent_id,
+            spawn_reason=spawn_reason,
+            bind_ip_ua=bind_ip_ua,
+            trajectory_required=trajectory_required,
+            expires_at=expires_at,
+            mint_guard=mint_guard,
+        )
+        if outcome == "blocked":
+            logger.warning(
+                "[S21A_PG_BINDING_BLOCKED] session mirror refused overwrite of a "
+                "different agent_uuid for session_key=%s...", session_key[:24],
+            )
+    except Exception as e:
+        logger.debug(f"session-binding shadow mirror skipped: {e}")
+
 
 async def _cache_session_redis_write(
     session_cache,

--- a/src/mcp_handlers/identity/session.py
+++ b/src/mcp_handlers/identity/session.py
@@ -951,7 +951,7 @@ async def set_onboard_pin(
         logger.debug("[ONBOARD_PIN] No fingerprint — skip pin-set")
         return False
     try:
-        return await asyncio.wait_for(
+        result = await asyncio.wait_for(
             _set_onboard_pin_inner(
                 base_fingerprint,
                 agent_uuid,
@@ -968,10 +968,45 @@ async def set_onboard_pin(
             f"[ONBOARD_PIN] Pin-set timed out after {_PIN_REDIS_TIMEOUT}s "
             "— onboard proceeds, future requests skip pin"
         )
-        return False
+        result = False
     except Exception as e:
         logger.warning(f"[ONBOARD_PIN] Could not set pin: {e}")
-        return False
+        result = False
+
+    # Redis-retirement Phase 1A: dual-write the pins into the PostgreSQL mirror
+    # (core.onboard_pins) when the shadow flag is on. Best-effort/behavior-neutral
+    # — Redis stays authoritative, nothing reads the PG pins yet, failures are
+    # swallowed. Deliberately OUTSIDE the Redis _PIN_REDIS_TIMEOUT budget (so a
+    # slow PG write can't make a successful Redis pin report timed-out) and
+    # independent of Redis availability (so the mirror is populated even when
+    # Redis is down). Bounded by its own timeout. The Redis pin result is
+    # returned regardless of the mirror outcome.
+    try:
+        from config.governance_config import session_mirror_shadow_enabled
+        _mirror_on = session_mirror_shadow_enabled()
+    except Exception:
+        _mirror_on = False
+    if _mirror_on:
+        candidates = _build_pin_fingerprint_candidates(
+            base_fingerprint,
+            client_hint=client_hint,
+            model_type=model_type,
+            user_agent=user_agent,
+            include_unscoped_fallback=not bool(client_hint or model_type),
+        )
+        if candidates:
+            try:
+                await asyncio.wait_for(
+                    _shadow_mirror_onboard_pins(
+                        candidates, agent_uuid, client_session_id, if_absent=if_absent,
+                    ),
+                    timeout=_PIN_REDIS_TIMEOUT,
+                )
+            except asyncio.TimeoutError:
+                logger.debug("[ONBOARD_PIN] shadow mirror timed out — skipped")
+            except Exception as e:
+                logger.debug(f"[ONBOARD_PIN] shadow mirror skipped: {e}")
+    return result
 
 
 async def _set_onboard_pin_inner(
@@ -1028,3 +1063,38 @@ async def _set_onboard_pin_inner(
         wrote_any = True
         logger.info(f"[ONBOARD_PIN] Set pin for agent {agent_uuid[:8]}...")
     return wrote_any
+
+
+async def _shadow_mirror_onboard_pins(
+    candidates: list,
+    agent_uuid: str,
+    client_session_id: str,
+    *,
+    if_absent: bool = False,
+) -> None:
+    """Best-effort dual-write of onboard pins to core.onboard_pins.
+
+    Gated on session_mirror_shadow_enabled(); no-op when off. Failures swallowed
+    (debug-logged) so the durable mirror never breaks pin-setting. The PG
+    fingerprint column holds the full suffix after "recent_onboard:" — i.e. each
+    candidate fp verbatim — so it matches the future PG lookup. Phase 1A.
+    """
+    try:
+        from config.governance_config import session_mirror_shadow_enabled
+        if not session_mirror_shadow_enabled():
+            return
+    except Exception:
+        return
+    try:
+        from src.db import get_db
+        db = get_db()
+        for fp in candidates:
+            try:
+                await db.set_onboard_pin_pg(
+                    fp, agent_uuid, client_session_id,
+                    ttl_seconds=_PIN_TTL, if_absent=if_absent,
+                )
+            except Exception as e:
+                logger.debug(f"onboard-pin shadow mirror skipped for {fp}: {e}")
+    except Exception as e:
+        logger.debug(f"onboard-pin shadow mirror unavailable: {e}")

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -153,6 +153,10 @@ async def ensure_test_database_schema() -> None:
         # (extends the 026/042 grammar CHECK). Applied after 042 here because
         # it supersedes the same surface_id_grammar constraint.
         await _execute_sql_file(conn, "db/postgres/migrations/050_lease_plane_maintenance_scheme.sql")
+        # Migration 051: Redis-retirement Phase 1 session-binding + onboard-pin
+        # mirror tables (FK-less; additive/inert). Depends only on the core
+        # schema. See docs/proposals/redis-retirement-phase-1-plan.md.
+        await _execute_sql_file(conn, "db/postgres/migrations/051_session_mirror_tables.sql")
 
         # Ensure partitioned audit tables can accept inserts for current month.
         await _execute_sql_file(conn, "db/postgres/partitions.sql")
@@ -183,6 +187,8 @@ TRUNCATE_TABLES = [
     "core.agent_state",
     "core.agent_sessions",
     "core.agent_baselines",
+    "core.session_bindings",
+    "core.onboard_pins",
     "core.sessions",
     "core.identities",
     "core.agents",

--- a/tests/test_session_mirror_shadow_write.py
+++ b/tests/test_session_mirror_shadow_write.py
@@ -1,0 +1,128 @@
+"""Unit tests for the Redis-retirement Phase 1A shadow dual-write.
+
+When UNITARES_SESSION_MIRROR_SHADOW is off (default), the mirror helpers must be
+no-ops. When on, they must dual-write to the PG mirror (best-effort: a DB failure
+is swallowed and never propagates to the live identity path).
+
+See docs/proposals/redis-retirement-phase-1-plan.md.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch, AsyncMock
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from src.mcp_handlers.identity import persistence, session as session_mod
+
+_SK = "agent-abc123def456"
+_AU = "11111111-1111-4111-8111-111111111111"
+
+
+# ---------------------------------------------------------------------------
+# config flags default off
+# ---------------------------------------------------------------------------
+
+def test_flags_default_off(monkeypatch):
+    from config import governance_config as gc
+    monkeypatch.delenv("UNITARES_SESSION_MIRROR_SHADOW", raising=False)
+    monkeypatch.delenv("UNITARES_SESSION_MIRROR_APPLY", raising=False)
+    assert gc.session_mirror_shadow_enabled() is False
+    assert gc.session_mirror_apply_enabled() is False
+    monkeypatch.setenv("UNITARES_SESSION_MIRROR_SHADOW", "1")
+    assert gc.session_mirror_shadow_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# session-binding mirror
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_binding_mirror_noop_when_flag_off():
+    db = AsyncMock()
+    with patch("config.governance_config.session_mirror_shadow_enabled", return_value=False), \
+         patch("src.mcp_handlers.identity.persistence.get_db", return_value=db):
+        await persistence._shadow_mirror_session_binding(_SK, _AU, bind_ip_ua="1.2.3.4:ab")
+    db.upsert_session_binding.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_binding_mirror_writes_when_flag_on():
+    db = AsyncMock()
+    db.upsert_session_binding = AsyncMock(return_value="inserted")
+    with patch("config.governance_config.session_mirror_shadow_enabled", return_value=True), \
+         patch("src.mcp_handlers.identity.persistence.get_db", return_value=db):
+        await persistence._shadow_mirror_session_binding(
+            _SK, _AU, display_agent_id="Claude_Code", spawn_reason="new_session",
+            bind_ip_ua="1.2.3.4:ab", trajectory_required=True, mint_guard=True,
+        )
+    db.upsert_session_binding.assert_awaited_once()
+    args, kwargs = db.upsert_session_binding.call_args
+    assert args[0] == _SK and args[1] == _AU
+    assert kwargs["public_agent_id"] == "Claude_Code"
+    assert kwargs["bind_ip_ua"] == "1.2.3.4:ab"
+    assert kwargs["trajectory_required"] is True
+    assert kwargs["mint_guard"] is True
+
+
+@pytest.mark.asyncio
+async def test_binding_mirror_swallows_db_failure():
+    db = AsyncMock()
+    db.upsert_session_binding = AsyncMock(side_effect=Exception("pg down"))
+    with patch("config.governance_config.session_mirror_shadow_enabled", return_value=True), \
+         patch("src.mcp_handlers.identity.persistence.get_db", return_value=db):
+        # must not raise
+        await persistence._shadow_mirror_session_binding(_SK, _AU)
+
+
+@pytest.mark.asyncio
+async def test_binding_mirror_logs_on_blocked(caplog):
+    db = AsyncMock()
+    db.upsert_session_binding = AsyncMock(return_value="blocked")
+    with patch("config.governance_config.session_mirror_shadow_enabled", return_value=True), \
+         patch("src.mcp_handlers.identity.persistence.get_db", return_value=db), \
+         caplog.at_level("WARNING"):
+        await persistence._shadow_mirror_session_binding(_SK, _AU)
+    assert any("S21A_PG_BINDING_BLOCKED" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# onboard-pin mirror
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_pin_mirror_noop_when_flag_off():
+    db = AsyncMock()
+    with patch("config.governance_config.session_mirror_shadow_enabled", return_value=False), \
+         patch("src.db.get_db", return_value=db):
+        await session_mod._shadow_mirror_onboard_pins(["ua:aa", "ua:bb"], _AU, "agent-csid")
+    db.set_onboard_pin_pg.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pin_mirror_writes_each_candidate_when_on():
+    db = AsyncMock()
+    db.set_onboard_pin_pg = AsyncMock(return_value=True)
+    with patch("config.governance_config.session_mirror_shadow_enabled", return_value=True), \
+         patch("src.db.get_db", return_value=db):
+        await session_mod._shadow_mirror_onboard_pins(
+            ["ua:aa|claude", "ua:bb"], _AU, "agent-csid", if_absent=True,
+        )
+    assert db.set_onboard_pin_pg.await_count == 2
+    seen_fps = {c.args[0] for c in db.set_onboard_pin_pg.call_args_list}
+    assert seen_fps == {"ua:aa|claude", "ua:bb"}
+    for c in db.set_onboard_pin_pg.call_args_list:
+        assert c.kwargs["if_absent"] is True
+
+
+@pytest.mark.asyncio
+async def test_pin_mirror_swallows_per_candidate_failure():
+    db = AsyncMock()
+    db.set_onboard_pin_pg = AsyncMock(side_effect=Exception("pg down"))
+    with patch("config.governance_config.session_mirror_shadow_enabled", return_value=True), \
+         patch("src.db.get_db", return_value=db):
+        # must not raise even though every candidate write fails
+        await session_mod._shadow_mirror_onboard_pins(["ua:aa"], _AU, "agent-csid")

--- a/tests/test_session_mirror_tables.py
+++ b/tests/test_session_mirror_tables.py
@@ -1,0 +1,193 @@
+"""Integration tests for the Redis-retirement Phase 1 session-binding +
+onboard-pin mirror tables (migration 051) and their DB mixin methods.
+
+Runs against governance_test; skips if unavailable. The methods are inert in
+production (nothing wires them yet) — these tests exercise them directly against
+a real PostgreSQL so the durable mirror is proven before the dual-write PR.
+
+See docs/proposals/redis-retirement-phase-1-plan.md.
+"""
+
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+try:
+    import asyncpg  # noqa: F401
+except ImportError:
+    pytest.skip("asyncpg not installed", allow_module_level=True)
+
+from tests.test_db_utils import can_connect_to_test_db
+
+if not can_connect_to_test_db():
+    pytest.skip("governance_test database not available", allow_module_level=True)
+
+
+@pytest_asyncio.fixture
+async def backend(live_postgres_backend):
+    """Alias for the conftest live_postgres_backend fixture (governance_test)."""
+    return live_postgres_backend
+
+
+def _uuid() -> str:
+    return str(uuid.uuid4())
+
+
+def _future(seconds: int = 3600) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(seconds=seconds)
+
+
+def _past(seconds: int = 3600) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(seconds=seconds)
+
+
+# ---------------------------------------------------------------------------
+# session_bindings
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_insert_then_get_roundtrips_rich_fields(backend):
+    sk, au = "agent-" + _uuid()[:12], _uuid()
+    outcome = await backend.upsert_session_binding(
+        sk, au,
+        public_agent_id="Claude_Code_20260628",
+        display_agent_id="Claude_Code_20260628",
+        api_key_hash="hash-abc",
+        spawn_reason="new_session",
+        bind_ip_ua="127.0.0.1:deadbe",
+        trajectory_required=True,
+        expires_at=_future(),
+    )
+    assert outcome == "inserted"
+
+    row = await backend.get_session_binding(sk)
+    assert row is not None
+    assert isinstance(row, dict)  # B2: callers do row.get("bind_ip_ua")
+    assert row["agent_uuid"] == au
+    assert row["public_agent_id"] == "Claude_Code_20260628"
+    assert row["api_key_hash"] == "hash-abc"
+    assert row["spawn_reason"] == "new_session"
+    assert row["bind_ip_ua"] == "127.0.0.1:deadbe"
+    assert row["trajectory_required"] is True
+    assert row["bind_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_same_uuid_reupsert_updates_and_bumps_bind_count(backend):
+    sk, au = "agent-" + _uuid()[:12], _uuid()
+    await backend.upsert_session_binding(sk, au, expires_at=_future())
+    outcome = await backend.upsert_session_binding(sk, au, expires_at=_future())
+    assert outcome == "updated"
+    row = await backend.get_session_binding(sk)
+    assert row["bind_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_mint_guard_blocks_divergent_uuid(backend):
+    """S21-a: mint_guard must refuse to overwrite a binding for a different uuid."""
+    sk, au1, au2 = "agent-" + _uuid()[:12], _uuid(), _uuid()
+    assert await backend.upsert_session_binding(sk, au1, expires_at=_future()) == "inserted"
+
+    outcome = await backend.upsert_session_binding(sk, au2, mint_guard=True, expires_at=_future())
+    assert outcome == "blocked"
+
+    row = await backend.get_session_binding(sk)
+    assert row["agent_uuid"] == au1  # original binding intact
+
+
+@pytest.mark.asyncio
+async def test_corrective_write_overwrites_divergent_uuid(backend):
+    """Without mint_guard, a corrective write may overwrite (authoritative source)."""
+    sk, au1, au2 = "agent-" + _uuid()[:12], _uuid(), _uuid()
+    await backend.upsert_session_binding(sk, au1, expires_at=_future())
+    outcome = await backend.upsert_session_binding(sk, au2, mint_guard=False, expires_at=_future())
+    assert outcome == "updated"
+    row = await backend.get_session_binding(sk)
+    assert row["agent_uuid"] == au2
+
+
+@pytest.mark.asyncio
+async def test_expired_binding_is_invisible(backend):
+    sk, au = "agent-" + _uuid()[:12], _uuid()
+    await backend.upsert_session_binding(sk, au, expires_at=_past())
+    assert await backend.get_session_binding(sk) is None
+
+
+@pytest.mark.asyncio
+async def test_permanent_binding_null_expiry_visible(backend):
+    sk, au = "agent-" + _uuid()[:12], _uuid()
+    await backend.upsert_session_binding(sk, au, expires_at=None)
+    row = await backend.get_session_binding(sk)
+    assert row is not None and row["expires_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_missing_binding_returns_none(backend):
+    assert await backend.get_session_binding("agent-" + _uuid()[:12]) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_session_binding(backend):
+    sk, au = "agent-" + _uuid()[:12], _uuid()
+    await backend.upsert_session_binding(sk, au, expires_at=_future())
+    assert await backend.delete_session_binding(sk) is True
+    assert await backend.get_session_binding(sk) is None
+    assert await backend.delete_session_binding(sk) is False  # already gone
+
+
+@pytest.mark.asyncio
+async def test_uuid_check_rejects_display_label(backend):
+    """The agent_uuid CHECK enforces 'proof not label' at the schema layer."""
+    sk = "agent-" + _uuid()[:12]
+    with pytest.raises(Exception):  # asyncpg.CheckViolationError
+        await backend.upsert_session_binding(sk, "Claude_Code_20260628", expires_at=_future())
+
+
+# ---------------------------------------------------------------------------
+# onboard_pins
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_set_and_lookup_onboard_pin(backend):
+    fp, au, csid = f"ua:{_uuid()[:6]}|unknown|claude", _uuid(), "agent-" + _uuid()[:12]
+    assert await backend.set_onboard_pin_pg(fp, au, csid) is True
+    assert await backend.lookup_onboard_pin_pg(fp) == csid
+
+
+@pytest.mark.asyncio
+async def test_onboard_pin_if_absent_nx_semantics(backend):
+    """if_absent must not displace an existing pin (subagent NX-claim)."""
+    fp = f"ua:{_uuid()[:6]}|unknown"
+    csid1, csid2 = "agent-" + _uuid()[:12], "agent-" + _uuid()[:12]
+    assert await backend.set_onboard_pin_pg(fp, _uuid(), csid1, if_absent=True) is True
+    assert await backend.set_onboard_pin_pg(fp, _uuid(), csid2, if_absent=True) is False
+    assert await backend.lookup_onboard_pin_pg(fp) == csid1  # first claim wins
+
+
+@pytest.mark.asyncio
+async def test_onboard_pin_upsert_overwrites(backend):
+    fp = f"ua:{_uuid()[:6]}|claude"
+    csid1, csid2 = "agent-" + _uuid()[:12], "agent-" + _uuid()[:12]
+    await backend.set_onboard_pin_pg(fp, _uuid(), csid1)
+    await backend.set_onboard_pin_pg(fp, _uuid(), csid2)  # default upsert
+    assert await backend.lookup_onboard_pin_pg(fp) == csid2
+
+
+@pytest.mark.asyncio
+async def test_expired_onboard_pin_is_invisible(backend):
+    fp, au, csid = f"ua:{_uuid()[:6]}", _uuid(), "agent-" + _uuid()[:12]
+    # negative TTL -> already expired
+    await backend.set_onboard_pin_pg(fp, au, csid, ttl_seconds=-10)
+    assert await backend.lookup_onboard_pin_pg(fp) is None
+
+
+@pytest.mark.asyncio
+async def test_lookup_missing_onboard_pin_returns_none(backend):
+    assert await backend.lookup_onboard_pin_pg(f"ua:{_uuid()[:6]}") is None


### PR DESCRIPTION
## Summary

Wires the **shadow dual-write** for Redis retirement. Behind `UNITARES_SESSION_MIRROR_SHADOW` (**default off**): when on, `_cache_session` and `set_onboard_pin` ALSO write to `core.session_bindings` / `core.onboard_pins` alongside Redis. **Behavior-neutral when off; best-effort when on** (failures swallowed, nothing reads the mirror yet — Redis stays authoritative). This populates the durable mirror so write-path parity can be measured before any read flip.

**Stacked on #1123** (needs the migration + DB methods). Base is the groundwork branch; will retarget to master once #1123 merges.

## Implementation-council review applied
Ran a code-reviewer council on the actual diff before opening. Two must-fixes incorporated:
- **Latency bound on the session-binding mirror:** wrapped in `asyncio.wait_for(_REDIS_WRITE_TIMEOUT)`. `get_db()` is ExecutorPool-wrapped so there's no anyio-asyncio *deadlock* — but `pool.acquire()` can still block ~10s when saturated, and a best-effort shadow write must not hold the onboard path that long.
- **Onboard-pin mirror moved out of the 0.5s Redis budget:** it was inside `_set_onboard_pin_inner`'s `_PIN_REDIS_TIMEOUT` wrapper, so a slow PG write could make an *already-successful* Redis pin report `timed-out → False`. Moved to `set_onboard_pin` after the Redis `wait_for`, with its own timeout, and it now runs even when Redis is down. Flag checked before building candidates (zero flag-off cost).
- Documented the `api_key_hash` NULL gap to close before the Phase 1B read flip.

Council confirmed the anyio-asyncio deadlock class is a **non-issue** here (ExecutorPool), the flag-off path is behavior-neutral, and the `mint_guard` S21-a semantics pass through correctly.

## Tests
8 new unit tests (`test_session_mirror_shadow_write.py`): flags default off; mirror no-ops when off; writes when on (correct field mapping incl. mint_guard); swallows DB failure; logs `S21A_PG_BINDING_BLOCKED`; per-candidate pin writes with NX. `test_onboard_pin`/`test_sticky_identity`/`test_identity_s21a` green (behavior-neutral when off). Full local gate was green on the pre-fix revision; focused suites green post-fix.

## Not in this PR
The **read flip** (`UNITARES_SESSION_MIRROR_APPLY`: PATH 2 reads `core.session_bindings`, pin lookup reads PG, hijack-helper extraction) — separate change, gated on a shadow-soak parity measurement per the plan.