### PR TITLE
ops(deploy): add deploy-apply.sh sweep + fix deploy-status --json

### DIFF
--- a/scripts/ops/deploy-apply.sh
+++ b/scripts/ops/deploy-apply.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# deploy-apply.sh — one command to "deploy what needs it": read deploy-status.sh
+# verdicts and run each service's dedicated deploy script for everything that is
+# STALE (running older code than its checkout) or BEHIND (checkout behind
+# origin). The composable answer to "reboot the things that need a restart to
+# pick up deploy changes."
+#
+# SAFE BY CONSTRUCTION: this never pulls or restarts a service itself. It only
+# dispatches to per-service deploy scripts (deploy-mcp.sh / deploy-lease-plane.sh
+# / deploy-sentinel.sh), each of which deploys from a master-pinned worktree and
+# REFUSES if its LaunchAgent still loads from the shared dev checkout. Services
+# still on restart-DEV with no deploy script (e.g. gateway-mcp, wave3a-handlers)
+# are REPORTED, never touched — give them a deploy worktree + a deploy script to
+# bring them into the sweep.
+#
+# Detection is delegated to deploy-status.sh (single source of truth for "what's
+# live vs on disk"), so this stays a thin, safe orchestrator.
+#
+# Flags:
+#   --dry-run   show what would be deployed; run nothing
+#   --no-fetch  use cached remotes (default refreshes them for accurate verdicts)
+set -uo pipefail
+
+OPS_DIR="$(cd "$(dirname "$0")" && pwd)"
+STATUS="$OPS_DIR/deploy-status.sh"
+
+DRY_RUN=0
+FETCH=1
+for a in "$@"; do
+  case "$a" in
+    --dry-run)  DRY_RUN=1 ;;
+    --no-fetch) FETCH=0 ;;
+    -h|--help)  sed -n '2,21p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $a" >&2; exit 2 ;;
+  esac
+done
+
+# name -> deploy script. Extend this as services move off restart-DEV onto
+# dedicated deploy worktrees with their own deploy-*.sh. (case, not an
+# associative array, so this runs on macOS's stock bash 3.2 like the siblings.)
+deploy_script_for() {
+  case "$1" in
+    governance-mcp) echo "$OPS_DIR/deploy-mcp.sh" ;;
+    lease-plane)    echo "$OPS_DIR/deploy-lease-plane.sh" ;;
+    sentinel-beam)  echo "$OPS_DIR/deploy-sentinel.sh" ;;
+    *)              echo "" ;;
+  esac
+}
+
+status_args="--json"
+[ "$FETCH" = 1 ] && status_args="$status_args --fetch"
+
+echo "[apply] reading deploy-status.sh (${FETCH:+fetch }verdicts) ..."
+# shellcheck disable=SC2086
+status_json="$("$STATUS" $status_args)" || { echo "[apply] deploy-status.sh failed" >&2; exit 1; }
+
+# Emit one TAB-separated "name<TAB>verdict" line per STALE/BEHIND service.
+# deploy-status.sh --json is valid JSON; parse it with python3 (tolerant of the
+# verdict's optional " [DEV]" suffix).
+needs="$(
+  printf '%s' "$status_json" | python3 -c '
+import json, sys
+for svc in json.load(sys.stdin):
+    v = svc.get("verdict", "")
+    if v.startswith("STALE") or v.startswith("BEHIND"):
+        print("%s\t%s" % (svc.get("name", ""), v))
+'
+)" || { echo "[apply] could not parse deploy-status --json" >&2; exit 1; }
+
+if [ -z "$needs" ]; then
+  echo "[apply] nothing to deploy — no service is STALE or BEHIND."
+  exit 0
+fi
+
+deployed=""; skipped=""; failed=""
+while IFS=$'\t' read -r name verdict; do
+  [ -z "$name" ] && continue
+  script="$(deploy_script_for "$name")"
+
+  if [ -z "$script" ]; then
+    echo "[apply] SKIP  $name ($verdict) — no deploy script (still restart-DEV?); migrate it to a worktree first" >&2
+    skipped="$skipped $name"
+    continue
+  fi
+  if [ ! -x "$script" ]; then
+    echo "[apply] SKIP  $name ($verdict) — $(basename "$script") missing or not executable" >&2
+    skipped="$skipped $name"
+    continue
+  fi
+  if [ "$DRY_RUN" = 1 ]; then
+    echo "[apply] DRY   would deploy $name ($verdict) via $(basename "$script")"
+    deployed="$deployed $name(dry)"
+    continue
+  fi
+
+  echo "[apply] ===> deploying $name ($verdict) via $(basename "$script")"
+  if "$script"; then
+    deployed="$deployed $name"
+  else
+    echo "[apply] FAILED $name — see output above" >&2
+    failed="$failed $name"
+  fi
+done <<EOF
+$needs
+EOF
+
+echo
+echo "[apply] summary:"
+echo "  deployed:${deployed:-  none}"
+echo "  skipped: ${skipped:-  none}"
+echo "  failed:  ${failed:-  none}"
+
+# Non-zero if anything failed, so callers/CI can gate on it.
+[ -z "$failed" ]

