### PR TITLE
fix(eisv): de-leak per-class anchors — generic classes public, named residents via overlay

### DIFF
--- a/config/governance_config.py
+++ b/config/governance_config.py
@@ -225,17 +225,14 @@ class GovernanceConfig:
     # 0.30 (= VOID_THRESHOLD_MAX) for residents widens the gate enough to clear
     # the observed substrate-asymmetry baseline while still being a real bound.
     #
-    # Class names match `src/grounding/class_indicator.py::classify_agent`
-    # output. KNOWN_RESIDENT_LABELS plus tag-derived `embodied` and
+    # Generic behavior classes from `classify_agent` (USER-AGNOSTIC — no named
+    # residents). The tag-derived resident tiers `embodied` and
     # `resident_persistent` get the wider threshold; everything else (default,
-    # ephemeral, engaged_ephemeral) keeps standard behavior.
+    # ephemeral, engaged_ephemeral) keeps standard behavior. A deployment whose
+    # residents classify by unique label (UNITARES_RESIDENTS) adds them via the
+    # UNITARES_CLASS_CALIBRATION "void_threshold" overlay; without it a named
+    # resident keeps the standard threshold.
     VOID_THRESHOLD_BY_CLASS: ClassVar[dict[str, float]] = {
-        "Lumen": 0.30,
-        "Vigil": 0.30,
-        "Sentinel": 0.30,
-        "Watcher": 0.30,
-        "Steward": 0.30,
-        "Chronicler": 0.30,
         "embodied": 0.30,
         "resident_persistent": 0.30,
     }
@@ -827,6 +824,10 @@ class ScaleConstant:
                        agent is a known resident but has no independent corpus
                        yet (makes the fallback explicit in config instead of
                        relying on silent get(…, DEFAULT) at lookup time)
