### PR TITLE
fix(dialectic): auto-resolve sweeper skips sessions with in-flight saga (C1)

### DIFF
--- a/src/dialectic_db.py
+++ b/src/dialectic_db.py
@@ -277,6 +277,39 @@ class DialecticDB:
             )
             return False
 
+    async def has_inflight_saga(self, session_id: str) -> bool:
+        """True if a non-terminal resolution saga is in flight for this session.
+
+        The BEAM session owner (forthcoming) claims a row in
+        ``coordination.session_resolution_sagas`` for the lifetime of a
+        SYNTHESIS->RESOLVED resolution. The Python auto-resolve sweeper must NOT
+        mark such a session ``failed`` or reassign its reviewer mid-resolution —
+        doing so would race the saga and corrupt the outcome. Non-terminal saga
+        states are: reserved, paused_agent_applied, both_agents_applied,
+        reverting (pg_committed / reverted are terminal and do not block).
+
+        Fail-open: any error (e.g. the saga table absent in a bare test schema)
+        returns False. That is safe — if no saga infrastructure is live, BEAM is
+        not writing sagas, so there is nothing to race.
+        """
+        await self._ensure_pool()
+        try:
+            async with self._pool.acquire() as conn:
+                row = await conn.fetchrow(
+                    """
+                    SELECT 1 FROM coordination.session_resolution_sagas
+                    WHERE session_id = $1
+                      AND state IN ('reserved', 'paused_agent_applied',
+                                    'both_agents_applied', 'reverting')
+                    LIMIT 1
+                    """,
+                    session_id,
+                )
+                return row is not None
+        except Exception as e:  # pragma: no cover - defensive fail-open
+            logger.debug(f"has_inflight_saga check failed for {session_id[:16]}...: {e}")
+            return False
+
     async def add_message(
         self,
         session_id: str,
@@ -467,6 +500,11 @@ async def get_all_sessions_by_agent_async(agent_id: str) -> List[Dict[str, Any]]
 async def is_agent_in_active_session_async(agent_id: str) -> bool:
     db = await get_dialectic_db()
     return await db.is_agent_in_active_session(agent_id)
+
+
+async def has_inflight_saga_async(session_id: str) -> bool:
+    db = await get_dialectic_db()
+    return await db.has_inflight_saga(session_id)
 
 
 async def has_recently_reviewed_async(reviewer_id: str, paused_agent_id: str, hours: int = 24) -> bool:

--- a/src/mcp_handlers/dialectic/auto_resolve.py
+++ b/src/mcp_handlers/dialectic/auto_resolve.py
@@ -16,6 +16,7 @@ from src.dialectic_db import (
     update_session_status_async,
     update_session_reviewer_async,
     add_message_async,
+    has_inflight_saga_async,
 )
 
 logger = get_logger(__name__)
@@ -102,6 +103,18 @@ async def auto_resolve_stuck_sessions() -> Dict[str, Any]:
             phase = session.get("phase")
 
             if not session_id:
+                continue
+
+            # Saga-inflight guard (C1, council 2026-06-28): if a BEAM session
+            # owner is mid-resolution for this session, skip it entirely this
+            # cycle. Marking it failed / reassigning its reviewer here would race
+            # the saga and corrupt the outcome. Fail-open (no saga infra -> no
+            # skip), so this is a no-op until BEAM begins writing sagas.
+            if await has_inflight_saga_async(session_id):
+                logger.info(
+                    f"Skipping stuck-session sweep for {session_id[:16]}...: "
+                    "resolution saga in flight (BEAM owns this transition)"
+                )
                 continue
 
             check_time = _parse_timestamp(session.get("updated_at") or session.get("created_at"))

--- a/tests/test_dialectic_auto_resolve.py
+++ b/tests/test_dialectic_auto_resolve.py
@@ -18,6 +18,19 @@ sys.path.insert(0, str(project_root))
 AUTO_RESOLVE = "src.mcp_handlers.dialectic.auto_resolve"
 
 
+@pytest.fixture(autouse=True)
+def _no_inflight_saga():
+    """Default the C1 saga-inflight guard to False (no BEAM saga in flight).
+
+    The sweeper now calls has_inflight_saga_async before touching a session;
+    these tests exercise the no-saga path. The guard behavior itself is covered
+    in test_dialectic_sweeper_saga_guard.py.
+    """
+    with patch(f"{AUTO_RESOLVE}.has_inflight_saga_async",
+               new_callable=AsyncMock, return_value=False):
+        yield
+
+
 def _make_mock_server(agents=None):
     mock = MagicMock()
     mock.agent_metadata = agents or {}

--- a/tests/test_dialectic_sweeper_saga_guard.py
+++ b/tests/test_dialectic_sweeper_saga_guard.py
@@ -1,0 +1,88 @@
+"""
+Regression tests for the auto-resolve sweeper saga-inflight guard (C1,
+council 2026-06-28).
+
+The periodic stuck-session sweeper writes status='failed' (and reassigns
+reviewers) on sessions inactive for >2h. Once the BEAM session owner drives a
+SYNTHESIS->RESOLVED resolution it holds a non-terminal row in
+coordination.session_resolution_sagas, possibly for >2h. The sweeper must skip
+such a session, or it races the saga and corrupts the outcome.
+"""
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+AUTO_RESOLVE = "src.mcp_handlers.dialectic.auto_resolve"
+
+
+def _old_time(hours: int) -> str:
+    return (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
+
+
+@pytest.mark.asyncio
+async def test_sweeper_skips_session_with_inflight_saga():
+    """A stuck session with an in-flight resolution saga is NOT touched."""
+    sessions = [
+        {
+            "session_id": "saga-inflight-1",
+            "updated_at": _old_time(5),
+            "paused_agent_id": "a1",
+            "reviewer_agent_id": "r1",
+            "phase": "synthesis",
+        }
+    ]
+    mock_update = AsyncMock()
+    mock_reviewer = AsyncMock()
+    mock_add_msg = AsyncMock()
+
+    with patch(f"{AUTO_RESOLVE}.get_active_sessions_async",
+               new_callable=AsyncMock, return_value=sessions), \
+         patch(f"{AUTO_RESOLVE}.has_inflight_saga_async",
+               new_callable=AsyncMock, return_value=True), \
+         patch(f"{AUTO_RESOLVE}.update_session_status_async", mock_update), \
+         patch(f"{AUTO_RESOLVE}.update_session_reviewer_async", mock_reviewer), \
+         patch(f"{AUTO_RESOLVE}.add_message_async", mock_add_msg):
+        from src.mcp_handlers.dialectic.auto_resolve import auto_resolve_stuck_sessions
+        result = await auto_resolve_stuck_sessions()
+
+    # The guard must prevent every write to the saga-owned session.
+    mock_update.assert_not_called()
+    mock_reviewer.assert_not_called()
+    mock_add_msg.assert_not_called()
+    assert result["resolved_count"] == 0
+    assert result["reassigned_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_sweeper_proceeds_when_no_inflight_saga():
+    """With no saga in flight, the sweeper still fails a long-stuck session."""
+    sessions = [
+        {
+            "session_id": "no-saga-1",
+            "updated_at": _old_time(5),
+            "paused_agent_id": "a1",
+            "reviewer_agent_id": None,
+            "phase": "thesis",
+        }
+    ]
+    mock_update = AsyncMock()
+    mock_add_msg = AsyncMock()
+
+    with patch(f"{AUTO_RESOLVE}.get_active_sessions_async",
+               new_callable=AsyncMock, return_value=sessions), \
+         patch(f"{AUTO_RESOLVE}.has_inflight_saga_async",
+               new_callable=AsyncMock, return_value=False), \
+         patch(f"{AUTO_RESOLVE}.update_session_status_async", mock_update), \
+         patch(f"{AUTO_RESOLVE}.add_message_async", mock_add_msg):
+        from src.mcp_handlers.dialectic.auto_resolve import auto_resolve_stuck_sessions
+        result = await auto_resolve_stuck_sessions()
+
+    mock_update.assert_called_once_with("no-saga-1", "failed")
+    assert result["resolved_count"] == 1


### PR DESCRIPTION
## What

Second prerequisite for **dialectic-on-BEAM** (stacked on #1171). The periodic stuck-session sweeper marks sessions `status='failed'` / reassigns reviewers after >2h inactivity, with **no awareness of an in-progress resolution**. When the BEAM session owner drives SYNTHESIS→RESOLVED it holds a non-terminal `coordination.session_resolution_sagas` row that can outlive the stuck threshold — so the sweeper would race it (falsely-fail a resolving session, or get overwritten). Split-brain.

Adds `DialecticDB.has_inflight_saga(session_id)` (+ `_async` wrapper): True iff a saga row is non-terminal (`reserved` / `paused_agent_applied` / `both_agents_applied` / `reverting`). The sweeper checks it at the top of the per-session loop and **skips entirely** when a saga is in flight.

## Safety

**Fail-open by construction** — any error (e.g. saga table absent in a bare schema) returns False, so this is a **no-op until BEAM begins writing sagas**. The saga table (migration 049) currently has 0 rows, so zero behavior change today.

## Tests

- New `tests/test_dialectic_sweeper_saga_guard.py`: skips when a saga is in flight; proceeds (fails a long-stuck session) when not.
- Existing auto-resolve tests get an autouse fixture defaulting the guard to False (no saga) — realistic path.
- Full suite green: **11013 passed, 21 skipped**.

## Stacking

Base = `claude/dialectic-resolve-idempotent` (#1171). Review/merge #1171 first; this retargets to master automatically once #1171 lands.

## Next

BEAM Slice 1 — `SessionServer` GenServer (`:transient`) + `SessionSupervisor` + `/v1/dialectic/resolve`, owning only synthesis→resolved behind `UNITARES_DIALECTIC_BEAM_RESOLUTION` (default off).

https://claude.ai/code/session_011Qw3sfs6vCjFwrqmbgxMhD