### PR TITLE
feat(ops): session-mirror birth-cohort parity checker (Redis-retirement Phase 1B)

### DIFF
--- a/db/postgres/migrations/051_session_mirror_tables.sql
+++ b/db/postgres/migrations/051_session_mirror_tables.sql
@@ -1,0 +1,74 @@
+-- 051_session_mirror_tables.sql
+--
+-- Redis-retirement Phase 1A (docs/proposals/redis-retirement-phase-1-plan.md):
+-- durable PostgreSQL mirror for session/identity state that today lives only in
+-- Redis. ADDITIVE and INERT: nothing writes here yet. The dual-write wiring
+-- (modifying _cache_session / set_onboard_pin / resolution.py) is a separate,
+-- flag-gated PR; this migration only lands the tables the DB methods target.
+--
+-- Two tables:
+--   * core.onboard_pins      — durable mirror of Redis recent_onboard:* keys.
+--     The IP:UA-fallback session-routing anchor (Claude Desktop, REST clients
+--     without client_session_id). Phase 1A — needed regardless.
+--   * core.session_bindings  — FK-less mirror of the Redis session: payload.
+--     Phase 1B — built as instrumented shadow; kept only if a soak measurement
+--     shows material cold-mints not covered by an onboard pin.
+--
+-- Design notes (from the v1.1 council review):
+--   * NO foreign keys (cf. the 043/044 shadow replicas). The Redis session:
+--     payload stores an agent_uuid *string* with no core.identities row for the
+--     ephemeral persist=False majority; a FK would force eager identity
+--     persistence, polluting the agent population. These are write-only
+--     resolution mirrors, not referential targets.
+--   * agent_uuid carries a CHECK enforcing UUID shape, so the "this column holds
+--     the UUID-proof, never a display label" identity invariant is enforced at
+--     the schema layer, not just by discipline.
+--   * Column set verified against 865 live Redis session: payloads — includes
+--     public_agent_id (59.8% of payloads) and api_key_hash (40.2%, legacy
+--     sessions) which an earlier draft omitted.
+--   * IF NOT EXISTS throughout so the migration is safe to re-run.
+--   * Reaping: get_session_binding / lookup_onboard_pin_pg filter expires_at, so
+--     expired rows are already invisible. Physical cleanup (extending
+--     core.cleanup_expired_sessions) lands with the dual-write wiring PR, when
+--     there is actually something to reap.
+
+CREATE TABLE IF NOT EXISTS core.onboard_pins (
+    fingerprint        TEXT PRIMARY KEY,   -- full suffix after "recent_onboard:" e.g. "ua:<hash>|<transport>|<model>" (1-3 pipe segments)
+    agent_uuid         TEXT NOT NULL CHECK (agent_uuid ~ '^[0-9a-fA-F-]{36}$'),
+    client_session_id  TEXT NOT NULL,
+    expires_at         TIMESTAMPTZ NOT NULL   -- 30-min TTL (PIN_TTL=1800) in the Redis original
+);
+
+CREATE INDEX IF NOT EXISTS idx_onboard_pins_expires ON core.onboard_pins(expires_at);
+
+CREATE TABLE IF NOT EXISTS core.session_bindings (
+    session_key         TEXT PRIMARY KEY,
+    agent_uuid          TEXT NOT NULL CHECK (agent_uuid ~ '^[0-9a-fA-F-]{36}$'),  -- maps from Redis JSON "agent_id"
+    public_agent_id     TEXT NULL,
+    display_agent_id    TEXT NULL,
+    api_key_hash        TEXT NULL,
+    spawn_reason        TEXT NULL,
+    bind_ip_ua          TEXT NULL,   -- consumed by the PATH 2 fingerprint hijack check
+    trajectory_required BOOLEAN NOT NULL DEFAULT FALSE,
+    bind_count          INTEGER NOT NULL DEFAULT 1,
+    bound_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at          TIMESTAMPTZ NULL   -- NULL = permanent (Redis TTL=-1)
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_bindings_expires ON core.session_bindings(expires_at);
+CREATE INDEX IF NOT EXISTS idx_session_bindings_uuid    ON core.session_bindings(agent_uuid);
+
+COMMENT ON TABLE core.onboard_pins IS
+    'Redis-retirement Phase 1A: durable mirror of recent_onboard:* — the IP:UA-'
+    'fallback session-routing anchor. Inert until the dual-write wiring PR.';
+
+COMMENT ON TABLE core.session_bindings IS
+    'Redis-retirement Phase 1B: FK-less mirror of the Redis session: payload '
+    '(session_key -> agent_uuid + rich fields). Inert; kept only if a shadow '
+    'soak shows material cold-mints not covered by an onboard pin. Distinct from '
+    'coordination.session_resolution_sagas (Wave 3 saga state).';
+
+-- Register migration
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (51, 'session_mirror_tables', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/scripts/ops/session_mirror_parity_check.py
+++ b/scripts/ops/session_mirror_parity_check.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Redis-retirement Phase 1B: session-mirror parity checker.
+
+Measures how faithfully the PostgreSQL mirror (core.session_bindings) reflects
+the authoritative Redis session: keys, so the operator can decide whether to
+flip UNITARES_SESSION_MIRROR_APPLY (the read flip). READ-ONLY.
+
+Why birth-cohort, not a point-in-time snapshot
+----------------------------------------------
+The implementation council flagged that a naive "iterate all Redis keys, are
+they in PG?" ratio conflates writer-correctness with expiry-race noise: with the
+keyspace churning and Redis/PG expiry clocks independent, a key can be live in
+Redis but already reaped in PG, or written to Redis microseconds before the PG
+dual-write commits — both count as spurious "divergence" that never converges.
+
+So we sample a BIRTH COHORT: Redis session: bindings whose bound_at is old
+enough to have committed to PG (>= --min-age-min) but young enough not to have
+expired out of either store (<= --max-age-min). Within that window a faithful
+writer should show ~100% match; misses are real dropped writes, not races.
+
+Direction: Redis -> PG (does the mirror reflect what Redis holds?) — this is the
+one that catches dropped/under-mirrored writes, the failure that would cause a
+cold-mint after the read flip.
+
+Output: a single JSON summary to stdout (cron/dashboard friendly). We do NOT
+emit per-row audit events — at ~900 keys per scan that would flood the audit
+partition (council note); the summary is the signal.
+
+Exit codes: 0 = ran successfully (parity is informational — the operator picks
+the flip threshold); 1 = runner error (store unreachable, etc.).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+SESSION_PREFIX = "session:"
+DEFAULT_DSN = os.environ.get(
+    "GOVERNANCE_DATABASE_URL",
+    "postgresql://postgres:postgres@localhost:5432/governance",
+)
+DEFAULT_REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+
+
+def _parse_bound_at(payload: Dict[str, Any]) -> Optional[datetime]:
+    """Parse the ISO bound_at from a Redis session payload, tz-aware, or None."""
+    raw = payload.get("bound_at")
+    if not isinstance(raw, str):
+        return None
+    try:
+        dt = datetime.fromisoformat(raw)
+    except (ValueError, TypeError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def compare_birth_cohort(
+    redis_items: Dict[str, Dict[str, Any]],
+    pg_uuid_by_key: Dict[str, str],
+    *,
+    now: datetime,
+    min_age: timedelta,
+    max_age: timedelta,
+) -> Dict[str, Any]:
+    """Pure comparison core (no I/O) — unit-testable.
+
+    redis_items:    session_key -> parsed Redis payload (must carry agent_id, bound_at)
+    pg_uuid_by_key: session_key -> agent_uuid present in core.session_bindings
+    Returns a summary dict with the cohort size, match/miss/mismatch counts, the
+    parity ratio, and a small sample of divergences.
+    """
+    lo, hi = now - max_age, now - min_age  # cohort: bound_at in [lo, hi]
+    cohort = 0
+    matched = 0
+    missing_in_pg: List[str] = []
+    uuid_mismatch: List[Dict[str, str]] = []
+
+    for session_key, payload in redis_items.items():
+        bound_at = _parse_bound_at(payload)
+        if bound_at is None or not (lo <= bound_at <= hi):
+            continue  # outside the birth cohort (too young/old or unparseable)
+        cohort += 1
+        redis_uuid = payload.get("agent_id")  # Redis JSON key is agent_id (= the UUID)
+        pg_uuid = pg_uuid_by_key.get(session_key)
+        if pg_uuid is None:
+            missing_in_pg.append(session_key)
+        elif pg_uuid != redis_uuid:
+            uuid_mismatch.append(
+                {"session_key": session_key, "redis": redis_uuid, "pg": pg_uuid}
+            )
+        else:
+            matched += 1
+
+    ratio = (matched / cohort) if cohort else None
+    return {
+        "cohort_size": cohort,
+        "matched": matched,
+        "missing_in_pg": len(missing_in_pg),
+        "uuid_mismatch": len(uuid_mismatch),
+        "parity_ratio": ratio,
+        "window_min": [int(min_age.total_seconds() // 60), int(max_age.total_seconds() // 60)],
+        "sample_missing": missing_in_pg[:10],
+        "sample_mismatch": uuid_mismatch[:10],
+    }
+
+
+async def _gather_redis_items(redis_url: str) -> Dict[str, Dict[str, Any]]:
+    import redis.asyncio as aioredis  # local import so the module loads without redis
+    client = aioredis.from_url(redis_url, decode_responses=True)
+    items: Dict[str, Dict[str, Any]] = {}
+    try:
+        async for key in client.scan_iter(match=f"{SESSION_PREFIX}*", count=500):
+            raw = await client.get(key)
+            if not raw:
+                continue
+            try:
+                payload = json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            items[key[len(SESSION_PREFIX):]] = payload
+    finally:
+        await client.aclose()
+    return items
+
+
+async def _gather_pg_uuids(dsn: str, session_keys: List[str]) -> Dict[str, str]:
+    import asyncpg  # local import
+    if not session_keys:
+        return {}
+    conn = await asyncpg.connect(dsn, timeout=10)
+    try:
+        rows = await conn.fetch(
+            """
+            SELECT session_key, agent_uuid
+            FROM core.session_bindings
+            WHERE session_key = ANY($1::text[])
+              AND (expires_at IS NULL OR expires_at > now())
+            """,
+            session_keys,
+        )
+        return {r["session_key"]: r["agent_uuid"] for r in rows}
+    finally:
+        await conn.close()
+
+
+async def _pg_binding_count(dsn: str) -> int:
+    import asyncpg
+    conn = await asyncpg.connect(dsn, timeout=10)
+    try:
+        return await conn.fetchval("SELECT count(*) FROM core.session_bindings") or 0
+    finally:
+        await conn.close()
+
+
+async def run(dsn: str, redis_url: str, min_age_min: int, max_age_min: int) -> int:
+    # Inert gate: an empty mirror means the shadow writer hasn't run
+    # (UNITARES_SESSION_MIRROR_SHADOW off) — every key would report
+    # missing_in_pg, which is non-signal. Report and exit 0.
+    mirror_rows = await _pg_binding_count(dsn)
+    if mirror_rows == 0:
+        print(json.dumps({
+            "status": "inert",
+            "reason": "core.session_bindings is empty — enable UNITARES_SESSION_MIRROR_SHADOW first",
+            "mirror_rows": 0,
+        }))
+        return 0
+
+    redis_items = await _gather_redis_items(redis_url)
+    pg_uuids = await _gather_pg_uuids(dsn, list(redis_items.keys()))
+    now = datetime.now(timezone.utc)
+    summary = compare_birth_cohort(
+        redis_items, pg_uuids, now=now,
+        min_age=timedelta(minutes=min_age_min),
+        max_age=timedelta(minutes=max_age_min),
+    )
+    summary["status"] = "ran"
+    summary["mirror_rows"] = mirror_rows
+    summary["redis_session_keys"] = len(redis_items)
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Session-mirror birth-cohort parity checker")
+    ap.add_argument("--dsn", default=DEFAULT_DSN)
+    ap.add_argument("--redis-url", default=DEFAULT_REDIS_URL)
+    ap.add_argument("--min-age-min", type=int, default=5,
+                    help="cohort lower bound: bindings at least this old (committed)")
+    ap.add_argument("--max-age-min", type=int, default=60,
+                    help="cohort upper bound: bindings at most this old (not yet expired)")
+    args = ap.parse_args()
+    try:
+        return asyncio.run(run(args.dsn, args.redis_url, args.min_age_min, args.max_age_min))
+    except Exception as e:  # runner error
+        print(json.dumps({"status": "error", "error": str(e)}), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/db/mixins/session.py
+++ b/src/db/mixins/session.py
@@ -145,3 +145,182 @@ class SessionMixin:
             client_info=json.loads(row["client_info"]) if isinstance(row["client_info"], str) else row["client_info"],
             metadata=json.loads(row["metadata"]) if isinstance(row["metadata"], str) else row["metadata"],
         )
+
+    # ------------------------------------------------------------------
+    # Session-binding mirror (Redis-retirement Phase 1)
+    #
+    # FK-less durable mirror of the Redis session: payload, keyed by
+    # session_key. INERT — nothing in production calls these yet; the
+    # dual-write/read wiring is a separate flag-gated PR. See
+    # docs/proposals/redis-retirement-phase-1-plan.md.
+    # ------------------------------------------------------------------
+
+    async def upsert_session_binding(
+        self,
+        session_key: str,
+        agent_uuid: str,
+        *,
+        public_agent_id: Optional[str] = None,
+        display_agent_id: Optional[str] = None,
+        api_key_hash: Optional[str] = None,
+        spawn_reason: Optional[str] = None,
+        bind_ip_ua: Optional[str] = None,
+        trajectory_required: bool = False,
+        expires_at=None,
+        mint_guard: bool = False,
+    ) -> str:
+        """Upsert a session_key -> agent_uuid binding into core.session_bindings.
+
+        Returns one of:
+          - "inserted": a new row was created
+          - "updated":  an existing row for the same agent_uuid was refreshed
+          - "blocked":  mint_guard=True and an existing row binds a *different*
+                        agent_uuid — the S21-a collision case; the write is
+                        refused (atomic, via the ON CONFLICT ... WHERE guard).
+
+        The (xmax = 0) RETURNING idiom distinguishes insert (xmax=0) from update
+        (xmax<>0); when mint_guard blocks, the conditional UPDATE matches no row
+        and RETURNING yields nothing -> "blocked".
+        """
+        guard_clause = (
+            "WHERE core.session_bindings.agent_uuid = EXCLUDED.agent_uuid"
+            if mint_guard else ""
+        )
+        sql = f"""
+            INSERT INTO core.session_bindings (
+                session_key, agent_uuid, public_agent_id, display_agent_id,
+                api_key_hash, spawn_reason, bind_ip_ua, trajectory_required,
+                bound_at, expires_at
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now(), $9)
+            ON CONFLICT (session_key) DO UPDATE SET
+                agent_uuid          = EXCLUDED.agent_uuid,
+                public_agent_id     = EXCLUDED.public_agent_id,
+                display_agent_id    = EXCLUDED.display_agent_id,
+                api_key_hash        = EXCLUDED.api_key_hash,
+                spawn_reason        = COALESCE(EXCLUDED.spawn_reason, core.session_bindings.spawn_reason),
+                bind_ip_ua          = COALESCE(EXCLUDED.bind_ip_ua, core.session_bindings.bind_ip_ua),
+                trajectory_required = EXCLUDED.trajectory_required,
+                bind_count          = core.session_bindings.bind_count + 1,
+                expires_at          = EXCLUDED.expires_at
+            {guard_clause}
+            RETURNING (xmax = 0) AS inserted
+        """
+        async with self.acquire() as conn:
+            row = await conn.fetchrow(
+                sql,
+                session_key, agent_uuid, public_agent_id, display_agent_id,
+                api_key_hash, spawn_reason, bind_ip_ua, trajectory_required,
+                expires_at,
+            )
+        if row is None:
+            return "blocked"
+        return "inserted" if row["inserted"] else "updated"
+
+    async def get_session_binding(self, session_key: str) -> Optional[Dict[str, Any]]:
+        """Read a live (unexpired) session binding as a plain dict, or None.
+
+        Returns a dict (not a dataclass) so callers like the PATH 2 fingerprint
+        hijack check can do binding.get("bind_ip_ua") uniformly. Expired rows
+        (expires_at <= now) are treated as absent — Redis enforced this via TTL;
+        PG must filter explicitly. expires_at IS NULL means permanent.
+        """
+        async with self.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT session_key, agent_uuid, public_agent_id, display_agent_id,
+                       api_key_hash, spawn_reason, bind_ip_ua, trajectory_required,
+                       bind_count, bound_at, expires_at
+                FROM core.session_bindings
+                WHERE session_key = $1
+                  AND (expires_at IS NULL OR expires_at > now())
+                """,
+                session_key,
+            )
+            return dict(row) if row else None
+
+    async def delete_session_binding(self, session_key: str) -> bool:
+        """Remove a session binding (e.g. on force_new). True if a row was removed."""
+        async with self.acquire() as conn:
+            result = await conn.execute(
+                "DELETE FROM core.session_bindings WHERE session_key = $1",
+                session_key,
+            )
+            return "DELETE 1" in result
+
+    # ------------------------------------------------------------------
+    # Onboard pins (Redis-retirement Phase 1A) — durable recent_onboard:* mirror
+    # ------------------------------------------------------------------
+
+    async def set_onboard_pin_pg(
+        self,
+        fingerprint: str,
+        agent_uuid: str,
+        client_session_id: str,
+        *,
+        ttl_seconds: int = 1800,
+        if_absent: bool = False,
+    ) -> bool:
+        """Write an onboard pin (fingerprint -> client_session_id) with a TTL.
+
+        if_absent=True implements the NX-claim semantics (a subagent must not
+        displace the driver's pin): INSERT ... ON CONFLICT DO NOTHING, returning
+        True only when this call actually claimed the slot. if_absent=False
+        upserts unconditionally and always returns True.
+        """
+        async with self.acquire() as conn:
+            if if_absent:
+                result = await conn.execute(
+                    """
+                    INSERT INTO core.onboard_pins (fingerprint, agent_uuid, client_session_id, expires_at)
+                    VALUES ($1, $2, $3, now() + ($4 * interval '1 second'))
+                    ON CONFLICT (fingerprint) DO NOTHING
+                    """,
+                    fingerprint, agent_uuid, client_session_id, ttl_seconds,
+                )
+                return "INSERT 0 1" in result
+            await conn.execute(
+                """
+                INSERT INTO core.onboard_pins (fingerprint, agent_uuid, client_session_id, expires_at)
+                VALUES ($1, $2, $3, now() + ($4 * interval '1 second'))
+                ON CONFLICT (fingerprint) DO UPDATE SET
+                    agent_uuid        = EXCLUDED.agent_uuid,
+                    client_session_id = EXCLUDED.client_session_id,
+                    expires_at        = EXCLUDED.expires_at
+                """,
+                fingerprint, agent_uuid, client_session_id, ttl_seconds,
+            )
+            return True
+
+    async def lookup_onboard_pin_pg(
+        self,
+        fingerprint: str,
+        *,
+        refresh_ttl: bool = False,
+        ttl_seconds: int = 1800,
+    ) -> Optional[str]:
+        """Return the pinned client_session_id for a fingerprint, or None.
+
+        Expired pins are treated as absent. refresh_ttl extends the pin's TTL on
+        a hit (mirrors the Redis expire-on-read behavior).
+        """
+        async with self.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT client_session_id
+                FROM core.onboard_pins
+                WHERE fingerprint = $1 AND expires_at > now()
+                """,
+                fingerprint,
+            )
+            if not row:
+                return None
+            if refresh_ttl:
+                await conn.execute(
+                    """
+                    UPDATE core.onboard_pins
+                    SET expires_at = now() + ($2 * interval '1 second')
+                    WHERE fingerprint = $1
+                    """,
+                    fingerprint, ttl_seconds,
+                )
+            return row["client_session_id"]

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -153,6 +153,10 @@ async def ensure_test_database_schema() -> None:
         # (extends the 026/042 grammar CHECK). Applied after 042 here because
         # it supersedes the same surface_id_grammar constraint.
         await _execute_sql_file(conn, "db/postgres/migrations/050_lease_plane_maintenance_scheme.sql")
+        # Migration 051: Redis-retirement Phase 1 session-binding + onboard-pin
+        # mirror tables (FK-less; additive/inert). Depends only on the core
+        # schema. See docs/proposals/redis-retirement-phase-1-plan.md.
+        await _execute_sql_file(conn, "db/postgres/migrations/051_session_mirror_tables.sql")
 
         # Ensure partitioned audit tables can accept inserts for current month.
         await _execute_sql_file(conn, "db/postgres/partitions.sql")
@@ -183,6 +187,8 @@ TRUNCATE_TABLES = [
     "core.agent_state",
     "core.agent_sessions",
     "core.agent_baselines",
+    "core.session_bindings",
+    "core.onboard_pins",
     "core.sessions",
     "core.identities",
     "core.agents",

--- a/tests/test_session_mirror_parity_check.py
+++ b/tests/test_session_mirror_parity_check.py
@@ -1,0 +1,98 @@
+"""Unit tests for the session-mirror birth-cohort parity checker (pure logic).
+
+No Redis/PG needed — exercises compare_birth_cohort and _parse_bound_at directly.
+See scripts/ops/session_mirror_parity_check.py and
+docs/proposals/redis-retirement-phase-1-plan.md.
+"""
+
+import importlib.util
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).parent.parent
+_MOD_PATH = _PROJECT_ROOT / "scripts" / "ops" / "session_mirror_parity_check.py"
+_spec = importlib.util.spec_from_file_location("session_mirror_parity_check", _MOD_PATH)
+mod = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = mod
+_spec.loader.exec_module(mod)
+
+NOW = datetime(2026, 6, 28, 12, 0, 0, tzinfo=timezone.utc)
+MIN_AGE = timedelta(minutes=5)
+MAX_AGE = timedelta(minutes=60)
+
+
+def _payload(agent_id, *, age_min):
+    bound = (NOW - timedelta(minutes=age_min)).isoformat()
+    return {"agent_id": agent_id, "bound_at": bound}
+
+
+# --- _parse_bound_at ---
+
+def test_parse_bound_at_naive_becomes_utc():
+    dt = mod._parse_bound_at({"bound_at": "2026-06-28T11:30:00"})
+    assert dt is not None and dt.tzinfo is not None
+
+
+def test_parse_bound_at_bad_and_missing():
+    assert mod._parse_bound_at({"bound_at": "not-a-date"}) is None
+    assert mod._parse_bound_at({}) is None
+    assert mod._parse_bound_at({"bound_at": 12345}) is None
+
+
+# --- compare_birth_cohort ---
+
+def _run(redis_items, pg):
+    return mod.compare_birth_cohort(redis_items, pg, now=NOW, min_age=MIN_AGE, max_age=MAX_AGE)
+
+
+def test_full_match_in_cohort():
+    redis = {"sk1": _payload("u1", age_min=30), "sk2": _payload("u2", age_min=10)}
+    pg = {"sk1": "u1", "sk2": "u2"}
+    s = _run(redis, pg)
+    assert s["cohort_size"] == 2 and s["matched"] == 2
+    assert s["parity_ratio"] == 1.0
+    assert s["missing_in_pg"] == 0 and s["uuid_mismatch"] == 0
+
+
+def test_missing_in_pg_counted():
+    redis = {"sk1": _payload("u1", age_min=30)}
+    s = _run(redis, {})  # PG has nothing
+    assert s["cohort_size"] == 1 and s["matched"] == 0
+    assert s["missing_in_pg"] == 1
+    assert s["parity_ratio"] == 0.0
+    assert s["sample_missing"] == ["sk1"]
+
+
+def test_uuid_mismatch_counted():
+    redis = {"sk1": _payload("u1", age_min=30)}
+    pg = {"sk1": "DIFFERENT"}
+    s = _run(redis, pg)
+    assert s["uuid_mismatch"] == 1 and s["matched"] == 0
+    assert s["sample_mismatch"][0]["redis"] == "u1"
+    assert s["sample_mismatch"][0]["pg"] == "DIFFERENT"
+
+
+def test_too_young_and_too_old_excluded():
+    redis = {
+        "young": _payload("u1", age_min=2),    # < 5 min, mid-flight
+        "old": _payload("u2", age_min=120),    # > 60 min, may be reaped
+        "incohort": _payload("u3", age_min=30),
+    }
+    pg = {"incohort": "u3"}  # only the in-cohort one mirrored
+    s = _run(redis, pg)
+    assert s["cohort_size"] == 1  # young + old excluded -> no spurious divergence
+    assert s["matched"] == 1 and s["parity_ratio"] == 1.0
+
+
+def test_unparseable_bound_at_excluded():
+    redis = {"bad": {"agent_id": "u1", "bound_at": "garbage"}}
+    s = _run(redis, {})
+    assert s["cohort_size"] == 0 and s["parity_ratio"] is None
+
+
+def test_empty_cohort_ratio_none():
+    s = _run({}, {})
+    assert s["cohort_size"] == 0 and s["parity_ratio"] is None

--- a/tests/test_session_mirror_tables.py
+++ b/tests/test_session_mirror_tables.py
@@ -1,0 +1,193 @@
+"""Integration tests for the Redis-retirement Phase 1 session-binding +
+onboard-pin mirror tables (migration 051) and their DB mixin methods.
+
+Runs against governance_test; skips if unavailable. The methods are inert in
+production (nothing wires them yet) — these tests exercise them directly against
+a real PostgreSQL so the durable mirror is proven before the dual-write PR.
+
+See docs/proposals/redis-retirement-phase-1-plan.md.
+"""
+
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+try:
+    import asyncpg  # noqa: F401
+except ImportError:
+    pytest.skip("asyncpg not installed", allow_module_level=True)
+
+from tests.test_db_utils import can_connect_to_test_db
+
+if not can_connect_to_test_db():
+    pytest.skip("governance_test database not available", allow_module_level=True)
+
+
+@pytest_asyncio.fixture
+async def backend(live_postgres_backend):
+    """Alias for the conftest live_postgres_backend fixture (governance_test)."""
+    return live_postgres_backend
+
+
+def _uuid() -> str:
+    return str(uuid.uuid4())
+
+
+def _future(seconds: int = 3600) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(seconds=seconds)
+
+
+def _past(seconds: int = 3600) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(seconds=seconds)
+
+
+# ---------------------------------------------------------------------------
+# session_bindings
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_insert_then_get_roundtrips_rich_fields(backend):
+    sk, au = "agent-" + _uuid()[:12], _uuid()
+    outcome = await backend.upsert_session_binding(
+        sk, au,
+        public_agent_id="Claude_Code_20260628",
+        display_agent_id="Claude_Code_20260628",
+        api_key_hash="hash-abc",
+        spawn_reason="new_session",
+        bind_ip_ua="127.0.0.1:deadbe",
+        trajectory_required=True,
+        expires_at=_future(),
+    )
+    assert outcome == "inserted"
+
+    row = await backend.get_session_binding(sk)
+    assert row is not None
+    assert isinstance(row, dict)  # B2: callers do row.get("bind_ip_ua")
+    assert row["agent_uuid"] == au
+    assert row["public_agent_id"] == "Claude_Code_20260628"
+    assert row["api_key_hash"] == "hash-abc"
+    assert row["spawn_reason"] == "new_session"
+    assert row["bind_ip_ua"] == "127.0.0.1:deadbe"
+    assert row["trajectory_required"] is True
+    assert row["bind_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_same_uuid_reupsert_updates_and_bumps_bind_count(backend):
+    sk, au = "agent-" + _uuid()[:12], _uuid()
+    await backend.upsert_session_binding(sk, au, expires_at=_future())
+    outcome = await backend.upsert_session_binding(sk, au, expires_at=_future())
+    assert outcome == "updated"
+    row = await backend.get_session_binding(sk)
+    assert row["bind_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_mint_guard_blocks_divergent_uuid(backend):
+    """S21-a: mint_guard must refuse to overwrite a binding for a different uuid."""
+    sk, au1, au2 = "agent-" + _uuid()[:12], _uuid(), _uuid()
+    assert await backend.upsert_session_binding(sk, au1, expires_at=_future()) == "inserted"
+
+    outcome = await backend.upsert_session_binding(sk, au2, mint_guard=True, expires_at=_future())
+    assert outcome == "blocked"
+
+    row = await backend.get_session_binding(sk)
+    assert row["agent_uuid"] == au1  # original binding intact
+
+
+@pytest.mark.asyncio
+async def test_corrective_write_overwrites_divergent_uuid(backend):
+    """Without mint_guard, a corrective write may overwrite (authoritative source)."""
+    sk, au1, au2 = "agent-" + _uuid()[:12], _uuid(), _uuid()
+    await backend.upsert_session_binding(sk, au1, expires_at=_future())
+    outcome = await backend.upsert_session_binding(sk, au2, mint_guard=False, expires_at=_future())
+    assert outcome == "updated"
+    row = await backend.get_session_binding(sk)
+    assert row["agent_uuid"] == au2
+
+
+@pytest.mark.asyncio
+async def test_expired_binding_is_invisible(backend):
+    sk, au = "agent-" + _uuid()[:12], _uuid()
+    await backend.upsert_session_binding(sk, au, expires_at=_past())
+    assert await backend.get_session_binding(sk) is None
+
+
+@pytest.mark.asyncio
+async def test_permanent_binding_null_expiry_visible(backend):
+    sk, au = "agent-" + _uuid()[:12], _uuid()
+    await backend.upsert_session_binding(sk, au, expires_at=None)
+    row = await backend.get_session_binding(sk)
+    assert row is not None and row["expires_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_missing_binding_returns_none(backend):
+    assert await backend.get_session_binding("agent-" + _uuid()[:12]) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_session_binding(backend):
+    sk, au = "agent-" + _uuid()[:12], _uuid()
+    await backend.upsert_session_binding(sk, au, expires_at=_future())
+    assert await backend.delete_session_binding(sk) is True
+    assert await backend.get_session_binding(sk) is None
+    assert await backend.delete_session_binding(sk) is False  # already gone
+
+
+@pytest.mark.asyncio
+async def test_uuid_check_rejects_display_label(backend):
+    """The agent_uuid CHECK enforces 'proof not label' at the schema layer."""
+    sk = "agent-" + _uuid()[:12]
+    with pytest.raises(Exception):  # asyncpg.CheckViolationError
+        await backend.upsert_session_binding(sk, "Claude_Code_20260628", expires_at=_future())
+
+
+# ---------------------------------------------------------------------------
+# onboard_pins
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_set_and_lookup_onboard_pin(backend):
+    fp, au, csid = f"ua:{_uuid()[:6]}|unknown|claude", _uuid(), "agent-" + _uuid()[:12]
+    assert await backend.set_onboard_pin_pg(fp, au, csid) is True
+    assert await backend.lookup_onboard_pin_pg(fp) == csid
+
+
+@pytest.mark.asyncio
+async def test_onboard_pin_if_absent_nx_semantics(backend):
+    """if_absent must not displace an existing pin (subagent NX-claim)."""
+    fp = f"ua:{_uuid()[:6]}|unknown"
+    csid1, csid2 = "agent-" + _uuid()[:12], "agent-" + _uuid()[:12]
+    assert await backend.set_onboard_pin_pg(fp, _uuid(), csid1, if_absent=True) is True
+    assert await backend.set_onboard_pin_pg(fp, _uuid(), csid2, if_absent=True) is False
+    assert await backend.lookup_onboard_pin_pg(fp) == csid1  # first claim wins
+
+
+@pytest.mark.asyncio
+async def test_onboard_pin_upsert_overwrites(backend):
+    fp = f"ua:{_uuid()[:6]}|claude"
+    csid1, csid2 = "agent-" + _uuid()[:12], "agent-" + _uuid()[:12]
+    await backend.set_onboard_pin_pg(fp, _uuid(), csid1)
+    await backend.set_onboard_pin_pg(fp, _uuid(), csid2)  # default upsert
+    assert await backend.lookup_onboard_pin_pg(fp) == csid2
+
+
+@pytest.mark.asyncio
+async def test_expired_onboard_pin_is_invisible(backend):
+    fp, au, csid = f"ua:{_uuid()[:6]}", _uuid(), "agent-" + _uuid()[:12]
+    # negative TTL -> already expired
+    await backend.set_onboard_pin_pg(fp, au, csid, ttl_seconds=-10)
+    assert await backend.lookup_onboard_pin_pg(fp) is None
+
+
+@pytest.mark.asyncio
+async def test_lookup_missing_onboard_pin_returns_none(backend):
+    assert await backend.lookup_onboard_pin_pg(f"ua:{_uuid()[:6]}") is None


### PR DESCRIPTION
## Summary

Read-only measurement tool that **gates the eventual read flip** (`UNITARES_SESSION_MIRROR_APPLY`): how faithfully does `core.session_bindings` mirror the authoritative Redis `session:` keys? The plan and both councils say flip APPLY only after a shadow soak proves parity — this is how you measure it.

**Stacked on #1123** (reads `core.session_bindings`). Sibling of #1129 (the shadow writer that populates the mirror).

## Birth-cohort, not snapshot
The council flagged that a naive "iterate all Redis keys, are they in PG?" ratio conflates writer-correctness with expiry-race noise (independent Redis/PG expiry clocks, fast churn) — it never converges to 100% even with a perfect writer. So this samples a **birth cohort**: Redis bindings whose `bound_at` is old enough to have committed to PG (`>= --min-age-min`, default 5) but young enough not to have expired from either store (`<= --max-age-min`, default 60). Within that window a faithful writer shows ~100% match; misses are real dropped writes, not races.

Direction **Redis → PG** — catches under-mirroring, which is the cold-mint risk after the flip.

## Output / safety
- One JSON summary to stdout (cron/dashboard friendly): cohort size, matched, missing_in_pg, uuid_mismatch, parity_ratio, sample divergences. **No per-row audit events** — ~900 keys/scan would flood the audit partition (council note).
- **Inert gate:** empty mirror (shadow writer not yet enabled) → reports `inert`, exit 0.
- Read-only; exit 0 on success (parity is informational — operator picks the flip threshold), 1 on runner error.

## Tests
`compare_birth_cohort` and `_parse_bound_at` factored as pure functions; 8 unit tests (full match, missing_in_pg, uuid_mismatch, too-young/too-old exclusion, unparseable bound_at, empty cohort). CLI `--help` smoke-checked.

## How it fits
Phase 1A shadow writer (#1129) populates the mirror → operator runs this during a soak → parity ratio + write-path counters inform the keep/drop decision on `core.session_bindings` (Phase 1B) and gate the APPLY read flip. The flip code itself is the next, separate PR.