### PR TITLE
Fix BEAM adoption conversion signal

### DIFF
--- a/scripts/dev/adoption_kpi.py
+++ b/scripts/dev/adoption_kpi.py
@@ -12,14 +12,12 @@ numbers that baseline it:
      NAMED agents, excluding operator credentials (the dashboard).
      Baseline: 3 per 14d, and both callers were burn-in probes — real
      agent-initiated retrieval was zero.
-  3. Onboard engagement (three honest cuts). The legacy "conversion" (did a
-     ceremonial process_agent_update) is artifact-prone: ~22% of onboards are
-     infra (dispatch_beam_harness / operator / probes) that never check in by
-     design, and most real agents do value work WITHOUT the discouraged
-     ceremonial check-in. Reports: legacy `converted`; adopter-cohort
+  3. Onboard engagement (three honest cuts). `converted` means the agent made
+     itself visible through either ceremonial process_agent_update OR the BEAM
+     harness's external outcome signal. `ceremonial_converted` preserves the old
+     process_agent_update-only cut. Reports: `converted`; adopter-cohort
      `cohort_engaged` (any value action — check-in / KG / outcome); and
      `did_nothing` (onboarded, made no UUID-attributed call = true bounce).
-     The legacy ~19% is mostly measurement artifact; true bounce is far lower.
   4. Ground-truth pipe health — outcome_event success rate.
      Baseline: 17% (290/416 identity_error); fixed client-side 2026-06-12.
 
@@ -44,8 +42,8 @@ def connect():
     return psycopg2.connect(dsn)
 
 