+      - "overlay":     supplied at load by a deployment-local calibration file
+                       (UNITARES_CLASS_CALIBRATION) — measured off-repo, e.g.
+                       per-named-resident anchors that must not ship in the
+                       user-agnostic repo
     """
     name: str
     value: float
@@ -837,7 +838,7 @@ class ScaleConstant:
     notes: str = ""
 
     def __post_init__(self) -> None:
-        if self.provenance not in {"placeholder", "measured", "derived", "alias"}:
+        if self.provenance not in {"placeholder", "measured", "derived", "alias", "overlay"}:
             raise ValueError(f"unknown provenance {self.provenance!r}")
         if self.value <= 0:
             raise ValueError(f"scale constant {self.name} must be positive")
@@ -910,50 +911,27 @@ I_SCALE_BY_CLASS: Dict[str, ScaleConstant] = {}
 E_SCALE_BY_CLASS: Dict[str, ScaleConstant] = {}
 
 # Manifold radius — the 95th percentile of state-space distance from each
-# class's own healthy operating point. Re-measured 2026-06-27 on a 30-day
-# healthy-regime slice of core.agent_state via
-# `UNITARES_RESIDENTS='Lumen,Vigil,Sentinel,Watcher,Steward,Chronicler' \
-#   python3 scripts/calibrate_class_conditional.py` (roster matches the live
-# classifier so per-label residents map to these keys). Per-class envelopes
-# differ by ~3.4× (Vigil 0.09 vs engaged_ephemeral 0.30), confirming the
-# homogenization failure mode of paper §2.
+# class's own healthy operating point. USER-AGNOSTIC: only generic behavior
+# classes (the tag taxonomy from classify_agent) ship here — no named residents.
+# Measured 2026-06-27 on a 30-day healthy-regime slice via
+# `python3 scripts/calibrate_class_conditional.py` (empty roster → tag classes).
+# Per-class envelopes differ ~3.4× (ephemeral 0.09 vs engaged_ephemeral 0.30),
+# confirming the homogenization failure mode of paper §2.
 #
-# The 2026-04-18 values went stale (esp. Lumen's healthy E, see
-# HEALTHY_OPERATING_POINT_BY_CLASS) — the manifold coherence saturated to 0 for
-# Lumen on every check-in until this refresh. Re-run the generator when the
-# fleet's operating regime shifts.
+# A deployment that names specific residents (UNITARES_RESIDENTS → they classify
+# by their unique label, e.g. "Lumen") supplies their per-agent anchors via the
+# UNITARES_CLASS_CALIBRATION overlay (see _apply_class_calibration_overlay) —
+# deployment-local, OUT of this repo. Without an overlay, a named resident falls
+# back to DEFAULT here.
 DELTA_NORM_MAX_BY_CLASS: Dict[str, ScaleConstant] = {
-    "Lumen": ScaleConstant(
-        name="DELTA_NORM_MAX[Lumen]", value=0.1635, measured_on="2026-06-27",
-        corpus_size=12500, percentile=95, provenance="measured",
+    "embodied": ScaleConstant(
+        name="DELTA_NORM_MAX[embodied]", value=0.1635, measured_on="2026-06-27",
+        corpus_size=12501, percentile=95, provenance="measured",
         notes="Class-conditional manifold radius from healthy slice."),
-    "default": ScaleConstant(
-        name="DELTA_NORM_MAX[default]", value=0.2018, measured_on="2026-04-18",
-        corpus_size=2033, percentile=95, provenance="measured",
-        notes="Retained from 2026-04-18; 2026-06-27 slice had N=16 (<30 "
-              "threshold), too thin to re-measure."),
-    "Sentinel": ScaleConstant(
-        name="DELTA_NORM_MAX[Sentinel]", value=0.0881, measured_on="2026-06-27",
-        corpus_size=5529, percentile=95, provenance="measured",
+    "resident_persistent": ScaleConstant(
+        name="DELTA_NORM_MAX[resident_persistent]", value=0.1237, measured_on="2026-06-27",
+        corpus_size=8406, percentile=95, provenance="measured",
         notes="Class-conditional manifold radius from healthy slice."),
-    "Vigil": ScaleConstant(
-        name="DELTA_NORM_MAX[Vigil]", value=0.0885, measured_on="2026-06-27",
-        corpus_size=1415, percentile=95, provenance="measured",
-        notes="Class-conditional manifold radius from healthy slice."),
-    "Watcher": ScaleConstant(
-        name="DELTA_NORM_MAX[Watcher]", value=0.2391, measured_on="2026-06-27",
-        corpus_size=1436, percentile=95, provenance="measured",
-        notes="Class-conditional manifold radius from healthy slice."),
-    "Steward": ScaleConstant(
-        name="DELTA_NORM_MAX[Steward]", value=0.2018, measured_on="2026-06-27",
-        corpus_size=0, percentile=None, provenance="alias",
-        notes="Alias to default. Still 0 healthy rows in the 2026-06-27 window. "
-              "Re-run scripts/calibrate_class_conditional.py once corpus exists."),
-    "Chronicler": ScaleConstant(
-        name="DELTA_NORM_MAX[Chronicler]", value=0.2018, measured_on="2026-06-27",
-        corpus_size=26, percentile=None, provenance="alias",
-        notes="Alias to default. N=26 in the 2026-06-27 window, below the 30 "
-              "threshold. Re-run scripts/calibrate_class_conditional.py later."),
     "engaged_ephemeral": ScaleConstant(
         name="DELTA_NORM_MAX[engaged_ephemeral]", value=0.2952, measured_on="2026-06-27",
         corpus_size=2115, percentile=95, provenance="measured",
@@ -961,32 +939,29 @@ DELTA_NORM_MAX_BY_CLASS: Dict[str, ScaleConstant] = {
     "ephemeral": ScaleConstant(
         name="DELTA_NORM_MAX[ephemeral]", value=0.0857, measured_on="2026-06-27",
         corpus_size=277, percentile=95, provenance="measured",
-        notes="Class-conditional manifold radius from healthy slice (new key; "
-              "the tag-classified ephemeral population is now large enough)."),
+        notes="Class-conditional manifold radius from healthy slice."),
+    "default": ScaleConstant(
+        name="DELTA_NORM_MAX[default]", value=0.2018, measured_on="2026-04-18",
+        corpus_size=2033, percentile=95, provenance="measured",
+        notes="Fleet fallback; 2026-06-27 slice had N=16 (<30), too thin to re-measure."),
 }
 
 # Healthy operating points per class — median (E, I, S) on healthy-regime
 # slice. Used by _compute_manifold as the class-conditional baseline that
-# replaces the fleet-wide BASIN_HIGH corner. Re-measured 2026-06-27 (same
-# generator + roster as DELTA_NORM_MAX_BY_CLASS above).
+# replaces the fleet-wide BASIN_HIGH corner. USER-AGNOSTIC: generic behavior
+# classes only (measured 2026-06-27, empty-roster generator). Named residents
+# come from the UNITARES_CLASS_CALIBRATION overlay, deployment-local.
 #
-# NOTE: Lumen's healthy E moved 0.745 -> 0.316 between 2026-04-18 and
-# 2026-06-27 (N=12500 healthy-slice samples). This is Lumen's GENUINE normal —
-# a low-energy Pi edge resident — not degradation; the old anchor assumed it ran
-# hot like a coding agent (the individuality axiom: judge against its own
-# normal). The stale anchor was why Lumen's manifold coherence read 0 on every
-# check-in. healthy_S also feeds get_s_setpoint (live when UNITARES_S_SETPOINT
-# is on) — the S shifts here are small but live-affecting.
+# NOTE: `embodied` healthy E is ~0.32 — embodied/edge agents (e.g. a Pi
+# resident) genuinely run low-energy; that is their normal, not degradation (the
+# individuality axiom). healthy_S also feeds get_s_setpoint (live when
+# UNITARES_S_SETPOINT is on), so these are live-affecting, not shadow-only.
 HEALTHY_OPERATING_POINT_BY_CLASS: Dict[str, Tuple[float, float, float]] = {
-    "Lumen":    (0.3160, 0.7824, 0.2104),   # N=12500 (E 0.745 -> 0.316; see note)
-    "default":  (0.7264, 0.7934, 0.2364),   # retained 2026-04-18 (N=16 in 06-27 window)
-    "Sentinel": (0.7804, 0.6852, 0.2492),   # N=5529
-    "Vigil":    (0.7576, 0.7639, 0.1596),   # N=1415
-    "Watcher":  (0.7932, 0.7097, 0.2140),   # N=1436
-    "Steward":  (0.7264, 0.7934, 0.2364),   # alias=default (N=0; see DELTA_NORM_MAX[Steward])
-    "Chronicler": (0.7264, 0.7934, 0.2364), # alias=default (N=26<30; see DELTA_NORM_MAX[Chronicler])
-    "engaged_ephemeral": (0.7685, 0.6918, 0.3536), # N=2115
-    "ephemeral": (0.7032, 0.7995, 0.1898),  # N=277 (new key)
+    "embodied":            (0.3159, 0.7824, 0.2104),  # N=12501
+    "resident_persistent": (0.7804, 0.6855, 0.2185),  # N=8406
+    "engaged_ephemeral":   (0.7685, 0.6918, 0.3536),  # N=2115
+    "ephemeral":           (0.7032, 0.7995, 0.1898),  # N=277
+    "default":             (0.7264, 0.7934, 0.2364),  # fleet fallback (N=16 in 06-27 window)
 }
 
 # Default healthy operating point (fleet fallback for unclassified agents).
@@ -1021,6 +996,64 @@ def get_e_scale(agent_class: str = "default") -> ScaleConstant:
 def get_delta_norm_max(agent_class: str = "default") -> ScaleConstant:
     """Return class-conditional manifold radius; fall back to fleet-wide default."""
     return DELTA_NORM_MAX_BY_CLASS.get(agent_class, DELTA_NORM_MAX_DEFAULT)
+
+
+def _apply_class_calibration_overlay() -> None:
+    """Merge a deployment-local per-class calibration overlay into the
+    class-keyed dicts, if ``UNITARES_CLASS_CALIBRATION`` names a JSON file.
+
+    The public repo ships only generic behavior-class anchors (embodied,
+    resident_persistent, engaged_ephemeral, ephemeral, default) — user-agnostic.
+    A deployment that names specific residents via ``UNITARES_RESIDENTS`` (so they
+    classify by their unique label) supplies their per-agent calibration HERE,
+    out of the repo. Schema (every section optional)::
+
+        {
+          "healthy_operating_point": {"<class>": [E, I, S], ...},
+          "delta_norm_max":          {"<class>": <float>, ...},
+          "void_threshold":          {"<class>": <float>, ...}
+        }
+
+    Fail-soft: a missing/unreadable/malformed file is a silent no-op so the
+    user-agnostic defaults always stand.
+    """
+    path = os.getenv("UNITARES_CLASS_CALIBRATION", "").strip()
+    if not path:
+        return
+    try:
+        import json
+        with open(os.path.expanduser(path)) as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return
+    if not isinstance(data, dict):
+        return
+
+    for cls, triple in (data.get("healthy_operating_point") or {}).items():
+        try:
+            HEALTHY_OPERATING_POINT_BY_CLASS[cls] = (
+                float(triple[0]), float(triple[1]), float(triple[2]))
+        except (TypeError, ValueError, IndexError, KeyError):
+            pass
+
+    for cls, val in (data.get("delta_norm_max") or {}).items():
+        try:
+            DELTA_NORM_MAX_BY_CLASS[cls] = ScaleConstant(
+                name=f"DELTA_NORM_MAX[{cls}]", value=float(val),
+                measured_on="", corpus_size=0, percentile=None,
+                provenance="overlay",
+                notes="Deployment-local (UNITARES_CLASS_CALIBRATION).")
+        except (TypeError, ValueError):
+            pass
+
+    for cls, val in (data.get("void_threshold") or {}).items():
+        try:
+            GovernanceConfig.VOID_THRESHOLD_BY_CLASS[cls] = float(val)
+        except (TypeError, ValueError):
+            pass
+
+
+_apply_class_calibration_overlay()
 
 
 # =====================================================================

--- a/docs/FLAGS.md
+++ b/docs/FLAGS.md
@@ -12,17 +12,17 @@ For *consequential, flag-gated capabilities* and their **wake conditions**, see
 `docs/operations/dormant-capability-registry.md` (Theme 6) — this file is the flat
 index; that one is the curated decision record.
 
-**90 flags.**
+**91 flags.**
 
 | Flag | Default | Purpose | Read at |
 |---|---|---|---|
 | `GOVERNANCE_AGENT_PREFIX` | `(required)` | Detect interface and context information for name generation | src/mcp_handlers/support/naming_helpers.py:24, src/mcp_handlers/support/naming_helpers.py:25 |
-| `GOVERNANCE_BEHAVIORAL_VERDICT` | `'true'` | — | config/governance_config.py:406 |
+| `GOVERNANCE_BEHAVIORAL_VERDICT` | `'true'` | — | config/governance_config.py:403 |
 | `GOVERNANCE_DATABASE_URL` | `'postgresql://postgres:postgr…` | Poll lease_plane_events for forced-release alarms; emit findings | agents/sentinel/agent.py:658 |
 | `GOVERNANCE_HEALTH_URL` | `'http://localhost:8767/health'` | — | agents/vigil/checks/governance_health.py:18 |
 | `GOVERNANCE_TOOL_MODE` | `'lite'` | — | src/tool_modes.py:18 |
 | `GOVERNANCE_URL` | `''` | read by _governance_url() | src/mcp_handlers/dialectic/orchestrator_dispatch.py:54, agents/dialectic_reviewer/reviewer.py:242 |
-| `GOVERNANCE_WARMUP_STRUCTURAL_GRACE` | `'true'` | — | config/governance_config.py:716 |
+| `GOVERNANCE_WARMUP_STRUCTURAL_GRACE` | `'true'` | — | config/governance_config.py:713 |
 | `UNITARES_AGENT_LOCK_BACKEND` | `'advisory'` | Async exclusive lock for agent state updates | src/state_locking.py:331, src/services/update_workflow_service.py:88 |
 | `UNITARES_ANCHORS_DIR` | `(required)` | Return the anchors directory path | src/identity/substrate.py:92 |
 | `UNITARES_API_TOKEN` | `(required)` | Return continuity token support details for diagnostics. | src/mcp_handlers/identity/session.py:106, src/mcp_handlers/identity/session.py:169 |
@@ -32,6 +32,7 @@ index; that one is the curated decision record.
 | `UNITARES_AUTO_DIALECTIC_RECOVERY` | `'1'` | Process governance update with authentication enforcement (async version) | src/agent_loop_detection.py:612 |
 | `UNITARES_BASELINE_CACHE_MAXLEN` | `'1000'` | — | governance_core/ethical_drift.py:55 |
 | `UNITARES_CALIBRATION_BACKEND` | `'postgres'` | Initialize calibration checker with confidence bins | src/calibration.py:106 |
+| `UNITARES_CLASS_CALIBRATION` | `''` | Merge a deployment-local per-class calibration overlay into the class-keyed dicts, if ``UNITARES_CLASS_CALIBRATION`` names a JSON file | config/governance_config.py:1020 |
 | `UNITARES_CONNECT_RETRIES` | `'1'` | read by __init__() | agents/sdk/src/unitares_sdk/client.py:107 |
 | `UNITARES_CONNECT_TIMEOUT` | `'10'` | read by __init__() | agents/sdk/src/unitares_sdk/client.py:105 |
 | `UNITARES_CONTINUITY_TOKEN_SECRET` | `(required)` | Return continuity token support details for diagnostics. | src/mcp_handlers/identity/session.py:94, src/mcp_handlers/identity/session.py:167 |
@@ -50,15 +51,15 @@ index; that one is the curated decision record.
 | `UNITARES_FINDINGS_URL` | `'http://localhost:8767/api/fi…` | — | agents/common/findings.py:21 |
 | `UNITARES_FIRST_RUN` | `(required)` | Resolve Watcher identity via proof-owned UUID-direct → fresh onboard | agents/watcher/agent.py:271, agents/sdk/src/unitares_sdk/agent.py:364 |
 | `UNITARES_GOVERNANCE_URL` | `(required)` | read by _governance_url() | src/mcp_handlers/dialectic/orchestrator_dispatch.py:53, agents/dialectic_reviewer/reviewer.py:242 |
-| `UNITARES_GROUNDING_APPLY` | `''` | Whether grounded E/I/S/coherence actually replace the ODE/heuristic values in the canonical metrics (UNITARES_GROUNDING_APPLY) | config/governance_config.py:1076 |
-| `UNITARES_GROUNDING_SHADOW` | `''` | Whether to shadow-compare grounded vs ungrounded canonical metrics each check-in (UNITARES_GROUNDING_SHADOW) | config/governance_config.py:1064 |
+| `UNITARES_GROUNDING_APPLY` | `''` | Whether grounded E/I/S/coherence actually replace the ODE/heuristic values in the canonical metrics (UNITARES_GROUNDING_APPLY) | config/governance_config.py:1129 |
+| `UNITARES_GROUNDING_SHADOW` | `''` | Whether to shadow-compare grounded vs ungrounded canonical metrics each check-in (UNITARES_GROUNDING_SHADOW) | config/governance_config.py:1117 |
 | `UNITARES_HEALTH_PROBE_INTERVAL_SECONDS` | `(required)` | Periodically run the deep health check and cache the result | src/background_tasks.py:526 |
 | `UNITARES_HTTP_API_TOKEN` | `(required)` | List all tools in OpenAI-compatible format Query params: mode: Tool mode filter - "minimal", "lite", "full" | src/http_api.py:436, src/http_api.py:485 (+34 more) |
 | `UNITARES_HTTP_CORS_ALLOW_ORIGIN` | `(required)` | Main entry point for governance MCP server. | src/mcp_server.py:841, src/mcp_server.py:883 |
-| `UNITARES_IDENTITY_STRICT` | `'log'` | Runtime accessor — respects env changes set after module load | config/governance_config.py:1129, config/governance_config.py:1138 |
+| `UNITARES_IDENTITY_STRICT` | `'log'` | Runtime accessor — respects env changes set after module load | config/governance_config.py:1182, config/governance_config.py:1191 |
 | `UNITARES_INCLUDE_API_KEY_IN_RESPONSES` | `(required)` | Include onboarding guidance, API key hints, welcome message. | src/mcp_handlers/updates/enrichments.py:533 |
 | `UNITARES_INTEGRATOR` | `'rk4'` | Returns the ODE integration method | governance_core/parameters.py:143 |
-| `UNITARES_IPUA_PIN_CHECK` | `'strict'` | Runtime accessor — respects env changes set after module load | config/governance_config.py:1251, config/governance_config.py:1262 |
+| `UNITARES_IPUA_PIN_CHECK` | `'strict'` | Runtime accessor — respects env changes set after module load | config/governance_config.py:1304, config/governance_config.py:1315 |
 | `UNITARES_I_DYNAMICS` | `'linear'` | Returns the I-channel dynamics mode | governance_core/parameters.py:160 |
 | `UNITARES_KG_PROACTIVE_EVERY` | `'0'` | Gate the proactive (steady-state) KG surface — cadence + warmup + length | src/mcp_handlers/updates/enrichments.py:1555 |
 | `UNITARES_KNOWLEDGE_BACKEND` | `'auto'` | Get global knowledge graph instance (singleton) | src/knowledge_graph.py:265, src/knowledge_graph.py:340 |
@@ -79,10 +80,10 @@ index; that one is the curated decision record.
 | `UNITARES_PARAMS_JSON` | `(required)` | Returns the active dynamics parameters | governance_core/parameters.py:269 |
 | `UNITARES_PARAMS_PROFILE` | `'default'` | Returns the active parameters profile name | governance_core/parameters.py:243 |
 | `UNITARES_PARENT_AGENT_ID` | `(required)` | read by main() | agents/dialectic_reviewer/reviewer.py:243 |
-| `UNITARES_PAUSE_AUTO_EXPIRE_SECONDS` | `str(72 * 3600)` | — | config/governance_config.py:749 |
+| `UNITARES_PAUSE_AUTO_EXPIRE_SECONDS` | `str(72 * 3600)` | — | config/governance_config.py:746 |
 | `UNITARES_PHASE5_EVIDENCE_WRITE` | `''` | Health check, CIRS emissions, PG record, outcome events | src/mcp_handlers/updates/phases.py:2049 |
-| `UNITARES_PHI_TELEMETRY_ONLY` | `'1'` | Whether Φ is demoted to telemetry (UNITARES_PHI_TELEMETRY_ONLY) | config/governance_config.py:1050 |
-| `UNITARES_PREFIX_BIND_FINGERPRINT` | `'off'` | Runtime accessor — respects env changes set after module load | config/governance_config.py:1213, config/governance_config.py:1222 |
+| `UNITARES_PHI_TELEMETRY_ONLY` | `'1'` | Whether Φ is demoted to telemetry (UNITARES_PHI_TELEMETRY_ONLY) | config/governance_config.py:1103 |
+| `UNITARES_PREFIX_BIND_FINGERPRINT` | `'off'` | Runtime accessor — respects env changes set after module load | config/governance_config.py:1266, config/governance_config.py:1275 |
 | `UNITARES_PROCESS_UPDATE_RESPONSE_MODE` | `'auto'` | Apply response mode filtering to fully-built response_data | src/mcp_handlers/response_formatter.py:238 |
 | `UNITARES_PROGRESS_FLAT_PROBE_INTERVAL_SECONDS` | `(required)` | Resident-progress telemetry probe | src/background_tasks.py:579 |
 | `UNITARES_PROXY_URL` | `(required)` | — | src/mcp_server_std.py:127 |
@@ -90,15 +91,15 @@ index; that one is the curated decision record.
 | `UNITARES_RERANKER_MODEL` | `'bge-m3'` | — | src/reranker.py:38 |
 | `UNITARES_RESIDENT_AGENTS` | `''` | Figure out which agent labels to treat as residents | src/http_api.py:2661 |
 | `UNITARES_SENSOR_COUPLING` | `(required)` | Whether sensor-derived EISV spring-couples into the ODE | governance_core/parameters.py:182, governance_core/parameters.py:204 |
-| `UNITARES_SESSION_FINGERPRINT_CHECK` | `'log'` | Runtime accessor — respects env changes set after module load | config/governance_config.py:1165, config/governance_config.py:1176 |
-| `UNITARES_SESSION_MIRROR_APPLY` | `''` | Whether the resolver READS the PostgreSQL session mirror as a source of truth (UNITARES_SESSION_MIRROR_APPLY) | config/governance_config.py:1100 |
-| `UNITARES_SESSION_MIRROR_SHADOW` | `''` | Whether to dual-write session/identity bindings into the PostgreSQL mirror tables (core.session_bindings, core.onboard_pins) alongside the R | config/governance_config.py:1090 |
+| `UNITARES_SESSION_FINGERPRINT_CHECK` | `'log'` | Runtime accessor — respects env changes set after module load | config/governance_config.py:1218, config/governance_config.py:1229 |
+| `UNITARES_SESSION_MIRROR_APPLY` | `''` | Whether the resolver READS the PostgreSQL session mirror as a source of truth (UNITARES_SESSION_MIRROR_APPLY) | config/governance_config.py:1153 |
+| `UNITARES_SESSION_MIRROR_SHADOW` | `''` | Whether to dual-write session/identity bindings into the PostgreSQL mirror tables (core.session_bindings, core.onboard_pins) alongside the R | config/governance_config.py:1143 |
 | `UNITARES_STDIO_PROXY_HTTP_BEARER_TOKEN` | `(required)` | — | src/mcp_server_std.py:131 |
 | `UNITARES_STDIO_PROXY_HTTP_URL` | `(required)` | — | src/mcp_server_std.py:126 |
 | `UNITARES_STDIO_PROXY_SSE_URL` | `(required)` | — | src/mcp_server_std.py:129 |
 | `UNITARES_STDIO_PROXY_STRICT` | `'1'` | — | src/mcp_server_std.py:130 |
 | `UNITARES_STDIO_PROXY_URL` | `(required)` | — | src/mcp_server_std.py:128 |
-| `UNITARES_S_SETPOINT` | `'1'` | Whether the per-class S setpoint is active (UNITARES_S_SETPOINT) | config/governance_config.py:1033 |
+| `UNITARES_S_SETPOINT` | `'1'` | Whether the per-class S setpoint is active (UNITARES_S_SETPOINT) | config/governance_config.py:1086 |
 | `UNITARES_TOOL_SCHEMA_STRIP_FIELD_DESCRIPTIONS` | `'0'` | Build the list of MCP Tool objects from Pydantic schemas + descriptions. | src/tool_schemas.py:234 |
 | `UNITARES_TOOL_SCHEMA_VERBOSITY` | `'short'` | Build the list of MCP Tool objects from Pydantic schemas + descriptions. | src/tool_schemas.py:231 |
 | `UNITARES_TOOL_USAGE_LOG` | `(required)` | read by __init__() | src/tool_usage_tracker.py:57 |

--- a/scripts/dev/check-repo-scope.sh
+++ b/scripts/dev/check-repo-scope.sh
@@ -111,6 +111,44 @@ done <<EOF
 $FILES
 EOF
 
+# Rule 4: the per-class config dicts must use only generic behavior classes —
+# never named residents. The 2026-06-27 anchor recalibration baked one
+# deployment's residents (Lumen/Vigil/Sentinel/...) with their measured EISV
+# operating points into this user-agnostic repo; named residents belong in the
+# deployment-local UNITARES_CLASS_CALIBRATION overlay. Allowlist-based (AST, no
+# import) so a NEW resident name is caught too, not just the known set.
+CFG="config/governance_config.py"
+if printf '%s\n' "$FILES" | grep -qx "$CFG" && [ -f "$CFG" ] && ! is_allowed "$CFG" && command -v python3 >/dev/null 2>&1; then
+  leaked="$(python3 - "$CFG" <<'PY'
+import ast, sys
+ALLOWED = {"embodied", "resident_persistent", "engaged_ephemeral", "ephemeral", "default"}
+TARGETS = {"DELTA_NORM_MAX_BY_CLASS", "HEALTHY_OPERATING_POINT_BY_CLASS", "VOID_THRESHOLD_BY_CLASS"}
+bad = set()
+def keys_of(node):
+    if isinstance(node, ast.Dict):
+        for k in node.keys:
+            if isinstance(k, ast.Constant) and isinstance(k.value, str) and k.value not in ALLOWED:
+                bad.add(k.value)
+try:
+    tree = ast.parse(open(sys.argv[1]).read())
+except Exception:
+    sys.exit(0)  # parse failure is handled elsewhere, not here
+for node in ast.walk(tree):
+    if isinstance(node, ast.Assign):
+        for t in node.targets:
+            if isinstance(t, ast.Name) and t.id in TARGETS:
+                keys_of(node.value)
+    elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) \
+            and node.target.id in TARGETS and node.value is not None:
+        keys_of(node.value)
+print(",".join(sorted(bad)))
+PY
+)"
+  if [ -n "$leaked" ]; then
+    report "$CFG" "Named-resident keys in class-conditional dicts: ${leaked}. unitares is user-agnostic — use generic behavior classes (embodied/resident_persistent/engaged_ephemeral/ephemeral/default) and put named residents in the deployment-local UNITARES_CLASS_CALIBRATION overlay."
+  fi
+fi
+
 if [ "$violations" -gt 0 ]; then
   echo ""
   echo "❌ Repo scope guard: $violations issue(s). unitares is user/agent-agnostic — see docs/REPO_SCOPE.md."

--- a/tests/test_eisv_s_setpoint.py
+++ b/tests/test_eisv_s_setpoint.py
@@ -63,13 +63,13 @@ def test_get_s_setpoint_off_when_disabled(monkeypatch):
     monkeypatch.setenv("UNITARES_S_SETPOINT", "0")
     assert not s_setpoint_enabled()
     assert get_s_setpoint("default") == 0.0
-    assert get_s_setpoint("Lumen") == 0.0
+    assert get_s_setpoint("embodied") == 0.0
 
 
 def test_get_s_setpoint_enabled(monkeypatch):
     monkeypatch.setenv("UNITARES_S_SETPOINT", "1")
     assert s_setpoint_enabled()
-    for cls in ("default", "Lumen", "Watcher"):
+    for cls in ("default", "embodied", "resident_persistent"):
         expected = get_healthy_operating_point(cls)[2] - S_SETPOINT_DRIVER_OFFSET
         assert get_s_setpoint(cls) == pytest.approx(expected, abs=1e-9)
 
@@ -77,32 +77,39 @@ def test_get_s_setpoint_enabled(monkeypatch):
 def test_setpoint_lands_on_measured_healthy_S():
     """With the per-class setpoint, the ODE S-rest ≈ that class's measured healthy
     S, for every class (S is the only axis the setpoint drives)."""
-    for cls in ("default", "Lumen", "Watcher", "Vigil"):
+    for cls in ("default", "embodied", "resident_persistent", "engaged_ephemeral"):
         hp = get_healthy_operating_point(cls)
         sigma = hp[2] - S_SETPOINT_DRIVER_OFFSET
         r = _rest(sigma)
         assert r.S == pytest.approx(hp[2], abs=0.02), f"{cls}: S-rest off target"
 
 
-def test_manifold_at_ode_rest_clears_critical_where_e_rest_matches_healthy():
-    """Manifold-at-ODE-rest clears the 0.40 critical line for classes whose ODE
-    E/I rest coincides with their measured healthy E/I (the Stage-B enabler).
+def _manifold_at_rest(cls: str) -> float:
+    hp = get_healthy_operating_point(cls)
+    r = _rest(hp[2] - S_SETPOINT_DRIVER_OFFSET)
+    norm = math.sqrt((r.E-hp[0])**2 + (r.I-hp[1])**2 + (r.S-hp[2])**2)
+    return 1.0 - max(0.0, min(1.0, norm / get_delta_norm_max(cls).value))
 
