### PR TITLE
fix(dialectic): saga-slot advisory lock on phase transitions (BEAM-port prereq)

### DIFF
--- a/src/dialectic_db.py
+++ b/src/dialectic_db.py
@@ -16,6 +16,25 @@ from src.db.acquire_compat import compatible_acquire
 logger = get_logger(__name__)
 
 
+# Saga-slot namespace for dialectic phase transitions (BEAM-port prerequisite).
+# A transaction-scoped PG advisory lock keyed on this int4 classid + the session
+# id is the *cross-process* serialization point for phase/status mutations on
+# core.dialectic_sessions. The in-process asyncio.Lock in
+# mcp_handlers/dialectic/session.py only serializes one Python process; this lock
+# is honored by every writer — a second Python worker, the REST path, and a
+# future BEAM GenServer alike — so dual-writer becomes SAFE rather than
+# split-brain. That is the correctness prerequisite the dialectic-on-BEAM port
+# needs, and it also closes the already-documented intra-Python double-resolve
+# race (session.py NEW-1).
+#
+# 0x444C5048 = 'DLPH'. Deliberately DISJOINT from the agent-lock advisory
+# namespace (0x41474E54 'AGNT', src/services/update_workflow_service.py) so the
+# two lock spaces never collide (PR #1017 council note on advisory lock-space
+# separation). Both use the two-arg pg_advisory_*_lock(classid int4, key int4)
+# form, which lives in a different space from the single-arg form.
+_DIALECTIC_PHASE_LOCK_NS = 0x444C5048
+
+
 # =============================================================================
 # PostgreSQL Backend (Primary and Only)
 # =============================================================================
@@ -190,38 +209,59 @@ class DialecticDB:
                     sessions.append(session)
             return sessions
 
+    async def _acquire_phase_slot(self, conn, session_id: str) -> None:
+        """Take the transaction-scoped saga slot for a session's phase line.
+
+        MUST be called as the first statement inside the same transaction as a
+        phase/status mutation. pg_advisory_xact_lock auto-releases at COMMIT/
+        ROLLBACK, so there is no unlock to leak (unlike a session-level lock).
+        Serializes every cross-process writer of this session's phase — see
+        _DIALECTIC_PHASE_LOCK_NS.
+        """
+        await conn.execute(
+            "SELECT pg_advisory_xact_lock($1, hashtext($2))",
+            _DIALECTIC_PHASE_LOCK_NS,
+            session_id,
+        )
+
     async def update_session_phase(self, session_id: str, phase: str) -> bool:
-        """Update session phase/status."""
+        """Update session phase/status (saga-slot serialized)."""
         await self._ensure_pool()
         async with self._pool.acquire() as conn:
-            result = await conn.execute("""
-                UPDATE core.dialectic_sessions
-                SET phase = $1, updated_at = now()
-                WHERE session_id = $2
-            """, phase, session_id)
-            return "UPDATE 1" in result
+            async with conn.transaction():
+                await self._acquire_phase_slot(conn, session_id)
+                result = await conn.execute("""
+                    UPDATE core.dialectic_sessions
+                    SET phase = $1, updated_at = now()
+                    WHERE session_id = $2
+                """, phase, session_id)
+                return "UPDATE 1" in result
 
     async def update_session_reviewer(self, session_id: str, reviewer_agent_id: str) -> bool:
-        """Assign reviewer to session."""
+        """Assign reviewer to session (saga-slot serialized)."""
         await self._ensure_pool()
         async with self._pool.acquire() as conn:
-            result = await conn.execute("""
-                UPDATE core.dialectic_sessions
-                SET reviewer_agent_id = $1, updated_at = now()
-                WHERE session_id = $2
-            """, reviewer_agent_id, session_id)
-            return "UPDATE 1" in result
+            async with conn.transaction():
+                await self._acquire_phase_slot(conn, session_id)
+                result = await conn.execute("""
+                    UPDATE core.dialectic_sessions
+                    SET reviewer_agent_id = $1, updated_at = now()
+                    WHERE session_id = $2
+                """, reviewer_agent_id, session_id)
+                return "UPDATE 1" in result
 
     async def update_session_status(self, session_id: str, status: str) -> bool:
-        """Update session status (e.g., to 'failed' for auto-resolve)."""
+        """Update session status (e.g., to 'failed' for auto-resolve); saga-slot serialized."""
         await self._ensure_pool()
         async with self._pool.acquire() as conn:
-            result = await conn.execute("""
-                UPDATE core.dialectic_sessions
-                SET status = $1, phase = $1, updated_at = now()
-                WHERE session_id = $2
-            """, status, session_id)
-            return "UPDATE 1" in result
+            async with conn.transaction():
+                await self._acquire_phase_slot(conn, session_id)
+                result = await conn.execute("""
+                    UPDATE core.dialectic_sessions
+                    SET status = $1, phase = $1, updated_at = now()
+                    WHERE session_id = $2
+                """, status, session_id)
+                return "UPDATE 1" in result
 
     async def resolve_session(
         self,
@@ -229,18 +269,26 @@ class DialecticDB:
         resolution: Dict[str, Any],
         status: str = "resolved"
     ) -> bool:
-        """Mark session as resolved or failed with resolution data."""
+        """Mark session as resolved or failed with resolution data (saga-slot serialized).
+
+        The saga slot closes the NEW-1 race: two concurrent synthesis calls that
+        both pass the in-memory SYNTHESIS-phase check can no longer both write a
+        resolution — the second serializes behind the first and sees the
+        committed terminal state.
+        """
         await self._ensure_pool()
         # Phase should match status - don't hardcode 'resolved' when status is 'failed'
         phase = "resolved" if status == "resolved" else status
         async with self._pool.acquire() as conn:
-            result = await conn.execute("""
-                UPDATE core.dialectic_sessions
-                SET status = $1, phase = $2, resolution_json = $3, updated_at = now()
-                WHERE session_id = $4
-            """, status, phase, json.dumps(resolution), session_id)
-            logger.info(f"Resolved session {session_id[:16]}... with status {status}")
-            return "UPDATE 1" in result
+            async with conn.transaction():
+                await self._acquire_phase_slot(conn, session_id)
+                result = await conn.execute("""
+                    UPDATE core.dialectic_sessions
+                    SET status = $1, phase = $2, resolution_json = $3, updated_at = now()
+                    WHERE session_id = $4
+                """, status, phase, json.dumps(resolution), session_id)
+                logger.info(f"Resolved session {session_id[:16]}... with status {status}")
+                return "UPDATE 1" in result
 
     async def add_message(
         self,

--- a/tests/test_dialectic_db.py
+++ b/tests/test_dialectic_db.py
@@ -53,6 +53,14 @@ def _make_mock_pool():
     acm.__aexit__ = AsyncMock(return_value=False)
     pool.acquire.return_value = acm
 
+    # conn.transaction() is a SYNC call returning an async context manager
+    # (asyncpg semantics). The phase-mutating writers wrap their advisory-lock +
+    # UPDATE in `async with conn.transaction():` (the saga slot).
+    txn = AsyncMock()
+    txn.__aenter__ = AsyncMock(return_value=None)
+    txn.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction = MagicMock(return_value=txn)
+
     return pool, conn
 
 
@@ -632,8 +640,9 @@ class TestUpdateSessionPhase:
 
         result = await instance.update_session_phase("sess-001", "antithesis")
         assert result is True
-        conn.execute.assert_awaited_once()
-        call_args = conn.execute.call_args[0]
+        # Two awaited execs now: the saga-slot advisory lock, then the UPDATE.
+        assert conn.execute.await_count == 2
+        call_args = conn.execute.call_args[0]  # last call == the UPDATE
         assert call_args[1] == "antithesis"
         assert call_args[2] == "sess-001"
 
@@ -1386,3 +1395,63 @@ class TestEdgeCases:
         assert result["resolution"] == resolution
         assert "paused_agent_state_json" not in result
         assert "resolution_json" not in result
+
+
+# ============================================================================
+# Saga slot — cross-process phase-transition serialization (BEAM-port prereq)
+# ============================================================================
+
+from src.dialectic_db import _DIALECTIC_PHASE_LOCK_NS
+
+
+class TestPhaseSagaSlot:
+    """Every phase/status writer must take the transaction-scoped advisory slot
+    BEFORE its UPDATE, so a second Python worker / the REST path / a future BEAM
+    GenServer serialize on the same key instead of split-braining the row."""
+
+    def _assert_slot_then_update(self, conn, session_id):
+        # opened exactly one transaction
+        conn.transaction.assert_called_once()
+        calls = conn.execute.await_args_list
+        assert len(calls) == 2, "expected advisory-lock SELECT then UPDATE"
+        lock_sql, lock_args = calls[0][0][0], calls[0][0]
+        assert "pg_advisory_xact_lock" in lock_sql
+        assert lock_args[1] == _DIALECTIC_PHASE_LOCK_NS
+        assert lock_args[2] == session_id
+        # the UPDATE is the second statement, strictly after the lock
+        assert "UPDATE core.dialectic_sessions" in calls[1][0][0]
+
+    @pytest.mark.asyncio
+    async def test_update_session_phase_takes_slot_first(self, db):
+        instance, pool, conn = db
+        conn.execute = AsyncMock(return_value="UPDATE 1")
+        await instance.update_session_phase("sess-A", "synthesis")
+        self._assert_slot_then_update(conn, "sess-A")
+
+    @pytest.mark.asyncio
+    async def test_update_session_status_takes_slot_first(self, db):
+        instance, pool, conn = db
+        conn.execute = AsyncMock(return_value="UPDATE 1")
+        await instance.update_session_status("sess-B", "failed")
+        self._assert_slot_then_update(conn, "sess-B")
+
+    @pytest.mark.asyncio
+    async def test_update_session_reviewer_takes_slot_first(self, db):
+        instance, pool, conn = db
+        conn.execute = AsyncMock(return_value="UPDATE 1")
+        await instance.update_session_reviewer("sess-C", "reviewer-Z")
+        self._assert_slot_then_update(conn, "sess-C")
+
+    @pytest.mark.asyncio
+    async def test_resolve_session_takes_slot_first(self, db):
+        instance, pool, conn = db
+        conn.execute = AsyncMock(return_value="UPDATE 1")
+        await instance.resolve_session("sess-D", {"action": "approve"}, status="resolved")
+        self._assert_slot_then_update(conn, "sess-D")
+
+    def test_namespace_is_disjoint_from_agent_lock(self):
+        # 'DLPH' must differ from the agent-lock 'AGNT' classid so the two
+        # advisory-lock spaces never collide (PR #1017 council note).
+        assert _DIALECTIC_PHASE_LOCK_NS == 0x444C5048
+        assert _DIALECTIC_PHASE_LOCK_NS != 0x41474E54
+        assert 0 < _DIALECTIC_PHASE_LOCK_NS < 2**31  # valid positive int4


### PR DESCRIPTION
**The correctness prerequisite for porting dialectic resolution to a BEAM GenServer** — the next BEAM-footprint step. Small, standalone-valuable, no GenServer yet.

## Problem
Dialectic session phase transitions on the live `core.dialectic_sessions` table are serialized today only by a **per-session in-process `asyncio.Lock`** (`mcp_handlers/dialectic/session.py`). That lock is invisible to anything outside the one Python process — a second worker, the REST path, or a future BEAM GenServer would dual-write and split-brain the row. That's the blocker called out for dialectic-on-BEAM.

## Fix
A **transaction-scoped PG advisory lock** ("saga slot") keyed on `(0x444C5048 'DLPH', hashtext(session_id))`, taken as the first statement inside the same transaction as each phase/status UPDATE. `dialectic_db.py` is the **sole writer chokepoint** (verified — no raw `dialectic_sessions` UPDATE/INSERT anywhere else), so locking its four mutators (`update_session_phase` / `_status` / `_reviewer` / `resolve_session`) covers the entire surface.

This makes dual-writer **safe rather than forbidden**: the BEAM GenServer, when built, takes the *same* lock before its writes and serializes against Python instead of racing it. Incremental port, no big-bang cutover.

## Standalone value
It also closes the documented intra-Python **NEW-1 race** (two concurrent `submit_synthesis` calls both passing the in-memory SYNTHESIS check and both writing a resolution) at the DB layer, beneath the existing `asyncio.Lock`.

## Notes
- Namespace `'DLPH'` is **disjoint** from the agent-lock advisory namespace (`'AGNT'`, `update_workflow_service.py`) so the two lock spaces never collide.
- `pg_advisory_xact_lock` auto-releases at COMMIT/ROLLBACK — no unlock to leak.
- Phase transitions are rare (~dozens/month), so the added asyncpg await is **not** a hot-path/Substrate-Tax regression — unlike the check-in path, where the `asyncio.Lock` was deliberately kept await-free.

## Tests
Saga-slot ordering pinned (advisory lock first, in-transaction, disjoint namespace) for all four mutators. `test_dialectic_db.py` + `test_dialectic_toctou.py` green (asyncio.Lock layer preserved, not replaced); full `-k dialectic` sweep 574 passed.

Draft — touches a live-session write path; maintainer is the merge gate. Recommend a reviewer + live-verifier pass on the lock semantics before mark-ready.

**Next step after this lands:** the dialectic-resolution GenServer, taking the same saga slot.

https://claude.ai/code/session_015daY142TcQtwBCz1FW37hr