-def snapshot(days: int) -> dict:
-    queries = {
+def _snapshot_queries() -> dict:
+    return {
         "checkin_concentration": """
             WITH calls AS (
                 SELECT agent_id, count(*) n
@@ -71,16 +69,12 @@ def snapshot(days: int) -> dict:
               AND u.agent_id IS NOT NULL
               AND coalesce(a.label, '') NOT LIKE 'operator\\_%%'
         """,
-        # Onboard engagement. The legacy `converted` (did a process_agent_update)
-        # under-counts badly: ~22% of onboards are infra (dispatch_beam_harness,
-        # operator, probes) that never check in by design, and most real agents
-        # do value work (KG, outcomes) without the ceremonial check-in — which the
-        # session-start hook explicitly discourages. So we report three honest cuts:
-        #   converted        — legacy (process_agent_update only); kept for continuity
-        #   cohort_engaged    — real-agent cohort that did ANY value action
-        #   did_nothing       — onboarded and made no UUID-attributed call (true bounce)
-        # NOTE: BEAM-dispatch agents check in off-path → counted as non-converting
-        # (issue tracked); excluded from the adopter cohort so they don't distort it.
+        # Onboard engagement. `converted` used to mean process_agent_update only,
+        # which made BEAM-dispatch harness identities look like permanent
+        # non-converters even though they emit externally verified outcome_event
+        # rows under their governance UUID (#1055). Keep the ceremonial-only cut
+        # as a separate continuity field, and make the headline conversion count
+        # the real BEAM check-in surface too.
         "onboard_conversion": """
             WITH a AS (
                 SELECT a.id,
@@ -96,14 +90,28 @@ def snapshot(days: int) -> dict:
             f AS (
                 SELECT a.id, a.is_adopter,
                     EXISTS (SELECT 1 FROM audit.tool_usage t WHERE t.agent_id = a.id::text
-                            AND t.success AND t.tool_name = 'process_agent_update') AS checked_in,
-                    EXISTS (SELECT 1 FROM audit.tool_usage t WHERE t.agent_id = a.id::text AND t.success
-                            AND t.tool_name IN ('process_agent_update','knowledge','search_knowledge_graph','outcome_event')) AS engaged_value,
-                    EXISTS (SELECT 1 FROM audit.tool_usage t WHERE t.agent_id = a.id::text) AS did_anything
+                            AND t.success AND t.tool_name = 'process_agent_update') AS ceremonial_checked_in,
+                    EXISTS (SELECT 1 FROM audit.outcome_events oe WHERE oe.agent_id = a.id::text
+                            AND oe.ts > now() - make_interval(days => %(days)s)
+                            AND oe.verification_source = 'external_signal'
+                            AND oe.detail->>'harness' = 'beam') AS beam_checked_in,
+                    (
+                        EXISTS (SELECT 1 FROM audit.tool_usage t WHERE t.agent_id = a.id::text AND t.success
+                                AND t.tool_name IN ('process_agent_update','knowledge','search_knowledge_graph','outcome_event'))
+                        OR EXISTS (SELECT 1 FROM audit.outcome_events oe WHERE oe.agent_id = a.id::text
+                                   AND oe.ts > now() - make_interval(days => %(days)s))
+                    ) AS engaged_value,
+                    (
+                        EXISTS (SELECT 1 FROM audit.tool_usage t WHERE t.agent_id = a.id::text)
+                        OR EXISTS (SELECT 1 FROM audit.outcome_events oe WHERE oe.agent_id = a.id::text
+                                   AND oe.ts > now() - make_interval(days => %(days)s))
+                    ) AS did_anything
                 FROM a
             )
             SELECT count(*) AS minted,
-                   count(*) FILTER (WHERE checked_in) AS converted,
+                   count(*) FILTER (WHERE ceremonial_checked_in OR beam_checked_in) AS converted,
+                   count(*) FILTER (WHERE ceremonial_checked_in) AS ceremonial_converted,
+                   count(*) FILTER (WHERE beam_checked_in) AS beam_converted,
                    count(*) FILTER (WHERE is_adopter) AS cohort_minted,
                    count(*) FILTER (WHERE is_adopter AND engaged_value) AS cohort_engaged,
                    count(*) FILTER (WHERE NOT did_anything) AS did_nothing
@@ -131,6 +139,10 @@ def snapshot(days: int) -> dict:
               AND payload->'signals' @> '[{"signal_type": "kg_proactive_surface"}]'
         """,
     }
+
+
+def snapshot(days: int) -> dict:
+    queries = _snapshot_queries()
     out: dict = {"window_days": days}
     with connect() as conn:
         with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
@@ -141,6 +153,12 @@ def snapshot(days: int) -> dict:
     cc["top2_share_pct"] = round(100 * cc["top2"] / cc["total"], 1) if cc["total"] else None
     oc = out["onboard_conversion"]
     oc["conversion_pct"] = round(100 * oc["converted"] / oc["minted"], 1) if oc["minted"] else None
+    oc["ceremonial_conversion_pct"] = (
+        round(100 * oc["ceremonial_converted"] / oc["minted"], 1) if oc["minted"] else None
+    )
+    oc["beam_conversion_pct"] = (
+        round(100 * oc["beam_converted"] / oc["minted"], 1) if oc["minted"] else None
+    )
     oc["cohort_engaged_pct"] = round(100 * oc["cohort_engaged"] / oc["cohort_minted"], 1) if oc["cohort_minted"] else None
     oc["did_nothing_pct"] = round(100 * oc["did_nothing"] / oc["minted"], 1) if oc["minted"] else None
     op = out["outcome_pipe_health"]
@@ -181,8 +199,12 @@ def main() -> int:
     print(f"  check-ins: {cc['total']} total, top-2 callers {cc['top2_share_pct']}%")
     print(f"  voluntary KG retrieval (named agents): {kg['named_searches']} calls "
           f"by {kg['distinct_agents']} agents")
-    print(f"  onboard→checkin (legacy, ceremonial): {oc['converted']}/{oc['minted']} "
-          f"({oc['conversion_pct']}%) — counts infra + check-in only; under-reports")
+    print(f"  onboard→checkin (process + BEAM external): {oc['converted']}/{oc['minted']} "
+          f"({oc['conversion_pct']}%)")
+    print(f"    ceremonial-only: {oc['ceremonial_converted']}/{oc['minted']} "
+          f"({oc['ceremonial_conversion_pct']}%); "
+          f"BEAM external: {oc['beam_converted']}/{oc['minted']} "
+          f"({oc['beam_conversion_pct']}%)")
     print(f"  adopter value-engagement: {oc['cohort_engaged']}/{oc['cohort_minted']} "
           f"({oc['cohort_engaged_pct']}%) — real-agent cohort, ANY value action (check-in/KG/outcome)")
     print(f"  true bounce (onboarded, did nothing): {oc['did_nothing']}/{oc['minted']} "

--- a/scripts/dev/adoption_kpi.py
+++ b/scripts/dev/adoption_kpi.py
@@ -30,11 +30,10 @@ import argparse
 import json
 import os
 
-import psycopg2  # type: ignore
-import psycopg2.extras  # type: ignore
-
 
 def connect():
+    import psycopg2  # type: ignore
+
     dsn = os.environ.get(
         "GOVERNANCE_DATABASE_URL",
         "postgresql://postgres:postgres@localhost:5432/governance",
@@ -142,6 +141,8 @@ def _snapshot_queries() -> dict:
 
 
 def snapshot(days: int) -> dict:
+    import psycopg2.extras  # type: ignore
+
     queries = _snapshot_queries()
     out: dict = {"window_days": days}
     with connect() as conn:

--- a/src/mcp_server_std.py
+++ b/src/mcp_server_std.py
@@ -416,7 +416,8 @@ async def call_tool(name: str, arguments: dict[str, Any] | None) -> Sequence[Tex
                 )]
 
     # Activity tracking for auto-heartbeat
-    agent_id = arguments.get('agent_id')
+    agent_id = arguments.get('agent_id') if isinstance(arguments, dict) else None
+    session_id = arguments.get('client_session_id') if isinstance(arguments, dict) else None
     if agent_id and HEARTBEAT_CONFIG.enabled:
         should_trigger, trigger_reason = activity_tracker.track_tool_call(agent_id, name)
 
@@ -466,10 +467,12 @@ async def call_tool(name: str, arguments: dict[str, Any] | None) -> Sequence[Tex
             record_tool_usage(tool_name=name,
                               agent_id=resolve_minted_agent_id(name, agent_id, result),
                               success=success,
-                              error_type=error_type, latency_ms=latency_ms)
+                              error_type=error_type, latency_ms=latency_ms,
+                              session_id=session_id)
             return result
         record_tool_usage(tool_name=name, agent_id=agent_id, success=False,
-                          error_type="unknown_tool", latency_ms=latency_ms)
+                          error_type="unknown_tool", latency_ms=latency_ms,
+                          session_id=session_id)
         return [TextContent(type="text", text=json.dumps({"success": False, "error": f"Unknown tool: {name}"}, indent=2))]
     except ImportError:
         return [TextContent(type="text", text=json.dumps({"success": False, "error": f"Handler registry not available for tool '{name}'"}, indent=2))]
@@ -482,7 +485,8 @@ async def call_tool(name: str, arguments: dict[str, Any] | None) -> Sequence[Tex
             recovery={"action": "Check tool parameters and try again"}
         )
         record_tool_usage(tool_name=name, agent_id=agent_id, success=False,
-                          error_type="execution_error", latency_ms=latency_ms)
+                          error_type="execution_error", latency_ms=latency_ms,
+                          session_id=session_id)
         return [sanitized_error]
 
 

