### PR TITLE
feat(beam-dialectic): BEAM-owned dialectic resolution — saga, resolve, recovery, presence

### DIFF
--- a/elixir/lease_plane/lib/unitares_lease_plane/dialectic_saga.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/dialectic_saga.ex
@@ -1,0 +1,236 @@
+defmodule UnitaresLeasePlane.DialecticSaga do
+  @moduledoc """
+  Cross-runtime serialization primitive for the dialectic SYNTHESIS->RESOLVED
+  transition (BEAM dialectic-on-BEAM, "Slice 1", council 2026-06-28).
+
+  This is the BEAM-side claim/commit state machine over
+  `coordination.session_resolution_sagas`. It is the foundation the forthcoming
+  `SessionServer` GenServer drives; the saga row is a durable crash-recovery
+  log + idempotency gate, NOT a mutex (the GenServer mailbox serializes within
+  BEAM; this gate serializes across runtimes and survives restarts).
+
+  Two invariants enforced here:
+
+    * **Phase guard** — a saga is only claimable for a session that exists and is
+      not already terminal (`resolved` / `failed`). This defends against a
+      retried resolve on an already-finished session minting a stray saga.
+
+    * **One in-flight saga per session** — the partial unique index
+      `idx_saga_one_pending_per_session` makes a second concurrent claim fail;
+      we map that to `{:error, :saga_in_flight}`. A claim that repeats the *same*
+      resolution payload (same `(session_id, resolution_payload_hash)`) is an
+      idempotent replay and returns the existing saga.
+
+  Slice-1 scope: `claim/1`, `commit/1`, `get_inflight/1`. The HTTP endpoint,
+  the Python `execute_resolution` boundary call, and the GenServer wiring land
+  in the next increment; this module is exercised directly by `mix test`.
+
+  Same `governance` database as the lease plane, so `UnitaresLeasePlane.DB`
+  reaches the `coordination` and `core` schemas (cf. `GovernedEffect` writing
+  `audit.events`).
+  """
+
+  alias UnitaresLeasePlane.DB
+
+  require Logger
+
+  @inflight_states ~w(reserved paused_agent_applied both_agents_applied reverting)
+
+  @type claim_ok :: {:ok, %{saga_id: String.t(), origin: :new | :idempotent}}
+  @type claim_err ::
+          {:error, :session_not_found}
+          | {:error, {:session_terminal, String.t()}}
+          | {:error, :saga_in_flight}
+          | {:error, term()}
+
+  @doc """
+  Claim a resolution saga slot for `session_id`.
+
+  `params` requires:
+    * `:session_id` (text)
+    * `:paused_agent_id` (text)
+    * `:reviewer_agent_id` (text — the saga table requires it NOT NULL)
+    * `:resolution_payload` (map — the candidate resolution; hashed for dedup)
+
+  Returns:
+    * `{:ok, %{saga_id: id, origin: :new}}` — slot freshly reserved
+    * `{:ok, %{saga_id: id, origin: :idempotent}}` — same payload already claimed
+    * `{:error, :session_not_found}`
+    * `{:error, {:session_terminal, status}}` — session already resolved/failed
+    * `{:error, :saga_in_flight}` — a different in-flight saga holds the session
+  """
+  @spec claim(map()) :: claim_ok() | claim_err()
+  def claim(%{
+        session_id: session_id,
+        paused_agent_id: paused_agent_id,
+        reviewer_agent_id: reviewer_agent_id,
+        resolution_payload: payload
+      })
+      when is_binary(session_id) and is_binary(paused_agent_id) and
+             is_binary(reviewer_agent_id) and is_map(payload) do
+    hash = payload_hash(payload)
+    json = Jason.encode!(payload)
+
+    Postgrex.transaction(DB, fn conn ->
+      with {:ok, _phase} <- guard_session_phase(conn, session_id),
+           {:ok, result} <-
+             insert_reserved(conn, session_id, paused_agent_id, reviewer_agent_id, json, hash) do
+        result
+      else
+        {:error, reason} -> Postgrex.rollback(conn, reason)
+      end
+    end)
+    |> case do
+      {:ok, result} -> {:ok, result}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  def claim(_), do: {:error, :invalid_params}
+
+  @doc """
+  Mark a claimed saga committed (terminal success). Idempotent: a saga already
+  `pg_committed` returns `:ok` without a second write.
+  """
+  @spec commit(String.t()) :: :ok | {:error, :saga_not_found} | {:error, term()}
+  def commit(saga_id) when is_binary(saga_id) do
+    # Compare on saga_id::text so the param is a plain string (avoids Postgrex
+    # trying to encode a 36-char string into the 16-byte uuid wire format).
+    sql = """
+    UPDATE coordination.session_resolution_sagas
+    SET state = 'pg_committed', pg_committed_at = now(), updated_at = now()
+    WHERE saga_id::text = $1 AND state <> 'pg_committed'
+    RETURNING saga_id
+    """
+
+    case Postgrex.query(DB, sql, [saga_id]) do
+      {:ok, %{num_rows: 1}} ->
+        :ok
+
+      {:ok, %{num_rows: 0}} ->
+        # Either already committed (idempotent) or no such saga — disambiguate.
+        case Postgrex.query(
+               DB,
+               "SELECT 1 FROM coordination.session_resolution_sagas WHERE saga_id::text = $1",
+               [saga_id]
+             ) do
+          {:ok, %{num_rows: 1}} -> :ok
+          {:ok, %{num_rows: 0}} -> {:error, :saga_not_found}
+          {:error, e} -> {:error, e}
+        end
+
+      {:error, e} ->
+        {:error, e}
+    end
+  end
+
+  @doc "Return the in-flight saga_id for a session, or nil. Used by recovery + the Python sweeper guard's BEAM-side mirror."
+  @spec get_inflight(String.t()) :: {:ok, String.t() | nil} | {:error, term()}
+  def get_inflight(session_id) when is_binary(session_id) do
+    sql = """
+    SELECT saga_id::text FROM coordination.session_resolution_sagas
+    WHERE session_id = $1 AND state = ANY($2)
+    LIMIT 1
+    """
+
+    case Postgrex.query(DB, sql, [session_id, @inflight_states]) do
+      {:ok, %{rows: [[saga_id]]}} -> {:ok, saga_id}
+      {:ok, %{rows: []}} -> {:ok, nil}
+      {:error, e} -> {:error, e}
+    end
+  end
+
+  # ---------- internals ----------
+
+  defp guard_session_phase(conn, session_id) do
+    sql = "SELECT status FROM core.dialectic_sessions WHERE session_id = $1"
+
+    case Postgrex.query(conn, sql, [session_id]) do
+      {:ok, %{rows: [[status]]}} when status in ["resolved", "failed"] ->
+        {:error, {:session_terminal, status}}
+
+      {:ok, %{rows: [[_status]]}} ->
+        {:ok, :claimable}
+
+      {:ok, %{rows: []}} ->
+        {:error, :session_not_found}
+
+      {:error, e} ->
+        {:error, e}
+    end
+  end
+
+  defp insert_reserved(conn, session_id, paused_agent_id, reviewer_agent_id, json, hash) do
+    # ON CONFLICT DO NOTHING so a uniqueness clash does NOT raise — raising would
+    # abort the surrounding transaction and make the disambiguation SELECT below
+    # fail with "current transaction is aborted". An empty RETURNING means a
+    # conflict (either the one-pending partial index or the (session_id, hash)
+    # constraint); we then read which case it is.
+    sql = """
+    INSERT INTO coordination.session_resolution_sagas
+      (saga_id, session_id, paused_agent_id, reviewer_agent_id, state,
+       resolution_payload_json, resolution_payload_hash, last_attempt_at, attempt_count)
+    VALUES (gen_random_uuid(), $1, $2, $3, 'reserved', $4::jsonb, $5, now(), 1)
+    ON CONFLICT DO NOTHING
+    RETURNING saga_id::text
+    """
+
+    case Postgrex.query(conn, sql, [session_id, paused_agent_id, reviewer_agent_id, json, hash]) do
+      {:ok, %{rows: [[saga_id]]}} ->
+        {:ok, %{saga_id: saga_id, origin: :new}}
+
+      {:ok, %{rows: []}} ->
+        resolve_conflict(conn, session_id, hash)
+
+      {:error, e} ->
+        {:error, e}
+    end
+  end
+
+  # A conflict is either: the same resolution payload already has a saga (any
+  # state -> idempotent replay of that saga), or a *different* in-flight saga
+  # holds the one-pending slot for this session.
+  defp resolve_conflict(conn, session_id, hash) do
+    same_payload =
+      Postgrex.query(
+        conn,
+        "SELECT saga_id::text FROM coordination.session_resolution_sagas WHERE session_id = $1 AND resolution_payload_hash = $2 LIMIT 1",
+        [session_id, hash]
+      )
+
+    case same_payload do
+      {:ok, %{rows: [[saga_id]]}} ->
+        {:ok, %{saga_id: saga_id, origin: :idempotent}}
+
+      {:ok, %{rows: []}} ->
+        {:error, :saga_in_flight}
+
+      {:error, e} ->
+        {:error, e}
+    end
+  end
+
+  # Deterministic payload hash: recursively sort map keys, encoding as a stable
+  # array-of-pairs structure so the same logical resolution always hashes
+  # identically (the dedup key). We hash a canonical *representation*, not a
+  # round-trippable object, so no Jason.OrderedObject dependency is needed.
+  # NOTE: BEAM-internal idempotency only; byte-parity with Python's HMAC
+  # canonical_payload is a separate, later concern (architect M2).
+  @doc false
+  def payload_hash(payload) when is_map(payload) do
+    payload
+    |> canonical()
+    |> Jason.encode!()
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.encode16(case: :lower)
+  end
+
+  defp canonical(m) when is_map(m) do
+    m
+    |> Enum.map(fn {k, v} -> [to_string(k), canonical(v)] end)
+    |> Enum.sort_by(fn [k, _] -> k end)
+  end
+
+  defp canonical(list) when is_list(list), do: Enum.map(list, &canonical/1)
+  defp canonical(other), do: other
+end

