### PR TITLE
fix(dialectic): idempotent terminal-transition guard in resolve_session (B-4)

### DIFF
--- a/src/dialectic_db.py
+++ b/src/dialectic_db.py
@@ -229,18 +229,53 @@ class DialecticDB:
         resolution: Dict[str, Any],
         status: str = "resolved"
     ) -> bool:
-        """Mark session as resolved or failed with resolution data."""
+        """Mark session as resolved or failed with resolution data.
+
+        Idempotent terminal-transition guard (council 2026-06-28, "B-4"): the
+        UPDATE refuses to write a session that is already in a terminal state
+        (``resolved``/``failed``). This is the database-layer defense that makes
+        the transition safe across *processes* — the in-process asyncio.Lock in
+        ``mcp_handlers/dialectic/session.py`` only serializes within one Python
+        process, so a crash-recovery re-drive or a second writer (e.g. the
+        forthcoming BEAM session owner) could otherwise overwrite a committed
+        ``resolution_json``. Return semantics:
+          * True  — this call performed the terminal transition, OR the session
+                    is already in the *requested* terminal state (idempotent).
+          * False — the session is missing, or is already in a *different*
+                    terminal state (conflict; the existing resolution is kept).
+        """
         await self._ensure_pool()
         # Phase should match status - don't hardcode 'resolved' when status is 'failed'
         phase = "resolved" if status == "resolved" else status
         async with self._pool.acquire() as conn:
-            result = await conn.execute("""
+            row = await conn.fetchrow("""
                 UPDATE core.dialectic_sessions
                 SET status = $1, phase = $2, resolution_json = $3, updated_at = now()
-                WHERE session_id = $4
+                WHERE session_id = $4 AND status NOT IN ('resolved', 'failed')
+                RETURNING session_id
             """, status, phase, json.dumps(resolution), session_id)
-            logger.info(f"Resolved session {session_id[:16]}... with status {status}")
-            return "UPDATE 1" in result
+            if row is not None:
+                logger.info(f"Resolved session {session_id[:16]}... with status {status}")
+                return True
+            # No row written: inspect why (idempotent replay vs conflict vs missing).
+            existing = await conn.fetchrow(
+                "SELECT status FROM core.dialectic_sessions WHERE session_id = $1",
+                session_id,
+            )
+            if existing is None:
+                logger.warning(f"resolve_session: {session_id[:16]}... not found")
+                return False
+            if existing["status"] == status:
+                logger.info(
+                    f"resolve_session: {session_id[:16]}... already {status} "
+                    "(idempotent no-op, overwrite prevented)"
+                )
+                return True
+            logger.warning(
+                f"resolve_session: {session_id[:16]}... already terminal as "
+                f"{existing['status']!r}; refused overwrite to {status!r}"
+            )
+            return False
 
     async def add_message(
         self,

--- a/tests/test_dialectic_db.py
+++ b/tests/test_dialectic_db.py
@@ -709,38 +709,45 @@ class TestUpdateSessionStatus:
 class TestResolveSession:
     @pytest.mark.asyncio
     async def test_resolve_session_success(self, db):
-        """resolve_session sets status, phase, resolution_json."""
+        """resolve_session sets status, phase, resolution_json via the guarded UPDATE."""
         instance, pool, conn = db
-        conn.execute = AsyncMock(return_value="UPDATE 1")
+        # B-4 guard: UPDATE...RETURNING now goes through fetchrow; a returned row
+        # means the terminal transition was performed.
+        conn.fetchrow = AsyncMock(return_value={"session_id": "sess-001"})
 
         resolution = {"outcome": "resumed", "conditions": ["monitor"]}
         result = await instance.resolve_session("sess-001", resolution)
 
         assert result is True
-        call_args = conn.execute.call_args[0]
-        # args: status, phase, resolution_json, session_id
+        call_args = conn.fetchrow.call_args_list[0][0]  # UPDATE...RETURNING
+        # args: sql, status, phase, resolution_json, session_id
         assert call_args[1] == "resolved"  # status
         assert call_args[2] == "resolved"  # phase matches status
         assert call_args[3] == json.dumps(resolution)
         assert call_args[4] == "sess-001"
+        assert "NOT IN ('resolved', 'failed')" in call_args[0]  # idempotent guard
 
     @pytest.mark.asyncio
     async def test_resolve_session_custom_status(self, db):
         """resolve_session accepts custom status (e.g. failed)."""
         instance, pool, conn = db
-        conn.execute = AsyncMock(return_value="UPDATE 1")
+        conn.fetchrow = AsyncMock(return_value={"session_id": "sess-001"})
 
         result = await instance.resolve_session("sess-001", {"x": 1}, status="failed")
         assert result is True
-        call_args = conn.execute.call_args[0]
+        call_args = conn.fetchrow.call_args_list[0][0]
         assert call_args[1] == "failed"   # status
         assert call_args[2] == "failed"   # phase matches status (no longer hardcoded 'resolved')
 
     @pytest.mark.asyncio
     async def test_resolve_session_not_found(self, db):
-        """resolve_session returns False when session missing."""
+        """resolve_session returns False when session missing.
+
+        The guarded UPDATE matches no row (fetchrow -> None); the follow-up
+        existence SELECT also returns None -> the session does not exist.
+        """
         instance, pool, conn = db
-        conn.execute = AsyncMock(return_value="UPDATE 0")
+        conn.fetchrow = AsyncMock(side_effect=[None, None])
 
         result = await instance.resolve_session("sess-nope", {"x": 1})
         assert result is False
@@ -1292,7 +1299,7 @@ class TestEdgeCases:
     async def test_resolve_session_serializes_complex_resolution(self, db):
         """resolve_session correctly JSON-serializes complex resolution objects."""
         instance, pool, conn = db
-        conn.execute = AsyncMock(return_value="UPDATE 1")
+        conn.fetchrow = AsyncMock(return_value={"session_id": "sess-complex"})
 
         resolution = {
             "outcome": "resumed",
@@ -1305,8 +1312,8 @@ class TestEdgeCases:
 
         await instance.resolve_session("sess-complex", resolution)
 
-        call_args = conn.execute.call_args[0]
-        # args: status, phase, resolution_json, session_id
+        call_args = conn.fetchrow.call_args_list[0][0]  # UPDATE...RETURNING
+        # args: sql, status, phase, resolution_json, session_id
         assert json.loads(call_args[3]) == resolution
 
     @pytest.mark.asyncio

--- a/tests/test_dialectic_resolve_idempotent.py
+++ b/tests/test_dialectic_resolve_idempotent.py
@@ -1,0 +1,107 @@
+"""
+Regression tests for the idempotent terminal-transition guard in
+DialecticDB.resolve_session (council 2026-06-28, "B-4").
+
+The guard makes SYNTHESIS->RESOLVED safe across *processes*: the conditional
+UPDATE (`WHERE status NOT IN ('resolved','failed')`) refuses to overwrite a
+session that is already terminal. This defends against a crash-recovery
+re-drive or a second writer (the forthcoming BEAM session owner) clobbering a
+committed resolution_json — something the in-process asyncio.Lock cannot do.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from src.dialectic_db import DialecticDB
+
+
+def _db_with_conn(conn):
+    """Build a DialecticDB whose pool.acquire() yields `conn`."""
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=conn)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=cm)
+    # _pool_is_alive() reads getattr(pool, '_closed', False); a bare MagicMock
+    # auto-creates a truthy `_closed`, which would trigger a backend refresh and
+    # replace our mock. Pin it False so _ensure_pool() no-ops.
+    pool._closed = False
+    return DialecticDB(pool=pool)
+
+
+@pytest.mark.asyncio
+async def test_fresh_resolve_performs_transition():
+    """A non-terminal session is resolved; the conditional UPDATE returns a row."""
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={"session_id": "sess-1"})
+    db = _db_with_conn(conn)
+
+    ok = await db.resolve_session("sess-1", {"verdict": "ok"}, status="resolved")
+
+    assert ok is True
+    # Only the UPDATE...RETURNING runs on the happy path (no follow-up SELECT).
+    assert conn.fetchrow.await_count == 1
+    sql = conn.fetchrow.await_args_list[0].args[0]
+    assert "NOT IN ('resolved', 'failed')" in sql, "guard predicate must be present"
+
+
+@pytest.mark.asyncio
+async def test_already_resolved_is_idempotent_noop():
+    """Re-resolving an already-resolved session returns True without overwrite."""
+    conn = MagicMock()
+    # UPDATE...RETURNING matches 0 rows (guard blocked) -> None;
+    # follow-up SELECT shows it is already in the requested terminal state.
+    conn.fetchrow = AsyncMock(side_effect=[None, {"status": "resolved"}])
+    db = _db_with_conn(conn)
+
+    ok = await db.resolve_session("sess-1", {"verdict": "second"}, status="resolved")
+
+    assert ok is True  # idempotent success, not a lie and not a failure
+    assert conn.fetchrow.await_count == 2  # UPDATE (no row) + status SELECT
+
+
+@pytest.mark.asyncio
+async def test_conflicting_terminal_state_refuses_overwrite():
+    """A failed session is NOT silently overwritten to resolved; returns False."""
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=[None, {"status": "failed"}])
+    db = _db_with_conn(conn)
+
+    ok = await db.resolve_session("sess-1", {"verdict": "late"}, status="resolved")
+
+    assert ok is False  # conflict surfaced, existing 'failed' resolution preserved
+    assert conn.fetchrow.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_missing_session_returns_false():
+    """Resolving a non-existent session_id returns False, not a phantom success."""
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=[None, None])
+    db = _db_with_conn(conn)
+
+    ok = await db.resolve_session("ghost", {"verdict": "x"}, status="resolved")
+
+    assert ok is False
+    assert conn.fetchrow.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_failed_status_sets_failed_phase():
+    """status='failed' writes phase='failed' (not hardcoded 'resolved')."""
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={"session_id": "sess-1"})
+    db = _db_with_conn(conn)
+
+    ok = await db.resolve_session("sess-1", {"reason": "stuck"}, status="failed")
+
+    assert ok is True
+    args = conn.fetchrow.await_args_list[0].args
+    # args: (sql, status, phase, resolution_json, session_id)
+    assert args[1] == "failed" and args[2] == "failed"


