### PR TITLE
feat(beam-dialectic): re-land stranded dialectic-on-BEAM slices (1.3/1.4/2.x)

### DIFF
--- a/elixir/lease_plane/lib/unitares_lease_plane/application.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/application.ex
@@ -90,13 +90,24 @@ defmodule UnitaresLeasePlane.Application do
       Application.put_env(:lease_plane, :governance_api_token, token)
     end
 
+    # dialectic-on-BEAM Slice 2: per-session liveness timers. The flag gates only
+    # whether a stuck-timeout *acts* (fails the session); the watcher processes
+    # and presence run regardless and are always safe.
+    Application.put_env(
+      :lease_plane,
+      :dialectic_beam_liveness,
+      System.get_env("UNITARES_DIALECTIC_BEAM_LIVENESS") == "1"
+    )
+
     children =
       [
         {Postgrex, postgrex_opts()},
         {Registry, keys: :unique, name: UnitaresLeasePlane.HolderRegistry},
         UnitaresLeasePlane.LeaseSupervisor,
         UnitaresLeasePlane.HandoffServer,
-        UnitaresLeasePlane.SurfaceRegistry
+        UnitaresLeasePlane.SurfaceRegistry,
+        {Registry, keys: :unique, name: UnitaresLeasePlane.DialecticLivenessRegistry},
+        UnitaresLeasePlane.DialecticLivenessSupervisor
       ] ++ worker_children() ++ http_children()
 
     opts = [strategy: :one_for_one, name: UnitaresLeasePlane.Supervisor]
@@ -138,7 +149,27 @@ defmodule UnitaresLeasePlane.Application do
          worker: UnitaresLeasePlane.AuditOutboxForwarder,
          interval_ms: Application.get_env(:lease_plane, :audit_outbox_forward_interval_ms, 30_000),
          initial_delay_ms:
-           Application.get_env(:lease_plane, :audit_outbox_forward_initial_delay_ms, 2_000)}
+           Application.get_env(:lease_plane, :audit_outbox_forward_initial_delay_ms, 2_000)},
+        {UnitaresLeasePlane.PeriodicWorker,
+         id: UnitaresLeasePlane.DialecticSagaReaper,
+         name: UnitaresLeasePlane.DialecticSagaReaperScheduler,
+         worker: UnitaresLeasePlane.DialecticSagaReaper,
+         interval_ms:
+           Application.get_env(:lease_plane, :dialectic_saga_reaper_interval_ms, 60_000),
+         initial_delay_ms:
+           Application.get_env(:lease_plane, :dialectic_saga_reaper_initial_delay_ms, 5_000)},
+        {UnitaresLeasePlane.PeriodicWorker,
+         id: UnitaresLeasePlane.DialecticLivenessReconciler,
+         name: UnitaresLeasePlane.DialecticLivenessReconcilerScheduler,
+         worker: UnitaresLeasePlane.DialecticLivenessReconciler,
+         interval_ms:
+           Application.get_env(:lease_plane, :dialectic_liveness_reconcile_interval_ms, 30_000),
+         initial_delay_ms:
+           Application.get_env(
+             :lease_plane,
+             :dialectic_liveness_reconcile_initial_delay_ms,
+             7_000
+           )}
       ]
     else
       []

--- a/elixir/lease_plane/lib/unitares_lease_plane/dialectic_liveness.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/dialectic_liveness.ex
@@ -1,0 +1,168 @@
+defmodule UnitaresLeasePlane.DialecticLiveness do
+  @moduledoc """
+  Per-session liveness process for an active dialectic session (dialectic-on-BEAM
+  Slice 2 — the live-timer aliveness layer).
+
+  One supervised GenServer per active session, registered in
+  `UnitaresLeasePlane.DialecticLivenessRegistry`. It replaces the Python
+  `auto_resolve` stuck-session sweep's 10-minute poll with a live timer: instead
+  of a fleet-wide cron scanning the table, each session has its own process that
+  knows it is alive and, when it goes inactive past the hard timeout, acts.
+
+  The process self-terminates as soon as its session is terminal or gone, so the
+  live set of these processes IS the live dialectic set — a process-level
+  liveness signal, not a derived query.
+
+  ## Acting is flag-gated and corruption-safe
+
+  When `:dialectic_beam_liveness` is enabled and a session has been inactive past
+  the hard timeout, the timer drives a `failed` resolve through
+  `DialecticSaga.resolve/1` — i.e. through the saga + the guarded session-row
+  write. That composition makes it safe to run alongside the Python sweeper with
+  NO cross-runtime coordination flag:
+
+    * the saga serializes (one in-flight per session);
+    * the Python sweeper already skips saga-held sessions (C1);
+    * B-4's guarded write makes a double-fail a no-op.
+
+  So the worst case is the sweeper occasionally beating BEAM to the same terminal
+  outcome — benign and idempotent, never corruption. When acting is disabled
+  (default), the process is pure liveness/observation and never writes.
+  """
+
+  use GenServer
+
+  alias UnitaresLeasePlane.DialecticSaga
+
+  require Logger
+
+  # Default hard inactivity timeout before a stuck session is failed (4h, matching
+  # the Python FACILITATION_TIMEOUT). The check cadence is far finer than the old
+  # 10-minute sweep so the judgment is near-live.
+  @default_hard_timeout_s 14_400
+  @default_check_interval_ms 30_000
+
+  def child_spec(opts) do
+    session_id = Keyword.fetch!(opts, :session_id)
+
+    %{
+      id: {__MODULE__, session_id},
+      start: {__MODULE__, :start_link, [opts]},
+      restart: :transient,
+      type: :worker
+    }
+  end
+
+  def start_link(opts) do
+    session_id = Keyword.fetch!(opts, :session_id)
+    GenServer.start_link(__MODULE__, opts, name: via(session_id))
+  end
+
+  @doc "Registry tuple for a session's liveness process."
+  def via(session_id),
+    do: {:via, Registry, {UnitaresLeasePlane.DialecticLivenessRegistry, session_id}}
+
+  @doc "In-memory snapshot of this session's liveness, or :gone if no process."
+  def snapshot(session_id) do
+    case Registry.lookup(UnitaresLeasePlane.DialecticLivenessRegistry, session_id) do
+      [{pid, _}] -> GenServer.call(pid, :snapshot)
+      [] -> :gone
+    end
+  end
+
+  @impl true
+  def init(opts) do
+    state = %{
+      session_id: Keyword.fetch!(opts, :session_id),
+      hard_timeout_s: Keyword.get(opts, :hard_timeout_s, @default_hard_timeout_s),
+      check_interval_ms: Keyword.get(opts, :check_interval_ms, @default_check_interval_ms),
+      inactive_seconds: 0,
+      stuck: false
+    }
+
+    Process.send_after(
+      self(),
+      :check,
+      Keyword.get(opts, :initial_check_ms, state.check_interval_ms)
+    )
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call(:snapshot, _from, state) do
+    {:reply,
+     %{
+       session_id: state.session_id,
+       inactive_seconds: state.inactive_seconds,
+       stuck: state.stuck
+     }, state}
+  end
+
+  @impl true
+  def handle_info(:check, state) do
+    case DialecticSaga.get_session_liveness(state.session_id) do
+      {:ok, nil} ->
+        # Session gone — nothing to watch.
+        {:stop, :normal, state}
+
+      {:ok, %{status: status}} when status in ["resolved", "failed", "escalated"] ->
+        # Reached a terminal state (by us, the sweeper, or normal flow) — done.
+        {:stop, :normal, state}
+
+      {:ok, info} ->
+        evaluate(state, info)
+
+      {:error, _} ->
+        # Transient DB issue — try again next tick.
+        reschedule(state)
+        {:noreply, state}
+    end
+  end
+
+  defp evaluate(state, info) do
+    inactive = info.inactive_seconds
+    stuck? = inactive >= state.hard_timeout_s
+    state = %{state | inactive_seconds: inactive, stuck: stuck?}
+
+    cond do
+      stuck? and acting_enabled?() and is_binary(info.reviewer_agent_id) ->
+        fail_stuck(state, info)
+        {:stop, :normal, state}
+
+      stuck? ->
+        # Detected stuck but not acting (flag off, or no reviewer to attribute).
+        # The Python sweeper remains the backstop. Surface via snapshot only.
+        reschedule(state)
+        {:noreply, state}
+
+      true ->
+        reschedule(state)
+        {:noreply, state}
+    end
+  end
+
+  defp fail_stuck(state, info) do
+    payload = %{"action" => "failed", "reason" => "liveness_timeout"}
+
+    result =
+      DialecticSaga.resolve(%{
+        session_id: state.session_id,
+        paused_agent_id: info.paused_agent_id,
+        reviewer_agent_id: info.reviewer_agent_id,
+        resolution_payload: payload,
+        status: "failed"
+      })
+
+    Logger.warning(
+      "dialectic_liveness: failed stuck session #{String.slice(state.session_id, 0, 16)} " <>
+        "(inactive #{info.inactive_seconds}s) -> #{inspect(result)}"
+    )
+  end
+
+  defp reschedule(state),
+    do: Process.send_after(self(), :check, state.check_interval_ms)
+
+  defp acting_enabled?,
+    do: Application.get_env(:lease_plane, :dialectic_beam_liveness, false) == true
+end

