### PR TITLE
feat(identity): descriptive harness census from S22 write-context

### DIFF
--- a/scripts/analysis/harness_census.py
+++ b/scripts/analysis/harness_census.py
@@ -45,12 +45,13 @@ def _render_markdown(census: dict) -> str:
         f"unattributed {census['unattributed_entries']})",
         f"- distinct harnesses: **{census['distinct_harnesses']}**",
         "",
-        "| harness | entries | agents | situated | first seen | last seen | transports | models |",
-        "|---|--:|--:|--:|---|---|---|---|",
+        "| harness | entries | agents | instances | inst.label | situated | first seen | last seen | transports | models |",
+        "|---|--:|--:|--:|--:|--:|---|---|---|---|",
     ]
     for h in census["harnesses"]:
         lines.append(
             f"| `{h['canonical_harness']}` | {h['entry_count']} | {h['distinct_agents']} | "
+            f"{h['distinct_harness_ids']} | {h['instance_label_ratio']:.2f} | "
             f"{h['situating_metadata_ratio']:.2f} | {h['first_seen'] or '—'} | "
             f"{h['last_seen'] or '—'} | {', '.join(h['transports']) or '—'} | "
             f"{', '.join(h['models']) or '—'} |"

--- a/scripts/analysis/harness_census.py
+++ b/scripts/analysis/harness_census.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Descriptive harness census — inventory every harness seen in S22 provenance.
+
+Read-only. Reads durable S22 write context from
+``core.agent_state.state_json.provenance_context`` and
+``knowledge.discoveries.provenance.s22_context`` (reusing the s22_h5 collector),
+then rolls it up by canonical harness: entry counts, distinct agents, first/last
+seen, transports/models, and per-harness situating-metadata ratio.
+
+This is a *census*, not a registry: harness labels are self-declared and confer no
+authority (``docs/ontology/harness-substrate-plurality.md``). It is the evidence
+``docs/ontology/plan.md`` Track D wants before promoting ``harness_id``.
+
+Usage:
+    python3 scripts/analysis/harness_census.py
+    python3 scripts/analysis/harness_census.py --json
+    python3 scripts/analysis/harness_census.py --limit-per-source 1000 --output data/analysis/harness_census.md
+
+Env:
+    GOVERNANCE_DATABASE_URL  (whatever src.db.get_db resolves)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from src.db import close_db  # noqa: E402
+from src.identity.s22_h5_comparison import collect_s22_h5_entries  # noqa: E402
+from src.identity.harness_census import build_harness_census  # noqa: E402
+
+
+def _render_markdown(census: dict) -> str:
+    lines = [
+        "# Harness census (descriptive)",
+        "",
+        f"- entries: **{census['total_entries']}** "
+        f"(attributed {census['attributed_entries']}, "
+        f"unattributed {census['unattributed_entries']})",
+        f"- distinct harnesses: **{census['distinct_harnesses']}**",
+        "",
+        "| harness | entries | agents | situated | first seen | last seen | transports | models |",
+        "|---|--:|--:|--:|---|---|---|---|",
+    ]
+    for h in census["harnesses"]:
+        lines.append(
+            f"| `{h['canonical_harness']}` | {h['entry_count']} | {h['distinct_agents']} | "
+            f"{h['situating_metadata_ratio']:.2f} | {h['first_seen'] or '—'} | "
+            f"{h['last_seen'] or '—'} | {', '.join(h['transports']) or '—'} | "
+            f"{', '.join(h['models']) or '—'} |"
+        )
+    if census["unattributed_entries"]:
+        lines += ["", f"_{census['unattributed_entries']} entries carried no harness "
+                  "label (the labelling gap — these are invisible to any future registry)._"]
+    return "\n".join(lines) + "\n"
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--limit-per-source", type=int, default=500,
+                    help="Max S22 rows to read from agent_state and KG independently.")
+    ap.add_argument("--json", action="store_true", help="Emit the full census as JSON.")
+    ap.add_argument("--output", default=None, help="Write the markdown report here.")
+    args = ap.parse_args()
+
+    try:
+        entries = await collect_s22_h5_entries(limit_per_source=args.limit_per_source)
+        census = build_harness_census(entries)
+    finally:
+        await close_db()
+
+    if args.json:
+        print(json.dumps(census, indent=2, sort_keys=True))
+        return 0
+    report = _render_markdown(census)
+    if args.output:
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.output).write_text(report)
+        print(f"Wrote {args.output}")
+    else:
+        print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/src/identity/harness_census.py
+++ b/src/identity/harness_census.py
@@ -1,0 +1,134 @@
+"""Descriptive harness census — what harnesses have actually written, from S22 provenance.
+
+Read-only aggregation over S22 write-context
+(``core.agent_state.state_json.provenance_context`` +
+``knowledge.discoveries.provenance.s22_context``). It reuses the existing
+collection/normalization in ``s22_h5_comparison`` and rolls the entries up *by
+harness* into an inventory: which harnesses appear, how often, since when, with
+which transports/models, and — crucially — how much situating metadata each
+carries.
+
+Two things this is **not**:
+
+* **Not an authoritative registry.** ``harness_id`` / ``harness_type`` are
+  self-declared *labels*, not identity (``docs/ontology/harness-substrate-plurality.md``;
+  the field is a "convenience label", explicitly NOT promoted). This census only
+  *describes* what has been observed; it confers no authority and gates nothing.
+* **Not the H5 comparison gate.** ``s22_h5_comparable_entries.py`` asks whether one
+  shared comparison key spans the required harnesses (a promotion-evidence gate).
+  This asks the broader question "what harnesses exist at all, and how well are they
+  situated?" — which is exactly the evidence ``docs/ontology/plan.md`` Track D
+  (D3/D4) wants before promoting ``harness_id`` to a first-class field. Building the
+  authoritative registry is the deferred, council-gated decision; this census feeds it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Optional
+
+from src.identity.s22_h5_comparison import (
+    S22H5Entry,
+    normalize_s22_h5_entry,
+)
+
+
+def _ensure_entry(entry: S22H5Entry | Mapping[str, Any]) -> Optional[S22H5Entry]:
+    if isinstance(entry, S22H5Entry):
+        return entry
+    if isinstance(entry, Mapping):
+        return normalize_s22_h5_entry(entry)
+    return None
+
+
+def _minmax(current_min, current_max, value):
+    """ISO-8601 timestamps compare correctly lexicographically; skip Nones."""
+    if not value:
+        return current_min, current_max
+    new_min = value if current_min is None or value < current_min else current_min
+    new_max = value if current_max is None or value > current_max else current_max
+    return new_min, new_max
+
+
+def build_harness_census(
+    entries: Sequence[S22H5Entry | Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Roll S22 write-context entries up by canonical harness.
+
+    Pure and deterministic — no DB, no I/O. Entries with no harness label are
+    counted as ``unattributed_entries`` (the size of the labelling gap is itself a
+    finding). The per-harness ``situating_metadata_ratio`` is the promotion-
+    readiness signal Track D keys on.
+    """
+    normalized = [e for e in (_ensure_entry(x) for x in entries) if e is not None]
+
+    acc: dict[str, dict[str, Any]] = {}
+    unattributed = 0
+    for e in normalized:
+        canon = e.canonical_harness
+        if not canon:
+            unattributed += 1
+            continue
+        rec = acc.setdefault(canon, {
+            "canonical_harness": canon,
+            "raw_harness_types": set(),
+            "entry_count": 0,
+            "_agents": set(),
+            "first_seen": None,
+            "last_seen": None,
+            "sources": {},
+            "transports": set(),
+            "models": set(),
+            "model_providers": set(),
+            "_comparison_keys": set(),
+            "_situated": 0,
+        })
+        rec["entry_count"] += 1
+        if e.harness_type:
+            rec["raw_harness_types"].add(e.harness_type)
+        if e.agent_id:
+            rec["_agents"].add(e.agent_id)
+        rec["first_seen"], rec["last_seen"] = _minmax(
+            rec["first_seen"], rec["last_seen"], e.recorded_at
+        )
+        if e.source:
+            rec["sources"][e.source] = rec["sources"].get(e.source, 0) + 1
+        if e.transport:
+            rec["transports"].add(e.transport)
+        if e.model:
+            rec["models"].add(e.model)
+        if e.model_provider:
+            rec["model_providers"].add(e.model_provider)
+        if e.comparison_key:
+            rec["_comparison_keys"].add(e.comparison_key)
+        if e.has_situating_metadata:
+            rec["_situated"] += 1
+
+    harnesses = []
+    for rec in acc.values():
+        count = rec["entry_count"]
+        harnesses.append({
+            "canonical_harness": rec["canonical_harness"],
+            "raw_harness_types": sorted(rec["raw_harness_types"]),
+            "entry_count": count,
+            "distinct_agents": len(rec["_agents"]),
+            "first_seen": rec["first_seen"],
+            "last_seen": rec["last_seen"],
+            "sources": dict(sorted(rec["sources"].items())),
+            "transports": sorted(rec["transports"]),
+            "models": sorted(rec["models"]),
+            "model_providers": sorted(rec["model_providers"]),
+            "distinct_comparison_keys": len(rec["_comparison_keys"]),
+            "situating_metadata_ratio": round(rec["_situated"] / count, 3) if count else 0.0,
+        })
+    # Most-active harness first; ties broken by name for determinism.
+    harnesses.sort(key=lambda h: (-h["entry_count"], h["canonical_harness"]))
+
+    attributed = len(normalized) - unattributed
+    return {
+        "total_entries": len(normalized),
+        "attributed_entries": attributed,
+        "unattributed_entries": unattributed,
+        "distinct_harnesses": len(acc),
+        "harnesses": harnesses,
+    }