--- a/src/services/http_tool_service.py
+++ b/src/services/http_tool_service.py
@@ -221,6 +221,7 @@ async def execute_http_tool(tool_name: str, arguments: Dict[str, Any]) -> Any:
     Records tool_usage telemetry (JSONL + audit.tool_usage) at every exit point.
     """
     agent_id = arguments.get("agent_id") if isinstance(arguments, dict) else None
+    session_id = arguments.get("client_session_id") if isinstance(arguments, dict) else None
     t0 = time.monotonic()
     try:
         # #425 strict-identity gate — REST parity with the MCP dispatch
@@ -242,7 +243,7 @@ async def execute_http_tool(tool_name: str, arguments: Dict[str, Any]) -> Any:
             # triage queries can subtract refusals without log archaeology.
             record_tool_usage(tool_name=tool_name, agent_id=None,
                               success=False, error_type="identity_required",
-                              latency_ms=latency_ms)
+                              latency_ms=latency_ms, session_id=session_id)
             return refusal
 
         # Wave 3a routing — HTTP path symmetric with MCP-protocol wrapper.
@@ -261,7 +262,8 @@ async def execute_http_tool(tool_name: str, arguments: Dict[str, Any]) -> Any:
             if proxy_result.ok:
                 latency_ms = int((time.monotonic() - t0) * 1000)
                 record_tool_usage(tool_name=tool_name, agent_id=agent_id,
-                                  success=True, latency_ms=latency_ms)
+                                  success=True, latency_ms=latency_ms,
+                                  session_id=session_id)
                 # The proxy already wrote the success-row measurement
                 # (FIND-A5 fold in ``wave3a_beam_proxy.py``); do not
                 # duplicate the write here.
@@ -276,18 +278,20 @@ async def execute_http_tool(tool_name: str, arguments: Dict[str, Any]) -> Any:
             success, error_type = classify_tool_result(result)
             record_tool_usage(tool_name=tool_name,
                               agent_id=resolve_minted_agent_id(tool_name, agent_id, result),
-                              success=success, error_type=error_type, latency_ms=latency_ms)
+                              success=success, error_type=error_type,
+                              latency_ms=latency_ms, session_id=session_id)
             return _normalize_direct_http_result(result)
         result = await execute_http_dispatch_fallback(tool_name, arguments)
         latency_ms = int((time.monotonic() - t0) * 1000)
         success, error_type = classify_tool_result(result)
         record_tool_usage(tool_name=tool_name,
                           agent_id=resolve_minted_agent_id(tool_name, agent_id, result),
-                          success=success, error_type=error_type, latency_ms=latency_ms)
+                          success=success, error_type=error_type,
+                          latency_ms=latency_ms, session_id=session_id)
         return result
     except Exception as e:
         latency_ms = int((time.monotonic() - t0) * 1000)
         record_tool_usage(tool_name=tool_name, agent_id=agent_id,
                           success=False, error_type=type(e).__name__,
-                          latency_ms=latency_ms)
+                          latency_ms=latency_ms, session_id=session_id)
         raise

--- a/src/services/tool_usage_recorder.py
+++ b/src/services/tool_usage_recorder.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 from typing import Any, Optional, Tuple
+from uuid import UUID
 
 from src.logging_utils import get_logger
 
@@ -86,6 +87,55 @@ def classify_tool_result(result: Any) -> Tuple[bool, Optional[str]]:
 _IDENTITY_MINTING_TOOLS = frozenset({"onboard", "start_session"})
 
 
+# Off-path activity that proves process liveness without going through the
+# ceremonial process_agent_update handler. The check-in path already refreshes
+# presence directly; keep this list to value-bearing tools that otherwise leave
+# onboard+work agents with an expiring agent:/ lease.
+_PRESENCE_REFRESH_TOOLS = frozenset({
+    "knowledge",
+    "search_knowledge_graph",
+    "store_knowledge_graph",
+    "leave_note",
+    "outcome_event",
+    "observe",
+    "observe_agent",
+})
+
+
+def _is_uuid_like(value: Optional[str]) -> bool:
+    if not value:
+        return False
+    try:
+        UUID(str(value))
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
+def _schedule_presence_refresh(
+    *,
+    tool_name: str,
+    agent_id: Optional[str],
+    success: bool,
+    session_id: Optional[str],
+) -> None:
+    """Refresh agent:/ presence for successful off-path value activity."""
+    if (
+        not success
+        or tool_name not in _PRESENCE_REFRESH_TOOLS
+        or not _is_uuid_like(agent_id)
+    ):
+        return
+    try:
+        from src.mcp_handlers.identity.agent_presence_lease import (
+            schedule_agent_presence_heartbeat,
+        )
+
+        schedule_agent_presence_heartbeat(str(agent_id), session_id)
+    except Exception as e:  # pragma: no cover - observability must never break tools
+        logger.debug(f"agent presence refresh scheduling failed (non-fatal): {e}")
+
+
 def resolve_minted_agent_id(tool_name: str, agent_id: Optional[str], result: Any) -> Optional[str]:
     """Return the audit-attribution agent_id for a completed tool call.
 
