### PR TITLE
ops(deploy): add deploy-gateway.sh + deploy-wave3a.sh; complete the sweep

### DIFF
--- a/scripts/ops/deploy-apply.sh
+++ b/scripts/ops/deploy-apply.sh
@@ -40,10 +40,12 @@ done
 # associative array, so this runs on macOS's stock bash 3.2 like the siblings.)
 deploy_script_for() {
   case "$1" in
-    governance-mcp) echo "$OPS_DIR/deploy-mcp.sh" ;;
-    lease-plane)    echo "$OPS_DIR/deploy-lease-plane.sh" ;;
-    sentinel-beam)  echo "$OPS_DIR/deploy-sentinel.sh" ;;
-    *)              echo "" ;;
+    governance-mcp)  echo "$OPS_DIR/deploy-mcp.sh" ;;
+    gateway-mcp)     echo "$OPS_DIR/deploy-gateway.sh" ;;
+    lease-plane)     echo "$OPS_DIR/deploy-lease-plane.sh" ;;
+    sentinel-beam)   echo "$OPS_DIR/deploy-sentinel.sh" ;;
+    wave3a-handlers) echo "$OPS_DIR/deploy-wave3a.sh" ;;
+    *)               echo "" ;;
   esac
 }
 

--- a/scripts/ops/deploy-gateway.sh
+++ b/scripts/ops/deploy-gateway.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Deploy the Gateway MCP (com.unitares.gateway-mcp) from the DEDICATED clean
+# worktree pinned to origin/master — never the shared dev tree.
+#
+# The gateway is a Python reduced-surface proxy on :8768 (src/gateway_server.py)
+# that fronts the governance MCP on :8767. Like that MCP it has run from
+# ~/projects/unitares (restart-DEV/⚠DEV in deploy-status.sh), so a merged fix
+# wasn't live until a manual pull + kickstart — the running-process-vs-master-
+# commit drift class. The Python-side analogue of deploy-sentinel.sh; the same
+# shape as deploy-mcp.sh but for the gateway process. No compile step (Python);
+# deps come from the worktree's environment exactly as the governance MCP's do.
+#
+# Idempotent: creates the worktree if missing, fast-forwards (never resets),
+# restarts the LaunchAgent, and verifies /health on :8768.
+set -euo pipefail
+
+REPO="${UNITARES_REPO:-$HOME/projects/unitares}"
+DEPLOY="${UNITARES_DEPLOY:-$HOME/projects/unitares-deploy}"
+LABEL="com.unitares.gateway-mcp"
+PLIST="${UNITARES_GATEWAY_PLIST:-$HOME/Library/LaunchAgents/$LABEL.plist}"
+PORT="${UNITARES_GATEWAY_PORT:-8768}"
+UID_NUM="$(id -u)"
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+# ── Serialize deploys (shared worktree) ──────────────────────────────────────
+LOCK_DIR="${UNITARES_DEPLOY_LOCK:-${TMPDIR:-/tmp}/unitares-deploy$(printf '%s' "$DEPLOY" | tr -c 'A-Za-z0-9' '_').lock}"
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  holder="$(cat "$LOCK_DIR/pid" 2>/dev/null || echo '?')"
+  if [[ "$holder" != '?' ]] && ! kill -0 "$holder" 2>/dev/null; then
+    echo "[deploy] reclaiming stale deploy lock (holder PID $holder is dead): $LOCK_DIR" >&2
+    rm -rf "$LOCK_DIR"
+    mkdir "$LOCK_DIR" 2>/dev/null || { echo "[deploy] lost a lock race — another deploy just started; refusing" >&2; exit 1; }
+  else
+    echo "[deploy] another deploy is in progress (lock: $LOCK_DIR, holder PID $holder) — refusing to run concurrently" >&2
+    exit 1
+  fi
+fi
+printf '%s' "$$" > "$LOCK_DIR/pid"
+trap 'rm -rf "$LOCK_DIR"' EXIT
+
+# ── Pre-flight: the LaunchAgent must load from the deploy worktree ────────────
+# Match the exact program path so a kickstart can't silently restart the dev
+# checkout and then have /health pass against the OLD process.
+if [[ -f "$PLIST" ]] && ! grep -q "$DEPLOY/src/gateway_server.py" "$PLIST"; then
+  echo "[deploy] WARNING: $LABEL does not run $DEPLOY/src/gateway_server.py (still restart-DEV)." >&2
+  echo "[deploy] kickstart would restart the OLD location and /health would pass against it." >&2
+  echo "[deploy] One-time migration (interactive login shell — a RELOAD, kickstart won't re-read the plist):" >&2
+  echo "[deploy]   cp \"$PLIST\" \"$PLIST.bak\"" >&2
+  echo "[deploy]   sed -i '' 's|$REPO|$DEPLOY|g' \"$PLIST\"" >&2
+  echo "[deploy]   launchctl unload \"$PLIST\" && launchctl load \"$PLIST\"" >&2
+  echo "[deploy] Refusing (set UNITARES_GATEWAY_ALLOW_DEV=1 to restart the dev checkout anyway)." >&2
+  [[ "${UNITARES_GATEWAY_ALLOW_DEV:-0}" == "1" ]] || exit 2
+fi
+
+echo "[deploy] fetching origin/master"
+git -C "$REPO" fetch origin master --quiet
+
+if ! git -C "$REPO" worktree list --porcelain | grep -qx "worktree $DEPLOY"; then
+  echo "[deploy] creating dedicated deploy worktree at $DEPLOY (on master)"
+  git -C "$REPO" worktree add "$DEPLOY" master
+fi
+
+echo "[deploy] fast-forwarding $DEPLOY to origin/master (ff-only; refuses if it would lose work)"
+git -C "$DEPLOY" merge --ff-only origin/master
+mkdir -p "$DEPLOY/data/logs"
+
+echo "[deploy] restarting $LABEL"
+launchctl kickstart -k "gui/$UID_NUM/$LABEL"
+
+echo "[deploy] verifying /health on :$PORT"
+ok=""
+for _ in $(seq 1 12); do
+  sleep 3
+  if curl -fsS "http://127.0.0.1:$PORT/health" >/dev/null 2>&1; then
+    ok=yes
+    break
+  fi
+done
+
+if [[ "$ok" == yes ]]; then
+  echo "[deploy] OK — gateway-mcp healthy on :$PORT (serving from $DEPLOY @ $(git -C "$DEPLOY" rev-parse --short HEAD))"
+else
+  echo "[deploy] FAILED — /health on :$PORT did not respond within timeout." >&2
+  echo "[deploy] Check: launchctl list | grep $LABEL ; tail -80 $DEPLOY/data/logs/gateway_server_error.log" >&2
+  exit 1
+fi

