### PR TITLE
feat(dialectic): route SYNTHESIS→RESOLVED commit to BEAM behind flag (Slice 1.2)

### DIFF
--- a/src/mcp_handlers/dialectic/beam_resolve_client.py
+++ b/src/mcp_handlers/dialectic/beam_resolve_client.py
@@ -1,0 +1,97 @@
+"""Client for routing the dialectic SYNTHESIS->RESOLVED commit to BEAM.
+
+dialectic-on-BEAM Slice 1.2. When ``UNITARES_DIALECTIC_BEAM_RESOLUTION`` is on,
+the Python convergence path hands the finished resolution payload to the BEAM
+lease plane (`POST /v1/dialectic/resolve`), which owns the cross-runtime saga
+slot and is the sole writer of the terminal `core.dialectic_sessions` row.
+
+Fail-safe by construction: this returns ``None`` — telling the caller to use the
+Python ``pg_resolve_session`` path — whenever the flag is off, the lease plane
+is not configured, a required field is missing, or BEAM is unreachable / returns
+non-OK. It never raises. A resolution therefore never hangs or is lost because
+of BEAM; the Python B-4 guard protects the row in either path.
+"""
+
+import asyncio
+import os
+from typing import Any, Dict, Optional
+
+from src.logging_utils import get_logger
+
+logger = get_logger(__name__)
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def beam_resolution_enabled() -> bool:
+    """True iff the operator has flipped UNITARES_DIALECTIC_BEAM_RESOLUTION on."""
+    return os.getenv("UNITARES_DIALECTIC_BEAM_RESOLUTION", "0").strip().lower() in _TRUTHY
+
+
+async def beam_resolve(
+    session_id: str,
+    paused_agent_id: Optional[str],
+    reviewer_agent_id: Optional[str],
+    resolution: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """Commit a resolution via BEAM.
+
+    Returns the BEAM result dict on success (the session row is resolved + saga
+    committed BEAM-side), or ``None`` to signal the caller to fall back to the
+    Python path. Never raises.
+    """
+    if not beam_resolution_enabled():
+        return None
+
+    bearer = os.getenv("LEASE_PLANE_BEARER_TOKEN") or ""
+    # The BEAM endpoint requires non-empty session/paused/reviewer; a session
+    # with no assigned reviewer falls back to the Python path.
+    if not (bearer and session_id and paused_agent_id and reviewer_agent_id):
+        return None
+
+    base_url = os.getenv("LEASE_PLANE_BASE_URL", "http://127.0.0.1:8788").rstrip("/")
+    payload = {
+        "session_id": session_id,
+        "paused_agent_id": paused_agent_id,
+        "reviewer_agent_id": reviewer_agent_id,
+        "resolution": resolution,
+    }
+
+    try:
+        import httpx
+    except Exception:  # pragma: no cover - httpx always present in this deploy
+        return None
+
+    def _post():
+        with httpx.Client(timeout=5.0) as client:
+            resp = client.post(
+                f"{base_url}/v1/dialectic/resolve",
+                headers={
+                    "Authorization": f"Bearer {bearer}",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+            )
+            body = resp.json() if resp.content else {}
+            return resp.status_code, body
+
+    try:
+        loop = asyncio.get_running_loop()
+        status, body = await loop.run_in_executor(None, _post)
+    except Exception as e:
+        logger.warning(f"[BEAM_RESOLVE] call failed for {session_id[:16]}, falling back to Python: {e}")
+        return None
+
+    if status == 200 and isinstance(body, dict) and body.get("ok"):
+        logger.info(
+            f"[BEAM_RESOLVE] session {session_id[:16]} resolved on BEAM "
+            f"(origin={body.get('origin')})"
+        )
+        return body
+
+    # 409 saga_in_flight / 404 / 503 / malformed -> fall back to the Python
+    # path, whose B-4 guard still prevents an overwrite.
+    logger.warning(
+        f"[BEAM_RESOLVE] non-OK ({status}) for {session_id[:16]}: {body}; falling back to Python"
+    )
+    return None

--- a/src/mcp_handlers/dialectic/handlers.py
+++ b/src/mcp_handlers/dialectic/handlers.py
@@ -92,6 +92,7 @@ from .calibration import (
     backfill_calibration_from_historical_sessions,  # noqa: F401 — re-exported; tests patch via this module
 )
 from .resolution import execute_resolution
+from .beam_resolve_client import beam_resolve
 from .reviewer import select_reviewer, is_agent_in_active_session
 
 # Import PostgreSQL async functions for dialectic session storage
@@ -1835,9 +1836,21 @@ async def handle_submit_synthesis(arguments: Dict[str, Any]) -> Sequence[TextCon
                                 execution_result.get("warning")
                             )
     
-                        # Execution succeeded - mark resolved in PG
+                        # Execution succeeded - mark resolved. When
+                        # UNITARES_DIALECTIC_BEAM_RESOLUTION is on, BEAM owns the
+                        # saga + the terminal session-row write; otherwise (or on
+                        # any BEAM error) fall back to the Python path, whose B-4
+                        # guard still prevents an overwrite. (dialectic-on-BEAM
+                        # Slice 1.2)
                         try:
-                            await pg_resolve_session(session_id=session_id, resolution=resolution.to_dict(), status="resolved")
+                            beam_result = await beam_resolve(
+                                session_id=session_id,
+                                paused_agent_id=session.paused_agent_id,
+                                reviewer_agent_id=session.reviewer_agent_id,
+                                resolution=resolution.to_dict(),
+                            )
+                            if beam_result is None:
+                                await pg_resolve_session(session_id=session_id, resolution=resolution.to_dict(), status="resolved")
                         except Exception as e:
                             logger.warning(f"Could not resolve session in PostgreSQL: {e}")
                     except Exception as e:

--- a/tests/test_dialectic_beam_resolve_client.py
+++ b/tests/test_dialectic_beam_resolve_client.py
@@ -1,0 +1,87 @@
+"""
+Tests for the BEAM dialectic-resolve client (dialectic-on-BEAM Slice 1.2).
+
+The client must be fail-safe: it returns None (caller falls back to the Python
+pg_resolve_session path) whenever the flag is off, the lease plane is not
+configured, a required field is missing, or BEAM returns non-OK — and must never
+raise.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from src.mcp_handlers.dialectic import beam_resolve_client as brc
+
+
+def _fake_httpx(status_code, body):
+    """Build a fake httpx module whose Client().post() returns the given response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.content = b"x"
+    resp.json.return_value = body
+    client_cm = MagicMock()
+    client_cm.__enter__.return_value.post.return_value = resp
+    client_cm.__exit__.return_value = False
+    fake = MagicMock()
+    fake.Client.return_value = client_cm
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_disabled_returns_none(monkeypatch):
+    monkeypatch.delenv("UNITARES_DIALECTIC_BEAM_RESOLUTION", raising=False)
+    out = await brc.beam_resolve("s1", "p", "r", {"verdict": "resume"})
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_enabled_but_no_bearer_returns_none(monkeypatch):
+    monkeypatch.setenv("UNITARES_DIALECTIC_BEAM_RESOLUTION", "1")
+    monkeypatch.delenv("LEASE_PLANE_BEARER_TOKEN", raising=False)
+    out = await brc.beam_resolve("s1", "p", "r", {"verdict": "resume"})
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_enabled_missing_reviewer_returns_none(monkeypatch):
+    monkeypatch.setenv("UNITARES_DIALECTIC_BEAM_RESOLUTION", "1")
+    monkeypatch.setenv("LEASE_PLANE_BEARER_TOKEN", "tok")
+    out = await brc.beam_resolve("s1", "p", None, {"verdict": "resume"})
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_success_returns_body(monkeypatch):
+    monkeypatch.setenv("UNITARES_DIALECTIC_BEAM_RESOLUTION", "true")
+    monkeypatch.setenv("LEASE_PLANE_BEARER_TOKEN", "tok")
+    body = {"ok": True, "status": "resolved", "saga_id": "abc", "origin": "new"}
+    with patch.dict(sys.modules, {"httpx": _fake_httpx(200, body)}):
+        out = await brc.beam_resolve("s1", "p", "r", {"verdict": "resume"})
+    assert out == body
+
+
+@pytest.mark.asyncio
+async def test_saga_in_flight_falls_back_to_none(monkeypatch):
+    monkeypatch.setenv("UNITARES_DIALECTIC_BEAM_RESOLUTION", "1")
+    monkeypatch.setenv("LEASE_PLANE_BEARER_TOKEN", "tok")
+    body = {"ok": False, "error": "saga_in_flight"}
+    with patch.dict(sys.modules, {"httpx": _fake_httpx(409, body)}):
+        out = await brc.beam_resolve("s1", "p", "r", {"verdict": "resume"})
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_transport_error_falls_back_to_none(monkeypatch):
+    monkeypatch.setenv("UNITARES_DIALECTIC_BEAM_RESOLUTION", "1")
+    monkeypatch.setenv("LEASE_PLANE_BEARER_TOKEN", "tok")
+    boom = MagicMock()
+    boom.Client.side_effect = RuntimeError("connection refused")
+    with patch.dict(sys.modules, {"httpx": boom}):
+        out = await brc.beam_resolve("s1", "p", "r", {"verdict": "resume"})
+    assert out is None


### PR DESCRIPTION
## What

The Python half of dialectic-on-BEAM Slice 1.2. When `UNITARES_DIALECTIC_BEAM_RESOLUTION` is on, `handle_submit_synthesis` hands the finished resolution payload to the BEAM lease plane (`POST /v1/dialectic/resolve`, PR #1175), which owns the saga slot and is the **sole writer of the terminal `core.dialectic_sessions` row**. Convergence + `execute_resolution` (agent-state mutation) stay in Python; only the terminal commit moves to BEAM.

## Fail-safe by construction

`beam_resolve_client.beam_resolve` returns `None` — caller uses the Python `pg_resolve_session` path (B-4 guard #1171 still prevents overwrite) — whenever:
- the flag is off (**default**), or
- `LEASE_PLANE_BEARER_TOKEN` is unset, or
- a required field is missing (e.g. session has no reviewer), or
- BEAM is unreachable / returns non-OK (409 saga_in_flight, 404, 503, malformed).

It never raises. A resolution can't hang or be lost because of BEAM. **Default off → zero behavior change** until an operator flips the flag.

## Tests

`tests/test_dialectic_beam_resolve_client.py` (6): disabled / no-bearer / missing-reviewer / success / saga_in_flight-fallback / transport-error-fallback. Existing synthesis + TOCTOU tests unchanged (flag off → Python path). **Full suite green: 11014 passed.**

## The Slice 1.2 set

| PR | Layer |
|---|---|
| #1175 | BEAM saga primitive + `/v1/dialectic/resolve` endpoint |
| **this** | Python routing behind the flag |
| #1171 / #1173 | Python prereqs (B-4 idempotent resolve, C1 sweeper guard) |

## Deploy / cutover (when ready, separate step)

Land all five PRs → deploy lease plane (BEAM endpoint) → deploy gov-mcp (Python) → flip `UNITARES_DIALECTIC_BEAM_RESOLUTION=1` in the gov-mcp plist (bootout+bootstrap). Flag off is safe at every intermediate point.

https://claude.ai/code/session_011Qw3sfs6vCjFwrqmbgxMhD