### PR TITLE
feat(dashboard): live-surface strangler — EISV diff-push, resident presence, Discoveries badge

### DIFF
--- a/dashboard/redesign/app.html
+++ b/dashboard/redesign/app.html
@@ -239,11 +239,20 @@ setInterval(() => {
 }, STATS_REFRESH_MS);
 document.addEventListener("visibilitychange", () => { if (!document.hidden) refreshActive(); });
 
-// Live event stream — pushed events trigger a debounced refresh of the active
-// monitor view (sub-second), so polling is just the fallback.
+// Live event stream. A section may register a direct apply that patches its
+// view straight from the pushed event payload (true diff-push, instant). If no
+// apply handles the event, we fall back to the doorbell: a debounced refresh of
+// the active monitor view through the normal render path. Polling is the last
+// resort (only when the stream is down).
+const APPLY = {
+  eisv: (msg) => window.EISV && window.EISV.applyEvent && window.EISV.applyEvent(msg),
+};
 let wsDebounce = null;
-function onWsEvent() {
-  if (document.hidden || isTyping() || !isAutoSection(activeSection) || wsDebounce) return;
+function onWsEvent(msg) {
+  if (document.hidden || isTyping() || !isAutoSection(activeSection)) return;
+  const apply = APPLY[activeSection];
+  if (apply && apply(msg)) return; // handled live — no refetch
+  if (wsDebounce) return;
   wsDebounce = setTimeout(() => { wsDebounce = null; refreshActive(); }, 1500);
 }
 function onWsStatus(s) { wsStatus = s; updateLivePill(); }

--- a/dashboard/redesign/app.html
+++ b/dashboard/redesign/app.html
@@ -255,8 +255,14 @@ setInterval(() => {
   if (document.hidden || activeSection !== "overview") return;
   if (window.Landing && window.Landing.tickSilence) window.Landing.tickSilence();
 }, 5000);
+// Badge notifications fire regardless of the active section (and while hidden),
+// so an explore pane can show "N new since you loaded" without auto-refetching.
+const NOTIFY = {
+  knowledge_write: () => window.Discoveries && window.Discoveries.notifyNew && window.Discoveries.notifyNew(),
+};
 let wsDebounce = null;
 function onWsEvent(msg) {
+  if (msg && NOTIFY[msg.type]) NOTIFY[msg.type]();
   if (document.hidden || isTyping() || !isAutoSection(activeSection)) return;
   const apply = APPLY[activeSection];
   if (apply && apply(msg)) return; // handled live — no refetch

--- a/dashboard/redesign/app.html
+++ b/dashboard/redesign/app.html
@@ -246,7 +246,15 @@ document.addEventListener("visibilitychange", () => { if (!document.hidden) refr
 // resort (only when the stream is down).
 const APPLY = {
   eisv: (msg) => window.EISV && window.EISV.applyEvent && window.EISV.applyEvent(msg),
+  overview: (msg) => window.Landing && window.Landing.applyEvent && window.Landing.applyEvent(msg),
 };
+// Silence ticker — re-render the Overview residents strip from its in-memory
+// model so "ran Xago" accrues during quiet periods (no network). Visibility-
+// gated; only matters while watching the Overview.
+setInterval(() => {
+  if (document.hidden || activeSection !== "overview") return;
+  if (window.Landing && window.Landing.tickSilence) window.Landing.tickSilence();
+}, 5000);
 let wsDebounce = null;
 function onWsEvent(msg) {
   if (document.hidden || isTyping() || !isAutoSection(activeSection)) return;

--- a/dashboard/redesign/data.js
+++ b/dashboard/redesign/data.js
@@ -52,7 +52,29 @@
 
   const S = () => window.SNAPSHOT;
 
+  // Fleet-average raw eisv_update events into 1-min buckets (last 20). Shared by
+  // the REST seed path (eisv() below) and the live push-apply path in the EISV
+  // section, so "the live point" and "the historical point" are computed the
+  // same way — a pushed event re-buckets the window exactly as a refetch would.
+  function bucketEisv(evs) {
+    const buckets = {};
+    (evs || []).forEach((e) => {
+      const ts = e.timestamp || "";
+      if (ts.length < 16) return;
+      const k = ts.slice(11, 16);
+      const m = e.eisv || {};
+      (buckets[k] || (buckets[k] = [])).push({ E: m.E, I: m.I, S: m.S, V: m.V, C: e.coherence, R: e.risk });
+    });
+    const avg = (xs, f) => { const v = xs.map((x) => x[f]).filter((n) => typeof n === "number"); return v.length ? v.reduce((a, n) => a + n, 0) / v.length : null; };
+    return Object.keys(buckets).sort().slice(-20).map((t) => {
+      const xs = buckets[t];
+      return { t, E: avg(xs, "E"), I: avg(xs, "I"), S: avg(xs, "S"), V: avg(xs, "V"), C: avg(xs, "C"), R: avg(xs, "R") };
+    });
+  }
+
   const DATA = {
+    bucketEisv,
+
     async health() {
       return withFallback(async () => {
         const h = await authFetch("/health");
@@ -244,22 +266,11 @@
         const r = await authFetch("/v1/eisv/recent?limit=120");
         const evs = (r && r.events) || [];
         if (!evs.length) return null;
-        // fleet-average into 1-min buckets (mirrors eisv-charts __fleet__)
-        const buckets = {};
-        evs.forEach((e) => {
-          const ts = e.timestamp || "";
-          if (ts.length < 16) return;
-          const k = ts.slice(11, 16);
-          const m = e.eisv || {};
-          (buckets[k] || (buckets[k] = [])).push({ E: m.E, I: m.I, S: m.S, V: m.V, C: e.coherence, R: e.risk });
-        });
-        const avg = (xs, f) => { const v = xs.map((x) => x[f]).filter((n) => typeof n === "number"); return v.length ? v.reduce((a, n) => a + n, 0) / v.length : null; };
-        const series = Object.keys(buckets).sort().slice(-20).map((t) => {
-          const xs = buckets[t];
-          return { t, E: avg(xs, "E"), I: avg(xs, "I"), S: avg(xs, "S"), V: avg(xs, "V"), C: avg(xs, "C"), R: avg(xs, "R") };
-        });
-        return { series, coherenceEq: 0.5 };
-      }, () => S().eisv);
+        // `raw` carries the unaveraged events so the section can keep
+        // accumulating live pushes (same shape arrives over /ws/eisv) and
+        // re-bucket the window itself, no refetch.
+        return { series: bucketEisv(evs), raw: evs, coherenceEq: 0.5 };
+      }, () => { const e = S().eisv; return { series: e.series, raw: e.raw || [], coherenceEq: e.coherenceEq }; });
     },
 
     async automations() {

--- a/dashboard/redesign/sections/discoveries.js
+++ b/dashboard/redesign/sections/discoveries.js
@@ -37,6 +37,10 @@
 
   let MODEL = { list: [], byType: {}, byStatus: {}, total: 0, source: "snapshot" };
   let typeFilter = "all", timeFilter = "all";
+  // "N new" since the last load. An explore pane stays manual, so a knowledge_write
+  // doesn't refetch (that would disrupt search/filter/scroll) — it just bumps this
+  // badge as a refresh nudge. Reset on load().
+  let newCount = 0;
 
   function card(d, q) {
     const tags = (d.tags || []).slice(0, 5).map((t) => `<span class="tag">${esc(t)}</span>`).join(" ");
@@ -102,6 +106,7 @@
          <input id="dsc-search" placeholder="search summary · details · tags" value="${esc(q)}"
            style="flex:1;min-width:200px;padding:var(--space-2) var(--space-3);font-family:var(--font-sans);font-size:var(--text-sm);background:var(--surface);color:var(--ink);border:var(--hairline) solid var(--line-2);border-radius:var(--radius-sm)" />
          <select id="dsc-time" class="theme-toggle">${[["all", "all time"], ["24h", "24h"], ["7d", "7 days"], ["30d", "30 days"]].map(([v, t]) => `<option value="${v}" ${v === timeFilter ? "selected" : ""}>${t}</option>`).join("")}</select>
+         <button id="dsc-new" class="theme-toggle" title="New knowledge written since you loaded — click to refresh" style="display:${newCount > 0 ? "inline-flex" : "none"};border-color:var(--accent);color:var(--accent)">${newCount} new · refresh</button>
        </div>
        <div style="display:flex;flex-direction:column;gap:var(--space-3)">
          ${rows.length ? rows.map((d) => card(d, q)).join("") : `<p class="empty">No matches. Clear filters or change search.</p>`}
@@ -113,12 +118,23 @@
     const s = $("#dsc-search"); if (s) { s.oninput = render; if (s.value) { s.focus(); s.setSelectionRange(s.value.length, s.value.length); } }
     const t = $("#dsc-time"); if (t) t.onchange = () => { timeFilter = t.value; render(); };
     document.querySelectorAll(".dsc-type").forEach((b) => b.onclick = () => { typeFilter = b.dataset.type; render(); });
+    const n = $("#dsc-new"); if (n) n.onclick = load;
   }
 
   async function load() {
     const r = await DATA.discoveries();
     MODEL = { list: r.data.list || [], byType: r.data.byType || {}, byStatus: r.data.byStatus || {}, total: r.data.total || (r.data.list || []).length, source: r.source };
+    newCount = 0; // freshly loaded — nothing new yet
     render();
   }
-  window.Discoveries = { load };
+
+  // A knowledge_write landed — bump the badge in place (no re-render, so a search
+  // in progress keeps its focus). The badge element is always present (hidden at
+  // 0), so this just flips it visible and updates the count.
+  function notifyNew() {
+    newCount += 1;
+    const b = $("#dsc-new");
+    if (b) { b.textContent = newCount + " new · refresh"; b.style.display = "inline-flex"; }
+  }
+  window.Discoveries = { load, notifyNew };
 })();

--- a/dashboard/redesign/sections/eisv.js
+++ b/dashboard/redesign/sections/eisv.js
@@ -14,6 +14,11 @@
 
   let MODEL = { series: [], coherenceEq: 0.5, source: "snapshot" };
   let upper = null, lower = null;
+  // Raw eisv_update events in the live window — seeded from the REST backfill,
+  // then grown by pushed events so the chart re-buckets in place (true diff-push
+  // instead of a full refetch). Bounded so a long-lived tab can't grow unbounded.
+  let RAW = [];
+  const RAW_MAX = 400;
 
   function rgba(hex, a) {
     const h = hex.replace("#", "");
@@ -120,13 +125,28 @@
 
   async function load() {
     const r = await DATA.eisv();
+    RAW = (r.data.raw || []).slice(-RAW_MAX);
     MODEL = { series: r.data.series || [], coherenceEq: r.data.coherenceEq || 0.5, source: r.source };
     // Refresh in place if the charts are already mounted; full render on first load.
     if (upper && lower && document.getElementById("eisv-upper") && window.Chart) updateInPlace();
     else render();
   }
+
+  // Apply one pushed eisv_update directly — no refetch. Returns true if it
+  // handled the event (the caller then skips the doorbell refetch). Only acts
+  // once the charts are mounted; first paint still goes through load().
+  function applyEvent(msg) {
+    if (!msg || msg.type !== "eisv_update" || !msg.eisv || !msg.timestamp) return false;
+    if (!upper || !lower || !window.Chart) return false;
+    RAW.push({ timestamp: msg.timestamp, eisv: msg.eisv, coherence: msg.coherence, risk: msg.risk });
+    if (RAW.length > RAW_MAX) RAW = RAW.slice(-RAW_MAX);
+    MODEL.series = DATA.bucketEisv(RAW);
+    MODEL.source = "live"; // a live push by definition
+    updateInPlace();
+    return true;
+  }
   // re-theme without refetch (called on theme toggle) — full rebuild reads new tokens
   function retheme() { if (MODEL.series.length && window.Chart) build(); }
 
-  window.EISV = { load, retheme };
+  window.EISV = { load, retheme, applyEvent };
 })();

--- a/dashboard/redesign/sections/landing.js
+++ b/dashboard/redesign/sections/landing.js
@@ -83,7 +83,7 @@
     // Anomalies — pure stats with no detail view) stay plain, so the clickable
     // affordance is honest rather than implied on everything.
     const cards = [
-      { h: "Fleet Coherence", num: num(fleetCoh), sub: `${live.length} of ${residents.length} residents reporting`, cls: "up", rule: true, href: "#residents" },
+      { h: "Fleet Coherence", id: "fleetcoh", num: num(fleetCoh), sub: `${live.length} of ${residents.length} residents reporting`, cls: "up", rule: true, href: "#residents" },
       { h: "Agents", num: un(stats.agentsActive) ? "—" : stats.agentsActive, of: un(stats.agentsTotal) ? "" : "/ " + stats.agentsTotal, sub: un(stats.agentsActive) ? "unavailable" : "active / total", href: "#agents" },
       { h: "Stuck", num: un(stats.stuck) ? "—" : stats.stuck, sub: un(stats.stuck) ? "unavailable" : (stats.stuck ? "needs attention" : "none flagged"), cls: un(stats.stuck) ? "" : (stats.stuck ? "down" : "up"), href: "#agents" },
       { h: "Automations", num: asum.total || 0, sub: autoSub, cls: aWarn ? "down" : "up", href: "#automations" },
@@ -113,7 +113,8 @@
       : `<div class="sub" style="color:var(--muted)">unavailable</div>`;
     $("stats").innerHTML = degradeBanner + cards.map((s) => {
       const tag = s.href ? "a" : "div"; const attr = s.href ? ` href="${s.href}" style="text-decoration:none;color:inherit"` : "";
-      return `<${tag} class="card ${s.rule ? "accent-rule" : ""}"${attr}><h3>${s.h}</h3>`
+      const dataAttr = s.id ? ` data-card="${s.id}"` : "";
+      return `<${tag} class="card ${s.rule ? "accent-rule" : ""}"${attr}${dataAttr}><h3>${s.h}</h3>`
         + `<div class="num">${s.num}${s.of ? `<span class="of"> ${s.of}</span>` : ""}</div>`
         + `<div class="sub ${s.cls || ""}">${s.sub}</div></${tag}>`;
     }).join("")
@@ -150,7 +151,70 @@
     }).join("");
   }
 
