### PR TITLE
fix(gateway): route notes through canonical knowledge tool

### DIFF
--- a/src/gateway/simplifiers.py
+++ b/src/gateway/simplifiers.py
@@ -118,11 +118,11 @@ def simplify_search(raw: dict) -> dict:
 
 
 def simplify_note(raw: dict) -> dict:
-    """Simplify leave_note response."""
+    """Simplify knowledge note response."""
     if not isinstance(raw, dict):
         return ok("Note saved", {"raw": raw})
 
-    node_id = raw.get("id") or raw.get("node_id") or raw.get("entry_id")
+    node_id = raw.get("id") or raw.get("node_id") or raw.get("note_id") or raw.get("entry_id")
     data = {"saved": True}
     if node_id:
         data["id"] = node_id

--- a/src/gateway/tools.py
+++ b/src/gateway/tools.py
@@ -14,6 +14,17 @@ from .query_engine import route_query
 logger = logging.getLogger("gateway.tools")
 
 
+def _normalize_tags(tags: Optional[str | list[str]]) -> list[str] | None:
+    """Normalize gateway tag input to the canonical knowledge schema."""
+    if tags is None:
+        return None
+    if isinstance(tags, str):
+        values = [tag.strip() for tag in tags.split(",")]
+    else:
+        values = [str(tag).strip() for tag in tags]
+    return [tag for tag in values if tag]
+
+
 def _error_envelope(exc: Exception) -> str:
     """Convert an exception to a JSON error envelope string."""
     if isinstance(exc, CircuitOpenError):
@@ -84,17 +95,18 @@ async def handle_search(
 async def handle_note(
     client: GovernanceMCPClient,
     content: str,
-    tags: Optional[str] = None,
+    tags: Optional[str | list[str]] = None,
     agent_id: Optional[str] = None,
 ) -> str:
     """Leave a note or discovery in the knowledge graph."""
     try:
-        args: dict = {"content": content}
-        if tags:
-            args["tags"] = tags
+        args: dict = {"action": "note", "summary": content}
+        normalized_tags = _normalize_tags(tags)
+        if normalized_tags:
+            args["tags"] = normalized_tags
         if agent_id:
             args["agent_id"] = agent_id
-        raw = await client.call_tool("leave_note", args)
+        raw = await client.call_tool("knowledge", args)
         return json.dumps(simplifiers.simplify_note(raw))
     except Exception as exc:
         logger.warning("note failed: %s", exc)

--- a/tests/test_gateway_simplifiers.py
+++ b/tests/test_gateway_simplifiers.py
@@ -107,6 +107,12 @@ class TestSimplifyNote:
         assert result["data"]["id"] == "n-123"
         assert result["data"]["saved"] is True
 
+    def test_with_canonical_note_id(self):
+        raw = {"note_id": "n-456", "message": "Note saved"}
+        result = simplify_note(raw)
+        assert result["ok"] is True
+        assert result["data"]["id"] == "n-456"
+
     def test_without_id(self):
         raw = {"status": "ok"}
         result = simplify_note(raw)

--- a/tests/test_gateway_tools.py
+++ b/tests/test_gateway_tools.py
@@ -122,8 +122,16 @@ class TestHandleNote:
     async def test_with_tags(self, mock_client):
         mock_client.call_tool.return_value = {"node_id": "n-2"}
         await handle_note(mock_client, content="Test", tags="redis,perf")
-        mock_client.call_tool.assert_called_with("leave_note", {
-            "content": "Test", "tags": "redis,perf",
+        mock_client.call_tool.assert_called_with("knowledge", {
+            "action": "note", "summary": "Test", "tags": ["redis", "perf"],
+        })
+
+    @pytest.mark.asyncio
+    async def test_routes_through_canonical_knowledge_tool(self, mock_client):
+        mock_client.call_tool.return_value = {"note_id": "n-3"}
+        await handle_note(mock_client, content="Important finding")
+        mock_client.call_tool.assert_called_with("knowledge", {
+            "action": "note", "summary": "Important finding",
         })
 
 


### PR DESCRIPTION
## Summary
- route gateway note writes through the canonical `knowledge(action='note')` tool instead of deprecated `leave_note`
- normalize gateway tag strings/lists to the canonical list shape
- preserve note IDs from canonical `note_id` responses in the gateway simplifier

## Tests
- `python3 -m pytest tests/test_gateway_tools.py tests/test_gateway_simplifiers.py`
- `./scripts/dev/test-cache.sh` (10940 passed, 21 skipped; coverage 81.74%)
- pre-push smoke (138 passed; doc-health reported existing ghost-tool warnings in docs/manual/04-integrating-agents.md and skills/unitares-dashboard/SKILL.md)

## Pre-PR Gate
- `git prepr --scope 'gateway knowledge note simplification'` failed only on long-running repo-referenced operator services: ipv6_loopback_proxy, deploy MCP server, gateway_server
- `git prepr --no-processes --scope 'gateway knowledge note simplification'` passed