-    Lumen is deliberately EXCLUDED: its measured healthy E is ~0.32 (a low-energy
-    Pi resident, recalibrated 2026-06-27) while the ODE rests E high (~0.74) —
-    the setpoint drives S but not E/I — so the manifold distance at the ODE rest
-    is large for Lumen. Harmless live (manifold coherence is read on the
-    *behavioral* EISV, where Lumen's E≈0.32 matches the anchor, and grounding
-    APPLY is off) but it flags a real gap: low-E classes need an E/I setpoint, or
-    the behavioral-path manifold, before the ODE rest itself reads coherent.
-    Tracked for the grounding-APPLY scope."""
-    for cls in ("default", "Watcher", "Vigil"):
-        hp = get_healthy_operating_point(cls)
-        sigma = hp[2] - S_SETPOINT_DRIVER_OFFSET
-        r = _rest(sigma)
-        dmax = get_delta_norm_max(cls).value
-        norm = math.sqrt((r.E-hp[0])**2 + (r.I-hp[1])**2 + (r.S-hp[2])**2)
-        manifold = 1.0 - max(0.0, min(1.0, norm / dmax))
-        assert manifold >= GC.COHERENCE_CRITICAL_THRESHOLD, (
-            f"{cls}: manifold@rest {manifold:.3f} still below critical line"
+
+def test_manifold_at_ode_rest_only_clears_critical_for_default():
+    """Characterizes a real, currently-open gap (NOT a passing Stage-B enabler).
+
+    The S-setpoint lands S on each class's measured healthy S, but there is no
+    E/I setpoint — the ODE rests near a single universal point (E≈0.70, I≈0.73)
+    regardless of class. With the generic 2026-06-27 anchors (which reflect where
+    classes ACTUALLY operate), only `default` sits close enough to that ODE rest
+    for manifold-at-rest to clear the 0.40 critical line; `embodied` (low-E),
+    `resident_persistent`, and `engaged_ephemeral` do not. (The old April anchors
+    masked this — they were all clustered near the ODE rest.)
+
+    Harmless live: manifold coherence is read on the *behavioral* EISV (which
+    matches the anchor) and grounding APPLY is off. But it is the concrete
+    precondition for GROUNDING_APPLY: low-/off-rest classes need an E/I setpoint
+    or a behavioral-path manifold before the ODE rest reads coherent. When that
+    lands, this test should flip — that's the signal to re-evaluate APPLY."""
+    assert _manifold_at_rest("default") >= GC.COHERENCE_CRITICAL_THRESHOLD
+    for cls in ("embodied", "resident_persistent", "engaged_ephemeral"):
+        assert _manifold_at_rest(cls) < GC.COHERENCE_CRITICAL_THRESHOLD, (
+            f"{cls}: manifold@rest now clears critical — E/I-setpoint gap may be "
+            f"closed; re-evaluate GROUNDING_APPLY and update this characterization"
         )

