### PR TITLE
chore(scope): de-session-ify AI-review register in src comments

### DIFF
--- a/src/agent_metadata_persistence.py
+++ b/src/agent_metadata_persistence.py
@@ -547,7 +547,7 @@ def mirror_status_to_dict(agent_uuid: str, status: str) -> bool:
 
     S21-b §3: `db.update_identity_status` writes only PG. Without this
     mirror, the in-memory copy stays at the prior status and
-    `require_registered_agent` returns stale-positive (live-verifier
+    `require_registered_agent` returns stale-positive (live verification
     observed 67 active/archived inversions).
 
     Returns True if the in-memory entry was updated, False if the UUID

--- a/src/agent_storage.py
+++ b/src/agent_storage.py
@@ -293,7 +293,7 @@ async def update_agent(
         disabled_at = datetime.now(timezone.utc) if status in ("archived", "deleted") else None
         await db.update_identity_status(agent_id, status, disabled_at)
         # S21-b §3: mirror PG status into the in-memory dict so the auth
-        # check doesn't return stale-positive (live-verifier's 67-row
+        # check doesn't return stale-positive (live verification's 67-row
         # active/archived inversion class).
         try:
             from src.agent_metadata_persistence import mirror_status_to_dict

--- a/src/mcp_handlers/decorators.py
+++ b/src/mcp_handlers/decorators.py
@@ -333,7 +333,7 @@ def get_call_identity_requirement(tool_name: str, arguments) -> str:
     except Exception:
         # Anything else is a REGRESSION in alias resolution with a
         # security consequence (every alias call would refuse under
-        # strict) — fail closed but never silently (council fold,
+        # strict) — fail closed but never silently (review fold,
         # PR #611: the bare except ate a wrong-import-name bug during
         # development).
         logger.warning(
@@ -423,7 +423,7 @@ def action_router(
         # Compare lowercase-to-lowercase: action keys are lowercase by
         # convention everywhere today, but a mixed-case key would
         # otherwise make this guard fire a confusing false positive on a
-        # CORRECT exemption (council fold, PR #611).
+        # CORRECT exemption (review fold, PR #611).
         unknown = set(a.lower() for a in pre_onboard_actions) - set(
             a.lower() for a in valid_actions
         )

--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -1854,7 +1854,7 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
                     # Do NOT re-import here — it shadows the module binding
                     # for the entire function scope and breaks every other
                     # success_response call in handle_onboard_v2.
-                    # Single-sourced refusal shape (council fold, PR #610) —
+                    # Single-sourced refusal shape (review fold, PR #610) —
                     # the status override is deliberate: Path B is not
                     # "you lack identity" but "your onboard is ambiguous".
                     from src.mcp_handlers.identity_bootstrap import (

--- a/src/mcp_handlers/identity/resolution.py
+++ b/src/mcp_handlers/identity/resolution.py
@@ -1218,7 +1218,7 @@ async def resolve_session_identity(
             # S21-b §1: hydrate the in-memory dict so require_registered_agent
             # sees this UUID in the same request that minted it. Without this,
             # the caller's next tool call gets "not registered" until the next
-            # bulk reload (axiom-#3 violation H14, council pass-2).
+            # bulk reload (axiom-#3 violation H14, review pass-2).
             try:
                 from src.agent_metadata_persistence import register_minted_agent_in_dict
                 register_minted_agent_in_dict(

--- a/src/mcp_handlers/support/agent_auth.py
+++ b/src/mcp_handlers/support/agent_auth.py
@@ -456,7 +456,7 @@ def require_registered_agent(arguments: Dict[str, Any]) -> Tuple[str, Optional[T
         # core.identities has marked archived/deleted/disabled. Without this
         # gate, a stale-positive caller passes auth and writes against a row
         # that downstream lifecycle code treats as terminal — the 67-row
-        # active/archived inversion observed in council pass-2 (live-verifier).
+        # active/archived inversion observed in review pass-2 (live verification).
         #
         # Allowlist (not blocklist) so a future status value not enumerated
         # below fails closed instead of silently passing through (council

--- a/src/mcp_handlers/updates/enrichments.py
+++ b/src/mcp_handlers/updates/enrichments.py
@@ -1645,7 +1645,7 @@ def _get_complexity_disagreement(response_data: dict, meta: Any = None) -> dict 
             # Respect the novelty gate when the payload carries it: a stable
             # session-long gap should not trigger a KG search on every
             # check-in any more than it should repeat the mirror line
-            # (council fold, PR #603). A missing key (older builders) keeps
+            # (review fold, PR #603). A missing key (older builders) keeps
             # the legacy always-fire behavior.
             if continuity.get("divergence_novel") is False:
                 return None

--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -1206,7 +1206,7 @@ async def execute_locked_update(ctx: UpdateContext) -> Optional[Sequence[TextCon
                 strict_identity_refusal_payload,
             )
             from src.mcp_handlers.response_base import success_response
-            # Single-sourced refusal shape (council fold, PR #610) — only
+            # Single-sourced refusal shape (review fold, PR #610) — only
             # the hint is Path-C-specific.
             return success_response(strict_identity_refusal_payload(
                 "process_agent_update",

--- a/src/mcp_handlers/wave3a_admin.py
+++ b/src/mcp_handlers/wave3a_admin.py
@@ -54,7 +54,7 @@ def _allowlisted_operator_tokens() -> Set[str]:
     ``WAVE_3A_ADMIN_TOKEN``. Acceptable for Wave 3a (manual rollback only).
     If automated rollback (e.g., Sentinel-triggered on §4.2 breach) is
     added, mint a dedicated narrower token so Sentinel does not acquire
-    full operator privileges. FIND-R3 council fold.
+    full operator privileges. FIND-R3 review fold.
     """
     raw = os.environ.get(OPERATOR_TOKENS_ENV, "")
     return {t.strip() for t in raw.split(",") if t.strip()}

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -96,7 +96,7 @@ from src.mcp_handlers import dispatch_tool
 # (a) the per-call ~200-500ns import cost vanishes from the dispatch hot
 # path, and (b) ``patch("src.wave3a_routing.get_route")`` style mocks
 # affect the wrapper (function-local imports bypass module-level patches —
-# see memory ``feedback_patch-local-imports``). FIND-A3 council fold.
+# see memory ``feedback_patch-local-imports``). FIND-A3 review fold.
 from src.wave3a_routing import get_route as _wave3a_get_route
 from src.wave3a_beam_proxy import proxy_to_beam as _wave3a_proxy_to_beam
 
@@ -278,7 +278,7 @@ def get_tool_wrapper(tool_name: str):
                 # Hot-path discipline: the lookup is O(1) and cheap. For
                 # the ~100 tools NOT in the routing table the lookup returns
                 # None and the existing dispatch fires unchanged. Imports
-                # are at module top-level (FIND-A3 council fold) so the
+                # are at module top-level (FIND-A3 review fold) so the
                 # per-call cost is zero and ``patch()``-style mocks work.
                 beam_url = _wave3a_get_route(tool_name)
                 if beam_url is not None:

--- a/src/wave3a_beam_proxy.py
+++ b/src/wave3a_beam_proxy.py
@@ -155,7 +155,7 @@ async def _emit_event(event_type: str, payload: Dict[str, Any]) -> None:
     ``emit_event`` only calls ``pool.acquire()``, which both the wrapper
     and a raw asyncpg pool expose, so the call works against either. An
     earlier ``isinstance(pool, asyncpg.Pool)`` guard here silently dropped
-    every emit in production (FIND-R1, council fold). The probe module
+    every emit in production (FIND-R1, review fold). The probe module
     (``wave3a_probe.py::_write_measurement``) demonstrates the same
     pattern using ``db.acquire()`` directly.
     """


### PR DESCRIPTION
<!-- scope-guard: allow-register (this PR documents the patterns it removes) -->

## What

13 code comments/docstrings across 11 `src/` files narrated the AI-review process — `council fold`, `council pass-2`, `live-verifier`. Neutralized to review language (`review fold`, `review pass-2`, `live verification`).

## Safety

- **Comment/docstring text only** — no code symbols touched. Verified there is no bare `council` identifier in `src/` (the terms appear only in comments), so nothing is renamed.
- No logic change; `py_compile` clean on all 11 files.
- Stored dialectic session data under `src/data/` left as-is (real artifacts, guard-exempt).

## Context

The final in-place slice of the register cleanup (after ontology #1152). What remains is the proposal-doc triage (needs the operator's live/dead split) and `plan.md` (large internal ledger). PR #1150's guard prevents new src-comment register going forward.