-  let lastResidents = null;
+  // In-memory resident model. Each entry is the DATA.residents() shape plus an
+  // absolute `_lastSeenMs` (when it last checked in), so silence is computed at
+  // render time rather than frozen at fetch time — it ticks up live and snaps to
+  // 0 when a resident checks in. Seeded from the REST fetch; mutated by pushed
+  // eisv_update events (see applyEvent) so the strip updates without a refetch.
+  let RMODEL = [];
+  let lastSource = "snapshot";
+
+  function seedResidents(list, source) {
+    const now = Date.now();
+    lastSource = source;
+    RMODEL = (list || []).map((r) => Object.assign({}, r, {
+      _lastSeenMs: typeof r.silence === "number" ? now - r.silence * 1000 : null,
+    }));
+  }
+  // Render-ready snapshot with live silence derived from _lastSeenMs.
+  function viewResidents() {
+    const now = Date.now();
+    return RMODEL.map((r) => Object.assign({}, r, {
+      silence: r._lastSeenMs != null ? Math.round((now - r._lastSeenMs) / 1000) : r.silence,
+    }));
+  }
+  // Recompute the Fleet Coherence card in place (a derived aggregate, so it
+  // shifts as residents report) without rebuilding the whole stats grid.
+  function updateFleetCoherence(residents) {
+    const el = document.querySelector('[data-card="fleetcoh"]');
+    if (!el) return;
+    const live = residents.filter((r) => r.coherence != null);
+    const fleetCoh = live.length ? live.reduce((a, r) => a + r.coherence, 0) / live.length : null;
+    const numEl = el.querySelector(".num"), subEl = el.querySelector(".sub");
+    if (numEl) numEl.textContent = num(fleetCoh);
+    if (subEl) subEl.textContent = `${live.length} of ${residents.length} residents reporting`;
+  }
+
+  // Apply one pushed eisv_update to the residents strip directly — no refetch.
+  // Returns true only when the event belongs to a known resident (matched by
+  // agent_name == label, the same rule the server uses); other agents' check-ins
+  // return false so the caller falls back to the doorbell refresh.
+  function applyEvent(msg) {
+    if (!msg || msg.type !== "eisv_update" || !msg.agent_name) return false;
+    const r = RMODEL.find((x) => x.name === msg.agent_name);
+    if (!r) return false;
+    if (msg.eisv) r.eisv = msg.eisv;
+    if (typeof msg.coherence === "number") r.coherence = msg.coherence;
+    if (typeof msg.risk === "number") r.risk = msg.risk;
+    const act = msg.decision && msg.decision.action;
+    if (act) r.verdict = act;
+    r._lastSeenMs = Date.now(); // just checked in: not silent, not dark
+    if (r.status === "dark" || r.status === "silent") r.status = "healthy";
+    const view = viewResidents();
+    renderResidents(view, lastSource);
+    renderPulse(view);
+    updateFleetCoherence(view);
+    return true;
+  }
+
+  // Re-render the strip from the model so silence visibly accrues during quiet
+  // periods (driven by app.html on a slow tick while the Overview is visible).
+  function tickSilence() {
+    if (!RMODEL.length || !$("residents")) return;
+    const view = viewResidents();
+    renderResidents(view, lastSource);
+    renderPulse(view);
+  }
 
   function applyHealth(health) {
     if (health.data) {
@@ -168,30 +232,32 @@
   // Full first render — light (residents/pulse/health) + heavy (stats) together.
   async function render() {
     const [health, residents, stats, auto] = await Promise.all([DATA.health(), DATA.residents(), DATA.stats(), DATA.automations()]);
-    lastResidents = residents;
+    seedResidents(residents.data, residents.source);
+    const view = viewResidents();
     applyHealth(health);
-    renderResidents(residents.data, residents.source);
-    renderStats(stats.data, residents.data, stats.source, auto.data);
-    renderPulse(residents.data);
+    renderResidents(view, residents.source);
+    renderStats(stats.data, view, stats.source, auto.data);
+    renderPulse(view);
     footnote([residents, stats, health].some((r) => r.source === "live"));
   }
 
   // Light refresh (fast cadence) — the "is the fleet alive" glance only.
   async function refresh() {
     const [health, residents] = await Promise.all([DATA.health(), DATA.residents()]);
-    lastResidents = residents;
+    seedResidents(residents.data, residents.source);
+    const view = viewResidents();
     applyHealth(health);
-    renderResidents(residents.data, residents.source);
-    renderPulse(residents.data);
+    renderResidents(view, residents.source);
+    renderPulse(view);
   }
 
-  // Heavy refresh (slow cadence) — the 7-tool headline batch; reuse last residents
-  // for fleet coherence rather than refetching them.
+  // Heavy refresh (slow cadence) — the 7-tool headline batch; reuse the resident
+  // model for fleet coherence rather than refetching it.
   async function refreshStats() {
     const [stats, auto] = await Promise.all([DATA.stats(), DATA.automations()]);
-    const residents = lastResidents || (lastResidents = await DATA.residents());
-    renderStats(stats.data, residents.data, stats.source, auto.data);
+    if (!RMODEL.length) { const residents = await DATA.residents(); seedResidents(residents.data, residents.source); }
+    renderStats(stats.data, viewResidents(), lastSource, auto.data);
   }
 
-  window.Landing = { render, refresh, refreshStats };
+  window.Landing = { render, refresh, refreshStats, applyEvent, tickSilence };
 })();