--- a/tests/test_eisv_s_setpoint_phi_coupling.py
+++ b/tests/test_eisv_s_setpoint_phi_coupling.py
@@ -45,8 +45,8 @@ def test_phi_eval_state_noop_when_flag_off(monkeypatch):
     S_SETPOINT now defaults ON, so force it off to exercise the no-op path.
     """
     monkeypatch.setenv("UNITARES_S_SETPOINT", "0")
-    st = _healthy_rest_state("Watcher")
-    mon = _FakeMonitor("Watcher", st)
+    st = _healthy_rest_state("resident_persistent")
+    mon = _FakeMonitor("resident_persistent", st)
     out = phi_eval_state(mon, st)
     assert (out.E, out.I, out.S, out.V) == (st.E, st.I, st.S, st.V)
     assert setpoint_for_monitor(mon) == 0.0
@@ -54,17 +54,17 @@ def test_phi_eval_state_noop_when_flag_off(monkeypatch):
 
 def test_phi_eval_state_detrends_by_sigma_when_on(monkeypatch):
     monkeypatch.setenv("UNITARES_S_SETPOINT", "1")
-    st = _healthy_rest_state("Watcher")
-    mon = _FakeMonitor("Watcher", st)
-    sigma = get_s_setpoint("Watcher")
+    st = _healthy_rest_state("resident_persistent")
+    mon = _FakeMonitor("resident_persistent", st)
+    sigma = get_s_setpoint("resident_persistent")
     assert sigma == pytest.approx(
-        get_healthy_operating_point("Watcher")[2] - S_SETPOINT_DRIVER_OFFSET, abs=1e-9)
+        get_healthy_operating_point("resident_persistent")[2] - S_SETPOINT_DRIVER_OFFSET, abs=1e-9)
     out = phi_eval_state(mon, st)
     assert out.S == pytest.approx(st.S - sigma, abs=1e-12)
     assert (out.E, out.I, out.V) == (st.E, st.I, st.V)
 
 
-@pytest.mark.parametrize("agent_class", ["default", "Watcher", "Vigil", "engaged_ephemeral"])
+@pytest.mark.parametrize("agent_class", ["default", "embodied", "resident_persistent", "engaged_ephemeral"])
 def test_coupling_keeps_healthy_verdict_safe(monkeypatch, agent_class):
     """At the measured-healthy ODE rest, the coupled Φ keeps verdict 'safe';
     the uncoupled Φ (raw state) would degrade — this is the regression guard."""
@@ -87,7 +87,7 @@ def test_coupled_phi_matches_historical_rest(monkeypatch):
     """Φ at the new (correct) attractor with coupling ≈ Φ at the old S≈0.091
     attractor without it: verdict/risk are invariant under the attractor move."""
     monkeypatch.setenv("UNITARES_S_SETPOINT", "1")
-    for agent_class in ("default", "Lumen", "Watcher", "engaged_ephemeral"):
+    for agent_class in ("default", "embodied", "resident_persistent", "engaged_ephemeral"):
         st_new = _healthy_rest_state(agent_class)
         mon = _FakeMonitor(agent_class, st_new)
         coupled_phi = phi_objective(

--- a/tests/test_grounding_scale_constants.py
+++ b/tests/test_grounding_scale_constants.py
@@ -101,28 +101,46 @@ def test_class_conditional_delta_norm_max_is_measured_or_alias():
             )
 
 
-def test_known_residents_have_explicit_class_entries():
-    """Every KNOWN_RESIDENT_LABELS member must appear as a key in the
-    class-conditional maps — measured or aliased, but never silently absent.
-
-    Silent absence caused Steward's class baseline to fall back to 'default'
-    undetected on the 2026-04-18 calibration run (Steward had 0 state rows
-    due to a loop-detection bug; the calibrator skipped it without comment).
+def test_public_dicts_are_user_agnostic_generic_classes_only():
+    """The shipped class-conditional maps must NOT name specific residents — the
+    repo is user-agnostic. Only generic behavior classes from the tag taxonomy
+    (+ 'default') ship here; named residents come from the deployment-local
+    UNITARES_CLASS_CALIBRATION overlay (see the overlay test below).
     """
     from config.governance_config import (
         DELTA_NORM_MAX_BY_CLASS, HEALTHY_OPERATING_POINT_BY_CLASS,
     )