### PR DESCRIPTION
## What

First build slice of **dialectic-on-BEAM** — the database-layer correctness foundation that must land before a BEAM session owner can safely take over.

`DialecticDB.resolve_session` did an unconditional `UPDATE`, so a crash-recovery re-drive or a second (cross-process) writer could silently overwrite a committed `resolution_json`. The existing fix for this race is an **in-process `asyncio.Lock`** (`mcp_handlers/dialectic/session.py`) which by construction can't protect across processes — exactly the gap when BEAM becomes a writer.

This makes the UPDATE conditional (`WHERE status NOT IN ('resolved','failed')`) and disambiguates a no-row result:

| Outcome | Return |
|---|---|
| Transition performed | `True` |
| Already in **requested** terminal state | `True` (idempotent no-op, overwrite prevented) |
| Already in a **different** terminal state | `False` (conflict; existing resolution kept) |
| Session missing | `False` |

## Why now

Design-council ("B-4", 2026-06-28) named this as a hard prerequisite for moving dialectic session lifecycle onto BEAM. It's also a standalone correctness win today: it closes the TOCTOU overwrite at the DB layer, not just the in-process lock. Live table is clean (0 stuck sessions) — good moment.

## Scope / not in scope

- In scope: `resolve_session` guard + tests.
- Next (separate PRs): C1 (auto-resolve sweeper saga-inflight guard), then the BEAM `SessionServer` slice behind `UNITARES_DIALECTIC_BEAM_RESOLUTION` (default off).

## Tests

- New `tests/test_dialectic_resolve_idempotent.py`: fresh / idempotent-replay / conflicting-terminal / missing / failed-phase.
- Updated existing `TestResolveSession` + complex-serialization test for the `fetchrow…RETURNING` path.
- Full suite green: **11011 passed, 21 skipped**.

https://claude.ai/code/session_011Qw3sfs6vCjFwrqmbgxMhD