--- a/elixir/lease_plane/lib/unitares_lease_plane/dialectic_liveness_reconciler.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/dialectic_liveness_reconciler.ex
@@ -1,0 +1,33 @@
+defmodule UnitaresLeasePlane.DialecticLivenessReconciler do
+  @moduledoc """
+  Periodic reconciler that keeps a `DialecticLiveness` process alive for every
+  active dialectic session (Slice 2). Because BEAM does not yet own session
+  *creation* (Python still mints sessions), this bridges the gap: it reads the
+  active set and ensures a watcher exists for each. Liveness processes
+  self-terminate when their session goes terminal, so the reconciler only needs
+  to *start* missing ones — it never has to stop anything.
+
+  Run by `PeriodicWorker` alongside the lease Reaper / saga reaper.
+  """
+
+  alias UnitaresLeasePlane.{DialecticSaga, DialecticLivenessSupervisor}
+
+  require Logger
+
+  @spec perform(map()) :: {:ok, map()} | {:error, term()}
+  def perform(_args) do
+    case DialecticSaga.live_sessions(500) do
+      {:ok, sessions} ->
+        started =
+          sessions
+          |> Enum.map(& &1.session_id)
+          |> Enum.map(&DialecticLivenessSupervisor.ensure_started/1)
+          |> Enum.count(&(&1 == :started))
+
+        {:ok, %{active_sessions: length(sessions), started: started}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+end

--- a/elixir/lease_plane/lib/unitares_lease_plane/dialectic_liveness_supervisor.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/dialectic_liveness_supervisor.ex
@@ -1,0 +1,43 @@
+defmodule UnitaresLeasePlane.DialecticLivenessSupervisor do
+  @moduledoc """
+  DynamicSupervisor for per-session `DialecticLiveness` processes (Slice 2).
+  `ensure_started/1` is idempotent — a session already being watched is a no-op,
+  so the reconciler can call it freely on every tick.
+  """
+
+  use DynamicSupervisor
+
+  alias UnitaresLeasePlane.DialecticLiveness
+
+  def start_link(init_arg) do
+    DynamicSupervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_init_arg) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+
+  @doc "Start a liveness process for `session_id` unless one already exists."
+  def ensure_started(session_id, opts \\ []) when is_binary(session_id) do
+    case Registry.lookup(UnitaresLeasePlane.DialecticLivenessRegistry, session_id) do
+      [{_pid, _}] ->
+        :already_started
+
+      [] ->
+        spec = {DialecticLiveness, [{:session_id, session_id} | opts]}
+
+        case DynamicSupervisor.start_child(__MODULE__, spec) do
+          {:ok, _pid} -> :started
+          {:error, {:already_started, _pid}} -> :already_started
+          {:error, reason} -> {:error, reason}
+        end
+    end
+  end
+
+  @doc "Number of sessions currently being watched."
+  def watched_count do
+    %{active: active} = DynamicSupervisor.count_children(__MODULE__)
+    active
+  end
+end

--- a/elixir/lease_plane/lib/unitares_lease_plane/dialectic_saga.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/dialectic_saga.ex
@@ -111,38 +111,188 @@ defmodule UnitaresLeasePlane.DialecticSaga do
     * `{:error, :saga_in_flight}` — a live resolve already holds the session
     * `{:error, :session_not_found}` / other `{:error, term}`
   """
+  @terminal_statuses ~w(resolved failed)
+
   @spec resolve(map()) :: {:ok, map()} | {:error, term()}
   def resolve(%{session_id: session_id, resolution_payload: payload} = params)
       when is_binary(session_id) and is_map(payload) do
-    case claim(params) do
-      {:ok, %{saga_id: saga_id, origin: origin}} ->
-        with :ok <- commit_session_row(session_id, payload),
-             :ok <- commit(saga_id) do
-          {:ok, %{status: "resolved", saga_id: saga_id, origin: origin}}
+    status = Map.get(params, :status, "resolved")
+
+    if status in @terminal_statuses do
+      do_resolve(params, session_id, payload, status)
+    else
+      {:error, :invalid_status}
+    end
+  end
+
+  def resolve(_), do: {:error, :invalid_params}
+
+  @doc """
+  BEAM-owned dialectic session creation: guarded INSERT into
+  `core.dialectic_sessions` + immediately start a liveness watcher, so a session
+  is watched from birth rather than waiting for the 30s reconciler. Idempotent on
+  `session_id` (`ON CONFLICT DO NOTHING`): a duplicate returns `{:ok, :exists}`.
+
+  Python still computes the `session_id` and field values (it owns id generation
+  + the request semantics); BEAM owns the write + the watcher start. Required:
+  `:session_id`, `:paused_agent_id`. Phase/status default to thesis/active (what
+  Python sets on create); all other fields are optional.
+  """
+  @spec create_session(map()) :: {:ok, :created | :exists} | {:error, term()}
+  def create_session(%{session_id: sid, paused_agent_id: paused} = p)
+      when is_binary(sid) and byte_size(sid) > 0 and is_binary(paused) and byte_size(paused) > 0 do
+    sql = """
+    INSERT INTO core.dialectic_sessions
+      (session_id, paused_agent_id, reviewer_agent_id, phase, status,
+       session_type, topic, reason, discovery_id, dispute_type,
+       max_synthesis_rounds, synthesis_round, paused_agent_state_json, trigger_source)
+    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13::jsonb,$14)
+    ON CONFLICT (session_id) DO NOTHING
+    RETURNING session_id
+    """
+
+    args = [
+      sid,
+      paused,
+      Map.get(p, :reviewer_agent_id),
+      Map.get(p, :phase, "thesis"),
+      Map.get(p, :status, "active"),
+      Map.get(p, :session_type),
+      Map.get(p, :topic),
+      Map.get(p, :reason),
+      Map.get(p, :discovery_id),
+      Map.get(p, :dispute_type),
+      Map.get(p, :max_synthesis_rounds),
+      Map.get(p, :synthesis_round, 0),
+      encode_json(Map.get(p, :paused_agent_state)),
+      Map.get(p, :trigger_source)
+    ]
+
+    case Postgrex.query(DB, sql, args) do
+      {:ok, %{rows: [[_sid]]}} ->
+        UnitaresLeasePlane.DialecticLivenessSupervisor.ensure_started(sid)
+        {:ok, :created}
+
+      {:ok, %{rows: []}} ->
+        {:ok, :exists}
+
+      {:error, e} ->
+        {:error, e}
+    end
+  end
+
+  def create_session(_), do: {:error, :invalid_params}
+
+  defp encode_json(nil), do: nil
+  defp encode_json(v), do: Jason.encode!(v)
+
+  @non_terminal_phases ~w(awaiting_thesis thesis antithesis synthesis quorum_voting)
+
+  @doc """
+  Guarded non-terminal phase advance (thesis -> antithesis -> synthesis ...) —
+  BEAM as sole writer of `core.dialectic_sessions.phase` for intermediate
+  transitions too, not just creation + the terminal write. Refuses to touch an
+  already-terminal session (those move only via `resolve/1`) and only accepts a
+  non-terminal target phase. Idempotent: a no-op UPDATE still returns `:ok`.
+  """
+  @spec update_phase(String.t(), String.t()) ::
+          :ok | {:error, :invalid_phase | :session_not_found | term()}
+  def update_phase(session_id, phase)
+      when is_binary(session_id) and phase in @non_terminal_phases do
+    sql = """
+    UPDATE core.dialectic_sessions
+    SET phase = $2, updated_at = now()
+    WHERE session_id = $1 AND status NOT IN ('resolved', 'failed', 'escalated')
+    RETURNING session_id
+    """
+
+    case Postgrex.query(DB, sql, [session_id, phase]) do
+      {:ok, %{num_rows: 1}} ->
+        :ok
+
+      {:ok, %{num_rows: 0}} ->
+        # No row updated: session missing or already terminal. Distinguish so the
+        # caller can fall back vs treat as a benign no-op.
+        case Postgrex.query(DB, "SELECT 1 FROM core.dialectic_sessions WHERE session_id = $1", [
+               session_id
+             ]) do
+          {:ok, %{num_rows: 1}} -> :ok
+          {:ok, %{num_rows: 0}} -> {:error, :session_not_found}
+          {:error, e} -> {:error, e}
         end
 
-      {:error, {:session_terminal, status}} ->
-        # Already resolved/failed: nothing to write, treat as idempotent success.
-        {:ok, %{status: status, saga_id: nil, origin: :already_terminal}}
+      {:error, e} ->
+        {:error, e}
+    end
+  end
+
+  def update_phase(_session_id, _phase), do: {:error, :invalid_phase}
+
+  @doc """
+  Guarded reviewer assignment/reassignment — the last session-row column written
+  Python-side. BEAM as sole writer of `reviewer_agent_id` too. Refuses an
+  already-terminal session; missing session -> :session_not_found; otherwise :ok.
+  """
+  @spec update_reviewer(String.t(), String.t()) ::
+          :ok | {:error, :invalid_reviewer | :session_not_found | term()}
+  def update_reviewer(session_id, reviewer)
+      when is_binary(session_id) and is_binary(reviewer) and byte_size(reviewer) > 0 do
+    sql = """
+    UPDATE core.dialectic_sessions
+    SET reviewer_agent_id = $2, updated_at = now()
+    WHERE session_id = $1 AND status NOT IN ('resolved', 'failed', 'escalated')
+    RETURNING session_id
+    """
+
+    case Postgrex.query(DB, sql, [session_id, reviewer]) do
+      {:ok, %{num_rows: 1}} ->
+        :ok
+
+      {:ok, %{num_rows: 0}} ->
+        case Postgrex.query(DB, "SELECT 1 FROM core.dialectic_sessions WHERE session_id = $1", [
+               session_id
+             ]) do
+          {:ok, %{num_rows: 1}} -> :ok
+          {:ok, %{num_rows: 0}} -> {:error, :session_not_found}
+          {:error, e} -> {:error, e}
+        end
+
+      {:error, e} ->
+        {:error, e}
+    end
+  end
+
+  def update_reviewer(_session_id, _reviewer), do: {:error, :invalid_reviewer}
+
+  defp do_resolve(params, session_id, payload, status) do
+    case claim(params) do
+      {:ok, %{saga_id: saga_id, origin: origin}} ->
+        with :ok <- commit_session_row(session_id, payload, status),
+             :ok <- commit(saga_id) do
+          {:ok, %{status: status, saga_id: saga_id, origin: origin}}
+        end
+
+      {:error, {:session_terminal, existing}} ->
+        # Already terminal: nothing to write, treat as idempotent success.
+        {:ok, %{status: existing, saga_id: nil, origin: :already_terminal}}
 
       {:error, reason} ->
         {:error, reason}
     end
   end
 
-  def resolve(_), do: {:error, :invalid_params}
-
-  # Guarded terminal write of the session row — BEAM is the sole writer. Mirrors
-  # the Python B-4 guard (#1171): refuses to overwrite an already-terminal row.
-  defp commit_session_row(session_id, payload) do
+  # Guarded terminal write of the session row — BEAM is the sole writer for both
+  # terminal transitions (resolved AND failed). Mirrors the Python B-4 guard
+  # (#1171): refuses to overwrite an already-terminal row. phase tracks status.
+  defp commit_session_row(session_id, payload, status) do
     sql = """
     UPDATE core.dialectic_sessions