-    from src.grounding.class_indicator import KNOWN_RESIDENT_LABELS
-    missing_delta = KNOWN_RESIDENT_LABELS - DELTA_NORM_MAX_BY_CLASS.keys()
-    missing_hop = KNOWN_RESIDENT_LABELS - HEALTHY_OPERATING_POINT_BY_CLASS.keys()
-    assert not missing_delta, (
-        f"Residents missing from DELTA_NORM_MAX_BY_CLASS: {missing_delta}. "
-        f"Add an explicit entry (measured or provenance='alias')."
-    )
-    assert not missing_hop, (
-        f"Residents missing from HEALTHY_OPERATING_POINT_BY_CLASS: {missing_hop}. "
-        f"Add an explicit entry (measured or alias tuple mirroring default)."
-    )
+    allowed = {"embodied", "resident_persistent", "engaged_ephemeral",
+               "ephemeral", "default"}
+    assert set(DELTA_NORM_MAX_BY_CLASS) <= allowed, (
+        f"non-generic keys leaked into DELTA_NORM_MAX_BY_CLASS: "
+        f"{set(DELTA_NORM_MAX_BY_CLASS) - allowed}")
+    assert set(HEALTHY_OPERATING_POINT_BY_CLASS) <= allowed, (
+        f"non-generic keys leaked into HEALTHY_OPERATING_POINT_BY_CLASS: "
+        f"{set(HEALTHY_OPERATING_POINT_BY_CLASS) - allowed}")
+
+
+def test_class_calibration_overlay_merges_named_residents(tmp_path, monkeypatch):
+    """A deployment supplies named-resident anchors via UNITARES_CLASS_CALIBRATION
+    (out of the repo); the loader merges them over the generic defaults."""
+    import json, importlib
+    overlay = tmp_path / "cc.json"
+    overlay.write_text(json.dumps({
+        "healthy_operating_point": {"Lumen": [0.316, 0.782, 0.210]},
+        "delta_norm_max": {"Lumen": 0.1635},
+        "void_threshold": {"Lumen": 0.30},
+    }))
+    monkeypatch.setenv("UNITARES_CLASS_CALIBRATION", str(overlay))
+    import config.governance_config as g
+    importlib.reload(g)
+    try:
+        assert g.get_healthy_operating_point("Lumen") == pytest.approx((0.316, 0.782, 0.210))
+        dnm = g.get_delta_norm_max("Lumen")
+        assert dnm.value == pytest.approx(0.1635) and dnm.provenance == "overlay"
+        assert g.GovernanceConfig.VOID_THRESHOLD_BY_CLASS.get("Lumen") == 0.30
+    finally:
+        monkeypatch.delenv("UNITARES_CLASS_CALIBRATION", raising=False)
+        importlib.reload(g)
 
 
 def test_class_conditional_lookup_falls_back_for_unknown_classes():