@@ -116,6 +166,7 @@ def record_tool_usage(
     success: bool,
     error_type: Optional[str] = None,
     latency_ms: Optional[int] = None,
+    session_id: Optional[str] = None,
 ) -> None:
     """Record a tool call. Never raises — telemetry failure must not break the call."""
     try:
@@ -136,6 +187,7 @@ def record_tool_usage(
                 latency_ms=latency_ms,
                 success=success,
                 error_type=error_type,
+                session_id=session_id,
             ),
             name="persist_tool_usage",
         )
@@ -143,3 +195,10 @@ def record_tool_usage(
         pass  # no running event loop (CLI / tests)
     except Exception as e:
         logger.debug(f"DB tool_usage persist failed (non-fatal): {e}")
+
+    _schedule_presence_refresh(
+        tool_name=tool_name,
+        agent_id=agent_id,
+        success=success,
+        session_id=session_id,
+    )

--- a/tests/test_adoption_kpi.py
+++ b/tests/test_adoption_kpi.py
@@ -1,0 +1,14 @@
+"""Regression tests for scripts/dev/adoption_kpi.py."""
+
+
+def test_onboard_conversion_query_counts_beam_external_outcomes():
+    from scripts.dev import adoption_kpi
+
+    sql = adoption_kpi._snapshot_queries()["onboard_conversion"]
+
+    assert "audit.outcome_events" in sql
+    assert "oe.verification_source = 'external_signal'" in sql
+    assert "oe.detail->>'harness' = 'beam'" in sql
+    assert "ceremonial_checked_in OR beam_checked_in" in sql
+    assert "ceremonial_converted" in sql
+    assert "beam_converted" in sql

--- a/tests/test_tool_usage_recorder_presence.py
+++ b/tests/test_tool_usage_recorder_presence.py
@@ -1,0 +1,70 @@
+"""Presence refresh for successful off-path agent activity."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from src.services import tool_usage_recorder as recorder
+
+
+AGENT_UUID = "7750bf80-20ad-4108-a952-5271b73845b8"
+
+
+def _consume_coro(coro, name=None):
+    if hasattr(coro, "close"):
+        coro.close()
+    return MagicMock()
+
+
+def _patch_recorder_io(monkeypatch):
+    tracker = MagicMock()
+    append = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "src.tool_usage_tracker.get_tool_usage_tracker",
+        lambda: tracker,
+    )
+    monkeypatch.setattr(
+        "src.audit_db.append_tool_usage_async",
+        append,
+    )
+    monkeypatch.setattr(
+        "src.background_tasks.create_tracked_task",
+        _consume_coro,
+    )
+    return tracker, append
+
+
+def test_successful_outcome_event_refreshes_presence(monkeypatch):
+    _tracker, append = _patch_recorder_io(monkeypatch)
+    scheduled = []
+    monkeypatch.setattr(
+        "src.mcp_handlers.identity.agent_presence_lease.schedule_agent_presence_heartbeat",
+        lambda agent_id, client_session_id=None: scheduled.append(
+            (agent_id, client_session_id)
+        ),
+    )
+
+    recorder.record_tool_usage(
+        tool_name="outcome_event",
+        agent_id=AGENT_UUID,
+        success=True,
+        session_id="sess-1",
+    )
+
+    assert scheduled == [(AGENT_UUID, "sess-1")]
+    assert append.call_args.kwargs["session_id"] == "sess-1"
+
+
+def test_presence_refresh_skips_failures_labels_and_non_activity(monkeypatch):
+    _patch_recorder_io(monkeypatch)
+    scheduled = []
+    monkeypatch.setattr(
+        "src.mcp_handlers.identity.agent_presence_lease.schedule_agent_presence_heartbeat",
+        lambda agent_id, client_session_id=None: scheduled.append(
+            (agent_id, client_session_id)
+        ),
+    )
+
+    recorder.record_tool_usage("outcome_event", AGENT_UUID, success=False)
+    recorder.record_tool_usage("outcome_event", "display-name", success=True)
+    recorder.record_tool_usage("health_check", AGENT_UUID, success=True)
+
+    assert scheduled == []


### PR DESCRIPTION
Summary
- Teach scripts/dev/adoption_kpi.py to count dispatch_beam_harness external outcome_event rows as BEAM check-ins, while preserving ceremonial_converted and beam_converted split fields.
- Refresh agent presence leases from successful off-path value activity recorded through central tool_usage, and thread client_session_id into audit rows.
- Add regression tests for the KPI query and off-path presence refresh.

Validation
- python3 -m pytest tests/test_tool_usage_recorder_presence.py tests/test_adoption_kpi.py tests/test_http_tool_service_tool_usage.py tests/test_mcp_server_std.py::TestToolUsageRecording tests/test_resolve_minted_agent_id.py
- python3 scripts/dev/adoption_kpi.py --days 14 --json: converted 277/766; ceremonial 140/766; BEAM external 137/766
- ./scripts/dev/test-cache.sh: 10941 passed, 21 skipped, 4 warnings; coverage 81.74%
- pre-push smoke: 138 passed, 10177 deselected, 1 warning

Pre-PR note
- git prepr --scope issue 1055 failed only on known repo-rooted resident processes; git prepr --scope issue 1055 --no-processes passed.

Closes #1055