### PR TITLE
fix(de-leak): move named-resident check-in intervals to the overlay

### DIFF
--- a/config/governance_config.py
+++ b/config/governance_config.py
@@ -993,6 +993,15 @@ def get_e_scale(agent_class: str = "default") -> ScaleConstant:
     return E_SCALE_BY_CLASS.get(agent_class, E_SCALE_DEFAULT)
 
 
+# Back-compat label → expected check-in interval (seconds), for residents that
+# classify by unique label and have no `cadence.*` tag yet (background_tasks'
+# silence detector reads it). USER-AGNOSTIC: empty in the repo — the generic
+# path is the `cadence.*` tag taxonomy (background_tasks.CADENCE_FROM_TAG). Named
+# residents come from the deployment-local UNITARES_CLASS_CALIBRATION overlay
+# ("label_intervals"), so one deployment's roster + schedule never ships here.
+LABEL_CHECKIN_INTERVALS: Dict[str, int] = {}
+
+
 def get_delta_norm_max(agent_class: str = "default") -> ScaleConstant:
     """Return class-conditional manifold radius; fall back to fleet-wide default."""
     return DELTA_NORM_MAX_BY_CLASS.get(agent_class, DELTA_NORM_MAX_DEFAULT)
@@ -1049,6 +1058,12 @@ def _apply_class_calibration_overlay() -> None:
     for cls, val in (data.get("void_threshold") or {}).items():
         try:
             GovernanceConfig.VOID_THRESHOLD_BY_CLASS[cls] = float(val)
+        except (TypeError, ValueError):
+            pass
+
+    for label, secs in (data.get("label_intervals") or {}).items():
+        try:
+            LABEL_CHECKIN_INTERVALS[label] = int(secs)
         except (TypeError, ValueError):
             pass
 

--- a/src/background_tasks.py
+++ b/src/background_tasks.py
@@ -1116,14 +1116,12 @@ def cadence_from_tags(tags) -> int | None:
     return None
 
 
-# Back-compat label-based intervals: used only when an agent has no
-# ``cadence.*`` tag yet. Retire this once Lumen/Vigil/Sentinel are tagged.
-_PERSISTENT_AGENT_INTERVALS = {
-    "Vigil": 1800,     # 30 min
-    "Lumen": 300,      # 5 min
-    "Sentinel": 600,   # 10 min
-    "Watcher": 21600,  # 6 hr; hook-driven, not a 5-minute daemon
-}
+# Back-compat label-based intervals: used only when an agent has no ``cadence.*``
+# tag yet. USER-AGNOSTIC: empty in the repo — named residents would leak one
+# deployment's roster + schedule. The generic path is the ``cadence.*`` tag
+# taxonomy (CADENCE_FROM_TAG above); per-label residents come from the
+# deployment-local UNITARES_CLASS_CALIBRATION overlay ("label_intervals").
+from config.governance_config import LABEL_CHECKIN_INTERVALS as _PERSISTENT_AGENT_INTERVALS
 
 _silence_alerted: set[str] = set()
 _silence_critical_alerted: set[str] = set()

--- a/tests/test_agent_lifecycle.py
+++ b/tests/test_agent_lifecycle.py
@@ -211,6 +211,15 @@ class TestCadenceFromTags:
 # ============================================================================
 
 class TestExpectedInterval:
+    @pytest.fixture(autouse=True)
+    def _inject_label_intervals(self, monkeypatch):
+        """Label-based intervals are deployment-local now (UNITARES_CLASS_CALIBRATION
+        overlay); inject representative test values so the label-fallback path has
+        a map to exercise, without depending on shipped per-resident config."""
+        import src.background_tasks as bt
+        monkeypatch.setattr(bt, "_PERSISTENT_AGENT_INTERVALS",
+                            {"Vigil": 1800, "Lumen": 300, "Sentinel": 600, "Watcher": 21600})
+
     def test_prefers_cadence_tag_over_label(self):
         """Tag-driven cadence wins even when the label matches the legacy map."""
         meta = _protection_meta(label="Lumen", tags=["cadence.10min"])

--- a/tests/test_background_tasks_silence.py
+++ b/tests/test_background_tasks_silence.py
@@ -39,6 +39,12 @@ def isolated_silence_state(monkeypatch):
     monkeypatch.setattr(broadcaster_module, "broadcaster_instance", broadcaster)
     monkeypatch.setattr(audit_module, "append_audit_event_async", audit)
 
+    # Label-based intervals are deployment-local now (UNITARES_CLASS_CALIBRATION
+    # overlay); inject representative test values so the silence detector has a
+    # label map to exercise, without depending on shipped per-resident config.
+    monkeypatch.setattr(background_tasks, "_PERSISTENT_AGENT_INTERVALS",
+                        {"Vigil": 1800, "Lumen": 300, "Sentinel": 600, "Watcher": 21600})
+
     yield broadcaster, audit
 
     agent_metadata.clear()


### PR DESCRIPTION
Follow-on to #1143 (the anchor de-leak, now merged). The last functional named-resident leak in code: `background_tasks._PERSISTENT_AGENT_INTERVALS` hardcoded the operator's residents (`Lumen/Vigil/Sentinel/Watcher` → check-in cadences). Same leak class as the anchors — lower sensitivity (a schedule, not operating points), but still one deployment's roster in a user-agnostic repo. It was already marked "back-compat, retire once tagged," and the generic path (`CADENCE_FROM_TAG`, `cadence.*` tags) already exists.

## Change
- `config.LABEL_CHECKIN_INTERVALS` ships **`{}`** and is populated from the `UNITARES_CLASS_CALIBRATION` overlay's new **`label_intervals`** section (same deployment-local file as the anchors). `background_tasks` imports it.
- Without an overlay, an untagged named resident gets no label fallback — tag it `cadence.*` (the generic mechanism) or list it in the overlay.

## Operator note
Your overlay (`~/.config/cirwel/class_calibration.json`) already has the `label_intervals` section added (Vigil 1800 / Lumen 300 / Sentinel 600 / Watcher 21600), so once `UNITARES_CLASS_CALIBRATION` is wired into the plist (see #1143), the silence detector keeps the same per-resident thresholds.

## Tests
Silence-detector + `TestExpectedInterval` inject representative label-intervals via fixtures, exercising the mechanism without depending on shipped per-resident config. Full suite green (10938). Scope-guard Rule 4 (from #1143) stays clean — the named dict is gone from the repo.

This closes the **functional** de-Lumen work (config anchors #1143 + this). Remaining is the docs/test *example* mentions — a separate, larger, lower-severity sweep that's mostly historical records and mechanism docs (handle with the "fix framing / setup-dependence, not blanket-delete" rule, not a sed).

https://claude.ai/code/session_01VsXq3pJjFtzdy7GCeJ4PBq