@@ -131,7 +149,7 @@ def test_class_conditional_lookup_falls_back_for_unknown_classes():
         get_delta_norm_max, DELTA_NORM_MAX_DEFAULT,
     )
     assert get_delta_norm_max("nonexistent_class") is DELTA_NORM_MAX_DEFAULT
-    assert get_delta_norm_max("Lumen").provenance == "measured"
+    assert get_delta_norm_max("embodied").provenance == "measured"
 
 
 def test_healthy_operating_point_class_conditional():
@@ -139,9 +157,9 @@ def test_healthy_operating_point_class_conditional():
     from config.governance_config import (
         get_healthy_operating_point, HEALTHY_OPERATING_POINT_DEFAULT,
     )
-    lumen_hop = get_healthy_operating_point("Lumen")
-    assert lumen_hop != HEALTHY_OPERATING_POINT_DEFAULT
-    assert all(0.0 <= v <= 1.0 for v in lumen_hop)
+    embodied_hop = get_healthy_operating_point("embodied")
+    assert embodied_hop != HEALTHY_OPERATING_POINT_DEFAULT
+    assert all(0.0 <= v <= 1.0 for v in embodied_hop)
 
     unknown_hop = get_healthy_operating_point("nonexistent")
     assert unknown_hop == HEALTHY_OPERATING_POINT_DEFAULT