-    SET status = 'resolved', phase = 'resolved', resolution_json = $2::jsonb, updated_at = now()
+    SET status = $2, phase = $2, resolution_json = $3::jsonb, updated_at = now()
     WHERE session_id = $1 AND status NOT IN ('resolved', 'failed')
     RETURNING session_id
     """
 
-    case Postgrex.query(DB, sql, [session_id, Jason.encode!(payload)]) do
+    case Postgrex.query(DB, sql, [session_id, status, Jason.encode!(payload)]) do
       {:ok, %{num_rows: 1}} -> :ok
       # Already terminal (raced/idempotent) — saga still commits; not an error.
       {:ok, %{num_rows: 0}} -> :ok
@@ -204,6 +354,91 @@ defmodule UnitaresLeasePlane.DialecticSaga do
           {:ok, %{num_rows: 0}} -> {:error, :saga_not_found}
           {:error, e} -> {:error, e}
         end
+
+      {:error, e} ->
+        {:error, e}
+    end
+  end
+
+  @doc """
+  Periodic recovery: revert every orphaned (old, still-`reserved`) saga across
+  ALL sessions. The on-claim `reclaim_stale_reserved` only frees a session being
+  re-claimed; this sweep frees an orphan even if its session is never resolved
+  again, so a crashed resolver can never permanently wedge a session. Returns
+  `{:ok, count}`. Run by `DialecticSagaReaper` under the PeriodicWorker.
+  """
+  @spec reclaim_all_stale() :: {:ok, non_neg_integer()} | {:error, term()}
+  def reclaim_all_stale do
+    sql = """
+    UPDATE coordination.session_resolution_sagas
+    SET state = 'reverted', reverted_at = now(), updated_at = now()
+    WHERE state = 'reserved'
+      AND last_attempt_at < now() - ($1 || ' seconds')::interval
+    """
+
+    case Postgrex.query(DB, sql, [Integer.to_string(@stale_reserved_seconds)]) do
+      {:ok, %{num_rows: n}} -> {:ok, n}
+      {:error, e} -> {:error, e}
+    end
+  end
+
+  @doc """
+  Live (non-terminal) dialectic sessions as a BEAM-served presence read: each
+  with phase, age in seconds, and whether a resolution saga is currently in
+  flight. Backs `GET /v1/dialectic/presence`.
+  """
+  @spec live_sessions(pos_integer()) :: {:ok, [map()]} | {:error, term()}
+  def live_sessions(limit \\ 100) when is_integer(limit) and limit > 0 do
+    sql = """
+    SELECT s.session_id, s.phase,
+           EXTRACT(EPOCH FROM (now() - s.created_at))::bigint AS age_s,
+           EXISTS(
+             SELECT 1 FROM coordination.session_resolution_sagas g
+             WHERE g.session_id = s.session_id AND g.state = ANY($1)
+           ) AS resolving
+    FROM core.dialectic_sessions s
+    WHERE s.status NOT IN ('resolved', 'failed', 'escalated')
+    ORDER BY s.created_at DESC
+    LIMIT $2
+    """
+
+    case Postgrex.query(DB, sql, [@inflight_states, limit]) do
+      {:ok, %{rows: rows}} ->
+        {:ok,
+         Enum.map(rows, fn [sid, phase, age, resolving] ->
+           %{session_id: sid, phase: phase, age_seconds: age, resolving: resolving}
+         end)}
+
+      {:error, e} ->
+        {:error, e}
+    end
+  end
+
+  @doc """
+  Per-session liveness snapshot for the live-timer layer: status, the two agent
+  ids (needed to drive a `failed` resolve), and seconds since the last update.
+  `{:ok, nil}` if the session is gone.
+  """
+  @spec get_session_liveness(String.t()) :: {:ok, map() | nil} | {:error, term()}
+  def get_session_liveness(session_id) when is_binary(session_id) do
+    sql = """
+    SELECT status, paused_agent_id, reviewer_agent_id,
+           EXTRACT(EPOCH FROM (now() - updated_at))::bigint AS inactive_s
+    FROM core.dialectic_sessions WHERE session_id = $1
+    """
+
+    case Postgrex.query(DB, sql, [session_id]) do
+      {:ok, %{rows: [[status, paused, reviewer, inactive_s]]}} ->
+        {:ok,
+         %{
+           status: status,
+           paused_agent_id: paused,
+           reviewer_agent_id: reviewer,
+           inactive_seconds: inactive_s
+         }}
+
+      {:ok, %{rows: []}} ->
+        {:ok, nil}
 
       {:error, e} ->
         {:error, e}

--- a/elixir/lease_plane/lib/unitares_lease_plane/dialectic_saga_reaper.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/dialectic_saga_reaper.ex
@@ -1,0 +1,35 @@
+defmodule UnitaresLeasePlane.DialecticSagaReaper do
+  @moduledoc """
+  Periodic recovery worker for orphaned dialectic resolution sagas.
+
+  A saga left `reserved` by a resolver that crashed mid-commit would otherwise
+  hold the one-pending slot until that exact session is re-claimed. This worker
+  reverts any such orphan on a timer (via `DialecticSaga.reclaim_all_stale/0`)
+  so a crash can never permanently wedge a session, even one that is never
+  resolved again. Always safe: it only touches `reserved` rows older than the
+  staleness floor, of which there are normally zero, so it is a no-op until a
+  real crash leaves one behind.
+
+  Scheduled by `PeriodicWorker` from the application supervision tree, alongside
+  the lease Reaper / HandoffTimeout / AuditOutboxForwarder.
+  """
+
+  alias UnitaresLeasePlane.DialecticSaga
+
+  require Logger
+
+  @spec perform(map()) :: {:ok, map()} | {:error, term()}
+  def perform(_args) do
+    case DialecticSaga.reclaim_all_stale() do
+      {:ok, 0} ->
+        {:ok, %{reclaimed: 0}}
+
+      {:ok, n} ->
+        Logger.warning("dialectic_saga_reaper: reverted #{n} orphaned reserved saga(s)")
+        {:ok, %{reclaimed: n}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+end

--- a/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
@@ -169,6 +169,88 @@ defmodule UnitaresLeasePlane.HTTPRouter do
     end
   end
 
+  # ---------- /v1/dialectic/session ----------
+  # BEAM-owned dialectic session creation (Slice 2): guarded INSERT + start a
+  # liveness watcher at birth. Python computes the session_id + fields; BEAM owns
+  # the write. Gated Python-side by UNITARES_DIALECTIC_BEAM_RESOLUTION.
+  post "/v1/dialectic/session" do
+    case extract_create_params(conn.body_params) do
+      {:ok, params} ->
+        case UnitaresLeasePlane.DialecticSaga.create_session(params) do
+          {:ok, :created} ->
+            json(conn, 201, %{ok: true, session_id: params.session_id, created: true})
+
+          {:ok, :exists} ->
+            json(conn, 200, %{ok: true, session_id: params.session_id, created: false})
+
+          {:error, _} ->
+            json(conn, 503, %{ok: false, error: "service_unavailable", reason: "internal error"})
+        end
+
+      {:error, detail} ->
+        json(conn, 422, %{ok: false, error: "schema_invalid", detail: detail})
+    end
+  end
+
+  # ---------- /v1/dialectic/phase ----------
+  # BEAM-owned non-terminal phase advance (thesis/antithesis/synthesis). Makes
+  # BEAM sole writer of the session row across the whole lifecycle. Gated
+  # Python-side by UNITARES_DIALECTIC_BEAM_RESOLUTION.
+  post "/v1/dialectic/phase" do
+    with %{"session_id" => sid, "phase" => phase} <- conn.body_params,
+         true <- is_binary(sid) and byte_size(sid) > 0 and is_binary(phase) do
+      case UnitaresLeasePlane.DialecticSaga.update_phase(sid, phase) do
+        :ok ->
+          json(conn, 200, %{ok: true, session_id: sid, phase: phase})
+
+        {:error, :invalid_phase} ->
+          json(conn, 422, %{
+            ok: false,
+            error: "schema_invalid",
+            detail: "invalid non-terminal phase"
+          })
+
+        {:error, :session_not_found} ->
+          json(conn, 404, %{ok: false, error: "session_not_found"})
+
+        {:error, _} ->
+          json(conn, 503, %{ok: false, error: "service_unavailable", reason: "internal error"})
+      end
+    else
+      _ ->
+        json(conn, 422, %{
+          ok: false,
+          error: "schema_invalid",
+          detail: "session_id and phase required"
+        })
+    end
+  end
+
+  # ---------- /v1/dialectic/reviewer ----------
+  # BEAM-owned reviewer assignment/reassignment — the last session-row column.
+  post "/v1/dialectic/reviewer" do
+    with %{"session_id" => sid, "reviewer_agent_id" => rev} <- conn.body_params,
+         true <- is_binary(sid) and byte_size(sid) > 0 and is_binary(rev) and byte_size(rev) > 0 do
+      case UnitaresLeasePlane.DialecticSaga.update_reviewer(sid, rev) do
+        :ok ->
+          json(conn, 200, %{ok: true, session_id: sid, reviewer_agent_id: rev})
+
+        {:error, :session_not_found} ->
+          json(conn, 404, %{ok: false, error: "session_not_found"})
+
+        {:error, _} ->
+          json(conn, 503, %{ok: false, error: "service_unavailable", reason: "internal error"})
+      end
+    else
+      _ ->
+        json(conn, 422, %{
+          ok: false,
+          error: "schema_invalid",
+          detail: "session_id and reviewer_agent_id required"
+        })
+    end
+  end
+
   # ---------- /v1/dialectic/resolve ----------
   # BEAM-owned dialectic SYNTHESIS->RESOLVED commit (dialectic-on-BEAM Slice 1).
   # Python computes the resolution payload (convergence + agent-state mutation
@@ -199,6 +281,26 @@ defmodule UnitaresLeasePlane.HTTPRouter do
 
       {:error, detail} ->
         json(conn, 422, %{ok: false, error: "schema_invalid", detail: detail})
+    end
+  end
+
+  # ---------- /v1/dialectic/presence ----------
+  # BEAM-served liveness read: which dialectic sessions are alive right now, each
+  # with phase, age, and whether a resolution saga is in flight. A coordination
+  # signal sourced from BEAM rather than each consumer polling the DB directly.
+  get "/v1/dialectic/presence" do
+    limit =
+      case Integer.parse(Map.get(conn.query_params, "limit", "100")) do
+        {n, _} when n > 0 and n <= 500 -> n
+        _ -> 100
+      end
+
+    case UnitaresLeasePlane.DialecticSaga.live_sessions(limit) do
+      {:ok, sessions} ->
+        json(conn, 200, %{ok: true, count: length(sessions), sessions: sessions})
+
+      {:error, _} ->
+        json(conn, 503, %{ok: false, error: "service_unavailable", reason: "internal error"})
     end
   end
 
@@ -570,22 +672,53 @@ defmodule UnitaresLeasePlane.HTTPRouter do
 
   defp acquire_for_surface(params), do: UnitaresLeasePlane.acquire_local_beam(params)
 
-  defp extract_resolve_params(%{
-         "session_id" => session_id,
-         "paused_agent_id" => paused,
-         "reviewer_agent_id" => reviewer,
-         "resolution" => resolution
-       })
+  defp extract_create_params(%{"session_id" => sid, "paused_agent_id" => paused} = body)
+       when is_binary(sid) and byte_size(sid) > 0 and is_binary(paused) and byte_size(paused) > 0 do
+    optional =
+      ~w(reviewer_agent_id session_type topic reason discovery_id dispute_type
+                  max_synthesis_rounds synthesis_round paused_agent_state trigger_source phase status)
+
+    params =
+      Enum.reduce(optional, %{session_id: sid, paused_agent_id: paused}, fn key, acc ->
+        case Map.get(body, key) do
+          nil -> acc
+          val -> Map.put(acc, String.to_atom(key), val)
+        end
+      end)
+
+    {:ok, params}
+  end
+
+  defp extract_create_params(_),
+    do: {:error, "session_id and paused_agent_id (non-empty strings) required"}
+
+  defp extract_resolve_params(
+         %{
+           "session_id" => session_id,
+           "paused_agent_id" => paused,
+           "reviewer_agent_id" => reviewer,
+           "resolution" => resolution
+         } = body
+       )
        when is_binary(session_id) and byte_size(session_id) > 0 and
               is_binary(paused) and byte_size(paused) > 0 and
               is_binary(reviewer) and byte_size(reviewer) > 0 and is_map(resolution) do
-    {:ok,
-     %{
-       session_id: session_id,
-       paused_agent_id: paused,
-       reviewer_agent_id: reviewer,
-       resolution_payload: resolution
-     }}
+    # status is optional, defaults to "resolved"; only the two terminal states
+    # are valid (BEAM owns both the resolved and failed terminal writes).
+    case Map.get(body, "status", "resolved") do
+      status when status in ["resolved", "failed"] ->
+        {:ok,
+         %{
+           session_id: session_id,
+           paused_agent_id: paused,
+           reviewer_agent_id: reviewer,
+           resolution_payload: resolution,
+           status: status
+         }}
+
+      _ ->
+        {:error, "status must be 'resolved' or 'failed'"}
+    end
   end
 
   defp extract_resolve_params(_),

--- a/elixir/lease_plane/test/dialectic_liveness_test.exs
+++ b/elixir/lease_plane/test/dialectic_liveness_test.exs
@@ -1,0 +1,111 @@
+defmodule UnitaresLeasePlane.DialecticLivenessTest do
+  @moduledoc """
+  Tests for the per-session liveness layer (dialectic-on-BEAM Slice 2): the
+  reconciler starts a watcher per active session, and a watcher whose session is
+  stuck past the hard timeout fails it via the saga path — but only when the
+  `:dialectic_beam_liveness` flag is enabled.
+  """
+  use ExUnit.Case, async: false
+
+  alias UnitaresLeasePlane.{
+    DialecticLiveness,
+    DialecticLivenessSupervisor,
+    DialecticLivenessReconciler,
+    DB
+  }
+
+  import LeaseTestHelpers
+
+  setup do
+    prior = Application.get_env(:lease_plane, :dialectic_beam_liveness, false)
+    on_exit(fn -> Application.put_env(:lease_plane, :dialectic_beam_liveness, prior) end)
+    :ok
+  end
+
+  defp session_status(session_id) do
+    %{rows: [[status]]} =
+      Postgrex.query!(DB, "SELECT status FROM core.dialectic_sessions WHERE session_id = $1", [
+        session_id
+      ])
+
+    status
+  end
+
+  defp wait_until(fun, tries \\ 50) do
+    cond do
+      fun.() ->
+        :ok
+
+      tries <= 0 ->
+        :timeout
+
+      true ->
+        Process.sleep(20)
+        wait_until(fun, tries - 1)
+    end
+  end
+
+  test "reconciler starts a watcher for an active session" do
+    session_id = insert_dialectic_session()
+    on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+    assert {:ok, %{}} = DialecticLivenessReconciler.perform(%{})
+    # A watcher process now exists for the session.
+    assert :gone != DialecticLiveness.snapshot(session_id)
+    # ensure_started is idempotent.
+    assert :already_started = DialecticLivenessSupervisor.ensure_started(session_id)
+  end
+
+  test "watcher fails a stuck session when acting is enabled" do
+    Application.put_env(:lease_plane, :dialectic_beam_liveness, true)
+    session_id = insert_dialectic_session(reviewer_agent_id: "rev-1")
+    on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+    # hard_timeout_s: 0 -> any age is "stuck"; initial_check_ms: 0 -> act now.
+    :started =
+      DialecticLivenessSupervisor.ensure_started(session_id,
+        hard_timeout_s: 0,
+        initial_check_ms: 0,
+        check_interval_ms: 50
+      )
+
+    assert :ok = wait_until(fn -> session_status(session_id) == "failed" end)
+  end
+
+  test "watcher does NOT write when acting is disabled (default)" do
+    Application.put_env(:lease_plane, :dialectic_beam_liveness, false)
+    session_id = insert_dialectic_session(reviewer_agent_id: "rev-1")
+    on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+    :started =
+      DialecticLivenessSupervisor.ensure_started(session_id,
+        hard_timeout_s: 0,
+        initial_check_ms: 0,
+        check_interval_ms: 50
+      )
+
+    # Give the timer a chance to fire; the session must remain active.
+    Process.sleep(120)
+    assert session_status(session_id) == "active"
+    # The watcher reports stuck in its snapshot even though it didn't act.
+    snap = DialecticLiveness.snapshot(session_id)
+    assert snap != :gone and snap.stuck == true
+  end
+
+  test "watcher self-terminates when the session is already terminal" do
+    Application.put_env(:lease_plane, :dialectic_beam_liveness, true)
+    session_id = insert_dialectic_session(status: "resolved", phase: "resolved")
+    on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+    :started =
+      DialecticLivenessSupervisor.ensure_started(session_id,
+        hard_timeout_s: 0,
+        initial_check_ms: 0,
+        check_interval_ms: 50
+      )
+
+    assert :ok = wait_until(fn -> DialecticLiveness.snapshot(session_id) == :gone end)
+    # Untouched: it was already resolved before the watcher ran.
+    assert session_status(session_id) == "resolved"
+  end
+end

--- a/elixir/lease_plane/test/dialectic_saga_test.exs
+++ b/elixir/lease_plane/test/dialectic_saga_test.exs
@@ -116,6 +116,24 @@ defmodule UnitaresLeasePlane.DialecticSagaTest do
                DialecticSaga.resolve(claim_params(session_id))
     end
 
+    test "commits a failed terminal transition when status=failed" do
+      session_id = insert_dialectic_session()
+      on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+      params = Map.put(claim_params(session_id, %{"reason" => "safety"}), :status, "failed")
+
+      assert {:ok, %{status: "failed", saga_id: saga_id, origin: :new}} =
+               DialecticSaga.resolve(params)
+
+      assert session_status(session_id) == "failed"
+      assert saga_state(saga_id) == "pg_committed"
+    end
+
+    test "rejects an invalid status" do
+      assert {:error, :invalid_status} =
+               DialecticSaga.resolve(Map.put(claim_params("s"), :status, "bogus"))
+    end
+
     test "rejects when a different live resolution is in flight" do
       session_id = insert_dialectic_session()
       on_exit(fn -> cleanup_dialectic_session(session_id) end)
@@ -161,6 +179,145 @@ defmodule UnitaresLeasePlane.DialecticSagaTest do
     end
   end
 
+  describe "reclaim_all_stale/0 + reaper" do
+    test "reverts orphaned reserved sagas across sessions" do
+      session_id = insert_dialectic_session()
+      on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+      insert_stale_reserved(session_id)
+      assert {:ok, n} = DialecticSaga.reclaim_all_stale()
+      assert n >= 1
+      # The session's one-pending slot is free again.
+      assert {:ok, nil} = DialecticSaga.get_inflight(session_id)
+    end
+
+    test "DialecticSagaReaper.perform returns a reclaimed count" do
+      session_id = insert_dialectic_session()
+      on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+      insert_stale_reserved(session_id)
+      assert {:ok, %{reclaimed: n}} = UnitaresLeasePlane.DialecticSagaReaper.perform(%{})
+      assert n >= 1
+    end
+  end
+
+  describe "live_sessions/1" do
+    test "lists a non-terminal session with phase, age, and resolving flag" do
+      session_id = insert_dialectic_session(phase: "synthesis", status: "active")
+      on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+      assert {:ok, %{origin: :new}} = DialecticSaga.claim(claim_params(session_id))
+
+      {:ok, sessions} = DialecticSaga.live_sessions(500)
+      mine = Enum.find(sessions, &(&1.session_id == session_id))
+      assert mine.phase == "synthesis"
+      assert mine.resolving == true
+      assert is_integer(mine.age_seconds)
+    end
+
+    test "excludes resolved sessions" do
+      session_id = insert_dialectic_session()
+      on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+      assert {:ok, _} = DialecticSaga.resolve(claim_params(session_id))
+      {:ok, sessions} = DialecticSaga.live_sessions(500)
+      refute Enum.any?(sessions, &(&1.session_id == session_id))
+    end
+  end
+
+  describe "update_phase/2" do
+    test "advances a non-terminal phase" do
+      session_id = insert_dialectic_session(phase: "thesis", status: "active")
+      on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+      assert :ok = DialecticSaga.update_phase(session_id, "antithesis")
+      assert session_phase(session_id) == "antithesis"
+    end
+
+    test "rejects an invalid / terminal target phase" do
+      assert {:error, :invalid_phase} = DialecticSaga.update_phase("x", "resolved")
+      assert {:error, :invalid_phase} = DialecticSaga.update_phase("x", "bogus")
+    end
+
+    test "does not move an already-terminal session (no-op :ok)" do
+      session_id = insert_dialectic_session(phase: "resolved", status: "resolved")
+      on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+      assert :ok = DialecticSaga.update_phase(session_id, "antithesis")
+      assert session_phase(session_id) == "resolved"
+    end
+
+    test "missing session -> :session_not_found" do
+      assert {:error, :session_not_found} =
+               DialecticSaga.update_phase("test_elixir_nope_phase", "thesis")
+    end
+  end
+
+  describe "update_reviewer/2" do
+    test "assigns a reviewer on an active session" do
+      session_id = insert_dialectic_session(phase: "antithesis", status: "active")
+      on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+      assert :ok = DialecticSaga.update_reviewer(session_id, "rev-99")
+      assert session_reviewer(session_id) == "rev-99"
+    end
+
+    test "rejects a blank reviewer" do
+      assert {:error, :invalid_reviewer} = DialecticSaga.update_reviewer("x", "")
+    end
+
+    test "missing session -> :session_not_found" do
+      assert {:error, :session_not_found} =
+               DialecticSaga.update_reviewer("test_elixir_nope_rev", "rev-1")
+    end
+  end
+
+  describe "create_session/1" do
+    test "inserts a session and starts a liveness watcher" do
+      sid = "test_elixir_create_" <> Integer.to_string(System.unique_integer([:positive]))
+      on_exit(fn -> cleanup_dialectic_session(sid) end)
+
+      assert {:ok, :created} =
+               DialecticSaga.create_session(%{
+                 session_id: sid,
+                 paused_agent_id: "p",
+                 reviewer_agent_id: "r",
+                 reason: "test"
+               })
+
+      assert session_status(sid) == "active"
+      assert :gone != UnitaresLeasePlane.DialecticLiveness.snapshot(sid)
+    end
+
+    test "is idempotent on a duplicate session_id" do
+      sid = "test_elixir_create_" <> Integer.to_string(System.unique_integer([:positive]))
+      on_exit(fn -> cleanup_dialectic_session(sid) end)
+
+      assert {:ok, :created} =
+               DialecticSaga.create_session(%{session_id: sid, paused_agent_id: "p"})
+
+      assert {:ok, :exists} =
+               DialecticSaga.create_session(%{session_id: sid, paused_agent_id: "p"})
+    end
+
+    test "rejects missing paused_agent_id" do
+      assert {:error, :invalid_params} = DialecticSaga.create_session(%{session_id: "x"})
+    end
+  end
+
+  defp insert_stale_reserved(session_id) do
+    Postgrex.query!(
+      DB,
+      """
+      INSERT INTO coordination.session_resolution_sagas
+        (saga_id, session_id, paused_agent_id, reviewer_agent_id, state,
+         resolution_payload_json, resolution_payload_hash, last_attempt_at, attempt_count)
+      VALUES (gen_random_uuid(), $1, 'p', 'r', 'reserved', '{}'::jsonb, $2, now() - interval '10 minutes', 1)
+      """,
+      [session_id, "stale-hash-#{session_id}"]
+    )
+  end
+
   defp session_status(session_id) do
     %{rows: [[status]]} =
       Postgrex.query!(DB, "SELECT status FROM core.dialectic_sessions WHERE session_id = $1", [
@@ -168,6 +325,26 @@ defmodule UnitaresLeasePlane.DialecticSagaTest do
       ])
 
     status
+  end
+
+  defp session_phase(session_id) do
+    %{rows: [[phase]]} =
+      Postgrex.query!(DB, "SELECT phase FROM core.dialectic_sessions WHERE session_id = $1", [
+        session_id
+      ])
+
+    phase
+  end
+
+  defp session_reviewer(session_id) do
+    %{rows: [[rev]]} =
+      Postgrex.query!(
+        DB,
+        "SELECT reviewer_agent_id FROM core.dialectic_sessions WHERE session_id = $1",
+        [session_id]
+      )
+
+    rev
   end
 
   defp saga_state(saga_id) do

--- a/elixir/lease_plane/test/http_router_test.exs
+++ b/elixir/lease_plane/test/http_router_test.exs
@@ -47,6 +47,89 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
 
   defp parsed(conn), do: Jason.decode!(conn.resp_body)
 
+  describe "/v1/dialectic/phase" do
+    test "advances a non-terminal phase (200)" do
+      session_id = insert_dialectic_session(phase: "thesis", status: "active")
+      on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+      resp = post_json("/v1/dialectic/phase", %{session_id: session_id, phase: "antithesis"})
+      assert resp.status == 200
+      assert parsed(resp)["phase"] == "antithesis"
+    end
+
+    test "invalid phase -> 422" do
+      resp = post_json("/v1/dialectic/phase", %{session_id: "x", phase: "resolved"})
+      assert resp.status == 422
+    end
+
+    test "missing session -> 404" do
+      resp =
+        post_json("/v1/dialectic/phase", %{
+          session_id: "test_elixir_nope_#{System.unique_integer([:positive])}",
+          phase: "antithesis"
+        })
+
+      assert resp.status == 404
+    end
+  end
+
+  describe "/v1/dialectic/session" do
+    test "creates a session (201) then idempotent replay (200)" do
+      sid = "test_elixir_httpcreate_" <> Integer.to_string(System.unique_integer([:positive]))
+      on_exit(fn -> cleanup_dialectic_session(sid) end)
+
+      r1 =
+        post_json("/v1/dialectic/session", %{
+          session_id: sid,
+          paused_agent_id: "p",
+          reviewer_agent_id: "r",
+          reason: "test"
+        })
+
+      assert r1.status == 201
+      assert parsed(r1)["created"] == true
+
+      r2 = post_json("/v1/dialectic/session", %{session_id: sid, paused_agent_id: "p"})
+      assert r2.status == 200
+      assert parsed(r2)["created"] == false
+    end
+
+    test "missing fields → 422 schema_invalid" do
+      assert post_json("/v1/dialectic/session", %{session_id: "x"}).status == 422
+    end
+  end
+
+  describe "/v1/dialectic/presence" do
+    test "lists live sessions; resolved ones drop off" do
+      session_id = insert_dialectic_session()
+      on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+      live =
+        :get
+        |> conn("/v1/dialectic/presence")
+        |> authed()
+        |> HTTPRouter.call(@opts)
+
+      assert live.status == 200
+      body = parsed(live)
+      assert body["ok"] == true
+      assert Enum.any?(body["sessions"], &(&1["session_id"] == session_id))
+
+      # Resolve it, then it should no longer appear.
+      post_json("/v1/dialectic/resolve", %{
+        session_id: session_id,
+        paused_agent_id: "p",
+        reviewer_agent_id: "r",
+        resolution: %{verdict: "resume"}
+      })
+
+      after_resolve =
+        :get |> conn("/v1/dialectic/presence") |> authed() |> HTTPRouter.call(@opts)
+
+      refute Enum.any?(parsed(after_resolve)["sessions"], &(&1["session_id"] == session_id))
+    end
+  end
+
   describe "/v1/dialectic/resolve" do
     test "missing fields → 422 schema_invalid" do
       resp = post_json("/v1/dialectic/resolve", %{session_id: "x"})
@@ -88,6 +171,36 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
       resp2 = post_json("/v1/dialectic/resolve", body)
       assert resp2.status == 200
       assert parsed(resp2)["origin"] == "already_terminal"
+    end
+
+    test "status=failed commits a failed terminal transition" do
+      session_id = insert_dialectic_session()
+      on_exit(fn -> cleanup_dialectic_session(session_id) end)
+
+      resp =
+        post_json("/v1/dialectic/resolve", %{
+          session_id: session_id,
+          paused_agent_id: "p",
+          reviewer_agent_id: "r",
+          resolution: %{reason: "safety_violation"},
+          status: "failed"
+        })
+
+      assert resp.status == 200
+      assert parsed(resp)["status"] == "failed"
+    end
+
+    test "invalid status → 422 schema_invalid" do
+      resp =
+        post_json("/v1/dialectic/resolve", %{
+          session_id: "x",
+          paused_agent_id: "p",
+          reviewer_agent_id: "r",
+          resolution: %{},
+          status: "bogus"
+        })
+
+      assert resp.status == 422
     end
 
     test "unknown session → 404 session_not_found" do

--- a/elixir/lease_plane/test/support/lease_test_helpers.ex
+++ b/elixir/lease_plane/test/support/lease_test_helpers.ex
@@ -94,13 +94,14 @@ defmodule LeaseTestHelpers do
   def insert_dialectic_session(opts \\ []) do
     session_id = Keyword.get(opts, :session_id, "test_elixir_dia_" <> short_rand())
     paused = Keyword.get(opts, :paused_agent_id, "test_paused_" <> short_rand())
+    reviewer = Keyword.get(opts, :reviewer_agent_id)
     phase = Keyword.get(opts, :phase, "synthesis")
     status = Keyword.get(opts, :status, "active")
 
     Postgrex.query!(
       DB,
-      "INSERT INTO core.dialectic_sessions (session_id, paused_agent_id, phase, status) VALUES ($1, $2, $3, $4)",
-      [session_id, paused, phase, status]
+      "INSERT INTO core.dialectic_sessions (session_id, paused_agent_id, reviewer_agent_id, phase, status) VALUES ($1, $2, $3, $4, $5)",
+      [session_id, paused, reviewer, phase, status]
     )
 
     session_id

--- a/elixir/lease_plane/test/test_helper.exs
+++ b/elixir/lease_plane/test/test_helper.exs
@@ -42,3 +42,8 @@ parsed =
 {:ok, _} = Registry.start_link(keys: :unique, name: UnitaresLeasePlane.HolderRegistry)
 {:ok, _} = UnitaresLeasePlane.LeaseSupervisor.start_link(:ok)
 {:ok, _} = UnitaresLeasePlane.HandoffServer.start_link(:ok)
+
+{:ok, _} =
+  Registry.start_link(keys: :unique, name: UnitaresLeasePlane.DialecticLivenessRegistry)
+
+{:ok, _} = UnitaresLeasePlane.DialecticLivenessSupervisor.start_link(:ok)

--- a/src/mcp_handlers/dialectic/beam_resolve_client.py
+++ b/src/mcp_handlers/dialectic/beam_resolve_client.py
@@ -28,19 +28,161 @@ def beam_resolution_enabled() -> bool:
     return os.getenv("UNITARES_DIALECTIC_BEAM_RESOLUTION", "0").strip().lower() in _TRUTHY
 
 
+async def beam_create_session(
+    session_id: str,
+    paused_agent_id: Optional[str],
+    fields: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
+    """Create a dialectic session via BEAM (it owns the write + starts a liveness
+    watcher at birth). `fields` carries the optional columns (reviewer_agent_id,
+    reason, dispute_type, session_type, topic, max_synthesis_rounds,
+    synthesis_round, paused_agent_state, trigger_source, discovery_id).
+
+    Returns the BEAM result on success, or ``None`` to fall back to the Python
+    `create_session_async` path (flag off / no bearer / missing ids / BEAM
+    unreachable / non-OK). Never raises. Gated by the same
+    UNITARES_DIALECTIC_BEAM_RESOLUTION flag as the resolve routing.
+    """
+    if not beam_resolution_enabled():
+        return None
+
+    bearer = os.getenv("LEASE_PLANE_BEARER_TOKEN") or ""
+    if not (bearer and session_id and paused_agent_id):
+        return None
+
+    base_url = os.getenv("LEASE_PLANE_BASE_URL", "http://127.0.0.1:8788").rstrip("/")
+    payload = {"session_id": session_id, "paused_agent_id": paused_agent_id}
+    for k, v in (fields or {}).items():
+        if v is not None:
+            payload[k] = v
+
+    try:
+        import httpx
+    except Exception:  # pragma: no cover
+        return None
+
+    def _post():
+        with httpx.Client(timeout=5.0) as client:
+            resp = client.post(
+                f"{base_url}/v1/dialectic/session",
+                headers={"Authorization": f"Bearer {bearer}", "Content-Type": "application/json"},
+                json=payload,
+            )
+            return resp.status_code, (resp.json() if resp.content else {})
+
+    try:
+        loop = asyncio.get_running_loop()
+        status, body = await loop.run_in_executor(None, _post)
+    except Exception as e:
+        logger.warning(f"[BEAM_CREATE] call failed for {session_id[:16]}, falling back to Python: {e}")
+        return None
+
+    if status in (200, 201) and isinstance(body, dict) and body.get("ok"):
+        logger.info(f"[BEAM_CREATE] session {session_id[:16]} created on BEAM (created={body.get('created')})")
+        return body
+
+    logger.warning(f"[BEAM_CREATE] non-OK ({status}) for {session_id[:16]}: {body}; falling back to Python")
+    return None
+
+
+async def beam_update_phase(session_id: str, phase: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Advance a non-terminal dialectic phase via BEAM (sole writer of the session
+    row). Returns the BEAM result on success, or ``None`` to fall back to the
+    Python `pg_update_phase` path. Never raises. Terminal phases are NOT routed
+    here (those go via resolve); BEAM rejects them with 422 -> None -> fallback.
+    """
+    if not beam_resolution_enabled():
+        return None
+    bearer = os.getenv("LEASE_PLANE_BEARER_TOKEN") or ""
+    if not (bearer and session_id and phase):
+        return None
+
+    base_url = os.getenv("LEASE_PLANE_BASE_URL", "http://127.0.0.1:8788").rstrip("/")
+
+    try:
+        import httpx
+    except Exception:  # pragma: no cover
+        return None
+
+    def _post():
+        with httpx.Client(timeout=5.0) as client:
+            resp = client.post(
+                f"{base_url}/v1/dialectic/phase",
+                headers={"Authorization": f"Bearer {bearer}", "Content-Type": "application/json"},
+                json={"session_id": session_id, "phase": phase},
+            )
+            return resp.status_code, (resp.json() if resp.content else {})
+
+    try:
+        loop = asyncio.get_running_loop()
+        status, body = await loop.run_in_executor(None, _post)
+    except Exception as e:
+        logger.warning(f"[BEAM_PHASE] call failed for {session_id[:16]}, falling back: {e}")
+        return None
+
+    if status == 200 and isinstance(body, dict) and body.get("ok"):
+        return body
+    logger.warning(f"[BEAM_PHASE] non-OK ({status}) for {session_id[:16]}: {body}; falling back")
+    return None
+
+
+async def beam_update_reviewer(session_id: str, reviewer_agent_id: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Assign/reassign a reviewer via BEAM (sole writer of reviewer_agent_id).
+    Returns the BEAM result on success, or ``None`` to fall back to the Python
+    `pg_update_reviewer` path. Never raises.
+    """
+    if not beam_resolution_enabled():
+        return None
+    bearer = os.getenv("LEASE_PLANE_BEARER_TOKEN") or ""
+    if not (bearer and session_id and reviewer_agent_id):
+        return None
+
+    base_url = os.getenv("LEASE_PLANE_BASE_URL", "http://127.0.0.1:8788").rstrip("/")
+
+    try:
+        import httpx
+    except Exception:  # pragma: no cover
+        return None
+
+    def _post():
+        with httpx.Client(timeout=5.0) as client:
+            resp = client.post(
+                f"{base_url}/v1/dialectic/reviewer",
+                headers={"Authorization": f"Bearer {bearer}", "Content-Type": "application/json"},
+                json={"session_id": session_id, "reviewer_agent_id": reviewer_agent_id},
+            )
+            return resp.status_code, (resp.json() if resp.content else {})
+
+    try:
+        loop = asyncio.get_running_loop()
+        status, body = await loop.run_in_executor(None, _post)
+    except Exception as e:
+        logger.warning(f"[BEAM_REVIEWER] call failed for {session_id[:16]}, falling back: {e}")
+        return None
+
+    if status == 200 and isinstance(body, dict) and body.get("ok"):
+        return body
+    logger.warning(f"[BEAM_REVIEWER] non-OK ({status}) for {session_id[:16]}: {body}; falling back")
+    return None
+
+
 async def beam_resolve(
     session_id: str,
     paused_agent_id: Optional[str],
     reviewer_agent_id: Optional[str],
     resolution: Dict[str, Any],
+    status: str = "resolved",
 ) -> Optional[Dict[str, Any]]:
-    """Commit a resolution via BEAM.
+    """Commit a terminal dialectic transition via BEAM.
 
-    Returns the BEAM result dict on success (the session row is resolved + saga
-    committed BEAM-side), or ``None`` to signal the caller to fall back to the
-    Python path. Never raises.
+    ``status`` is "resolved" or "failed" — BEAM is the sole writer of the
+    session row for both. Returns the BEAM result dict on success (row written
+    + saga committed BEAM-side), or ``None`` to signal the caller to fall back
+    to the Python path. Never raises.
     """
     if not beam_resolution_enabled():
+        return None
+    if status not in ("resolved", "failed"):
         return None
 
     bearer = os.getenv("LEASE_PLANE_BEARER_TOKEN") or ""
@@ -55,6 +197,7 @@ async def beam_resolve(
         "paused_agent_id": paused_agent_id,
         "reviewer_agent_id": reviewer_agent_id,
         "resolution": resolution,
+        "status": status,
     }
 
     try:

--- a/src/mcp_handlers/dialectic/handlers.py
+++ b/src/mcp_handlers/dialectic/handlers.py
@@ -92,7 +92,12 @@ from .calibration import (
     backfill_calibration_from_historical_sessions,  # noqa: F401 — re-exported; tests patch via this module
 )
 from .resolution import execute_resolution
-from .beam_resolve_client import beam_resolve
+from .beam_resolve_client import (
+    beam_resolve,
+    beam_create_session,
+    beam_update_phase,
+    beam_update_reviewer,
+)
 from .reviewer import select_reviewer, is_agent_in_active_session
 
 # Import PostgreSQL async functions for dialectic session storage
@@ -481,7 +486,9 @@ async def _apply_reviewer_reassignment(
     session.transcript.append(reassign_msg)
 
     try:
-        await pg_update_reviewer(session_id, new_reviewer_id)
+        # BEAM owns the reviewer write when flagged; else Python. (Slice 2.3)
+        if await beam_update_reviewer(session_id, new_reviewer_id) is None:
+            await pg_update_reviewer(session_id, new_reviewer_id)
         await pg_add_message(
             session_id=session_id,
             agent_id="system",
@@ -709,20 +716,40 @@ async def handle_request_dialectic_review(arguments: Dict[str, Any]) -> Sequence
     # Persist to PostgreSQL (single source of truth)
     # JSON snapshots removed - use export_dialectic_session() for debugging
     try:
-        await pg_create_session(
+        # BEAM owns the write + starts a liveness watcher at birth when flagged;
+        # otherwise (or on any BEAM error) fall back to the Python insert.
+        # (dialectic-on-BEAM Slice 2.1)
+        beam_created = await beam_create_session(
             session_id=session.session_id,
             paused_agent_id=session.paused_agent_id,
-            reviewer_agent_id=session.reviewer_agent_id,
-            reason=reason,
-            discovery_id=discovery_id,
-            dispute_type=dispute_type,
-            session_type=session_type,
-            topic=topic,
-            max_synthesis_rounds=session.max_synthesis_rounds,
-            synthesis_round=session.synthesis_round,
-            paused_agent_state=paused_agent_state,
-            trigger_source=trigger_source,
+            fields={
+                "reviewer_agent_id": session.reviewer_agent_id,
+                "reason": reason,
+                "discovery_id": discovery_id,
+                "dispute_type": dispute_type,
+                "session_type": session_type,
+                "topic": topic,
+                "max_synthesis_rounds": session.max_synthesis_rounds,
+                "synthesis_round": session.synthesis_round,
+                "paused_agent_state": paused_agent_state,
+                "trigger_source": trigger_source,
+            },
         )
+        if beam_created is None:
+            await pg_create_session(
+                session_id=session.session_id,
+                paused_agent_id=session.paused_agent_id,
+                reviewer_agent_id=session.reviewer_agent_id,
+                reason=reason,
+                discovery_id=discovery_id,
+                dispute_type=dispute_type,
+                session_type=session_type,
+                topic=topic,
+                max_synthesis_rounds=session.max_synthesis_rounds,
+                synthesis_round=session.synthesis_round,
+                paused_agent_state=paused_agent_state,
+                trigger_source=trigger_source,
+            )
         logger.info(f"Dialectic session {session.session_id} persisted to PostgreSQL")
     except Exception as e:
         logger.error(f"Dialectic session create FAILED: {e}")
@@ -1363,7 +1390,10 @@ async def handle_submit_thesis(arguments: Dict[str, Any]) -> Sequence[TextConten
                     proposed_conditions=proposed_conditions,
                     reasoning=arguments.get('reasoning'),
                 )
-                await pg_update_phase(session_id, session.phase.value)
+                # BEAM owns the phase write when flagged; else Python. (Slice 2.2)
+                _beam_ph = await beam_update_phase(session_id, session.phase.value)
+                if _beam_ph is None:
+                    await pg_update_phase(session_id, session.phase.value)
             except Exception as e:
                 logger.warning(f"Could not update PostgreSQL after thesis: {e}")
 
@@ -1606,7 +1636,8 @@ async def handle_submit_antithesis(arguments: Dict[str, Any]) -> Sequence[TextCo
             # If reviewer was auto-assigned (first-responder pattern), persist to PG
             if original_reviewer_id is None and session.reviewer_agent_id == agent_id:
                 try:
-                    await pg_update_reviewer(session_id, agent_id)
+                    if await beam_update_reviewer(session_id, agent_id) is None:
+                        await pg_update_reviewer(session_id, agent_id)
                     result["reviewer_auto_assigned"] = True
                     logger.info("Reviewer auto-assigned for dialectic session")
                 except Exception as e:
@@ -1627,7 +1658,10 @@ async def handle_submit_antithesis(arguments: Dict[str, Any]) -> Sequence[TextCo
                     concerns=arguments.get('concerns', []),
                     reasoning=arguments.get('reasoning'),
                 )
-                await pg_update_phase(session_id, session.phase.value)
+                # BEAM owns the phase write when flagged; else Python. (Slice 2.2)
+                _beam_ph = await beam_update_phase(session_id, session.phase.value)
+                if _beam_ph is None:
+                    await pg_update_phase(session_id, session.phase.value)
             except Exception as e:
                 logger.warning(f"Could not update PostgreSQL after antithesis: {e}")
 
@@ -1786,7 +1820,9 @@ async def handle_submit_synthesis(arguments: Dict[str, Any]) -> Sequence[TextCon
                         agrees=agrees,
                     )
                     if not result.get("converged"):
-                        await pg_update_phase(session_id, session.phase.value)
+                        _beam_ph = await beam_update_phase(session_id, session.phase.value)
+                        if _beam_ph is None:
+                            await pg_update_phase(session_id, session.phase.value)
                 except Exception as e:
                     logger.warning(f"Could not update PostgreSQL after synthesis: {e}")
     
@@ -1819,7 +1855,16 @@ async def handle_submit_synthesis(arguments: Dict[str, Any]) -> Sequence[TextCon
                     result["success"] = False
                     result["reason"] = f"Safety violation: {violation}"
                     try:
-                        await pg_resolve_session(session_id=session_id, resolution={"action": "block", "reason": violation}, status="failed")
+                        _block = {"action": "block", "reason": violation}
+                        beam_result = await beam_resolve(
+                            session_id=session_id,
+                            paused_agent_id=session.paused_agent_id,
+                            reviewer_agent_id=session.reviewer_agent_id,
+                            resolution=_block,
+                            status="failed",
+                        )
+                        if beam_result is None:
+                            await pg_resolve_session(session_id=session_id, resolution=_block, status="failed")
                     except Exception as e:
                         logger.warning(f"Could not resolve session in PostgreSQL: {e}")
                 else:
@@ -1860,7 +1905,15 @@ async def handle_submit_synthesis(arguments: Dict[str, Any]) -> Sequence[TextCon
                         result["execution_error"] = str(e)
                         result["next_step"] = next_step_execution_failed(e)
                         try:
-                            await pg_resolve_session(session_id=session_id, resolution=resolution.to_dict(), status="failed")
+                            beam_result = await beam_resolve(
+                                session_id=session_id,
+                                paused_agent_id=session.paused_agent_id,
+                                reviewer_agent_id=session.reviewer_agent_id,
+                                resolution=resolution.to_dict(),
+                                status="failed",
+                            )
+                            if beam_result is None:
+                                await pg_resolve_session(session_id=session_id, resolution=resolution.to_dict(), status="failed")
                         except Exception as pg_e:
                             logger.warning(f"Could not mark failed session in PostgreSQL: {pg_e}")
     

--- a/tests/test_dialectic_beam_resolve_client.py
+++ b/tests/test_dialectic_beam_resolve_client.py
@@ -77,6 +77,106 @@ async def test_saga_in_flight_falls_back_to_none(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_status_failed_is_sent_and_validated(monkeypatch):
+    monkeypatch.setenv("UNITARES_DIALECTIC_BEAM_RESOLUTION", "1")
+    monkeypatch.setenv("LEASE_PLANE_BEARER_TOKEN", "tok")
+    fake = _fake_httpx(200, {"ok": True, "status": "failed", "saga_id": "x", "origin": "new"})
+    with patch.dict(sys.modules, {"httpx": fake}):
+        out = await brc.beam_resolve("s1", "p", "r", {"reason": "boom"}, status="failed")
+    assert out is not None and out["status"] == "failed"
+    # The status was forwarded in the POST body.
+    sent = fake.Client.return_value.__enter__.return_value.post.call_args.kwargs["json"]
+    assert sent["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_invalid_status_returns_none(monkeypatch):
+    monkeypatch.setenv("UNITARES_DIALECTIC_BEAM_RESOLUTION", "1")
+    monkeypatch.setenv("LEASE_PLANE_BEARER_TOKEN", "tok")
+    out = await brc.beam_resolve("s1", "p", "r", {"x": 1}, status="bogus")
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_create_disabled_returns_none(monkeypatch):
+    monkeypatch.delenv("UNITARES_DIALECTIC_BEAM_RESOLUTION", raising=False)
+    out = await brc.beam_create_session("s1", "p", {"reason": "x"})
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_create_success_filters_none_fields(monkeypatch):
+    monkeypatch.setenv("UNITARES_DIALECTIC_BEAM_RESOLUTION", "1")
+    monkeypatch.setenv("LEASE_PLANE_BEARER_TOKEN", "tok")
+    fake = _fake_httpx(201, {"ok": True, "session_id": "s1", "created": True})
+    with patch.dict(sys.modules, {"httpx": fake}):
+        out = await brc.beam_create_session(
+            "s1", "p", {"reviewer_agent_id": "r", "topic": None, "reason": "boom"}
+        )
+    assert out is not None and out["created"] is True
+    sent = fake.Client.return_value.__enter__.return_value.post.call_args.kwargs["json"]
+    assert sent["reviewer_agent_id"] == "r"
+    assert "topic" not in sent  # None-valued fields are dropped
+
+
+@pytest.mark.asyncio
+async def test_create_non_ok_falls_back(monkeypatch):
+    monkeypatch.setenv("UNITARES_DIALECTIC_BEAM_RESOLUTION", "1")
+    monkeypatch.setenv("LEASE_PLANE_BEARER_TOKEN", "tok")
+    with patch.dict(sys.modules, {"httpx": _fake_httpx(503, {"ok": False})}):
+        out = await brc.beam_create_session("s1", "p", {"reason": "x"})
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_update_phase_disabled_returns_none(monkeypatch):
+    monkeypatch.delenv("UNITARES_DIALECTIC_BEAM_RESOLUTION", raising=False)
+    assert await brc.beam_update_phase("s1", "antithesis") is None
+
+
+@pytest.mark.asyncio
+async def test_update_phase_success(monkeypatch):
+    monkeypatch.setenv("UNITARES_DIALECTIC_BEAM_RESOLUTION", "1")
+    monkeypatch.setenv("LEASE_PLANE_BEARER_TOKEN", "tok")
+    fake = _fake_httpx(200, {"ok": True, "session_id": "s1", "phase": "antithesis"})
+    with patch.dict(sys.modules, {"httpx": fake}):
+        out = await brc.beam_update_phase("s1", "antithesis")
+    assert out is not None and out["phase"] == "antithesis"
+
+
+@pytest.mark.asyncio
+async def test_update_phase_non_ok_falls_back(monkeypatch):
+    monkeypatch.setenv("UNITARES_DIALECTIC_BEAM_RESOLUTION", "1")
+    monkeypatch.setenv("LEASE_PLANE_BEARER_TOKEN", "tok")
+    with patch.dict(sys.modules, {"httpx": _fake_httpx(422, {"ok": False})}):
+        assert await brc.beam_update_phase("s1", "resolved") is None
+
+
+@pytest.mark.asyncio
+async def test_update_reviewer_disabled_returns_none(monkeypatch):
+    monkeypatch.delenv("UNITARES_DIALECTIC_BEAM_RESOLUTION", raising=False)
+    assert await brc.beam_update_reviewer("s1", "rev") is None
+
+
+@pytest.mark.asyncio
+async def test_update_reviewer_success(monkeypatch):
+    monkeypatch.setenv("UNITARES_DIALECTIC_BEAM_RESOLUTION", "1")
+    monkeypatch.setenv("LEASE_PLANE_BEARER_TOKEN", "tok")
+    fake = _fake_httpx(200, {"ok": True, "session_id": "s1", "reviewer_agent_id": "rev"})
+    with patch.dict(sys.modules, {"httpx": fake}):
+        out = await brc.beam_update_reviewer("s1", "rev")
+    assert out is not None and out["reviewer_agent_id"] == "rev"
+
+
+@pytest.mark.asyncio
+async def test_update_reviewer_blank_returns_none(monkeypatch):
+    monkeypatch.setenv("UNITARES_DIALECTIC_BEAM_RESOLUTION", "1")
+    monkeypatch.setenv("LEASE_PLANE_BEARER_TOKEN", "tok")
+    # missing reviewer -> short-circuits to None (no HTTP)
+    assert await brc.beam_update_reviewer("s1", None) is None
+
+
+@pytest.mark.asyncio
 async def test_transport_error_falls_back_to_none(monkeypatch):
     monkeypatch.setenv("UNITARES_DIALECTIC_BEAM_RESOLUTION", "1")
     monkeypatch.setenv("LEASE_PLANE_BEARER_TOKEN", "tok")


### PR DESCRIPTION
Re-lands the dialectic-on-BEAM slices that never reached master because #1175/#1178/#1180 were merged mid-build while later commits were still being pushed to their branches. master had only Slice 1.1-1.2; this adds recovery, presence, failed-path, create, phase, reviewer, and the live-timer aliveness layer.

**Purely additive** vs current master (verified line-by-line: preserved #1174's comment fix; no other third-party divergence). All **flag-gated** (UNITARES_DIALECTIC_BEAM_RESOLUTION / _LIVENESS, default off) => zero behavior change until the operator flips flags.

Gates: **248 mix tests, 11052 pytest, 0 failures.**

Completes the dialectic write-surface on BEAM (sole writer of every core.dialectic_sessions column) + liveness + recovery + presence. Cutover after merge: deploy lease-plane then gov-mcp, flags stay off.

https://claude.ai/code/session_011Qw3sfs6vCjFwrqmbgxMhD