### PR TITLE
fix(lifecycle): gate orphan archive by max updates before mutation

### DIFF
--- a/src/mcp_handlers/lifecycle/operations.py
+++ b/src/mcp_handlers/lifecycle/operations.py
@@ -656,7 +656,11 @@ async def handle_archive_orphan_agents(arguments: Dict[str, Any]) -> Sequence[Te
     - max_updates: Skip agents with more updates than this (default: 3).
     - dry_run: Preview without archiving (default: true).
     """
-    from src.agent_lifecycle import auto_archive_orphan_agents, auto_agent_archival_enabled
+    from src.agent_lifecycle import (
+        _agent_update_count,
+        auto_archive_orphan_agents,
+        auto_agent_archival_enabled,
+    )
 
     max_age_hours = float(arguments.get("max_age_hours", 6))
     max_updates = int(arguments.get("max_updates", 3))
@@ -671,17 +675,25 @@ async def handle_archive_orphan_agents(arguments: Dict[str, Any]) -> Sequence[Te
     # threshold-based classification.
     await mcp_server.load_metadata_async()
 
+    eligible_metadata = {
+        agent_id: meta
+        for agent_id, meta in mcp_server.agent_metadata.items()
+        if _agent_update_count(meta) <= max_updates
+    }
+
     # Initializing agents (0 updates) are never archived — see
     # classify_for_archival. The old tier-1 zero_update_hours sweep is gone.
+    # Apply the max_updates gate before invoking the archival engine because
+    # that call can mutate when explicit auto-archival opt-in is enabled.
     results = await auto_archive_orphan_agents(
         low_update_hours=low_update_hours,
         unlabeled_hours=unlabeled_hours,
         dry_run=dry_run,
-        _metadata=mcp_server.agent_metadata,
+        _metadata=eligible_metadata,
         _monitors=mcp_server.monitors,
     )
 
-    filtered = [r for r in results if r.get("updates", 0) <= max_updates]
+    filtered = results
     archived = [r for r in filtered if r.get("archived")]
 
     for r in filtered:

--- a/tests/test_lifecycle_agents.py
+++ b/tests/test_lifecycle_agents.py
@@ -1533,6 +1533,39 @@ class TestArchiveOrphanAgents:
             assert data["archived_count"] == 0
 
     @pytest.mark.asyncio
+    async def test_max_updates_blocks_env_enabled_mutation(self, server, monkeypatch):
+        monkeypatch.setenv("UNITARES_ENABLE_AUTO_AGENT_ARCHIVAL", "true")
+        old = (datetime.now(timezone.utc) - timedelta(hours=30)).isoformat()
+        high_update_id = "12345678-1234-1234-1234-123456789abc"
+        low_update_id = "low-id"
+        server.agent_metadata = {
+            high_update_id: make_agent_meta(
+                status="active", total_updates=5, last_update=old, label=None
+            ),
+            low_update_id: make_agent_meta(
+                status="active", total_updates=1, last_update=old, label=None
+            ),
+        }
+        server.monitors = {
+            high_update_id: MagicMock(),
+            low_update_id: MagicMock(),
+        }
+        with patch_lifecycle_server(server), \
+             patch_agent_storage() as mock_storage:
+            mock_storage.archive_agent = AsyncMock()
+            from src.mcp_handlers.lifecycle.handlers import handle_archive_orphan_agents
+            result = await handle_archive_orphan_agents({"dry_run": False})
+            data = _parse(result)
+
+        archived_ids = [
+            call.args[0] for call in mock_storage.archive_agent.await_args_list
+        ]
+        assert archived_ids == [low_update_id]
+        assert data["archived_count"] == 1
+        assert server.agent_metadata[high_update_id].status == "active"
+        assert server.agent_metadata[low_update_id].status == "archived"
+
+    @pytest.mark.asyncio
     async def test_max_age_hours_scales_thresholds(self, server):
         # Tier-2 (non-UUID, unlabeled, 1 update): with max_age_hours=2 the
         # low_update_hours tier fires at 1.0h, agent is 2h old → archived.


### PR DESCRIPTION
## Summary
- filter archive_orphan_agents metadata by max_updates before invoking the archival engine
- preserve the max_updates cap even when UNITARES_ENABLE_AUTO_AGENT_ARCHIVAL=true and dry_run=false
- add an env-enabled regression test proving high-update stale UUID agents are not mutated

## Tests
- python3 -m pytest tests/test_lifecycle_agents.py::TestArchiveOrphanAgents
- python3 -m pytest tests/test_lifecycle_agents.py::TestArchiveOrphanAgents tests/test_lifecycle_agents.py::TestArchiveOrphanAgentsEdgeCases tests/test_handlers_lifecycle.py::TestArchiveOldTestAgents tests/test_manual_archive_liveness_guard.py
- git diff --check
- ./scripts/dev/test-cache.sh
- ./scripts/dev/test-cache.sh --staged
- pre-push smoke: 138 passed, 10270 deselected, 1 warning

## Notes
- Pre-push doc-health reported existing possible ghost-tool warnings for docs/manual/04-integrating-agents.md:138, skills/unitares-dashboard/SKILL.md:38, and skills/unitares-dashboard/SKILL.md:91.