--- a/tests/test_lease_plane_substrate_state.py
+++ b/tests/test_lease_plane_substrate_state.py
@@ -340,7 +340,7 @@ def test_resident_class_exempted_from_void_threshold():
     history = np.array([0.05] * 100)
     threshold_default = config.get_void_threshold(history, adaptive=True)
     threshold_resident = config.get_void_threshold(
-        history, adaptive=True, agent_class="Steward"
+        history, adaptive=True, agent_class="resident_persistent"
     )
     assert threshold_resident > threshold_default
     assert threshold_resident == 0.30

--- a/tests/test_void_threshold_class_aware.py
+++ b/tests/test_void_threshold_class_aware.py
@@ -52,10 +52,7 @@ def test_get_void_threshold_no_agent_class_uses_adaptive_default():
 def test_get_void_threshold_resident_class_returns_override():
     """Each known resident class returns 0.30 regardless of history shape."""
     history = np.array([0.05] * 100)
-    for cls in (
-        "Lumen", "Vigil", "Sentinel", "Watcher", "Steward", "Chronicler",
-        "embodied", "resident_persistent",
-    ):
+    for cls in ("embodied", "resident_persistent"):
         threshold = config.get_void_threshold(history, adaptive=True, agent_class=cls)
         assert threshold == 0.30, f"class {cls!r} should override to 0.30"
 