--- a/src/identity/harness_census.py
+++ b/src/identity/harness_census.py
@@ -74,6 +74,8 @@ def build_harness_census(
             "raw_harness_types": set(),
             "entry_count": 0,
             "_agents": set(),
+            "_harness_ids": set(),
+            "_labelled_ids": 0,
             "first_seen": None,
             "last_seen": None,
             "sources": {},
@@ -86,6 +88,9 @@ def build_harness_census(
         rec["entry_count"] += 1
         if e.harness_type:
             rec["raw_harness_types"].add(e.harness_type)
+        if e.harness_id:
+            rec["_harness_ids"].add(e.harness_id)
+            rec["_labelled_ids"] += 1
         if e.agent_id:
             rec["_agents"].add(e.agent_id)
         rec["first_seen"], rec["last_seen"] = _minmax(
@@ -112,6 +117,12 @@ def build_harness_census(
             "raw_harness_types": sorted(rec["raw_harness_types"]),
             "entry_count": count,
             "distinct_agents": len(rec["_agents"]),
+            # Type-vs-instance: how many concrete harness instances under this type,
+            # and how many entries carried an instance label at all (the Track D
+            # promotion question). instance_label_ratio < 1.0 means harness_id is
+            # sparse — not yet safe to promote to first-class.
+            "distinct_harness_ids": len(rec["_harness_ids"]),
+            "instance_label_ratio": round(rec["_labelled_ids"] / count, 3) if count else 0.0,
             "first_seen": rec["first_seen"],
             "last_seen": rec["last_seen"],
             "sources": dict(sorted(rec["sources"].items())),

--- a/src/identity/s22_h5_comparison.py
+++ b/src/identity/s22_h5_comparison.py
@@ -91,6 +91,11 @@ class S22H5Entry:
     memory_context: Optional[str]
     tool_surface: tuple[str, ...]
     has_situating_metadata: bool
+    # Instance granularity. harness_type/canonical_harness are the *type*; harness_id
+    # is the concrete body/runtime instance. The ontology (plan.md Track D) keys its
+    # promotion decision on type-vs-instance, so the census needs both. Defaulted so
+    # existing constructors stay valid.
+    harness_id: Optional[str] = None
 
     @property
     def is_comparable(self) -> bool:
@@ -184,6 +189,7 @@ def normalize_s22_h5_entry(raw: Mapping[str, Any]) -> Optional[S22H5Entry]:
         memory_context=memory_context,
         tool_surface=tool_surface,
         has_situating_metadata=has_situating_metadata,
+        harness_id=_first_text(context, ("harness_id",)),
     )
 
 

--- a/tests/test_harness_census.py
+++ b/tests/test_harness_census.py
@@ -1,0 +1,109 @@
+"""Tests for the descriptive harness census (src.identity.harness_census).
+
+Pure aggregation over normalized S22 write-context rows — no DB. Fixtures are
+DB-row-shaped dicts (``s22_context`` block), exercised through the real
+normalize_s22_h5_entry path the live collector uses.
+"""
+
+from src.identity.harness_census import build_harness_census
+
+
+def _row(entry_id, source, agent_id, recorded_at, ctx):
+    return {
+        "entry_id": entry_id,
+        "source": source,
+        "agent_id": agent_id,
+        "recorded_at": recorded_at,
+        "s22_context": ctx,
+    }
+
+
+# A small mixed population: two claude-code entries (one aliased "claude"), one
+# codex, one hermes, and one row with no harness label at all.
+ROWS = [
+    _row("e1", "agent_state", "agent-A", "2026-06-01T00:00:00+00:00",
+         {"harness_type": "claude-code", "transport": "cli", "model": "opus",
+          "model_provider": "anthropic", "comparison_key": "k1"}),
+    _row("e2", "agent_state", "agent-B", "2026-06-03T00:00:00+00:00",
+         {"harness_type": "claude", "transport": "cli", "comparison_key": "k2"}),  # alias
+    _row("e3", "knowledge_discovery", "agent-A", "2026-06-02T00:00:00+00:00",
+         {"harness_type": "claude-code", "transport": "vscode", "model": "sonnet"}),
+    _row("e4", "agent_state", "agent-C", "2026-06-04T00:00:00+00:00",
+         {"harness_type": "codex-cli", "transport": "cli"}),
+    _row("e5", "agent_state", "agent-D", "2026-06-05T00:00:00+00:00",
+         {"harness": "hermes-agent", "model": "local"}),  # 'harness' alias + canonicalized
+    _row("e6", "agent_state", "agent-E", "2026-06-06T00:00:00+00:00",
+         {"transport": "cli"}),  # NO harness label → unattributed
+]
+
+
+def _census():
+    return build_harness_census(ROWS)
+
+
+class TestTotals:
+    def test_entry_counts(self):
+        c = _census()
+        assert c["total_entries"] == 6
+        assert c["unattributed_entries"] == 1
+        assert c["attributed_entries"] == 5
+
+    def test_distinct_harnesses_canonicalized(self):
+        c = _census()
+        # claude + claude-code collapse to one canonical harness.
+        names = [h["canonical_harness"] for h in c["harnesses"]]
+        assert names.count("claude-code") == 1
+        assert set(names) == {"claude-code", "codex-cli", "hermes"}
+        assert c["distinct_harnesses"] == 3
+
+
+class TestPerHarnessRollup:
+    def _claude(self):
+        return next(h for h in _census()["harnesses"] if h["canonical_harness"] == "claude-code")
+
+    def test_claude_aggregates_three_entries(self):
+        h = self._claude()
+        assert h["entry_count"] == 3
+        assert h["distinct_agents"] == 2  # agent-A appears twice
+        assert sorted(h["raw_harness_types"]) == ["claude", "claude-code"]
+
+    def test_first_and_last_seen(self):
+        h = self._claude()
+        assert h["first_seen"] == "2026-06-01T00:00:00+00:00"
+        assert h["last_seen"] == "2026-06-03T00:00:00+00:00"
+
+    def test_sources_split(self):
+        h = self._claude()
+        assert h["sources"] == {"agent_state": 2, "knowledge_discovery": 1}
+
+    def test_transports_and_models_deduped(self):
+        h = self._claude()
+        assert h["transports"] == ["cli", "vscode"]
+        assert h["models"] == ["opus", "sonnet"]
+
+    def test_distinct_comparison_keys(self):
+        h = self._claude()
+        assert h["distinct_comparison_keys"] == 2
+
+
+class TestSituatingRatio:
+    def test_ratio_reflects_metadata_coverage(self):
+        c = _census()
+        # codex-cli's single entry has only transport → situated.
+        codex = next(h for h in c["harnesses"] if h["canonical_harness"] == "codex-cli")
+        assert codex["situating_metadata_ratio"] == 1.0
+
+
+class TestOrderingAndDeterminism:
+    def test_sorted_by_entry_count_desc(self):
+        names = [h["canonical_harness"] for h in _census()["harnesses"]]
+        assert names[0] == "claude-code"  # 3 entries, the most
+
+    def test_deterministic(self):
+        assert build_harness_census(ROWS) == build_harness_census(ROWS)
+
+    def test_empty_input(self):
+        c = build_harness_census([])
+        assert c["total_entries"] == 0
+        assert c["distinct_harnesses"] == 0
+        assert c["harnesses"] == []

--- a/tests/test_harness_census.py
+++ b/tests/test_harness_census.py
@@ -22,14 +22,16 @@ def _row(entry_id, source, agent_id, recorded_at, ctx):
 # codex, one hermes, and one row with no harness label at all.
 ROWS = [
     _row("e1", "agent_state", "agent-A", "2026-06-01T00:00:00+00:00",
-         {"harness_type": "claude-code", "transport": "cli", "model": "opus",
-          "model_provider": "anthropic", "comparison_key": "k1"}),
+         {"harness_type": "claude-code", "harness_id": "cc-inst-1", "transport": "cli",
+          "model": "opus", "model_provider": "anthropic", "comparison_key": "k1"}),
     _row("e2", "agent_state", "agent-B", "2026-06-03T00:00:00+00:00",
-         {"harness_type": "claude", "transport": "cli", "comparison_key": "k2"}),  # alias
+         {"harness_type": "claude", "harness_id": "cc-inst-2", "transport": "cli",
+          "comparison_key": "k2"}),  # alias type, second instance
     _row("e3", "knowledge_discovery", "agent-A", "2026-06-02T00:00:00+00:00",
-         {"harness_type": "claude-code", "transport": "vscode", "model": "sonnet"}),
+         {"harness_type": "claude-code", "harness_id": "cc-inst-1", "transport": "vscode",
+          "model": "sonnet"}),  # same instance as e1
     _row("e4", "agent_state", "agent-C", "2026-06-04T00:00:00+00:00",
-         {"harness_type": "codex-cli", "transport": "cli"}),
+         {"harness_type": "codex-cli", "transport": "cli"}),  # type but NO instance label
     _row("e5", "agent_state", "agent-D", "2026-06-05T00:00:00+00:00",
          {"harness": "hermes-agent", "model": "local"}),  # 'harness' alias + canonicalized
     _row("e6", "agent_state", "agent-E", "2026-06-06T00:00:00+00:00",
@@ -84,6 +86,19 @@ class TestPerHarnessRollup:
     def test_distinct_comparison_keys(self):
         h = self._claude()
         assert h["distinct_comparison_keys"] == 2
+
+    def test_instance_granularity_type_vs_instance(self):
+        # claude-code is one TYPE with two distinct INSTANCES (cc-inst-1 x2, cc-inst-2).
+        h = self._claude()
+        assert h["distinct_harness_ids"] == 2
+        assert h["instance_label_ratio"] == 1.0  # all 3 claude entries carry harness_id
+
+    def test_instance_label_gap_is_visible(self):
+        # codex-cli has a type label but NO instance label — the exact sparsity the
+        # ontology's promotion decision keys on.
+        codex = next(h for h in _census()["harnesses"] if h["canonical_harness"] == "codex-cli")
+        assert codex["distinct_harness_ids"] == 0
+        assert codex["instance_label_ratio"] == 0.0
 
 
 class TestSituatingRatio:


### PR DESCRIPTION
## Summary

A read-only **census** of which harnesses have actually written to governance, rolled up from the S22 write-context already attached to every write. There was no way to see "what harnesses exist and how well-situated are they" — `harness_id`/`harness_type` are scattered across `agent_state.provenance_context` and `knowledge.discoveries.s22_context` as self-declared labels.

> **Census, not registry.** `harness_id`/`harness_type` are convenience labels, **not identity** (`docs/ontology/harness-substrate-plurality.md`). This only *describes* what's been observed — it confers no authority and gates nothing. The *authoritative* harness registry is the deliberately-deferred, council-gated ontology decision (`docs/ontology/plan.md` Track D). This census is the **evidence D3/D4 ask for** before promoting `harness_id` to a first-class field — so it advances that decision rather than pre-empting it.

It is also distinct from `s22_h5_comparable_entries.py`, which is a *gate* (does one comparison key span the 3 required harnesses); this asks the broader "what harnesses exist at all, and how situated?"

## What's in it

| File | What |
|---|---|
| `src/identity/harness_census.py` | Pure aggregation (`build_harness_census`) — no DB, no I/O. Reuses the existing `s22_h5` collector + `normalize_s22_harness` canonicalizer (no rebuild). |
| `scripts/analysis/harness_census.py` | Read-only CLI (`--json` / `--output`) over live PG; runs on the operator's box. |
| `tests/test_harness_census.py` | 11 tests, all green. |

Per-harness rollup: canonical harness, raw label variants, entry count, distinct agents, first/last seen, source split (agent_state vs KG), transports, models, distinct comparison keys, and the **`situating_metadata_ratio`** — the promotion-readiness signal Track D keys on. Top-level also reports `unattributed_entries` (writes with no harness label — the size of the labelling gap, invisible to any future registry).

## Verification

- `tests/test_harness_census.py`: **11 passed** — canonicalization (`claude`→`claude-code`), dedup, first/last-seen, source split, situating ratio, the unattributed-label gap, determinism, empty input.
- Pure module; the CLI is read-only and needs live PG (not run in CI).

## Not in scope

The authoritative registry (declared set + capabilities, used for routing/gating) — that's the council-gated ontology decision this census is meant to inform. Happy to draft that proposal once the census shows what's actually out there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHNKpw3qWkrnFhQ6zMURFB)_