### PR TITLE
chore(scope): replace operator-local /Users/cirwel paths with portable forms

### DIFF
--- a/docs/operations/lease-plane-operator-runbook.md
+++ b/docs/operations/lease-plane-operator-runbook.md
@@ -342,7 +342,7 @@ A file rename, dialectic-session ID rotation, or resident relabel changes a surf
 
 **Failure mode**
 
-Agent A holds `file:///Users/cirwel/x.py`. Operator (or another tool) renames `x.py` → `y.py`. Agent A's lease still references `file:///Users/cirwel/x.py` — that path no longer exists. Agent B can now `acquire(file:///Users/cirwel/y.py)` and succeed; the "same surface semantically" is double-leased. The orphan ages out via TTL on its `original_ttl_s` clock — at most 1h per RFC §4.4 hard cap.
+Agent A holds `file:///home/user/x.py`. Operator (or another tool) renames `x.py` → `y.py`. Agent A's lease still references `file:///home/user/x.py` — that path no longer exists. Agent B can now `acquire(file:///home/user/y.py)` and succeed; the "same surface semantically" is double-leased. The orphan ages out via TTL on its `original_ttl_s` clock — at most 1h per RFC §4.4 hard cap.
 
 **Detection**
 

--- a/docs/proposals/orchestrator-vouched-identity-v0.md
+++ b/docs/proposals/orchestrator-vouched-identity-v0.md
@@ -451,7 +451,7 @@ that travels."
   (live-verifier 2026-06-17).** The orchestrator builds against **Erlang/OTP 28 /
   Elixir 1.19.5**, so `:gen_tcp.connect({:local, path}, 0, …)` AF_UNIX (OTP 19+) is
   available. The governance UDS listener is **live**: `UNITARES_UDS_SOCKET =
-  /Users/cirwel/.unitares/governance.sock` is set in the gov-mcp plist and the
+  ~/.unitares/governance.sock` is set in the gov-mcp plist and the
   socket exists (`srw-rw-rw-`, last bound today). It speaks HTTP framing over
   AF_UNIX (`uds_listener.py`, uvicorn H11). **The remaining cost, not a blocker:**
   `:httpc` cannot do AF_UNIX, and the existing `LeasePlaneClient` (`:httpc` + TCP)

--- a/docs/proposals/resolved/s19-attestation-mechanism.md
+++ b/docs/proposals/resolved/s19-attestation-mechanism.md
@@ -50,7 +50,7 @@ Out of scope (unchanged from v1):
 
 ### Transport: UDS additive to existing HTTP
 
-Governance-mcp gains a Unix-domain socket listener at `/Users/cirwel/.unitares/governance.sock` alongside the existing HTTP-on-loopback at port 8767. UDS is for substrate-anchored residents only; HTTP stays for non-substrate-anchored clients. Q1 confirmed by code-architect: HTTP-only listener today (`src/mcp_server.py:217-223, 714, 738-963`); UDS is additive surface; `SessionSignals` extends with one `peer_pid: Optional[int]` field; the existing ASGI pipeline handles requests identically once `peer_pid` is populated.
+Governance-mcp gains a Unix-domain socket listener at `~/.unitares/governance.sock` alongside the existing HTTP-on-loopback at port 8767. UDS is for substrate-anchored residents only; HTTP stays for non-substrate-anchored clients. Q1 confirmed by code-architect: HTTP-only listener today (`src/mcp_server.py:217-223, 714, 738-963`); UDS is additive surface; `SessionSignals` extends with one `peer_pid: Optional[int]` field; the existing ASGI pipeline handles requests identically once `peer_pid` is populated.
 
 Per the anyio-asyncio constraint (CLAUDE.md "Known Issue"), the verification call (launchctl + executable path + start-time) MUST be wrapped in `loop.run_in_executor` — the existing pattern at `src/agent_loop_detection.py:374` is the reference. Verification result is cached in the connection's contextvar for that connection's lifetime; not re-verified per tool call.
 
@@ -128,7 +128,7 @@ Implementation tests use fixture outputs (recorded `launchctl print` and `launch
 
 `agents/sdk/src/unitares_sdk/agent.py:_ensure_identity` (line 279) and `_save_session` (per-resident) adopt:
 
