### PR TITLE
fix(db): TTL/NX parity + reaper for session mirror (Codex review #1, #4)

### DIFF
--- a/db/postgres/migrations/051_session_mirror_tables.sql
+++ b/db/postgres/migrations/051_session_mirror_tables.sql
@@ -68,6 +68,43 @@ COMMENT ON TABLE core.session_bindings IS
     'soak shows material cold-mints not covered by an onboard pin. Distinct from '
     'coordination.session_resolution_sagas (Wave 3 saga state).';
 
+-- Reaper: extend core.cleanup_expired_sessions() (called by the session-cleanup
+-- background task) to also physically delete expired mirror rows. Without this,
+-- expired session_bindings / onboard_pins accumulate over a long soak AND the
+-- stale rows worsen the TTL/NX claim guards (Codex review #4). Read paths and the
+-- claim guards already filter expires_at, so this is hygiene, not correctness —
+-- but it bounds table growth and keeps the guards clean. CREATE OR REPLACE so the
+-- migration is re-runnable; runs after schema.sql in every bootstrap so this
+-- extended definition wins. session_bindings permanent rows (expires_at IS NULL)
+-- are intentionally never reaped here.
+CREATE OR REPLACE FUNCTION core.cleanup_expired_sessions()
+RETURNS INTEGER AS $$
+DECLARE
+    v_count INTEGER;
+BEGIN
+    WITH deleted_sessions AS (
+        DELETE FROM core.sessions
+        WHERE expires_at < now() OR (is_active = FALSE AND last_active < now() - INTERVAL '1 hour')
+        RETURNING 1
+    ),
+    deleted_bindings AS (
+        DELETE FROM core.session_bindings
+        WHERE expires_at IS NOT NULL AND expires_at < now()
+        RETURNING 1
+    ),
+    deleted_pins AS (
+        DELETE FROM core.onboard_pins
+        WHERE expires_at < now()
+        RETURNING 1
+    )
+    SELECT (SELECT COUNT(*) FROM deleted_sessions)
+         + (SELECT COUNT(*) FROM deleted_bindings)
+         + (SELECT COUNT(*) FROM deleted_pins)
+      INTO v_count;
+    RETURN v_count;
+END;
+$$ LANGUAGE plpgsql;
+
 -- Register migration
 INSERT INTO core.schema_migrations (version, name, applied_at)
 VALUES (51, 'session_mirror_tables', NOW())

--- a/src/db/mixins/session.py
+++ b/src/db/mixins/session.py
@@ -182,8 +182,15 @@ class SessionMixin:
         (xmax<>0); when mint_guard blocks, the conditional UPDATE matches no row
         and RETURNING yields nothing -> "blocked".
         """
+        # mint_guard blocks an overwrite ONLY when a *live* row binds a
+        # different agent_uuid. An expired row (expires_at in the past; NULL =
+        # permanent, never expired) is overwritable — it matches Redis TTL
+        # semantics where the key has vanished, so a fresh claim succeeds rather
+        # than being blocked by a stale binding (Codex review #1: TTL/NX parity).
         guard_clause = (
-            "WHERE core.session_bindings.agent_uuid = EXCLUDED.agent_uuid"
+            "WHERE core.session_bindings.agent_uuid = EXCLUDED.agent_uuid "
+            "OR (core.session_bindings.expires_at IS NOT NULL "
+            "AND core.session_bindings.expires_at <= now())"
             if mint_guard else ""
         )
         sql = f"""
@@ -263,21 +270,31 @@ class SessionMixin:
         """Write an onboard pin (fingerprint -> client_session_id) with a TTL.
 
         if_absent=True implements the NX-claim semantics (a subagent must not
-        displace the driver's pin): INSERT ... ON CONFLICT DO NOTHING, returning
-        True only when this call actually claimed the slot. if_absent=False
-        upserts unconditionally and always returns True.
+        displace the driver's *live* pin), returning True only when this call
+        actually claimed the slot. An EXPIRED pin is claimable — it matches Redis
+        SET NX EX where the expired key is gone, so a new NX claim succeeds
+        (Codex review #1: TTL/NX parity). if_absent=False upserts unconditionally
+        and always returns True.
         """
         async with self.acquire() as conn:
             if if_absent:
-                result = await conn.execute(
+                # Claim when the slot is empty OR the existing pin is expired;
+                # a live pin (expires_at in the future) is left untouched (the
+                # conditional UPDATE matches no row -> RETURNING is empty).
+                row = await conn.fetchrow(
                     """
                     INSERT INTO core.onboard_pins (fingerprint, agent_uuid, client_session_id, expires_at)
                     VALUES ($1, $2, $3, now() + ($4 * interval '1 second'))
-                    ON CONFLICT (fingerprint) DO NOTHING
+                    ON CONFLICT (fingerprint) DO UPDATE SET
+                        agent_uuid        = EXCLUDED.agent_uuid,
+                        client_session_id = EXCLUDED.client_session_id,
+                        expires_at        = EXCLUDED.expires_at
+                    WHERE core.onboard_pins.expires_at <= now()
+                    RETURNING 1
                     """,
                     fingerprint, agent_uuid, client_session_id, ttl_seconds,
                 )
-                return "INSERT 0 1" in result
+                return row is not None
             await conn.execute(
                 """
                 INSERT INTO core.onboard_pins (fingerprint, agent_uuid, client_session_id, expires_at)

--- a/tests/test_session_mirror_tables.py
+++ b/tests/test_session_mirror_tables.py
@@ -114,6 +114,59 @@ async def test_corrective_write_overwrites_divergent_uuid(backend):
 
 
 @pytest.mark.asyncio
+async def test_expired_binding_does_not_block_mint_guard(backend):
+    """TTL/NX parity (Codex #1): an EXPIRED row for a different uuid must NOT
+    block a fresh mint_guard claim — Redis TTL would have dropped the key."""
+    sk, au1, au2 = "agent-" + _uuid()[:12], _uuid(), _uuid()
+    await backend.upsert_session_binding(sk, au1, expires_at=_past())  # already expired
+    outcome = await backend.upsert_session_binding(sk, au2, mint_guard=True, expires_at=_future())
+    assert outcome == "updated"  # claimed the expired slot, not "blocked"
+    row = await backend.get_session_binding(sk)
+    assert row["agent_uuid"] == au2
+
+
+@pytest.mark.asyncio
+async def test_live_binding_still_blocks_mint_guard(backend):
+    """Counterpart: a LIVE different-uuid row still blocks (guard intact)."""
+    sk, au1, au2 = "agent-" + _uuid()[:12], _uuid(), _uuid()
+    await backend.upsert_session_binding(sk, au1, expires_at=_future())
+    assert await backend.upsert_session_binding(sk, au2, mint_guard=True, expires_at=_future()) == "blocked"
+
+
+@pytest.mark.asyncio
+async def test_expired_pin_is_claimable_via_nx(backend):
+    """TTL/NX parity (Codex #1): if_absent must claim over an EXPIRED pin."""
+    fp = f"ua:{_uuid()[:6]}|claude"
+    old_csid, new_csid = "agent-" + _uuid()[:12], "agent-" + _uuid()[:12]
+    await backend.set_onboard_pin_pg(fp, _uuid(), old_csid, ttl_seconds=-10)  # expired
+    claimed = await backend.set_onboard_pin_pg(fp, _uuid(), new_csid, if_absent=True)
+    assert claimed is True
+    assert await backend.lookup_onboard_pin_pg(fp) == new_csid
+
+
+@pytest.mark.asyncio
+async def test_reaper_deletes_expired_mirror_rows(backend):
+    """cleanup_expired_sessions() (Codex #4) physically removes expired mirror
+    rows in both tables while leaving live rows."""
+    live_sk, exp_sk = "agent-" + _uuid()[:12], "agent-" + _uuid()[:12]
+    live_fp, exp_fp = f"ua:{_uuid()[:6]}", f"ua:{_uuid()[:6]}"
+    await backend.upsert_session_binding(live_sk, _uuid(), expires_at=_future())
+    await backend.upsert_session_binding(exp_sk, _uuid(), expires_at=_past())
+    await backend.set_onboard_pin_pg(live_fp, _uuid(), "agent-" + _uuid()[:12], ttl_seconds=3600)
+    await backend.set_onboard_pin_pg(exp_fp, _uuid(), "agent-" + _uuid()[:12], ttl_seconds=-10)
+
+    await backend.cleanup_expired_sessions()
+
+    # expired rows physically gone; live rows remain (raw existence check, not the
+    # expiry-filtered getter, so we prove physical deletion).
+    async with backend.acquire() as conn:
+        assert await conn.fetchval("SELECT count(*) FROM core.session_bindings WHERE session_key=$1", exp_sk) == 0
+        assert await conn.fetchval("SELECT count(*) FROM core.session_bindings WHERE session_key=$1", live_sk) == 1
+        assert await conn.fetchval("SELECT count(*) FROM core.onboard_pins WHERE fingerprint=$1", exp_fp) == 0
+        assert await conn.fetchval("SELECT count(*) FROM core.onboard_pins WHERE fingerprint=$1", live_fp) == 1
+
+
+@pytest.mark.asyncio
 async def test_expired_binding_is_invisible(backend):
     sk, au = "agent-" + _uuid()[:12], _uuid()
     await backend.upsert_session_binding(sk, au, expires_at=_past())


### PR DESCRIPTION
## Summary

Follow-up to the merged #1123, addressing **Codex's pre-soak review**. The PG mirror guards diverged from Redis TTL semantics — an **expired** row still blocked a fresh claim, where Redis would have dropped the key. That corrupts shadow-soak parity and would mis-resolve after the read flip, so it must land **before** the soak.

### #1 — TTL/NX parity (the real bug)
- `upsert_session_binding` mint_guard now blocks only a **live** different-uuid row; an expired row (`expires_at` past; NULL = permanent) is overwritable.
- `set_onboard_pin_pg` `if_absent` now claims over an **expired** pin (`ON CONFLICT DO UPDATE … WHERE expires_at <= now() RETURNING`), matching Redis `SET NX EX`.

### #4 — reaper
Migration 051 extends `core.cleanup_expired_sessions()` (run by the session-cleanup background task) to physically delete expired `session_bindings` / `onboard_pins` — bounds growth over a long soak and keeps the guards clean.

## Tests
+4 (expired row doesn't block mint_guard; live row still blocks; expired pin claimable via NX; reaper deletes expired rows in both tables, leaves live). **18 mirror tests green.**

## The other two review items
- **#2 api_key_hash**: verified it's written as `""` by every caller and **not consumed for auth** on the resolution path; the parity checker only compares `agent_uuid`. So it's a legacy-faithfulness note, not a read-correctness blocker — I'll refine the docstring on the shadow-write branch rather than build plumbing for a vestigial field.
- **#3 parity gate criteria**: will add a `--gate` mode (require `status==ran`, non-trivial cohort, high parity, zero mismatch) on the parity-checker branch.

Branch note: #1123 merged and its branch was auto-deleted, so this is a fresh follow-up PR against master.