### PR TITLE
chore(scope-guard): flag chat-session / AI-deliberation register (Rule 5 + PR-body lint)

### DIFF
--- a/.github/workflows/repo-scope.yml
+++ b/.github/workflows/repo-scope.yml
@@ -42,6 +42,13 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
+          # Escape hatch for PRs that legitimately discuss these patterns (this
+          # guard, register cleanups, meta-docs): add the HTML comment
+          # <!-- scope-guard: allow-register --> to the PR body. Rare by design.
+          if printf '%s' "$PR_BODY" | grep -q 'scope-guard: allow-register'; then
+            echo "PR body register: allow-register marker present — skipping."
+            exit 0
+          fi
           bad=$(printf '%s' "$PR_BODY" | grep -niE '/Users/cirwel|per your guidance|your overlay|you flagged|questions for [Kk]enny|live-verifier|council pass|council fold' || true)
           if [ -n "$bad" ]; then
             echo "::error::PR body reads like a personal chat session or leaks an operator-local path. Rewrite third-person/imperative; move working notes out of the public record."

--- a/.github/workflows/repo-scope.yml
+++ b/.github/workflows/repo-scope.yml
@@ -33,3 +33,19 @@ jobs:
 
       - name: Run repo scope guard
         run: bash scripts/dev/check-repo-scope.sh --base "${{ steps.base.outputs.ref }}"
+
+      # The file guard checks committed content; a PR description is not a file,
+      # so lint it separately for the same chat-session register. Body passed via
+      # env (never inlined) to avoid script injection.
+      - name: Lint PR body for chat-session register
+        if: github.event_name == 'pull_request'
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          bad=$(printf '%s' "$PR_BODY" | grep -niE '/Users/cirwel|per your guidance|your overlay|you flagged|questions for [Kk]enny|live-verifier|council pass|council fold' || true)
+          if [ -n "$bad" ]; then
+            echo "::error::PR body reads like a personal chat session or leaks an operator-local path. Rewrite third-person/imperative; move working notes out of the public record."
+            printf '%s\n' "$bad"
+            exit 1
+          fi
+          echo "PR body register: clean"

--- a/docs/REPO_SCOPE.md
+++ b/docs/REPO_SCOPE.md
@@ -30,7 +30,9 @@ agent (or no agent) against it.
   `council fold`, `live-verifier`, `three-lane council`). It deliberately does
   **not** flag the real product vocabulary `operator`, `council`, or `dialectic`,
   and exempts stored session data under `src/data/`. Working notes belong in
-  `~/projects/_notes-archive/<repo>/`; ship clean docs.
+  `~/projects/_notes-archive/<repo>/`; ship clean docs. A PR that legitimately
+  discusses these patterns (this guard, a register cleanup, meta-docs) can opt
+  the PR-body lint out with the HTML comment `<!-- scope-guard: allow-register -->`.
 
 ## Why a guard, not just this doc
 

--- a/docs/REPO_SCOPE.md
+++ b/docs/REPO_SCOPE.md
@@ -21,6 +21,16 @@ agent (or no agent) against it.
   vendor-specific surface), not in this agnostic repo.
 - **Personal contact info** — personal emails / identifiers. Use the project's
   public contact surfaces only.
+- **Chat-session / AI-deliberation register** — committed docs, code comments,
+  and PR descriptions should read as product engineering, not as a continued
+  personal chat session or an AI-review scratchpad. The guard flags, in changed
+  files and in PR bodies: operator-local paths (`/Users/cirwel`), second-person
+  address of the operator (`per your guidance`, `your overlay`, `you flagged`,
+  `questions for Kenny`), and exposed AI-review process (`council pass`,
+  `council fold`, `live-verifier`, `three-lane council`). It deliberately does
+  **not** flag the real product vocabulary `operator`, `council`, or `dialectic`,
+  and exempts stored session data under `src/data/`. Working notes belong in
+  `~/projects/_notes-archive/<repo>/`; ship clean docs.
 
 ## Why a guard, not just this doc
 