--- a/scripts/ops/deploy-status.sh
+++ b/scripts/ops/deploy-status.sh
@@ -131,8 +131,11 @@ if [ "$JSON" = 1 ]; then
   for r in "${rows[@]}"; do
     IFS='|' read -r name verdict br sha behindf pidf pickup hz <<< "$r"
     [ "$first" = 1 ] || printf ','; first=0
-    printf '{"name":"%s","verdict":"%s","branch":"%s","commit":"%s","%s","%s","pickup":"%s","health":"%s"}' \
-      "$name" "$verdict" "$br" "$sha" "$behindf" "$pidf" "$pickup" "$(echo "$hz" | tr -d '"')"
+    # behindf/pidf carry "behind=N"/"pid=X"; strip the prefixes so the JSON has
+    # real keys (the previous form emitted keyless values → invalid JSON, which
+    # broke any agent trying to parse --json as the header promises).
+    printf '{"name":"%s","verdict":"%s","branch":"%s","commit":"%s","behind":"%s","pid":"%s","pickup":"%s","health":"%s"}' \
+      "$name" "$verdict" "$br" "$sha" "${behindf#behind=}" "${pidf#pid=}" "$pickup" "$(echo "$hz" | tr -d '"\\')"
   done
   printf ']\n'
 else


### PR DESCRIPTION
## What

The "one-command sweep" follow-up to #1146 — `scripts/ops/deploy-apply.sh`:

> read `deploy-status.sh` verdicts → for every service that's **STALE** (running older code than its checkout) or **BEHIND** (checkout behind origin), run that service's dedicated deploy script.

This is the full answer to *"can rebooting things that need a restart to pick up deploy changes be part of a workflow?"* — `deploy-status.sh` already detects what's stale; this acts on it.

## Safe by construction

`deploy-apply.sh` never pulls or restarts anything itself. It only dispatches to the per-service scripts (`deploy-mcp.sh` / `deploy-lease-plane.sh` / `deploy-sentinel.sh`), each of which deploys from a master-pinned worktree and **refuses if its LaunchAgent still loads from the shared dev checkout**. So:

- Services with a deploy script + worktree → deployed and verified.
- Services still on `restart-DEV` with no deploy script (`gateway-mcp`, `wave3a-handlers`) → **reported and skipped, never touched**. Add a worktree + deploy script to bring them into the sweep.
- `--dry-run` previews; the command exits non-zero if any deploy fails (CI/caller can gate on it).
- bash-3.2-safe (case dispatch, no associative arrays / `mapfile`) like the sibling scripts.

## Also: fixes a latent bug in `deploy-status.sh --json`

The `--json` output emitted **keyless values** (`…,"behind=0","pid=12345",…`) → invalid JSON, even though the script's header says "an agent reads `--json` and verifies against it." Now emits real `"behind"`/`"pid"` keys (and strips backslashes from the health string), so the sweep — and any other consumer — can actually parse it.

## Validation

`bash -n` clean on both. Verified locally: the fixed `--json` is valid JSON; the STALE/BEHIND selector picks the right services (and skips `HOT-RELOAD`/`CURRENT`); and an end-to-end run with mock `deploy-status.sh` + mock per-service scripts exercises dispatch, `--dry-run`, skip-unmigrated, and the non-zero-on-failure exit. (The real scripts target macOS `launchctl`, so they can't run in CI — review-gated.)

## Deferred

Bringing `gateway-mcp` and `wave3a-handlers` into the sweep needs each moved to a deploy worktree (operator plist reload, like the MCP/lease-plane/Sentinel migration) plus a `deploy-gateway.sh` / `deploy-wave3a.sh` mirroring `deploy-sentinel.sh`. Happy to do those next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BzBQCXUkx8NshtxPGSTPo1)_