--- a/dashboard/redesign/ws.js
+++ b/dashboard/redesign/ws.js
@@ -3,10 +3,11 @@
  * --------------------------------------------------------
  * Thin WebSocket client: the server pushes {type:"eisv_update", …} on every
  * agent check-in and {type:<event>, …} for governance events (lifecycle,
- * knowledge, circuit-breaker…). We don't surgically patch the DOM per event —
- * each pushed event just signals "something changed," and the consumer does a
- * debounced refresh of the active view through the normal render path. That's
- * real-time (sub-second) without per-event DOM fragility.
+ * knowledge, circuit-breaker…). The full event object is handed to the consumer
+ * (app.html onWsEvent). Sections that can patch from the payload do so directly
+ * (true diff-push, e.g. the EISV chart re-buckets in place); everything else
+ * treats the event as a doorbell and does a debounced refresh of the active view
+ * through the normal render path. Real-time (sub-second) either way.
  *
  * Reconnects with capped exponential backoff. Status is reported so the header
  * pill can show streaming vs the polling fallback.


### PR DESCRIPTION
Finishing the dashboard live-surface strangler (Track A). The redesign already subscribes to the broadcaster firehose (`/ws/eisv`), but every pushed event was treated as a **doorbell** that triggered a full REST refetch of the active pane. This makes each surface consume the push in the way that's *correct* for it.

