### PR TITLE
feat(ops)+docs: parity flip-gate + api_key_hash note (Codex review #2, #3)

### DIFF
--- a/scripts/ops/session_mirror_parity_check.py
+++ b/scripts/ops/session_mirror_parity_check.py
@@ -164,17 +164,56 @@ async def _pg_binding_count(dsn: str) -> int:
         await conn.close()
 
 
-async def run(dsn: str, redis_url: str, min_age_min: int, max_age_min: int) -> int:
+def evaluate_gate(summary: Dict[str, Any], *, min_cohort: int, min_ratio: float):
+    """Operational gate for the read flip (Codex review #3). A plain JSON
+    summary + exit 0 is fine for cron, but the *decision* to flip
+    UNITARES_SESSION_MIRROR_APPLY must require an actually-ran check with a
+    non-trivial cohort, high parity, and zero UUID mismatch — an `inert` or
+    thin-cohort run must NOT read as "safe to flip".
+
+    Returns (passed: bool, reasons: list[str]). Pure — unit-testable.
+    """
+    reasons: List[str] = []
+    if summary.get("status") != "ran":
+        reasons.append(f"status={summary.get('status')!r} (need 'ran' — mirror empty or runner error)")
+        return False, reasons
+    cohort = summary.get("cohort_size") or 0
+    if cohort < min_cohort:
+        reasons.append(f"cohort_size={cohort} < min_cohort={min_cohort} (insufficient signal)")
+    ratio = summary.get("parity_ratio")
+    if ratio is None or ratio < min_ratio:
+        reasons.append(f"parity_ratio={ratio} < min_ratio={min_ratio}")
+    mismatch = summary.get("uuid_mismatch") or 0
+    if mismatch > 0:
+        reasons.append(f"uuid_mismatch={mismatch} > 0 (corruption — never flip)")
+    return (len(reasons) == 0), reasons
+
+
+async def run(
+    dsn: str,
+    redis_url: str,
+    min_age_min: int,
+    max_age_min: int,
+    *,
+    gate: bool = False,
+    min_cohort: int = 100,
+    min_ratio: float = 0.99,
+) -> int:
     # Inert gate: an empty mirror means the shadow writer hasn't run
     # (UNITARES_SESSION_MIRROR_SHADOW off) — every key would report
     # missing_in_pg, which is non-signal. Report and exit 0.
     mirror_rows = await _pg_binding_count(dsn)
     if mirror_rows == 0:
-        print(json.dumps({
+        summary = {
             "status": "inert",
             "reason": "core.session_bindings is empty — enable UNITARES_SESSION_MIRROR_SHADOW first",
             "mirror_rows": 0,
-        }))
+        }
+        print(json.dumps(summary))
+        if gate:
+            passed, reasons = evaluate_gate(summary, min_cohort=min_cohort, min_ratio=min_ratio)
+            print(json.dumps({"gate": "FAIL", "reasons": reasons}), file=sys.stderr)
+            return 0 if passed else 1
         return 0
 
     redis_items = await _gather_redis_items(redis_url)
@@ -189,6 +228,10 @@ async def run(dsn: str, redis_url: str, min_age_min: int, max_age_min: int) -> i
     summary["mirror_rows"] = mirror_rows
     summary["redis_session_keys"] = len(redis_items)
     print(json.dumps(summary, indent=2))
+    if gate:
+        passed, reasons = evaluate_gate(summary, min_cohort=min_cohort, min_ratio=min_ratio)
+        print(json.dumps({"gate": "PASS" if passed else "FAIL", "reasons": reasons}), file=sys.stderr)
+        return 0 if passed else 1
     return 0
 
 
@@ -200,9 +243,19 @@ def main() -> int:
                     help="cohort lower bound: bindings at least this old (committed)")
     ap.add_argument("--max-age-min", type=int, default=60,
                     help="cohort upper bound: bindings at most this old (not yet expired)")
+    ap.add_argument("--gate", action="store_true",
+                    help="exit non-zero unless the run passes the flip gate "
+                         "(status=ran, cohort>=--min-cohort, parity>=--min-ratio, zero mismatch)")
+    ap.add_argument("--min-cohort", type=int, default=100,
+                    help="--gate: minimum birth-cohort size for a trustworthy reading")
+    ap.add_argument("--min-ratio", type=float, default=0.99,
+                    help="--gate: minimum parity_ratio to pass")
     args = ap.parse_args()
     try:
-        return asyncio.run(run(args.dsn, args.redis_url, args.min_age_min, args.max_age_min))
+        return asyncio.run(run(
+            args.dsn, args.redis_url, args.min_age_min, args.max_age_min,
+            gate=args.gate, min_cohort=args.min_cohort, min_ratio=args.min_ratio,
+        ))
     except Exception as e:  # runner error
         print(json.dumps({"status": "error", "error": str(e)}), file=sys.stderr)
         return 1