--- a/scripts/ops/deploy-wave3a.sh
+++ b/scripts/ops/deploy-wave3a.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Deploy the Wave 3a BEAM handler app (com.unitares.wave3a-handlers) from the
+# DEDICATED clean worktree pinned to origin/master — never the shared dev tree.
+#
+# Why: like the Sentinel, wave3a-handlers starts via `mix run` against a checkout
+# on disk and has run from ~/projects/unitares (restart-DEV/⚠DEV in
+# deploy-status.sh), so a merged fix wasn't live until a manual pull + kickstart
+# — the running-process-vs-master-commit drift class. Mirrors deploy-sentinel.sh
+# / deploy-lease-plane.sh: a dedicated worktree makes running-code ==
+# origin/master by construction.
+#
+# Verify uses the open /health endpoint on :8770 (the bearer-gated handler
+# routes are not probed). Idempotent: creates the worktree if missing,
+# fast-forwards (never resets), recompiles (MIX_ENV=prod, matching the plist),
+# restarts the LaunchAgent, and confirms /health.
+#
+# NOTE: the wave3a plist ships WITHOUT RunAtLoad (operator-gated cutover per RFC
+# beam-wave-3a §5). This script only deploys a service that is already loaded +
+# running; if it is intentionally unloaded, deploy-status reports DOWN (not
+# STALE) and the sweep skips it.
+set -euo pipefail
+
+REPO="${UNITARES_REPO:-$HOME/projects/unitares}"
+DEPLOY="${UNITARES_DEPLOY:-$HOME/projects/unitares-deploy}"
+LABEL="com.unitares.wave3a-handlers"
+PLIST="${UNITARES_WAVE3A_PLIST:-$HOME/Library/LaunchAgents/$LABEL.plist}"
+PORT="${UNITARES_WAVE3A_PORT:-8770}"
+UID_NUM="$(id -u)"
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+# ── Serialize deploys (shared worktree) ──────────────────────────────────────
+LOCK_DIR="${UNITARES_DEPLOY_LOCK:-${TMPDIR:-/tmp}/unitares-deploy$(printf '%s' "$DEPLOY" | tr -c 'A-Za-z0-9' '_').lock}"
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  holder="$(cat "$LOCK_DIR/pid" 2>/dev/null || echo '?')"
+  if [[ "$holder" != '?' ]] && ! kill -0 "$holder" 2>/dev/null; then
+    echo "[deploy] reclaiming stale deploy lock (holder PID $holder is dead): $LOCK_DIR" >&2
+    rm -rf "$LOCK_DIR"
+    mkdir "$LOCK_DIR" 2>/dev/null || { echo "[deploy] lost a lock race — another deploy just started; refusing" >&2; exit 1; }
+  else
+    echo "[deploy] another deploy is in progress (lock: $LOCK_DIR, holder PID $holder) — refusing to run concurrently" >&2
+    exit 1
+  fi
+fi
+printf '%s' "$$" > "$LOCK_DIR/pid"
+trap 'rm -rf "$LOCK_DIR"' EXIT
+
+# ── Pre-flight: the LaunchAgent must load from the deploy worktree ────────────
+if [[ -f "$PLIST" ]] && ! grep -q "$DEPLOY" "$PLIST"; then
+  echo "[deploy] WARNING: $LABEL does not appear to load from $DEPLOY (still restart-DEV)." >&2
+  echo "[deploy] kickstart would restart the OLD location and this deploy would not take effect." >&2
+  echo "[deploy] One-time migration: re-render the plist against the deploy worktree" >&2
+  echo "[deploy]   (sed __UNITARES_ROOT__ -> $DEPLOY ; see the template header), then reload:" >&2
+  echo "[deploy]   launchctl unload \"$PLIST\" && launchctl load \"$PLIST\"" >&2
+  echo "[deploy] Refusing (set UNITARES_WAVE3A_ALLOW_DEV=1 to restart the dev checkout anyway)." >&2
+  [[ "${UNITARES_WAVE3A_ALLOW_DEV:-0}" == "1" ]] || exit 2
+fi
+
+echo "[deploy] fetching origin/master"
+git -C "$REPO" fetch origin master --quiet
+
+if ! git -C "$REPO" worktree list --porcelain | grep -qx "worktree $DEPLOY"; then
+  echo "[deploy] creating dedicated deploy worktree at $DEPLOY (on master)"
+  git -C "$REPO" worktree add "$DEPLOY" master
+fi
+
+echo "[deploy] fast-forwarding $DEPLOY to origin/master (ff-only; refuses if it would lose work)"
+git -C "$DEPLOY" merge --ff-only origin/master
+
+echo "[deploy] compiling wave3a_handlers (MIX_ENV=prod; surfaces compile errors before restart)"
+( cd "$DEPLOY/elixir/wave3a_handlers" && mix deps.get && MIX_ENV=prod mix compile )
+
+echo "[deploy] restarting $LABEL"
+launchctl kickstart -k "gui/$UID_NUM/$LABEL"
+
+echo "[deploy] verifying /health on :$PORT"
+ok=""
+for _ in $(seq 1 12); do
+  sleep 3
+  if curl -fsS "http://127.0.0.1:$PORT/health" >/dev/null 2>&1; then
+    ok=yes
+    break
+  fi
+done
+
+if [[ "$ok" == yes ]]; then
+  echo "[deploy] OK — wave3a-handlers healthy on :$PORT (serving from $DEPLOY @ $(git -C "$DEPLOY" rev-parse --short HEAD))"
+else
+  echo "[deploy] FAILED — /health on :$PORT did not respond within timeout." >&2
+  echo "[deploy] Check: launchctl list | grep $LABEL ; tail -80 $HOME/Library/Logs/unitares-wave3a-handlers.log" >&2
+  exit 1
+fi