@@ -74,7 +71,7 @@ def test_get_void_threshold_override_ignores_adaptive_flag():
     """The class override returns the per-class value even when adaptive=False —
     the override is intentional, not derived from the adaptive window."""
     history = np.array([0.05] * 100)
-    assert config.get_void_threshold(history, adaptive=False, agent_class="Steward") == 0.30
+    assert config.get_void_threshold(history, adaptive=False, agent_class="resident_persistent") == 0.30
 
 
 # ---------- check_void_state integration ----------
@@ -97,7 +94,7 @@ def test_check_void_state_resident_class_kwarg_at_steward_v_ss_does_not_trip():
     standard 0.15 threshold. With agent_class='Steward' the threshold becomes
     0.30 — V_ss = 0.19 no longer trips."""
     state = _FakeState(V=0.19)
-    void = check_void_state(state, agent_class="Steward")
+    void = check_void_state(state, agent_class="resident_persistent")
     assert void is False
     assert state.void_active is False
 
@@ -114,7 +111,7 @@ def test_check_void_state_default_at_steward_v_ss_does_trip():
 def test_check_void_state_resident_class_via_state_attribute_also_works():
     """Per the resolution order in monitor_void: kwarg → state.agent_class → None.
     Populating state.agent_class is equivalent to passing the kwarg."""
-    state = _FakeState(V=0.19, agent_class="Sentinel")
+    state = _FakeState(V=0.19, agent_class="resident_persistent")
     void = check_void_state(state)  # no kwarg
     assert void is False
 
@@ -123,7 +120,7 @@ def test_check_void_state_kwarg_takes_precedence_over_state_attribute():
     """kwarg wins. State carries 'default' (no override); kwarg passes
     'Steward'. Should use the resident threshold, not fall through."""
     state = _FakeState(V=0.19, agent_class="default")
-    void = check_void_state(state, agent_class="Steward")
+    void = check_void_state(state, agent_class="resident_persistent")
     assert void is False
 
 
@@ -132,7 +129,7 @@ def test_check_void_state_extreme_v_still_trips_for_resident():
     0.30 still trips even for residents — the safety net is widening, not
     removal."""
     state = _FakeState(V=0.5)
-    void = check_void_state(state, agent_class="Steward")
+    void = check_void_state(state, agent_class="resident_persistent")
     assert void is True
 
 
@@ -260,7 +257,8 @@ def test_governance_monitor_check_void_state_residents_exempt_at_steward_v_ss():
     trip void_active — the API surface ties through correctly."""
     from src.governance_monitor import UNITARESMonitor
 
-    monitor = UNITARESMonitor(agent_id="Steward", load_state=False)
+    monitor = UNITARESMonitor(agent_id="some-uuid", load_state=False)
+    monitor.state.agent_class = "resident_persistent"
     monitor.state.unitaires_state.V = 0.19
     monitor.state.V_history = [0.19]
     void = monitor.check_void_state()


### PR DESCRIPTION
**Follow-up to #1138, which merged before the leak was caught.** You flagged that the class-conditional config leaks your specific fleet into the user-agnostic repo — correct, and #1138 (now on master) entrenched it. This removes the leak.

## The leak (now on master via #1138)
`HEALTHY_OPERATING_POINT_BY_CLASS`, `DELTA_NORM_MAX_BY_CLASS`, and `VOID_THRESHOLD_BY_CLASS` name **six residents of one deployment** (`Lumen/Vigil/Sentinel/Watcher/Steward/Chronicler`) with their measured EISV operating points. A generic cloner never sets `UNITARES_RESIDENTS`, so their agents classify by **tag** and the named keys are inert for them — but the repo still ships one operator's private fleet roster + operating points. `check-repo-scope.sh` only gates career/personal/vendor config, so nothing caught it.

## Fix (env-gate, not delete — per your guidance)
Ship **only the generic behavior classes** (the `classify_agent` tag taxonomy: `embodied`, `resident_persistent`, `engaged_ephemeral`, `ephemeral`, `default`), measured 2026-06-27 from the empty-roster generator. Named-resident calibration moves to a **deployment-local overlay** merged at load:
```
UNITARES_CLASS_CALIBRATION=<path-to-json>   # OUT of the repo
```
`_apply_class_calibration_overlay()` fail-soft-merges `{healthy_operating_point, delta_norm_max, void_threshold}` over the generic defaults; new `ScaleConstant` provenance `"overlay"`. Without it a named resident falls back to `DEFAULT`.

## Operator action (live regression guard)
Your overlay is already written to **`~/.config/cirwel/class_calibration.json`** (2026-06-27 with-roster values, chmod 600). Add to the gov-mcp plist + restart:
```
<key>UNITARES_CLASS_CALIBRATION</key><string>/Users/cirwel/.config/cirwel/class_calibration.json</string>
```
Verified: with the overlay, Lumen/Sentinel/Vigil/Watcher anchors + resident void threshold (0.30) all restore.

## Tests
New `test_public_dicts_are_user_agnostic_generic_classes_only` (guards against re-leaking) + `test_class_calibration_overlay_merges_named_residents`. Void / phi-coupling / setpoint tests reworked to generic tiers (label-resolution tests keep their names). The manifold-at-ODE-rest test now characterizes the real gap the fresh anchors exposed — only `default` clears critical at ODE rest (no E/I setpoint), the concrete `GROUNDING_APPLY` precondition. FLAGS.md regenerated. **Full suite green (10938).**

Follow-ups: (1) a `check-repo-scope.sh` rule flagging named-resident keys in config so this can't recur; (2) de-Lumen the docs/test *examples* (separate, larger, lower-severity sweep).

https://claude.ai/code/session_01VsXq3pJjFtzdy7GCeJ4PBq