--- a/src/mcp_handlers/identity/persistence.py
+++ b/src/mcp_handlers/identity/persistence.py
@@ -251,10 +251,14 @@ async def _shadow_mirror_session_binding(
     on the handler path, no anyio guard needed; the caller bounds latency with
     asyncio.wait_for). Redis-retirement Phase 1A.
 
-    KNOWN GAP (close before the Phase 1B read flip): api_key_hash is not written
-    here — _cache_session does not carry it — so legacy sessions (≈40% of live
-    Redis payloads) mirror with api_key_hash=NULL. Harmless while the mirror is
-    write-only; must be plumbed before the mirror is read as authoritative.
+    api_key_hash note (Codex review #2): not written here, so the mirror has
+    api_key_hash=NULL. Verified this is NOT a read-flip blocker: every identity
+    write on the resolution path passes api_key_hash="" (it is not populated for
+    new sessions and not consumed for auth — auth is the bearer/agent_id stack),
+    and the parity checker compares only agent_uuid. The ≈40% of *legacy* Redis
+    payloads that carry a non-empty api_key_hash predate current writes; nothing
+    reads it back. If a future change makes api_key_hash auth-bearing, plumb it
+    here and add it to the parity comparison first.
     """
     try:
         from config.governance_config import session_mirror_shadow_enabled

--- a/tests/test_session_mirror_parity_check.py
+++ b/tests/test_session_mirror_parity_check.py
@@ -96,3 +96,34 @@ def test_unparseable_bound_at_excluded():
 def test_empty_cohort_ratio_none():
     s = _run({}, {})
     assert s["cohort_size"] == 0 and s["parity_ratio"] is None
+
+
+# --- evaluate_gate (Codex review #3: flip-decision gate) ---
+
+def _gate(summary, min_cohort=100, min_ratio=0.99):
+    return mod.evaluate_gate(summary, min_cohort=min_cohort, min_ratio=min_ratio)
+
+
+def test_gate_fails_on_inert():
+    passed, reasons = _gate({"status": "inert"})
+    assert passed is False and any("status" in r for r in reasons)
+
+
+def test_gate_passes_on_clean_ran():
+    passed, reasons = _gate({"status": "ran", "cohort_size": 250, "parity_ratio": 1.0, "uuid_mismatch": 0})
+    assert passed is True and reasons == []
+
+
+def test_gate_fails_on_thin_cohort():
+    passed, reasons = _gate({"status": "ran", "cohort_size": 10, "parity_ratio": 1.0, "uuid_mismatch": 0})
+    assert passed is False and any("cohort_size" in r for r in reasons)
+
+
+def test_gate_fails_on_low_parity():
+    passed, reasons = _gate({"status": "ran", "cohort_size": 250, "parity_ratio": 0.80, "uuid_mismatch": 0})
+    assert passed is False and any("parity_ratio" in r for r in reasons)
+
+
+def test_gate_fails_on_any_uuid_mismatch():
+    passed, reasons = _gate({"status": "ran", "cohort_size": 250, "parity_ratio": 1.0, "uuid_mismatch": 1})
+    assert passed is False and any("uuid_mismatch" in r for r in reasons)


### PR DESCRIPTION
Follow-up to the merged shadow stack, closing the remaining two items from Codex's pre-soak review (findings #1 and #4 are in #1135).

## #3 — parity flip-gate
Adds `--gate` (+ `--min-cohort`, `--min-ratio`) to `session_mirror_parity_check.py`. Plain runs stay exit-0/informational (cron-friendly), but `--gate` makes the flip decision **enforceable**: exits non-zero unless the run is decision-grade — `status=ran`, cohort ≥ min, parity ≥ ratio, and **zero** uuid_mismatch. An `inert` or thin-cohort run no longer reads as "safe to flip". Pure `evaluate_gate()` + 5 unit tests.

## #2 — api_key_hash (corrected, with evidence)
Codex flagged this as a read-flip blocker. **Verified it isn't:** every identity write on the resolution path passes `api_key_hash=""` (not populated for new sessions, not consumed for auth — auth is the bearer/agent_id stack), and the parity checker compares only `agent_uuid`. The ~40% of *legacy* Redis payloads with a value predate current writes and nothing reads them back. Updated the mirror docstring to record this and the condition under which it *would* need plumbing — rather than build plumbing for a vestigial field.

## Disposition of the full review
- #1 TTL/NX parity — #1135 ✅
- #2 api_key_hash — here (verified non-blocker, documented)
- #3 parity gate — here ✅
- #4 reaper — #1135 ✅

13 parity tests green.