### PR DESCRIPTION
## What

Finishes the `deploy-apply.sh` sweep (follow-up to #1158): the last two `restart-DEV` services get dedicated worktree deploy scripts, mirroring `deploy-sentinel.sh`, and are wired into the dispatch table.

- **`deploy-gateway.sh`** — Python gateway MCP (`src/gateway_server.py`, `:8768` proxy to the governance MCP). Fast-forward the deploy worktree → `kickstart` → verify `/health`. No compile step (Python; deps come from the worktree env, same as `deploy-mcp.sh`). Pre-flight matches the exact `src/gateway_server.py` program path so a kickstart can't restart the dev checkout and then have `/health` pass against the *old* process.
- **`deploy-wave3a.sh`** — Wave 3a BEAM handlers (`:8770`). Fast-forward → `MIX_ENV=prod mix compile` (matches the plist) → `kickstart` → verify `/health`. Honors the operator-gated, no-`RunAtLoad` posture from RFC beam-wave-3a: it only deploys an already-running instance; an intentionally-unloaded one shows `DOWN` (not `STALE`) and the sweep skips it.

Both share the deploy-worktree lock and **refuse if their LaunchAgent still loads from the shared dev checkout** (printing the one-time migration), exactly like `deploy-sentinel.sh`/`deploy-mcp.sh`.

`deploy-apply.sh`'s dispatch table now covers **all five** restart-class services (`governance-mcp`, `gateway-mcp`, `lease-plane`, `sentinel-beam`, `wave3a-handlers`).

## Result

Once the operator migrates the two plists to the deploy worktree, `deploy-apply.sh` is a **total** one-command sweep — every service that's `STALE`/`BEHIND` gets pulled, restarted, and verified. No service is left on the running-from-dev-checkout footgun.

## Validation

`bash -n` clean on all three. Re-ran the end-to-end orchestration test with mock `deploy-status.sh` + mock per-service scripts: `gateway-mcp` → `deploy-gateway.sh`, `wave3a-handlers` → `deploy-wave3a.sh`, `sentinel-beam` → `deploy-sentinel.sh`, `CURRENT` services not selected, unknown services still skipped. (The real scripts target macOS `launchctl`, so they can't run in CI — review-gated.)

## Remaining operator step

For the sweep to act on these two, each plist needs the one-time migration to the deploy worktree (re-render with `__UNITARES_ROOT__=~/projects/unitares-deploy` + reload) and `deploy-status.sh`'s topology lines flipped `restart-DEV` → `restart`. Until then the scripts refuse and the sweep reports them skipped — never a silent no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BzBQCXUkx8NshtxPGSTPo1)_