### PR TITLE
chore(de-pii): sweep operator home path /Users/cirwel from pre-existing files

### DIFF
--- a/docs/proposals/plexus-scope.md
+++ b/docs/proposals/plexus-scope.md
@@ -124,13 +124,13 @@ Manual Plexus Zero may use human-readable `repo://unitares/...` aliases in Disco
 
 | Manual Plexus Zero alias | Canonical service surface | Purpose | Notes |
 |---|---|---|---|
-| `repo://unitares/docs/proposals/plexus-scope.md` | `file:///Users/cirwel/projects/unitares/docs/proposals/plexus-scope.md` | Canonical Plexus boundary | This document; one holder at a time for edits |
-| `repo://unitares/docs/proposals/surface-lease-plane-v0.md` | `file:///Users/cirwel/projects/unitares/docs/proposals/surface-lease-plane-v0.md` | Lease-plane contract/RFC | Existing canonical implementation contract |
-| `repo://unitares/docs/proposals/surface-lease-plane-phase-a-plan.md` | `file:///Users/cirwel/projects/unitares/docs/proposals/surface-lease-plane-phase-a-plan.md` | Phase A staging plan | Implementation sequencing |
-| `repo://unitares/docs/ontology/beam-coordination-kernel.md` | `file:///Users/cirwel/projects/unitares/docs/ontology/beam-coordination-kernel.md` | Ontology/integration framing | BEAM sidecar role and non-goals |
-| `repo://unitares/src/lease_plane/<file>` | `file:///Users/cirwel/projects/unitares/src/lease_plane/<file>` | Python client/advisory contract | Choose the exact file before acquiring |
-| `repo://unitares/elixir/lease_plane/<file>` | `file:///Users/cirwel/projects/unitares/elixir/lease_plane/<file>` | BEAM implementation | Choose the exact file before acquiring |
-| `repo://unitares/db/postgres/migrations/<lease-plane-migration>.sql` | `file:///Users/cirwel/projects/unitares/db/postgres/migrations/<lease-plane-migration>.sql` | Durable lease schema | Migrations are high-risk surfaces; use explicit exact-path claims |
+| `repo://unitares/docs/proposals/plexus-scope.md` | `file://$HOME/projects/unitares/docs/proposals/plexus-scope.md` | Canonical Plexus boundary | This document; one holder at a time for edits |
+| `repo://unitares/docs/proposals/surface-lease-plane-v0.md` | `file://$HOME/projects/unitares/docs/proposals/surface-lease-plane-v0.md` | Lease-plane contract/RFC | Existing canonical implementation contract |
+| `repo://unitares/docs/proposals/surface-lease-plane-phase-a-plan.md` | `file://$HOME/projects/unitares/docs/proposals/surface-lease-plane-phase-a-plan.md` | Phase A staging plan | Implementation sequencing |
+| `repo://unitares/docs/ontology/beam-coordination-kernel.md` | `file://$HOME/projects/unitares/docs/ontology/beam-coordination-kernel.md` | Ontology/integration framing | BEAM sidecar role and non-goals |
+| `repo://unitares/src/lease_plane/<file>` | `file://$HOME/projects/unitares/src/lease_plane/<file>` | Python client/advisory contract | Choose the exact file before acquiring |
+| `repo://unitares/elixir/lease_plane/<file>` | `file://$HOME/projects/unitares/elixir/lease_plane/<file>` | BEAM implementation | Choose the exact file before acquiring |
+| `repo://unitares/db/postgres/migrations/<lease-plane-migration>.sql` | `file://$HOME/projects/unitares/db/postgres/migrations/<lease-plane-migration>.sql` | Durable lease schema | Migrations are high-risk surfaces; use explicit exact-path claims |
 
 Do not generalize this table into a fleet-wide taxonomy until manual use shows which surfaces actually collide.
 

--- a/scripts/ops/deploy-mcp.sh
+++ b/scripts/ops/deploy-mcp.sh
@@ -24,7 +24,7 @@
 # ONE-TIME SETUP (run interactively from a normal login shell, NOT automated):
 #   PLIST=~/Library/LaunchAgents/com.unitares.governance-mcp.plist
 #   cp "$PLIST" "$PLIST.bak"
-#   sed -i '' 's|/Users/cirwel/projects/unitares|/Users/cirwel/projects/unitares-deploy|g' "$PLIST"
+#   sed -i '' 's|$HOME/projects/unitares|$HOME/projects/unitares-deploy|g' "$PLIST"
 #   launchctl unload "$PLIST" && launchctl load "$PLIST"   # RELOAD (kickstart won't)
 #   curl -s http://127.0.0.1:8767/health/ready             # expect {"status":"ready"}
 #   # rollback: cp "$PLIST.bak" "$PLIST"; launchctl unload "$PLIST"; launchctl load "$PLIST"