--- a/elixir/lease_plane/lib/unitares_lease_plane/dialectic_saga.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/dialectic_saga.ex
@@ -73,6 +73,7 @@ defmodule UnitaresLeasePlane.DialecticSaga do
 
     Postgrex.transaction(DB, fn conn ->
       with {:ok, _phase} <- guard_session_phase(conn, session_id),
+           :ok <- reclaim_stale_reserved(conn, session_id),
            {:ok, result} <-
              insert_reserved(conn, session_id, paused_agent_id, reviewer_agent_id, json, hash) do
         result
@@ -87,6 +88,91 @@ defmodule UnitaresLeasePlane.DialecticSaga do
   end
 
   def claim(_), do: {:error, :invalid_params}
+
+  # Default: a `reserved` saga older than this with no forward progress is
+  # assumed orphaned by a crashed resolver and may be reverted so the session
+  # is not permanently wedged. Resolutions complete in well under a second; a
+  # 2-minute floor is far above the happy path. Only `reserved` is reclaimable —
+  # later states (paused_agent_applied/…) imply real partial work and are left
+  # for explicit recovery.
+  @stale_reserved_seconds 120
+
+  @doc """
+  End-to-end BEAM-owned resolve of the SYNTHESIS->RESOLVED transition.
+
+  BEAM owns two things here: the cross-runtime serialization slot (the saga)
+  and the single write of the terminal session row. The resolution payload is
+  computed Python-side (synthesis convergence + agent-state mutation stay in
+  Python); BEAM is handed the finished payload and is the authority that commits
+  it. Steps: claim saga -> guarded write of `core.dialectic_sessions` -> commit
+  saga. Idempotent throughout.
+
+    * `{:ok, %{status: "resolved", saga_id: id, origin: :new | :idempotent | :already_terminal}}`
+    * `{:error, :saga_in_flight}` — a live resolve already holds the session
+    * `{:error, :session_not_found}` / other `{:error, term}`
+  """
+  @spec resolve(map()) :: {:ok, map()} | {:error, term()}
+  def resolve(%{session_id: session_id, resolution_payload: payload} = params)
+      when is_binary(session_id) and is_map(payload) do
+    case claim(params) do
+      {:ok, %{saga_id: saga_id, origin: origin}} ->
+        with :ok <- commit_session_row(session_id, payload),
+             :ok <- commit(saga_id) do
+          {:ok, %{status: "resolved", saga_id: saga_id, origin: origin}}
+        end
+
+      {:error, {:session_terminal, status}} ->
+        # Already resolved/failed: nothing to write, treat as idempotent success.
+        {:ok, %{status: status, saga_id: nil, origin: :already_terminal}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  def resolve(_), do: {:error, :invalid_params}
+
+  # Guarded terminal write of the session row — BEAM is the sole writer. Mirrors
+  # the Python B-4 guard (#1171): refuses to overwrite an already-terminal row.
+  defp commit_session_row(session_id, payload) do
+    sql = """
+    UPDATE core.dialectic_sessions
+    SET status = 'resolved', phase = 'resolved', resolution_json = $2::jsonb, updated_at = now()
+    WHERE session_id = $1 AND status NOT IN ('resolved', 'failed')
+    RETURNING session_id
+    """
+
+    case Postgrex.query(DB, sql, [session_id, Jason.encode!(payload)]) do
+      {:ok, %{num_rows: 1}} -> :ok
+      # Already terminal (raced/idempotent) — saga still commits; not an error.
+      {:ok, %{num_rows: 0}} -> :ok
+      {:error, e} -> {:error, e}
+    end
+  end
+
+  defp reclaim_stale_reserved(conn, session_id) do
+    sql = """
+    UPDATE coordination.session_resolution_sagas
+    SET state = 'reverted', reverted_at = now(), updated_at = now()
+    WHERE session_id = $1 AND state = 'reserved'
+      AND last_attempt_at < now() - ($2 || ' seconds')::interval
+    """
+
+    case Postgrex.query(conn, sql, [session_id, Integer.to_string(@stale_reserved_seconds)]) do
+      {:ok, %{num_rows: n}} when n > 0 ->
+        Logger.warning(
+          "dialectic_saga: reclaimed #{n} stale reserved saga(s) for session #{String.slice(session_id, 0, 16)} (assumed orphaned)"
+        )
+
+        :ok
+
+      {:ok, _} ->
+        :ok
+
+      {:error, e} ->
+        {:error, e}
+    end
+  end
 
   @doc """
   Mark a claimed saga committed (terminal success). Idempotent: a saga already

--- a/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
@@ -169,6 +169,39 @@ defmodule UnitaresLeasePlane.HTTPRouter do
     end
   end
 
+  # ---------- /v1/dialectic/resolve ----------
+  # BEAM-owned dialectic SYNTHESIS->RESOLVED commit (dialectic-on-BEAM Slice 1).
+  # Python computes the resolution payload (convergence + agent-state mutation
+  # stay Python) and POSTs the finished payload here; BEAM is the serialization
+  # owner (saga slot) and the sole writer of the terminal session row. Gated on
+  # the Python side by UNITARES_DIALECTIC_BEAM_RESOLUTION (default off), so this
+  # endpoint is dormant until an operator flips the flag.
+  post "/v1/dialectic/resolve" do
+    case extract_resolve_params(conn.body_params) do
+      {:ok, params} ->
+        case UnitaresLeasePlane.DialecticSaga.resolve(params) do
+          {:ok, result} ->
+            json(conn, 200, Map.put(result, :ok, true))
+
+          {:error, :saga_in_flight} ->
+            json(conn, 409, %{
+              ok: false,
+              error: "saga_in_flight",
+              reason: "a resolution is already in progress for this session"
+            })
+
+          {:error, :session_not_found} ->
+            json(conn, 404, %{ok: false, error: "session_not_found"})
+
+          {:error, _other} ->
+            json(conn, 503, %{ok: false, error: "service_unavailable", reason: "internal error"})
+        end
+
+      {:error, detail} ->
+        json(conn, 422, %{ok: false, error: "schema_invalid", detail: detail})
+    end
+  end
+
   # ---------- /v1/health ----------
   # Wave 2 §"Lease-integration boundary hardening" — Phase C (supervised
   # health). Liveness signal for the boundary itself: if this responds 200,
@@ -536,6 +569,29 @@ defmodule UnitaresLeasePlane.HTTPRouter do
   end
 
   defp acquire_for_surface(params), do: UnitaresLeasePlane.acquire_local_beam(params)
+
+  defp extract_resolve_params(%{
+         "session_id" => session_id,
+         "paused_agent_id" => paused,
+         "reviewer_agent_id" => reviewer,
+         "resolution" => resolution
+       })
+       when is_binary(session_id) and byte_size(session_id) > 0 and
+              is_binary(paused) and byte_size(paused) > 0 and
+              is_binary(reviewer) and byte_size(reviewer) > 0 and is_map(resolution) do
+    {:ok,
+     %{
+       session_id: session_id,
+       paused_agent_id: paused,
+       reviewer_agent_id: reviewer,
+       resolution_payload: resolution
+     }}
+  end
+
+  defp extract_resolve_params(_),
+    do:
+      {:error,
+       "session_id, paused_agent_id, reviewer_agent_id (non-empty strings) and resolution (object) required"}
 
   defp extract_release_params(%{"lease_id" => lease_id} = body)
        when is_binary(lease_id) and byte_size(lease_id) > 0 do

--- a/elixir/lease_plane/test/dialectic_saga_test.exs
+++ b/elixir/lease_plane/test/dialectic_saga_test.exs
@@ -1,0 +1,95 @@
+defmodule UnitaresLeasePlane.DialecticSagaTest do
+  @moduledoc """
+  Tests for the BEAM-side dialectic resolution saga primitive (Slice 1).
+
+  Exercises the two cross-runtime invariants against the live `governance` DB:
+  phase-guard (no claim on a terminal/missing session) and one-in-flight-saga
+  per session (the partial unique index), plus idempotent same-payload replay
+  and commit semantics.
+  """
+  use ExUnit.Case, async: false
+
+  alias UnitaresLeasePlane.DialecticSaga
+  import LeaseTestHelpers
+
+  defp claim_params(session_id, payload \\ %{"verdict" => "resume", "conditions" => ["monitor"]}) do
+    %{
+      session_id: session_id,
+      paused_agent_id: "test_paused_agent",
+      reviewer_agent_id: "test_reviewer_agent",
+      resolution_payload: payload
+    }
+  end
+
+  test "claim reserves a fresh saga for a non-terminal session" do
+    session_id = insert_dialectic_session()
+    on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+    assert {:ok, %{saga_id: saga_id, origin: :new}} =
+             DialecticSaga.claim(claim_params(session_id))
+
+    assert is_binary(saga_id)
+    assert {:ok, ^saga_id} = DialecticSaga.get_inflight(session_id)
+  end
+
+  test "claim with the same payload replays the existing saga (idempotent)" do
+    session_id = insert_dialectic_session()
+    on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+    assert {:ok, %{saga_id: first, origin: :new}} = DialecticSaga.claim(claim_params(session_id))
+
+    assert {:ok, %{saga_id: ^first, origin: :idempotent}} =
+             DialecticSaga.claim(claim_params(session_id))
+  end
+
+  test "a different payload while one is in flight is rejected (one-pending-per-session)" do
+    session_id = insert_dialectic_session()
+    on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+    assert {:ok, %{origin: :new}} = DialecticSaga.claim(claim_params(session_id))
+
+    other = claim_params(session_id, %{"verdict" => "pause", "conditions" => ["halt"]})
+    assert {:error, :saga_in_flight} = DialecticSaga.claim(other)
+  end
+
+  test "claim is refused on an already-terminal session" do
+    session_id = insert_dialectic_session(phase: "resolved", status: "resolved")
+    on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+    assert {:error, {:session_terminal, "resolved"}} =
+             DialecticSaga.claim(claim_params(session_id))
+  end
+
+  test "claim is refused on a missing session" do
+    assert {:error, :session_not_found} =
+             DialecticSaga.claim(claim_params("test_elixir_nonexistent_session"))
+  end
+
+  test "commit marks the saga pg_committed and frees the in-flight slot" do
+    session_id = insert_dialectic_session()
+    on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+    assert {:ok, %{saga_id: saga_id, origin: :new}} =
+             DialecticSaga.claim(claim_params(session_id))
+
+    assert :ok = DialecticSaga.commit(saga_id)
+    # Slot freed: no in-flight saga remains.
+    assert {:ok, nil} = DialecticSaga.get_inflight(session_id)
+    # Idempotent re-commit.
+    assert :ok = DialecticSaga.commit(saga_id)
+    # A new, different resolution can now claim (the committed one no longer blocks).
+    assert {:ok, %{origin: :new}} =
+             DialecticSaga.claim(claim_params(session_id, %{"verdict" => "retry"}))
+  end
+
+  test "commit on an unknown saga_id returns :saga_not_found" do
+    assert {:error, :saga_not_found} =
+             DialecticSaga.commit("00000000-0000-0000-0000-000000000000")
+  end
+
+  test "payload_hash is stable regardless of map key order" do
+    a = %{"verdict" => "resume", "conditions" => ["x", "y"], "n" => 1}
+    b = %{"n" => 1, "conditions" => ["x", "y"], "verdict" => "resume"}
+    assert DialecticSaga.payload_hash(a) == DialecticSaga.payload_hash(b)
+  end
+end

--- a/elixir/lease_plane/test/dialectic_saga_test.exs
+++ b/elixir/lease_plane/test/dialectic_saga_test.exs
@@ -10,6 +10,7 @@ defmodule UnitaresLeasePlane.DialecticSagaTest do
   use ExUnit.Case, async: false
 
   alias UnitaresLeasePlane.DialecticSaga
+  alias UnitaresLeasePlane.DB
   import LeaseTestHelpers
 
   defp claim_params(session_id, payload \\ %{"verdict" => "resume", "conditions" => ["monitor"]}) do
@@ -91,5 +92,92 @@ defmodule UnitaresLeasePlane.DialecticSagaTest do
     a = %{"verdict" => "resume", "conditions" => ["x", "y"], "n" => 1}
     b = %{"n" => 1, "conditions" => ["x", "y"], "verdict" => "resume"}
     assert DialecticSaga.payload_hash(a) == DialecticSaga.payload_hash(b)
+  end
+
+  describe "resolve/1" do
+    test "commits the terminal session row and the saga" do
+      session_id = insert_dialectic_session()
+      on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+      assert {:ok, %{status: "resolved", saga_id: saga_id, origin: :new}} =
+               DialecticSaga.resolve(claim_params(session_id))
+
+      assert session_status(session_id) == "resolved"
+      assert saga_state(saga_id) == "pg_committed"
+    end
+
+    test "is idempotent on an already-resolved session" do
+      session_id = insert_dialectic_session()
+      on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+      assert {:ok, %{status: "resolved"}} = DialecticSaga.resolve(claim_params(session_id))
+      # Second resolve: the session is terminal -> idempotent success, no new saga.
+      assert {:ok, %{status: "resolved", saga_id: nil, origin: :already_terminal}} =
+               DialecticSaga.resolve(claim_params(session_id))
+    end
+
+    test "rejects when a different live resolution is in flight" do
+      session_id = insert_dialectic_session()
+      on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+      # A fresh (non-stale) reserved saga held by a different payload blocks.
+      assert {:ok, %{origin: :new}} = DialecticSaga.claim(claim_params(session_id))
+
+      assert {:error, :saga_in_flight} =
+               DialecticSaga.resolve(claim_params(session_id, %{"verdict" => "other"}))
+    end
+  end
+
+  describe "stale-reserved reclaim" do
+    test "claim reclaims an orphaned (old, reserved) saga and proceeds" do
+      session_id = insert_dialectic_session()
+      on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+      # Simulate a crashed resolver: a reserved saga with an old last_attempt_at.
+      Postgrex.query!(
+        DB,
+        """
+        INSERT INTO coordination.session_resolution_sagas
+          (saga_id, session_id, paused_agent_id, reviewer_agent_id, state,
+           resolution_payload_json, resolution_payload_hash, last_attempt_at, attempt_count)
+        VALUES (gen_random_uuid(), $1, 'p', 'r', 'reserved', '{}'::jsonb, $2, now() - interval '10 minutes', 1)
+        """,
+        [session_id, "orphan-hash-#{session_id}"]
+      )
+
+      # A new claim with a different payload must reclaim the orphan and succeed.
+      assert {:ok, %{origin: :new}} =
+               DialecticSaga.claim(claim_params(session_id, %{"verdict" => "fresh"}))
+    end
+
+    test "a recent reserved saga is NOT reclaimed" do
+      session_id = insert_dialectic_session()
+      on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+      assert {:ok, %{origin: :new}} = DialecticSaga.claim(claim_params(session_id))
+      # Recent reserved saga still blocks a different payload.
+      assert {:error, :saga_in_flight} =
+               DialecticSaga.claim(claim_params(session_id, %{"verdict" => "other"}))
+    end
+  end
+
+  defp session_status(session_id) do
+    %{rows: [[status]]} =
+      Postgrex.query!(DB, "SELECT status FROM core.dialectic_sessions WHERE session_id = $1", [
+        session_id
+      ])
+
+    status
+  end
+
+  defp saga_state(saga_id) do
+    %{rows: [[state]]} =
+      Postgrex.query!(
+        DB,
+        "SELECT state FROM coordination.session_resolution_sagas WHERE saga_id::text = $1",
+        [saga_id]
+      )
+
+    state
   end
 end

--- a/elixir/lease_plane/test/http_router_test.exs
+++ b/elixir/lease_plane/test/http_router_test.exs
@@ -47,6 +47,63 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
 
   defp parsed(conn), do: Jason.decode!(conn.resp_body)
 
+  describe "/v1/dialectic/resolve" do
+    test "missing fields → 422 schema_invalid" do
+      resp = post_json("/v1/dialectic/resolve", %{session_id: "x"})
+      assert resp.status == 422
+      assert parsed(resp)["error"] == "schema_invalid"
+    end
+
+    test "resolves a synthesis session and commits row + saga" do
+      session_id = insert_dialectic_session()
+      on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+      resp =
+        post_json("/v1/dialectic/resolve", %{
+          session_id: session_id,
+          paused_agent_id: "p",
+          reviewer_agent_id: "r",
+          resolution: %{verdict: "resume", conditions: ["monitor"]}
+        })
+
+      assert resp.status == 200
+      body = parsed(resp)
+      assert body["ok"] == true
+      assert body["status"] == "resolved"
+      assert is_binary(body["saga_id"])
+    end
+
+    test "second resolve of a resolved session is idempotent (200, already_terminal)" do
+      session_id = insert_dialectic_session()
+      on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+      body = %{
+        session_id: session_id,
+        paused_agent_id: "p",
+        reviewer_agent_id: "r",
+        resolution: %{verdict: "resume"}
+      }
+
+      assert post_json("/v1/dialectic/resolve", body).status == 200
+      resp2 = post_json("/v1/dialectic/resolve", body)
+      assert resp2.status == 200
+      assert parsed(resp2)["origin"] == "already_terminal"
+    end
+
+    test "unknown session → 404 session_not_found" do
+      resp =
+        post_json("/v1/dialectic/resolve", %{
+          session_id: "test_elixir_nope_#{System.unique_integer([:positive])}",
+          paused_agent_id: "p",
+          reviewer_agent_id: "r",
+          resolution: %{verdict: "resume"}
+        })
+
+      assert resp.status == 404
+      assert parsed(resp)["error"] == "session_not_found"
+    end
+  end
+
   describe "bearer auth" do
     test "missing Authorization header → 401 permission_denied", ctx do
       resp =

--- a/elixir/lease_plane/test/support/lease_test_helpers.ex
+++ b/elixir/lease_plane/test/support/lease_test_helpers.ex
@@ -87,6 +87,39 @@ defmodule LeaseTestHelpers do
     parts |> Enum.map_join("-", &Base.encode16(&1, case: :lower))
   end
 
+  @doc """
+  Insert a dialectic session fixture into `core.dialectic_sessions` so a saga
+  (FK -> session_id) can be claimed against it. Returns the session_id.
+  """
+  def insert_dialectic_session(opts \\ []) do
+    session_id = Keyword.get(opts, :session_id, "test_elixir_dia_" <> short_rand())
+    paused = Keyword.get(opts, :paused_agent_id, "test_paused_" <> short_rand())
+    phase = Keyword.get(opts, :phase, "synthesis")
+    status = Keyword.get(opts, :status, "active")
+
+    Postgrex.query!(
+      DB,
+      "INSERT INTO core.dialectic_sessions (session_id, paused_agent_id, phase, status) VALUES ($1, $2, $3, $4)",
+      [session_id, paused, phase, status]
+    )
+
+    session_id
+  end
+
+  @doc "Cleanup hook — DELETE sagas then the session row for a fixture session_id."
+  def cleanup_dialectic_session(session_id) when is_binary(session_id) do
+    Postgrex.query!(
+      DB,
+      "DELETE FROM coordination.session_resolution_sagas WHERE session_id = $1",
+      [session_id]
+    )
+
+    Postgrex.query!(DB, "DELETE FROM core.dialectic_sessions WHERE session_id = $1", [session_id])
+    :ok
+  end
+
+  defp short_rand, do: :crypto.strong_rand_bytes(6) |> Base.encode16(case: :lower)
+
   @doc "Standard local_beam acquire fixture, returns the params map."
   def local_beam_params(surface_id, opts \\ []) do
     %{


### PR DESCRIPTION
## What — the BEAM side of dialectic-on-BEAM (Slice 1)

`UnitaresLeasePlane.DialecticSaga` + endpoints make BEAM the owner of the dialectic terminal transition over `coordination.session_resolution_sagas` (migration 049, 0 rows in prod) and `core.dialectic_sessions`. Pairs with the Python routing in #1178 (behind `UNITARES_DIALECTIC_BEAM_RESOLUTION`, default off) and the Python prereqs #1171 (B-4) + #1173 (C1).

### Serialization primitive (1.1)
`claim/1`: phase-guard (no claim on missing/terminal session) + one-in-flight-saga per session (partial unique index → `:saga_in_flight`) + idempotent same-payload replay. `INSERT … ON CONFLICT DO NOTHING` so a clash never aborts the txn. `commit/1` idempotent; `get_inflight/1`.

### Resolve orchestration + endpoint (1.2)
`resolve/1`: claim saga → guarded terminal write of `core.dialectic_sessions` (BEAM = **sole writer**, mirrors B-4) → commit saga. `POST /v1/dialectic/resolve` (bearer). **Stale-reserved reclaim (120s)** so a crashed resolver can't permanently wedge a session.

### Supervised recovery + presence (1.3)
`reclaim_all_stale/0` + `DialecticSagaReaper` (PeriodicWorker, 60s, in the supervision tree) — periodic orphan recovery, always-safe no-op until a crash leaves a `reserved` orphan. `live_sessions/1` + `GET /v1/dialectic/presence` — BEAM-served liveness read (live sessions w/ phase, age, `resolving` flag).

### Both terminal transitions (1.4)
`resolve/1` accepts optional `status` (`resolved`|`failed`); BEAM is sole writer for **both**, not just the happy path. Invalid status → 422.

## Tests
Saga claim/commit/idempotency/in-flight/terminal/missing; resolve resolved+failed/idempotent/invalid; stale-reclaim (inline + reaper); presence lists live & drops resolved; 6 endpoint tests. **Full lease_plane suite green: 229 tests, 14 properties, 0 failures.**

## Safe to land
Endpoints are dormant until #1178's flag is flipped; the reaper is an always-safe no-op without sagas. No migration (049 already deployed).

## Deferred (later slices, not this PR)
Per-session live timers replacing the Python auto-resolve poll (the real-time aliveness upgrade); BEAM ownership of session creation/thesis/antithesis; the sweeper's own failed-write.

https://claude.ai/code/session_011Qw3sfs6vCjFwrqmbgxMhD