### PR TITLE
feat(eisv): promote live-proven maths defaults — Φ→telemetry + S setpoint ON

### DIFF
--- a/config/governance_config.py
+++ b/config/governance_config.py
@@ -1027,21 +1027,27 @@ S_SETPOINT_DRIVER_OFFSET: float = 0.091
 
 
 def s_setpoint_enabled() -> bool:
-    """Whether the per-class S setpoint is active (UNITARES_S_SETPOINT). Default off."""
-    return os.getenv("UNITARES_S_SETPOINT", "").strip().lower() in {"1", "true", "on", "yes"}
+    """Whether the per-class S setpoint is active (UNITARES_S_SETPOINT). Default ON
+    (live-proven): the S equilibrium rests on the class's measured-healthy S rather
+    than decaying toward ~0. Set the env to 0/false/off/"" to force the legacy -μS."""
+    return os.getenv("UNITARES_S_SETPOINT", "1").strip().lower() in {"1", "true", "on", "yes"}
 
 
 def phi_telemetry_only() -> bool:
-    """Whether Φ is demoted to telemetry (UNITARES_PHI_TELEMETRY_ONLY). Default off.
+    """Whether Φ is demoted to telemetry (UNITARES_PHI_TELEMETRY_ONLY). Default ON
+    (live-proven; the central maths-revamp posture).
 
     When on, the behavioral/residual assessment is authoritative for the verdict
     and risk score whenever it is confident; Φ no longer floors them (it only
     over-flags hard work as risk — the RLHF/punish-toward-ideal shape, see
     docs/proposals/eisv-maths-roadmap-v0.md §8.0). Φ is still computed and
     surfaced as a telemetry field. Cold-start agents (behavioral confidence below
-    the gate) still fall back to the Φ path as the prior.
+    the gate) still fall back to the Φ path as the prior. Because authoritative
+    behavioral can only *de-escalate* relative to the Φ floor, this never
+    introduces a pause — it removes Φ's over-flagging. Set the env to
+    0/false/off/"" to restore Φ-floors-risk (the legacy invariant).
     """
-    return os.getenv("UNITARES_PHI_TELEMETRY_ONLY", "").strip().lower() in {"1", "true", "on", "yes"}
+    return os.getenv("UNITARES_PHI_TELEMETRY_ONLY", "1").strip().lower() in {"1", "true", "on", "yes"}
 
 
 def grounding_shadow_enabled() -> bool:

--- a/docs/FLAGS.md
+++ b/docs/FLAGS.md
@@ -12,7 +12,7 @@ For *consequential, flag-gated capabilities* and their **wake conditions**, see
 `docs/operations/dormant-capability-registry.md` (Theme 6) — this file is the flat
 index; that one is the curated decision record.
 
-**88 flags.**
+**90 flags.**
 
 | Flag | Default | Purpose | Read at |
 |---|---|---|---|
@@ -50,15 +50,15 @@ index; that one is the curated decision record.
 | `UNITARES_FINDINGS_URL` | `'http://localhost:8767/api/fi…` | — | agents/common/findings.py:21 |
 | `UNITARES_FIRST_RUN` | `(required)` | Resolve Watcher identity via proof-owned UUID-direct → fresh onboard | agents/watcher/agent.py:271, agents/sdk/src/unitares_sdk/agent.py:364 |
 | `UNITARES_GOVERNANCE_URL` | `(required)` | read by _governance_url() | src/mcp_handlers/dialectic/orchestrator_dispatch.py:53, agents/dialectic_reviewer/reviewer.py:242 |
-| `UNITARES_GROUNDING_APPLY` | `''` | Whether grounded E/I/S/coherence actually replace the ODE/heuristic values in the canonical metrics (UNITARES_GROUNDING_APPLY) | config/governance_config.py:1070 |
-| `UNITARES_GROUNDING_SHADOW` | `''` | Whether to shadow-compare grounded vs ungrounded canonical metrics each check-in (UNITARES_GROUNDING_SHADOW) | config/governance_config.py:1058 |
+| `UNITARES_GROUNDING_APPLY` | `''` | Whether grounded E/I/S/coherence actually replace the ODE/heuristic values in the canonical metrics (UNITARES_GROUNDING_APPLY) | config/governance_config.py:1076 |
+| `UNITARES_GROUNDING_SHADOW` | `''` | Whether to shadow-compare grounded vs ungrounded canonical metrics each check-in (UNITARES_GROUNDING_SHADOW) | config/governance_config.py:1064 |
 | `UNITARES_HEALTH_PROBE_INTERVAL_SECONDS` | `(required)` | Periodically run the deep health check and cache the result | src/background_tasks.py:526 |
 | `UNITARES_HTTP_API_TOKEN` | `(required)` | List all tools in OpenAI-compatible format Query params: mode: Tool mode filter - "minimal", "lite", "full" | src/http_api.py:436, src/http_api.py:485 (+34 more) |
 | `UNITARES_HTTP_CORS_ALLOW_ORIGIN` | `(required)` | Main entry point for governance MCP server. | src/mcp_server.py:841, src/mcp_server.py:883 |
-| `UNITARES_IDENTITY_STRICT` | `'log'` | Runtime accessor — respects env changes set after module load | config/governance_config.py:1099, config/governance_config.py:1108 |
+| `UNITARES_IDENTITY_STRICT` | `'log'` | Runtime accessor — respects env changes set after module load | config/governance_config.py:1129, config/governance_config.py:1138 |
 | `UNITARES_INCLUDE_API_KEY_IN_RESPONSES` | `(required)` | Include onboarding guidance, API key hints, welcome message. | src/mcp_handlers/updates/enrichments.py:533 |
 | `UNITARES_INTEGRATOR` | `'rk4'` | Returns the ODE integration method | governance_core/parameters.py:143 |
-| `UNITARES_IPUA_PIN_CHECK` | `'strict'` | Runtime accessor — respects env changes set after module load | config/governance_config.py:1221, config/governance_config.py:1232 |
+| `UNITARES_IPUA_PIN_CHECK` | `'strict'` | Runtime accessor — respects env changes set after module load | config/governance_config.py:1251, config/governance_config.py:1262 |
 | `UNITARES_I_DYNAMICS` | `'linear'` | Returns the I-channel dynamics mode | governance_core/parameters.py:160 |
 | `UNITARES_KG_PROACTIVE_EVERY` | `'0'` | Gate the proactive (steady-state) KG surface — cadence + warmup + length | src/mcp_handlers/updates/enrichments.py:1555 |
 | `UNITARES_KNOWLEDGE_BACKEND` | `'auto'` | Get global knowledge graph instance (singleton) | src/knowledge_graph.py:265, src/knowledge_graph.py:340 |
@@ -80,9 +80,9 @@ index; that one is the curated decision record.
 | `UNITARES_PARAMS_PROFILE` | `'default'` | Returns the active parameters profile name | governance_core/parameters.py:243 |
 | `UNITARES_PARENT_AGENT_ID` | `(required)` | read by main() | agents/dialectic_reviewer/reviewer.py:243 |
 | `UNITARES_PAUSE_AUTO_EXPIRE_SECONDS` | `str(72 * 3600)` | — | config/governance_config.py:749 |
-| `UNITARES_PHASE5_EVIDENCE_WRITE` | `''` | Health check, CIRS emissions, PG record, outcome events | src/mcp_handlers/updates/phases.py:2048 |
-| `UNITARES_PHI_TELEMETRY_ONLY` | `''` | Whether Φ is demoted to telemetry (UNITARES_PHI_TELEMETRY_ONLY) | config/governance_config.py:1044 |
-| `UNITARES_PREFIX_BIND_FINGERPRINT` | `'off'` | Runtime accessor — respects env changes set after module load | config/governance_config.py:1183, config/governance_config.py:1192 |
+| `UNITARES_PHASE5_EVIDENCE_WRITE` | `''` | Health check, CIRS emissions, PG record, outcome events | src/mcp_handlers/updates/phases.py:2049 |
+| `UNITARES_PHI_TELEMETRY_ONLY` | `'1'` | Whether Φ is demoted to telemetry (UNITARES_PHI_TELEMETRY_ONLY) | config/governance_config.py:1050 |
+| `UNITARES_PREFIX_BIND_FINGERPRINT` | `'off'` | Runtime accessor — respects env changes set after module load | config/governance_config.py:1213, config/governance_config.py:1222 |
 | `UNITARES_PROCESS_UPDATE_RESPONSE_MODE` | `'auto'` | Apply response mode filtering to fully-built response_data | src/mcp_handlers/response_formatter.py:238 |
 | `UNITARES_PROGRESS_FLAT_PROBE_INTERVAL_SECONDS` | `(required)` | Resident-progress telemetry probe | src/background_tasks.py:579 |
 | `UNITARES_PROXY_URL` | `(required)` | — | src/mcp_server_std.py:127 |
@@ -90,13 +90,15 @@ index; that one is the curated decision record.
 | `UNITARES_RERANKER_MODEL` | `'bge-m3'` | — | src/reranker.py:38 |
 | `UNITARES_RESIDENT_AGENTS` | `''` | Figure out which agent labels to treat as residents | src/http_api.py:2661 |
 | `UNITARES_SENSOR_COUPLING` | `(required)` | Whether sensor-derived EISV spring-couples into the ODE | governance_core/parameters.py:182, governance_core/parameters.py:204 |
-| `UNITARES_SESSION_FINGERPRINT_CHECK` | `'log'` | Runtime accessor — respects env changes set after module load | config/governance_config.py:1135, config/governance_config.py:1146 |
+| `UNITARES_SESSION_FINGERPRINT_CHECK` | `'log'` | Runtime accessor — respects env changes set after module load | config/governance_config.py:1165, config/governance_config.py:1176 |
+| `UNITARES_SESSION_MIRROR_APPLY` | `''` | Whether the resolver READS the PostgreSQL session mirror as a source of truth (UNITARES_SESSION_MIRROR_APPLY) | config/governance_config.py:1100 |
+| `UNITARES_SESSION_MIRROR_SHADOW` | `''` | Whether to dual-write session/identity bindings into the PostgreSQL mirror tables (core.session_bindings, core.onboard_pins) alongside the R | config/governance_config.py:1090 |
 | `UNITARES_STDIO_PROXY_HTTP_BEARER_TOKEN` | `(required)` | — | src/mcp_server_std.py:131 |
 | `UNITARES_STDIO_PROXY_HTTP_URL` | `(required)` | — | src/mcp_server_std.py:126 |
 | `UNITARES_STDIO_PROXY_SSE_URL` | `(required)` | — | src/mcp_server_std.py:129 |
 | `UNITARES_STDIO_PROXY_STRICT` | `'1'` | — | src/mcp_server_std.py:130 |
 | `UNITARES_STDIO_PROXY_URL` | `(required)` | — | src/mcp_server_std.py:128 |
-| `UNITARES_S_SETPOINT` | `''` | Whether the per-class S setpoint is active (UNITARES_S_SETPOINT) | config/governance_config.py:1031 |
+| `UNITARES_S_SETPOINT` | `'1'` | Whether the per-class S setpoint is active (UNITARES_S_SETPOINT) | config/governance_config.py:1033 |
 | `UNITARES_TOOL_SCHEMA_STRIP_FIELD_DESCRIPTIONS` | `'0'` | Build the list of MCP Tool objects from Pydantic schemas + descriptions. | src/tool_schemas.py:234 |
 | `UNITARES_TOOL_SCHEMA_VERBOSITY` | `'short'` | Build the list of MCP Tool objects from Pydantic schemas + descriptions. | src/tool_schemas.py:231 |
 | `UNITARES_TOOL_USAGE_LOG` | `(required)` | read by __init__() | src/tool_usage_tracker.py:57 |

--- a/tests/test_eisv_s_setpoint.py
+++ b/tests/test_eisv_s_setpoint.py
@@ -52,7 +52,15 @@ def test_setpoint_shifts_equilibrium_by_offset():
     assert _rest(sigma).S == pytest.approx(sigma + 0.091, abs=0.01)
 
 
-def test_get_s_setpoint_off_by_default():
+def test_get_s_setpoint_on_by_default(monkeypatch):
+    # Default ON (live-proven) when the env is unset.
+    monkeypatch.delenv("UNITARES_S_SETPOINT", raising=False)
+    assert s_setpoint_enabled()
+
+
+def test_get_s_setpoint_off_when_disabled(monkeypatch):
+    # Explicit off restores the legacy -μS behavior (setpoint 0.0).
+    monkeypatch.setenv("UNITARES_S_SETPOINT", "0")
     assert not s_setpoint_enabled()
     assert get_s_setpoint("default") == 0.0
     assert get_s_setpoint("Lumen") == 0.0

--- a/tests/test_eisv_s_setpoint_phi_coupling.py
+++ b/tests/test_eisv_s_setpoint_phi_coupling.py
@@ -39,8 +39,12 @@ def _healthy_rest_state(agent_class):
     return State(E=0.805, I=0.822, S=s_healthy, V=-0.013)
 
 
-def test_phi_eval_state_noop_when_flag_off():
-    """Flag off → phi_eval_state returns the state unchanged (byte-identical Φ)."""
+def test_phi_eval_state_noop_when_flag_off(monkeypatch):
+    """Flag off → phi_eval_state returns the state unchanged (byte-identical Φ).
+
+    S_SETPOINT now defaults ON, so force it off to exercise the no-op path.
+    """
+    monkeypatch.setenv("UNITARES_S_SETPOINT", "0")
     st = _healthy_rest_state("Watcher")
     mon = _FakeMonitor("Watcher", st)
     out = phi_eval_state(mon, st)

--- a/tests/test_governance_monitor.py
+++ b/tests/test_governance_monitor.py
@@ -1081,8 +1081,14 @@ class TestEstimateRisk:
         risk = monitor.estimate_risk({'response_text': 'Test'}, score_result=score_result)
         assert 0.0 <= risk <= 1.0
 
-    def test_worsening_declared_inputs_do_not_lower_risk_after_behavioral_override(self):
-        """Behavioral risk may add signal, but must not erase worse self-attested risk."""
+    def test_worsening_declared_inputs_do_not_lower_risk_after_behavioral_override(self, monkeypatch):
+        """Behavioral risk may add signal, but must not erase worse self-attested risk.
+
+        This is the Φ-FLOOR invariant. Since UNITARES_PHI_TELEMETRY_ONLY now
+        defaults ON (behavioral authoritative, which may de-escalate Φ), floor
+        mode is opt-in — force it off here to validate it still holds.
+        """
+        monkeypatch.setenv("UNITARES_PHI_TELEMETRY_ONLY", "0")
         monitor = UNITARESMonitor("test-risk-monotonic", load_state=False)
         sequence = [
             (0.40, 0.70, []),

--- a/tests/test_phi_telemetry.py
+++ b/tests/test_phi_telemetry.py
@@ -48,10 +48,15 @@ def test_off_is_byte_identical_to_historical_floor(pv, pr, bv, br):
     assert r == max(pr, br)
 
 
-def test_flag_default_off():
-    assert phi_telemetry_only() is False
+def test_flag_default_on(monkeypatch):
+    # Default ON (live-proven maths posture) when the env is unset.
+    monkeypatch.delenv("UNITARES_PHI_TELEMETRY_ONLY", raising=False)
+    assert phi_telemetry_only() is True
 
 
 def test_flag_reads_env(monkeypatch):
     monkeypatch.setenv("UNITARES_PHI_TELEMETRY_ONLY", "1")
     assert phi_telemetry_only() is True
+    # Explicit off override restores the legacy Φ-floor.
+    monkeypatch.setenv("UNITARES_PHI_TELEMETRY_ONLY", "0")
+    assert phi_telemetry_only() is False


### PR DESCRIPTION
Second of the gate-cleanup pass. The deployment has run `UNITARES_PHI_TELEMETRY_ONLY=1` and `UNITARES_S_SETPOINT=1` (the maths revamp) for a while, but the **code defaults stayed off** — so the flags could never retire, and every fresh checkout / CI run / external install ran the legacy path while production ran the new one. This promotes the two pure-behavior maths flips to match live.

### Decision in this PR (the one to eyeball)
`PHI_TELEMETRY_ONLY` default-on changes a **verdict invariant** for everyone, not just the live box: behavioral/residual becomes authoritative when confident, and Φ is demoted to telemetry. Because authoritative-behavioral can only **de-escalate** vs the Φ floor, **it never introduces a pause** — it removes Φ's over-flagging of hard work. Φ still floors as the cold-start prior. Both flags stay overridable (set env to `0`/`false`/`off`/`""` to restore legacy `Φ-floors-risk` / `-μS`).

### Promoted
- `phi_telemetry_only()` → default **ON**
- `s_setpoint_enabled()` → default **ON** (S equilibrium rests on the class's measured-healthy S instead of decaying to ~0)

### Deliberately NOT promoted (left opt-in — good gating, not debt)
- `UNITARES_DIALECTIC_ORCHESTRATED_REVIEW` — infra-dependent (needs the BEAM orchestrator running); default-on would break installs without it.
- `UNITARES_IDENTITY_STRICT` / `SESSION_FINGERPRINT_CHECK` — the `log` default is intentionally conservative so strict identity doesn't break external callers before an audit.

### Tests
Measured blast radius first (full suite with the flags forced on): exactly **4** tests pinned the old defaults. All updated:
- `test_phi_telemetry`: default-off → default-on; reads-env now checks the explicit-off override.
- `test_eisv_s_setpoint`: off-by-default → on-by-default + new explicit-off test for the 0.0 setpoint path.
- `test_eisv_s_setpoint_phi_coupling`: noop test forces the flag off explicitly.
- `test_governance_monitor`: the Φ-floor monotonicity invariant forces `phi_telemetry` off (floor mode is now opt-in); the on-path de-escalation is already covered in `test_phi_telemetry`.

FLAGS.md regenerated (`flags_catalog_fresh ✓`). **Full suite green: 10875 passed, 21 skipped.**

Pairs with #1131 (basin-shadow removal). Together these make the maths migration *true in code*, not just in the plist. Remaining genuine pending: `GROUNDING_APPLY` (needs more shadow data; per-class, never fleet-wide).

https://claude.ai/code/session_01VsXq3pJjFtzdy7GCeJ4PBq