--- a/tests/test_lease_plane_client.py
+++ b/tests/test_lease_plane_client.py
@@ -32,7 +32,7 @@ from src.lease_plane.client import LeaseHTTPRequest
 def _lease_payload(
     *,
     lease_id: UUID | None = None,
-    surface_id: str = "file:///Users/cirwel/projects/unitares/src/x.py",
+    surface_id: str = "file://$HOME/projects/unitares/src/x.py",
     holder_agent_uuid: UUID | None = None,
     holder_kind: str = "remote_heartbeat",
 ) -> dict[str, Any]:

--- a/tests/test_s19_e2e_regression.py
+++ b/tests/test_s19_e2e_regression.py
@@ -231,7 +231,7 @@ async def test_uds_path_with_executable_mismatch_rejects(db):
     # Right label, WRONG executable path — the binary was substituted.
     fake_pa = SimpleNamespace(
         read_service_label=lambda pid: label,
-        read_executable_path=lambda pid: "/Users/cirwel/projects/swapped-binary",
+        read_executable_path=lambda pid: "$HOME/projects/swapped-binary",
         read_process_start_time=lambda pid: 1_777_000_000,
     )
 

--- a/tests/test_substrate_verification.py
+++ b/tests/test_substrate_verification.py
@@ -154,7 +154,7 @@ def test_exec_mismatch_when_actual_path_differs() -> None:
     claim = _make_claim(executable="/opt/homebrew/bin/sentinel")
     pa = _fake_pa(
         label=claim.expected_launchd_label,
-        executable="/Users/cirwel/projects/unitares/agents/sentinel/agent.py",
+        executable="$HOME/projects/unitares/agents/sentinel/agent.py",
     )
     result = verify_substrate_claim(claim, peer_pid=1234, pa_module=pa)
     assert result.accepted is False

--- a/tests/test_utils_pure.py
+++ b/tests/test_utils_pure.py
@@ -282,9 +282,9 @@ class TestSanitizeErrorMessage:
     """Tests for _sanitize_error_message."""
 
     def test_removes_full_file_path_keeps_filename(self):
-        msg = "Error in /Users/cirwel/projects/unitares/src/mcp_handlers/utils.py"
+        msg = "Error in /Users/testuser/projects/unitares/src/mcp_handlers/utils.py"
         result = _sanitize_error_message(msg)
-        assert "/Users/cirwel/" not in result
+        assert "/Users/testuser/" not in result
         assert "utils.py" in result
 
     def test_removes_unix_path(self):

--- a/tests/test_ux_fixes.py
+++ b/tests/test_ux_fixes.py
@@ -330,10 +330,10 @@ class TestErrorSanitization:
         """Sanitization removes full file paths"""
         from src.mcp_handlers.utils import _sanitize_error_message
 
-        msg = "Error in /Users/cirwel/projects/unitares/src/mcp_handlers/utils.py"
+        msg = "Error in /Users/testuser/projects/unitares/src/mcp_handlers/utils.py"
         sanitized = _sanitize_error_message(msg)
 
-        assert "/Users/cirwel" not in sanitized
+        assert "/Users/testuser" not in sanitized
 
     def test_removes_stack_traces(self):
         """Sanitization simplifies stack traces"""


### PR DESCRIPTION
<!-- scope-guard: allow-register -->
De-personalizes the automation-overrides accountability metadata and sweeps the operator home path from committed files. (This PR necessarily names the patterns it removes — hence the allow-register marker.)

## 1. automation-overrides PII (option B — de-PII in place)
`docs/operations/automation-overrides.json` is operator-authored accountability metadata that flows to the deploy via edit-in-repo → PR → pull (a local symlink points the runtime at the deploy checkout's copy). That review workflow is deliberate and kept. The file carried operator identity in a user-agnostic repo:
- the operator name (×44 owner fields + 1 in notes) → `operator`
- the operator absolute home path (×26 repo/workdir paths) → `$HOME`

Option B (de-PII, keep the file + workflow) was chosen over A (relocate the file out). JSON validated (47 automations intact); the `/api/automations` census test stays green (it reads the census snapshot, not this overrides file); companion `automation-overrides.md` owner line de-named.

## 2. Home-path sweep
The scope guard already flags the operator home path (Rule 5) but only on changed files, so several pre-existing files were never re-scanned. Genericized 7 of them:
- proposal doc, ops-script comment, and test fixtures → `$HOME`
- two sanitizer tests → a generic `testuser` home path, so the "home path is stripped from error messages" assertion stays meaningful (the sanitizer matches any absolute `/…/<file>.py`)

235 affected tests green.

## Deferred / kept
- Two RFC docs carry the home path AND trip the AI-review-process rule (deliberation register) — cleaning the path alone would force stripping that register from active RFCs, a separate call. Left untouched.
- `CHANGELOG.md` (history) and the de-leak tooling doc (its find-command needs the literal) — kept.

The precise Rule 5 keeps catching new occurrences; not generalized (would false-positive on placeholder paths).

https://claude.ai/code/session_01VsXq3pJjFtzdy7GCeJ4PBq