### PR TITLE
feat(doctor): class_anchors_fresh — warn when per-class anchors go stale

### DIFF
--- a/scripts/dev/unitares_doctor.py
+++ b/scripts/dev/unitares_doctor.py
@@ -783,6 +783,62 @@ def check_flags_catalog_fresh(repo_root: Path) -> CheckResult:
     )
 
 
+def check_class_anchors_fresh(repo_root: Path) -> CheckResult:
+    """WARN if the per-class manifold anchors have gone stale.
+
+    HEALTHY_OPERATING_POINT_BY_CLASS / DELTA_NORM_MAX_BY_CLASS
+    (config/governance_config.py) are hand-snapshotted from a healthy-regime
+    slice via scripts/calibrate_class_conditional.py. They feed manifold
+    coherence and (via healthy_S) the live S-setpoint, but nothing forces a
+    refresh — so they silently drift from reality. In 2026-06 Lumen's anchor was
+    ~2 months stale, pinning its manifold coherence at 0 on every check-in. WARN
+    (not FAIL — staleness degrades a signal, it doesn't break the build) when the
+    newest 'measured_on' is older than the threshold.
+
+    Regenerate WITH the live roster so per-label residents map to the keys:
+      UNITARES_RESIDENTS=<csv> python3 scripts/calibrate_class_conditional.py
+    """
+    name, mode = "class_anchors_fresh", "local"
+    stale_days = 90
+    try:
+        if str(repo_root) not in sys.path:
+            sys.path.insert(0, str(repo_root))
+        from config.governance_config import DELTA_NORM_MAX_BY_CLASS
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc)
+        # Per-class, measured-only: an alias (provenance!='measured') is
+        # deliberately not a measurement, so it never counts as stale. Keying on
+        # the OLDEST measured class (not the newest) is the point — a fresh
+        # refresh of one class must not mask a stale neighbour (Lumen 2026-06).
+        stale = []
+        for cls, sc in DELTA_NORM_MAX_BY_CLASS.items():
+            if getattr(sc, "provenance", None) != "measured":
+                continue
+            mo = getattr(sc, "measured_on", None)
+            if not mo:
+                continue
+            try:
+                age = (now - datetime.strptime(mo, "%Y-%m-%d").replace(tzinfo=timezone.utc)).days
+            except ValueError:
+                continue
+            if age > stale_days:
+                stale.append((cls, age))
+        if not stale:
+            return CheckResult(name, mode, Status.PASS,
+                               "all measured class anchors within "
+                               f"{stale_days}d")
+        stale.sort(key=lambda x: -x[1])
+        worst = stale[0]
+        return CheckResult(
+            name, mode, Status.WARN,
+            f"{len(stale)} class anchor(s) stale (oldest {worst[0]} {worst[1]}d > {stale_days}d)",
+            detail=("stale: " + ", ".join(f"{c}({a}d)" for c, a in stale)
+                    + "  -> UNITARES_RESIDENTS=<csv> python3 scripts/calibrate_class_conditional.py"),
+        )
+    except Exception as e:
+        return CheckResult(name, mode, Status.SKIP, f"anchor freshness check skipped: {e}")
+
+
 def build_checks(repo_root: Path, db_url: str) -> list[Check]:
     loaded_cache: dict[str, set[str]] = {}
 
@@ -806,6 +862,8 @@ def build_checks(repo_root: Path, db_url: str) -> list[Check]:
               lambda: check_dockerfile_pinned_tags(repo_root)),
         Check("flags_catalog_fresh", "local",
               lambda: check_flags_catalog_fresh(repo_root)),
+        Check("class_anchors_fresh", "local",
+              lambda: check_class_anchors_fresh(repo_root)),
         Check("anchor_directory", "local", check_anchor_dir),
         Check("secrets_file", "local", check_secrets_file),
         Check("http_listening", "operator", check_http_listening),

--- a/tests/test_unitares_doctor_script.py
+++ b/tests/test_unitares_doctor_script.py
@@ -598,3 +598,20 @@ def test_dockerfile_pinned_tags_ignores_build_stage_refs(doctor, tmp_path):
     )
     result = doctor.check_dockerfile_pinned_tags(tmp_path)
     assert result.status == doctor.Status.PASS
+
+
+def test_check_class_anchors_fresh_runs_and_classifies(doctor):
+    """Against the real anchor dicts the freshness check returns a valid result
+    (PASS/WARN), is registered, and reports per-class age."""
+    result = doctor.check_class_anchors_fresh(REPO_ROOT)
+    assert result.name == "class_anchors_fresh"
+    assert result.status in {doctor.Status.PASS, doctor.Status.WARN}
+    # WARN must name the stale classes so the operator knows what to regenerate.
+    if result.status == doctor.Status.WARN:
+        assert "stale" in result.message
+        assert "calibrate_class_conditional.py" in (result.detail or "")
+
+
+def test_class_anchors_fresh_is_registered(doctor):
+    names = {c.name for c in doctor.build_checks(REPO_ROOT, "postgresql://x/y")}
+    assert "class_anchors_fresh" in names


### PR DESCRIPTION
The per-class manifold anchors (`HEALTHY_OPERATING_POINT_BY_CLASS` / `DELTA_NORM_MAX_BY_CLASS`) are hand-snapshotted via `scripts/calibrate_class_conditional.py`, and nothing forced a refresh — so they silently drifted. In 2026-06 Lumen's anchor was ~2 months stale and pinned its manifold coherence at 0 on every check-in (the blocker fixed in #1138). This adds a `unitares_doctor` check so that can't recur silently — the follow-up I flagged when scoping the recalibration.

### Behavior
- **WARN** (not FAIL — staleness degrades a signal, it doesn't break the build) when any **measured** class anchor's `measured_on` is older than **90d**.
- **Keys on the OLDEST measured class, not the newest** — this is the point. A fresh refresh of one class must not mask a stale neighbour, which is exactly how Lumen slipped through: `engaged_ephemeral` was refreshed 2026-05-30 while Lumen sat at 2026-04-18, so a "newest date" check would read fresh.
- Alias entries (`provenance != 'measured'`, e.g. Steward/Chronicler) are deliberately skipped — they're intentionally un-measured.
- The detail names the stale classes and the regen command **including the `UNITARES_RESIDENTS` roster** (the easy-to-miss step that, if omitted, misclassifies residents by tag).

### Tests
`runs-and-classifies` + `is-registered`; full doctor suite green (42).

### Honest limitation (follow-up)
A date check is a proxy — it can't catch a *wrong-but-recent* value. The stronger guard is drift-based: compare the live corpus median to the stored anchor and warn on divergence. Noted for later; this date floor is the cheap, deterministic, no-DB version that would have caught the Lumen case once it crossed 90d.

Caps the gate-cleanup arc: #1131 (delete dead flag) → #1133 (promote maths defaults) → #1138 (recalibrate stale anchors) → this (stop them going stale again).

https://claude.ai/code/session_01VsXq3pJjFtzdy7GCeJ4PBq