### PR TITLE
ops(deploy): add deploy-sentinel.sh — worktree deploy + build-stamp verify

### DIFF
--- a/scripts/ops/deploy-sentinel.sh
+++ b/scripts/ops/deploy-sentinel.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Deploy BEAM Sentinel (com.unitares.sentinel-beam) from the DEDICATED clean
+# worktree pinned to origin/master — never the shared developer working tree.
+#
+# Why: the Sentinel starts via `mix run` against a checkout on disk. It has been
+# running from ~/projects/unitares (the SHARED dev tree, marked restart-DEV/⚠DEV
+# in deploy-status.sh), so a merged fix was NOT live until someone manually
+# pulled + kickstarted. That is the running-process-vs-master-commit drift class
+# (feedback_running-process-vs-master-commit.md) — it caused the 2026-06-28
+# "forced-release fix merged but Sentinel still alerting" incident. Mirrors
+# deploy-lease-plane.sh: a dedicated worktree makes running-code == origin/master
+# by construction.
+#
+# Verify step uses the boot BUILD-STAMP (PR #1126): on startup the Sentinel logs
+#   "BEAM Sentinel booted: unitares_sentinel <vsn> @<sha>"
+# and emits a sentinel_build_finding. This script confirms the booted <sha>
+# matches the deployed worktree HEAD, so "is the fix live?" is checked, not
+# assumed — no HTTP health port exists for the Sentinel.
+#
+# Idempotent: creates the worktree if missing, fast-forwards to origin/master
+# (never a destructive reset), recompiles, restarts the LaunchAgent, and confirms
+# the booted sha.
+set -euo pipefail
+
+REPO="${UNITARES_REPO:-$HOME/projects/unitares}"
+DEPLOY="${UNITARES_DEPLOY:-$HOME/projects/unitares-deploy}"
+LABEL="com.unitares.sentinel-beam"
+LOG="${UNITARES_SENTINEL_LOG:-$HOME/Library/Logs/unitares-sentinel-beam.log}"
+PLIST="${UNITARES_SENTINEL_PLIST:-$HOME/Library/LaunchAgents/$LABEL.plist}"
+UID_NUM="$(id -u)"
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+# ── Serialize deploys (shared worktree) ──────────────────────────────────────
+# deploy-lease-plane.sh / deploy-mcp.sh / this script all fast-forward the SAME
+# deploy worktree, so concurrent runs race the git index. macOS has no flock(1);
+# guard with an atomic mkdir lock keyed to the worktree path (shared key on
+# purpose), reclaiming it only if the holder is dead. Override via
+# UNITARES_DEPLOY_LOCK.
+LOCK_DIR="${UNITARES_DEPLOY_LOCK:-${TMPDIR:-/tmp}/unitares-deploy$(printf '%s' "$DEPLOY" | tr -c 'A-Za-z0-9' '_').lock}"
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  holder="$(cat "$LOCK_DIR/pid" 2>/dev/null || echo '?')"
+  if [[ "$holder" != '?' ]] && ! kill -0 "$holder" 2>/dev/null; then
+    echo "[deploy] reclaiming stale deploy lock (holder PID $holder is dead): $LOCK_DIR" >&2
+    rm -rf "$LOCK_DIR"
+    mkdir "$LOCK_DIR" 2>/dev/null || { echo "[deploy] lost a lock race — another deploy just started; refusing" >&2; exit 1; }
+  else
+    echo "[deploy] another deploy is in progress (lock: $LOCK_DIR, holder PID $holder) — refusing to run concurrently" >&2
+    exit 1
+  fi
+fi
+printf '%s' "$$" > "$LOCK_DIR/pid"
+trap 'rm -rf "$LOCK_DIR"' EXIT
+
+# ── Pre-flight: the LaunchAgent must load from the deploy worktree ────────────
+# If the rendered plist still points at the dev checkout, a kickstart restarts
+# the OLD location and this deploy is a no-op. This is the one-time migration off
+# restart-DEV; warn loudly with the exact fix rather than silently doing nothing.
+if [[ -f "$PLIST" ]] && ! grep -q "$DEPLOY" "$PLIST"; then
+  echo "[deploy] WARNING: $LABEL does not appear to load from $DEPLOY." >&2
+  echo "[deploy] It is still on the shared dev checkout (restart-DEV). Until you migrate it," >&2
+  echo "[deploy] kickstart restarts the OLD location and this deploy will not take effect." >&2
+  echo "[deploy] One-time migration (render the plist against the deploy worktree, then reload):" >&2
+  echo "[deploy]   sed -e \"s|__UNITARES_ROOT__|$DEPLOY|g\" -e \"s|__HOME__|\$HOME|g\" \\\\" >&2
+  echo "[deploy]       (… plus the other placeholders in the template header …) \\\\" >&2
+  echo "[deploy]       \"$DEPLOY/scripts/ops/com.unitares.sentinel-beam.plist.template\" > \"$PLIST\"" >&2
+  echo "[deploy]   launchctl unload \"$PLIST\" && launchctl load \"$PLIST\"" >&2
+  echo "[deploy] Refusing to continue (set UNITARES_SENTINEL_ALLOW_DEV=1 to restart the dev checkout anyway)." >&2
+  [[ "${UNITARES_SENTINEL_ALLOW_DEV:-0}" == "1" ]] || exit 2
+fi
+
+echo "[deploy] fetching origin/master"
+git -C "$REPO" fetch origin master --quiet
+
+if ! git -C "$REPO" worktree list --porcelain | grep -qx "worktree $DEPLOY"; then
+  echo "[deploy] creating dedicated deploy worktree at $DEPLOY (on master)"
+  git -C "$REPO" worktree add "$DEPLOY" master
+fi
+
+echo "[deploy] fast-forwarding $DEPLOY to origin/master (ff-only; refuses if it would lose work)"
+git -C "$DEPLOY" merge --ff-only origin/master
+
+echo "[deploy] compiling sentinel (surfaces compile errors before the restart)"
+( cd "$DEPLOY/elixir/sentinel" && mix deps.get && mix compile )
+
+EXPECT_SHA="$(git -C "$DEPLOY" rev-parse --short=12 HEAD)"
+
+# Only match boot stamps written AFTER this restart, so a prior boot on the same
+# sha (idempotent re-run) or a stale line can't false-positive a crash-looping
+# node. Capture the current log length, then scan only the lines appended after.
+prev_lines=0
+[[ -f "$LOG" ]] && prev_lines="$(wc -l < "$LOG" | tr -d ' ')"
+
+echo "[deploy] restarting $LABEL (gui domain — it is a LaunchAgent, not a system daemon)"
+launchctl kickstart -k "gui/$UID_NUM/$LABEL"
+
+echo "[deploy] verifying booted sha == $EXPECT_SHA via build-stamp (PR #1126) in $LOG"
+ok=""
+for _ in $(seq 1 12); do
+  sleep 3
+  if [[ -f "$LOG" ]] && \
+     tail -n "+$((prev_lines + 1))" "$LOG" 2>/dev/null | grep -q "BEAM Sentinel booted:.*@$EXPECT_SHA"; then
+    ok=yes
+    break
+  fi
+done
+
+if [[ "$ok" == yes ]]; then
+  echo "[deploy] OK — sentinel-beam booted on $EXPECT_SHA (serving from $DEPLOY)"
+else
+  echo "[deploy] FAILED — did not observe a fresh boot stamp @$EXPECT_SHA in $LOG within timeout." >&2
+  echo "[deploy] The node may be crash-looping on the new code. Check:" >&2
+  echo "[deploy]   launchctl list | grep $LABEL" >&2
+  echo "[deploy]   tail -80 $LOG" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Why