The event-vocabulary blocker is resolved and the broadcaster is live — this is rendering-layer work over an existing Python event stream (no Phoenix; events and canonical state live in Python, so a LiveView rewrite would buy no colocation).

---

## A1 — true diff-push for the EISV fleet chart
`/v1/eisv/recent` serves the *same* `eisv_update` events the broadcaster streams, so the chart keeps the raw window and re-buckets in place on each push — no refetch.
- `data.js` — shared `bucketEisv()`; `eisv()` returns unaveraged `raw` alongside `series`; `bucketEisv` exposed on `DATA` so seed and live-apply average identically.
- `eisv.js` — bounded raw window seeded from backfill; `applyEvent(msg)` appends a push and re-buckets via existing `updateInPlace()`.
- `app.html` — `onWsEvent(msg)` routes to a section's direct apply first; debounced doorbell is the fallback. `ws.js` comment updated.

## A2 — live resident presence on the Overview
The residents strip + Fleet Coherence + Pulse are the presence surface. A resident check-in arrives as an `eisv_update`, applied directly — matched by **`agent_name == label`**, the server's own rule (`_latest_eisv_for_label`).
- `landing.js` — in-memory resident model with absolute `_lastSeenMs`, so silence is computed at render time (ticks up live, snaps to 0 on check-in) not frozen at fetch. `applyEvent()` patches the matched resident, re-renders strip + Pulse, recomputes Fleet Coherence in place. Returns false for non-resident/non-`eisv` events → doorbell.
- `app.html` — `APPLY.overview`; a visibility-gated 5s silence ticker (no network).