-- New env var `UNITARES_UDS_SOCKET=/Users/cirwel/.unitares/governance.sock` set in each substrate-anchored resident's plist. SDK's `GovernanceClient.connect()` (`agents/sdk/src/unitares_sdk/client.py:75-99`) detects this env var and routes through UDS instead of HTTP.
+- New env var `UNITARES_UDS_SOCKET=~/.unitares/governance.sock` set in each substrate-anchored resident's plist. SDK's `GovernanceClient.connect()` (`agents/sdk/src/unitares_sdk/client.py:75-99`) detects this env var and routes through UDS instead of HTTP.
 - Substrate-anchored mode detected by env var presence; in this mode, `_save_session()` writes only `{agent_uuid}` (and optional `parent_agent_id`); it does NOT persist `continuity_token` or `client_session_id`. The Steward-shape anchor becomes the canonical pattern for the substrate-anchored class.
 - `_ensure_identity` fast-path: when `agent_uuid` is in the anchor and `UNITARES_UDS_SOCKET` is set, calls `client.identity(agent_uuid=agent_uuid, resume=True)` over UDS. Server-side substrate-claim verification (§Verification at connection-accept above) gates the resume.
 

--- a/docs/proposals/resolved/wave-0-step-2-call-site-scoping.md
+++ b/docs/proposals/resolved/wave-0-step-2-call-site-scoping.md
@@ -110,7 +110,7 @@ PR descriptions for 2A and 2B MUST include a row in the test plan table:
 {"_coord_event":true,"service":"governance_mcp","event_type":"coordination_failure.asyncpg_connect_error.bootstrap","payload":{"error_class":"OSError","db_url_hash":"abc123","timeout_s":5.0,"attempt":1,"incident_id":"<uuid>"},"context":{...}}
 ```
 
-**Chronicler sweeper** (separate Wave 0 step 3 work — runs on its existing daily cadence): `tail -F /Users/cirwel/Library/Logs/governance-mcp-stderr.log | grep '_coord_event' | jq | INSERT into audit.coordination_events`. Buffered between sweeps; loss bounded to "events from windows where governance-mcp was down AND Chronicler hadn't run yet" — a small tail.
+**Chronicler sweeper** (separate Wave 0 step 3 work — runs on its existing daily cadence): `tail -F ~/Library/Logs/governance-mcp-stderr.log | grep '_coord_event' | jq | INSERT into audit.coordination_events`. Buffered between sweeps; loss bounded to "events from windows where governance-mcp was down AND Chronicler hadn't run yet" — a small tail.
 
 ### 1.runtime
 

--- a/src/substrate/path_safety.py
+++ b/src/substrate/path_safety.py
@@ -53,8 +53,8 @@ def first_user_writable_ancestor(path: str) -> Optional[str]:
     ``None`` if no path component up to root grants write access.
 
     Used by the enrollment CLI to make warning messages specific:
-    "binary at /Users/cirwel/projects/.../sentinel is user-writable via
-    /Users/cirwel/projects" rather than just "is user-writable."
+    "binary at /home/user/projects/.../sentinel is user-writable via
+    /home/user/projects" rather than just "is user-writable."
     """
     resolved = Path(path).expanduser().resolve()
 


### PR DESCRIPTION
## What

Operator-home-absolute paths (`/Users/cirwel/...`) leaked into committed docs and one code docstring, which reads as a single deployment rather than agnostic product content. Replaced with portable equivalents (`~`, `/home/user`). No behavior change — the `path_safety.py` edit is a docstring example; the runbook/proposal mentions are illustrative.

| File | Was | Now |
|---|---|---|
| `operations/lease-plane-operator-runbook.md` | `file:///Users/cirwel/x.py` | `file:///home/user/x.py` |
| `proposals/orchestrator-vouched-identity-v0.md` | `/Users/cirwel/.unitares/governance.sock` | `~/.unitares/governance.sock` |
| `proposals/resolved/s19-attestation-mechanism.md` | `/Users/cirwel/.unitares/...` | `~/.unitares/...` |
| `proposals/resolved/wave-0-step-2-call-site-scoping.md` | `/Users/cirwel/Library/Logs/...` | `~/Library/Logs/...` |
| `src/substrate/path_safety.py` | docstring `/Users/cirwel/projects` | `/home/user/projects` |

## Deliberately NOT touched (flagged, not skipped)
- `docs/CHANGELOG.md` — historical release record; not revised.
- `docs/install/cross-machine-surface.md` — a leak-audit doc where the path is the literal search target; belongs on the scope-guard allowlist, not edited.
- `docs/operations/automation-overrides.json` — a wired operator-specific automation census (40+ local paths, owner, repo list); needs the plist-style template treatment (generic example committed, real one gitignored), not a find/replace. Tracked as its own follow-up.

## Scope
Part of the docs-register cleanup. The larger register de-session-ification (`council`/`live-verifier` language in `docs/ontology/plan.md` and the live RFC threads, plus code comments) is staged separately — `plan.md` is a single-writer surface and saturated, so it needs careful in-place work, not a sweep. PR #1150's guard prevents new accumulation meanwhile.

## Verification
`check-repo-scope.sh --staged`: clean. `py_compile` OK on the touched module.

https://claude.ai/code/session_0139sb3KFNm6wm2KrLBVDJ4R