### PR TITLE
fix(gateway): route search through canonical knowledge tool

### DIFF
--- a/src/gateway/simplifiers.py
+++ b/src/gateway/simplifiers.py
@@ -94,7 +94,7 @@ def simplify_checkin(raw: dict) -> dict:
 
 
 def simplify_search(raw: dict) -> dict:
-    """Simplify search_knowledge_graph response."""
+    """Simplify knowledge search response."""
     if not isinstance(raw, dict):
         return ok("Search complete", {"raw": raw})
 

--- a/src/gateway/tools.py
+++ b/src/gateway/tools.py
@@ -71,10 +71,10 @@ async def handle_search(
 ) -> str:
     """Search the shared knowledge graph."""
     try:
-        args: dict = {"query": query, "limit": limit}
+        args: dict = {"action": "search", "query": query, "limit": limit}
         if agent_id:
-            args["agent_id_filter"] = agent_id
-        raw = await client.call_tool("search_knowledge_graph", args)
+            args["agent_id"] = agent_id
+        raw = await client.call_tool("knowledge", args)
         return json.dumps(simplifiers.simplify_search(raw))
     except Exception as exc:
         logger.warning("search failed: %s", exc)

--- a/tests/test_gateway_tools.py
+++ b/tests/test_gateway_tools.py
@@ -105,8 +105,16 @@ class TestHandleSearch:
     async def test_limit(self, mock_client):
         mock_client.call_tool.return_value = {"results": []}
         await handle_search(mock_client, query="test", limit=10)
-        mock_client.call_tool.assert_called_with("search_knowledge_graph", {
-            "query": "test", "limit": 10,
+        mock_client.call_tool.assert_called_with("knowledge", {
+            "action": "search", "query": "test", "limit": 10,
+        })
+
+    @pytest.mark.asyncio
+    async def test_agent_filter(self, mock_client):
+        mock_client.call_tool.return_value = {"results": []}
+        await handle_search(mock_client, query="test", agent_id="agent-1")
+        mock_client.call_tool.assert_called_with("knowledge", {
+            "action": "search", "query": "test", "limit": 5, "agent_id": "agent-1",
         })
 
 


### PR DESCRIPTION
## Summary
- route gateway search through the canonical `knowledge(action='search')` tool instead of legacy `search_knowledge_graph`
- pass the gateway agent filter as canonical `agent_id`
- update gateway tests and search simplifier wording for the canonical path

## Tests
- `python3 -m pytest tests/test_gateway_tools.py tests/test_gateway_simplifiers.py`
- `./scripts/dev/test-cache.sh` (10939 passed, 21 skipped; coverage 81.84%)
- pre-push smoke (138 passed; doc-health reported existing ghost-tool warnings in docs/manual/04-integrating-agents.md and skills/unitares-dashboard/SKILL.md)

## Notes
- Built in isolated worktree `.worktrees/codex-gateway-search` because the main checkout had unrelated local changes on `codex/adoption-beam-conversion-1055`.