### PR TITLE
fix(lifecycle): keep fresh parents out of succession archive

### DIFF
--- a/src/mcp_handlers/lifecycle/stuck.py
+++ b/src/mcp_handlers/lifecycle/stuck.py
@@ -675,6 +675,13 @@ async def _archive_superseded_parents(current_time) -> list:
         # 0 check-ins, because sibling ad111882 onboarded declaring it parent.)
         if int(getattr(meta, "total_updates", 0) or 0) == 0:
             continue
+        # A recently-checking-in parent is still an active participant, even if
+        # binding/lease liveness is absent or stale. Delay destructive
+        # succession archival until the parent has also gone quiet for the same
+        # freshness window that makes the child count as live.
+        parent_age = _agent_age_minutes(meta, current_time)
+        if parent_age is not None and parent_age <= LINEAGE_SUCCESSION_FRESH_WINDOW_MINUTES:
+            continue
         # Self-managed agents own their lifecycle — same exclusion as detection.
         agent_tags = getattr(meta, "tags", []) or []
         if {"autonomous", "embodied", "anima"} & set(t.lower() for t in agent_tags):

--- a/tests/test_lifecycle_detect_stuck.py
+++ b/tests/test_lifecycle_detect_stuck.py
@@ -995,7 +995,7 @@ class TestLineageSuccession:
     @pytest.mark.asyncio
     async def test_archive_superseded_parents_archives_parent(self):
         """auto_recover sweep retires a superseded parent as lineage_succession."""
-        old_time = datetime.now(timezone.utc) - timedelta(minutes=10)
+        old_time = datetime.now(timezone.utc) - timedelta(minutes=45)
         recent = datetime.now(timezone.utc) - timedelta(minutes=2)
         with patch(_PATCHES["mcp_server"]) as mock_server, \
              patch("src.mcp_handlers.lifecycle.helpers._archive_one_agent") as mock_arch, \
@@ -1025,6 +1025,47 @@ class TestLineageSuccession:
         assert archived_ids == ["p1"]
 
     @pytest.mark.asyncio
+    async def test_archive_superseded_parents_skips_freshly_active_parent(self):
+        """A parent that checked in recently is not safe to retire.
+
+        Regression for 2026-06-28: a Codex session checked in, continued a long
+        local test/PR workflow, and was archived four minutes later by
+        lineage_succession because binding/lease liveness was absent.
+        """
+        recent = datetime.now(timezone.utc) - timedelta(minutes=2)
+        with patch(_PATCHES["mcp_server"]) as mock_server, \
+             patch("src.mcp_handlers.lifecycle.helpers._archive_one_agent") as mock_arch, \
+             patch("src.mcp_handlers.identity.process_binding.get_live_bindings") as mock_live, \
+             patch("src.mcp_handlers.identity.process_binding.has_live_agent_lease") as mock_lease:
+            mock_server.agent_metadata = {
+                "parent": _make_agent_meta(last_update=recent, total_updates=7),
+                "child": _make_agent_meta(
+                    last_update=recent,
+                    parent_agent_id="parent",
+                    spawn_reason="new_session",
+                ),
+            }
+            mock_server.monitors = {}
+
+            async def _ok(*a, **k):
+                return True
+            mock_arch.side_effect = _ok
+
+            async def _no_bindings(*a, **k):
+                return []
+            mock_live.side_effect = _no_bindings
+
+            async def _no_lease(*a, **k):
+                return False
+            mock_lease.side_effect = _no_lease
+
+            from src.mcp_handlers.lifecycle.stuck import _archive_superseded_parents
+            results = await _archive_superseded_parents(datetime.now(timezone.utc))
+
+        assert mock_arch.call_args_list == []
+        assert results == []
+
+    @pytest.mark.asyncio
     async def test_archive_superseded_parents_skips_initializing_ghost(self):
         """A parent that has never checked in (total_updates == 0) is an
         initializing ghost and must NOT be archived even when a live child
@@ -1036,6 +1077,7 @@ class TestLineageSuccession:
         Mirrors classify_for_archival's ghost protection.
         """
         recent = datetime.now(timezone.utc) - timedelta(minutes=2)
+        stale = datetime.now(timezone.utc) - timedelta(minutes=45)
         with patch(_PATCHES["mcp_server"]) as mock_server, \
              patch("src.mcp_handlers.lifecycle.helpers._archive_one_agent") as mock_arch, \
              patch("src.mcp_handlers.identity.process_binding.get_live_bindings") as mock_live:
@@ -1046,7 +1088,7 @@ class TestLineageSuccession:
                     last_update=recent, parent_agent_id="ghost"
                 ),
                 # checked-in parent superseded by a live child → still archived
-                "done": _make_agent_meta(last_update=recent, total_updates=4),
+                "done": _make_agent_meta(last_update=stale, total_updates=4),
                 "c_done": _make_agent_meta(
                     last_update=recent, parent_agent_id="done"
                 ),
@@ -1121,13 +1163,14 @@ class TestLineageSuccession:
         conceptually-correct liveness signal (architect council finding).
         """
         recent = datetime.now(timezone.utc) - timedelta(minutes=2)
+        stale = datetime.now(timezone.utc) - timedelta(minutes=45)
         with patch(_PATCHES["mcp_server"]) as mock_server, \
              patch("src.mcp_handlers.lifecycle.helpers._archive_one_agent") as mock_arch, \
              patch("src.mcp_handlers.identity.process_binding.get_live_bindings") as mock_live:
             mock_server.agent_metadata = {
                 # checked-in parent, superseded by a live child, but its own
                 # process is still alive → must survive.
-                "alive": _make_agent_meta(last_update=recent, total_updates=7),
+                "alive": _make_agent_meta(last_update=stale, total_updates=7),
                 "c_alive": _make_agent_meta(
                     last_update=recent, parent_agent_id="alive"
                 ),

--- a/tests/test_lineage_transitive_flip.py
+++ b/tests/test_lineage_transitive_flip.py
@@ -87,7 +87,7 @@ async def _run_archive(srv_metadata, lease_fn=_false):
 
 
 def _chain_metadata():
-    old = datetime.now(timezone.utc) - timedelta(minutes=10)
+    old = datetime.now(timezone.utc) - timedelta(minutes=45)
     recent = datetime.now(timezone.utc) - timedelta(minutes=2)
     # p1 superseded single-hop (live child c1); gp1 reachable only transitively.
     return {


### PR DESCRIPTION
## Summary
- prevent lineage_succession auto-archive from retiring a parent that has checked in within the succession freshness window
- add a regression for the observed false archive: recently active parent, live child, no binding/lease signal
- keep stale-parent succession archival and transitive archival behavior covered by tests

## Bug Evidence
- agent 66c30f8c-5419-4da1-8d30-434afb3c9b47 was archived at 2026-06-28T09:07:12Z with reason lineage_succession
- that agent had checked in at 2026-06-28T09:03:10Z and was still in an active local test/PR workflow

## Tests
- python3 -m pytest tests/test_lifecycle_detect_stuck.py tests/test_lineage_transitive_flip.py tests/test_lineage_liveness_guard.py
- git diff --check
- ./scripts/dev/test-cache.sh
- git push pre-push smoke (138 passed, 10234 deselected, 1 warning)
- git prepr --scope "lineage succession fresh parent archival"