### PR TITLE
chore(scope): de-session last 'dialectic council' src comment

### DIFF
--- a/src/mcp_handlers/dialectic/handlers.py
+++ b/src/mcp_handlers/dialectic/handlers.py
@@ -1111,7 +1111,7 @@ def _synthetic_reviewer_enabled() -> bool:
     showing up (the historical failure mode: auto-select is disabled, no peer
     claims the slot, the session sits stuck for hours). The reviewer is a local
     model (gemma4) heterogeneous to Claude, so it satisfies the independence
-    requirement the 2026-06-02 dialectic council set: a genuine antithesis, not a
+    requirement the 2026-06-02 dialectic review set: a genuine antithesis, not a
     self-review at one remove. Set UNITARES_DIALECTIC_SYNTHETIC_REVIEWER=0 to fall
     back to pure peer/manual review (request leaves the slot open as before).
     """


### PR DESCRIPTION
<!-- scope-guard: allow-register -->

Orphaned tail of the src-comment register cleanup — `#1162` merged before this one line landed, so master still has `dialectic council` in a docstring at `src/mcp_handlers/dialectic/handlers.py:1114`. Changed to `dialectic review` (keeps the dialectic product concept; drops the AI-review-event register). Comment-only, `py_compile` clean. Closes the last register residue in `src/`.