Your question — *"can rebooting things that need a restart to pick up deploy changes be part of a workflow?"* — and the answer is yes. Most of the machinery already exists (`deploy-status.sh` computes `STALE`/`BEHIND` verdicts; `deploy-lease-plane.sh` is the per-service apply pattern). The gap was the **Sentinel**: it ran from the shared dev checkout (`restart-DEV`/⚠`DEV` in `deploy-status.sh`), so a merged fix wasn't live until someone manually pulled + kickstarted. That's the running-process-vs-master-commit drift that caused this week's "fix merged but Sentinel still alerting" incident.

## What

`scripts/ops/deploy-sentinel.sh` — the per-service deploy for `com.unitares.sentinel-beam`, mirroring `deploy-lease-plane.sh`:

1. Fast-forwards the dedicated deploy worktree (`~/projects/unitares-deploy`) to `origin/master` (ff-only, never a destructive reset).
2. `mix deps.get && mix compile` (surfaces compile errors *before* the restart).
3. `launchctl kickstart -k` the LaunchAgent.
4. **Verifies the booted git sha** via the PR #1126 boot build-stamp log line (`BEAM Sentinel booted: … @<sha>`) — the Sentinel has no HTTP health port, so the build-stamp *is* the verification. Confirms the running node is actually on the deployed commit instead of assuming.

Safety details:
- **Pre-flight guard**: refuses (exit 2) if the rendered plist still loads from the dev checkout, printing the one-time migration — because kickstarting the old location would silently no-op. Override with `UNITARES_SENTINEL_ALLOW_DEV=1`.
- **Fresh-boot verify**: scans only log lines appended *after* the restart, so a crash-loop or a prior same-sha boot can't false-positive.
- **Shared deploy-worktree lock** (same key as `deploy-lease-plane.sh`/`deploy-mcp.sh`) so concurrent deploys don't race the git index.

## Operator one-time migration (off `restart-DEV`)

For this to take effect, the `sentinel-beam` plist must load from the deploy worktree rather than the dev checkout (re-render the template with `__UNITARES_ROOT__=~/projects/unitares-deploy` and reload — the pre-flight prints the exact commands). After that, `deploy-status.sh`'s topology line for `sentinel-beam` should flip from `restart-DEV` → `restart` and repo → `unitares-deploy`. Left as a deliberate follow-up so this PR doesn't change the topology table before the migration is actually done.

## Validation

`bash -n` clean. Targets macOS `launchctl` so it can't run in CI; the logic mirrors the already-proven `deploy-lease-plane.sh`. Not auto-validated by CI (no ops-script harness) — review-gated.

## Deferred (the "unified" option)

A single `deploy-apply.sh` that reads `deploy-status.sh` verdicts and pulls+restarts+verifies *every* `STALE`/`BEHIND` service would be the complete version — but it needs the other `restart-DEV` BEAM apps (`gateway-mcp`, `wave3a-handlers`) moved to deploy worktrees first to be safe. Happy to do that next if you want the one-command sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BzBQCXUkx8NshtxPGSTPo1)_