## A3 — live "N new" badge on Discoveries
Explore panes stay manual by design — a `knowledge_write` must not refetch and disrupt search/filter/scroll. It bumps a "N new · refresh" nudge instead.
- `discoveries.js` — always-present badge (hidden at 0); `notifyNew()` updates it **in place** (no re-render, so a search keeps its focus); reset on load; click reloads.
- `app.html` — `NOTIFY` map dispatched before the auto-section/typing/hidden gates, so the badge accumulates regardless of active pane (you see what landed while away).

---

## Scope / non-goals
- **Only EISV, the Overview residents strip, and Discoveries get live treatment** — the surfaces where consuming a single event is correct. Most check-ins are non-resident agents; those return false and keep the doorbell.
- **Residents detail-panel section unchanged** — finding funnels / cycle counts from summary endpoints, not an EISV roster.
- **No new server event.** Existing `eisv_update` + lifecycle + the client ticker cover presence.
- **Dialectic badge DEFERRED.** Verified both contract asks are still open: the dialectic `list` SQL (`session.py`) selects no `awaiting_facilitation` column, and there is **no dialectic broadcast event at all** (`facilitation_needed` doesn't exist; `grep broadcast_event` over `mcp_handlers/dialectic/` is empty). A live dialectic badge has nothing to count, and defining the dialectic event vocabulary is the engine agent's coordination surface — building it here would name events two ways. Left for that sync.

## Honesty constraints
- EISV: re-buckets from raw, never fakes a partial fleet average.
- Presence: `applyEvent` does **not** fabricate the composite `status` (healthy/careful) from one event — Landing only special-cases dark/silent, and a check-in is demonstrably neither, so it only clears those. Everything written is event-derived.

## Verification
- **A1** `bucketEisv` vs live module in jsdom — 9/9.
- **A2** `Landing.applyEvent` vs live modules in jsdom (label match, fleet recompute, silence reset, Pulse, non-resident false) — 8/8.
- **A3** `Discoveries.notifyNew` vs live module in jsdom (present/hidden at 0, counts up, **search focus + value preserved**, accumulate, reset on refresh) — 10/10.
- Dashboard ESLint clean (only pre-existing `phase.js` warnings).
- **JS-only, no Python touched** — CI runs the full gate.

https://claude.ai/code/session_01AGFmFaYZUymoB9dxK87Dej