--- a/scripts/dev/check-repo-scope.sh
+++ b/scripts/dev/check-repo-scope.sh
@@ -107,6 +107,28 @@ while IFS= read -r f; do
   if grep -nIE '"includeCoAuthoredBy"|"attribution"[[:space:]]*:' "$f" >/dev/null 2>&1; then
     report "$f" "Per-vendor attribution config belongs in local ~/.claude config, not the agnostic repo."
   fi
+
+  # Rule 5: Claude session/deliberation register leaking into committed content.
+  # Public docs/code should read as product engineering, not as a continued chat
+  # session or an AI-review scratchpad. (Codex-authored content does not carry
+  # this register; this catches the Claude-specific pattern.) Tight, near-zero-
+  # false-positive markers ONLY — never bare "operator"/"council", which are real
+  # product vocab (src/mcp_handlers/identity/operator.py, the dialectic system).
+  # Stored dialectic session data under src/data/ is exempt.
+  case "$f" in
+    src/data/*) ;;
+    *)
+      if grep -nIE '/Users/cirwel' "$f" >/dev/null 2>&1; then
+        report "$f" "Leaks an operator-local path (/Users/cirwel) — use ~, \$HOME, or an env var, never a machine-absolute path."
+      fi
+      if grep -nIE 'per your guidance|your overlay|you flagged|questions for [Kk]enny' "$f" >/dev/null 2>&1; then
+        report "$f" "Addresses the operator in second person (chat-session register) — product docs/PRs are third-person/imperative, not a reply to one operator."
+      fi
+      if grep -nIE 'live-verifier|council pass|council fold|three-lane council' "$f" >/dev/null 2>&1; then
+        report "$f" "Exposes the AI-review process (council/live-verifier) — internal deliberation, not product content. Keep working notes in ~/projects/_notes-archive and ship clean docs."
+      fi
+      ;;
+  esac
 done <<EOF
 $FILES
 EOF


### PR DESCRIPTION
<!-- scope-guard: allow-register (this PR documents the patterns) -->

## Problem

Docs, some code comments, and PR descriptions read as a continued personal chat session or an AI-review scratchpad rather than product engineering. Measured on the current repo: ~60 docs carry `council`/`live-verifier` deliberation language, 11 docs leak `/Users/cirwel`, and merged PRs address the operator in second person ("per your guidance", "your overlay"). It is a Claude-specific register — Codex-authored content does not carry it — and it re-accreted after a prior manual sweep, so discipline alone has not held it.

## Fix: extend the existing diff-scoped scope guard

- **`check-repo-scope.sh` Rule 5** — flags, in changed files: operator-local paths (`/Users/cirwel`), second-person operator address (`per your guidance`, `your overlay`, `you flagged`, `questions for Kenny`), and exposed AI-review process (`council pass`, `council fold`, `live-verifier`, `three-lane council`).
- **`repo-scope.yml`** — a PR-body lint (a PR description is not a file), body passed via env to avoid injection. This catches web/cloud-authored PRs that bypass local hooks.
- **`REPO_SCOPE.md`** — documents the rule.

## Deliberately safe

- Never flags the real product vocabulary `operator`, `council`, or `dialectic` (`src/mcp_handlers/identity/operator.py`, the dialectic system). Verified by self-test.
- Exempts stored session data under `src/data/`.
- Diff-scoped: catches new additions without failing CI on the legacy backlog.

## Verification

Self-tested against fixtures: operator-path / second-person / council-register all caught; `operator`+`dialectic`+`council` prose and `src/data/` session data left clean. `bash -n` clean; guard passes on its own diff (guard files are self-exempt).

Cleaning the existing backlog (de-session-ifying live proposals + code comments in place; archiving is entangled via cross-refs) is a separate staged follow-up.

https://claude.ai/code/session_0139sb3KFNm6wm2KrLBVDJ4R