### PR TITLE
feat(dialectic): propagate BEAM routing flag to orchestrated reviewer spawns

### DIFF
--- a/src/mcp_handlers/dialectic/orchestrator_dispatch.py
+++ b/src/mcp_handlers/dialectic/orchestrator_dispatch.py
@@ -91,6 +91,21 @@ def _build_spec(session_id: str, thesis: Dict[str, Any], parent_agent_id: Option
     if parent_agent_id:
         env["UNITARES_PARENT_AGENT_ID"] = parent_agent_id
 
+    # Propagate the dialectic-on-BEAM routing flag + lease-plane creds so the
+    # spawned reviewer's OWN session-row writes (its antithesis phase advance,
+    # reviewer-slot claim, and any synthesis resolve it drives) route through
+    # BEAM too — matching the gov-mcp process. Forward-only: a key absent from
+    # the parent env is simply not set, so the reviewer falls back to the Python
+    # path. Stays flag-off-safe (nothing forwarded when gov-mcp is off).
+    for _key in (
+        "UNITARES_DIALECTIC_BEAM_RESOLUTION",
+        "LEASE_PLANE_BEARER_TOKEN",
+        "LEASE_PLANE_BASE_URL",
+    ):
+        _val = os.environ.get(_key)
+        if _val:
+            env[_key] = _val
+
     return {
         "cmd": sys.executable,  # the MCP process's own interpreter has the deps
         "args": ["-m", "agents.dialectic_reviewer"],

--- a/tests/test_dialectic_orchestrated_dispatch.py
+++ b/tests/test_dialectic_orchestrated_dispatch.py
@@ -54,6 +54,29 @@ def test_build_spec_omits_parent_when_absent():
     assert json.loads(spec["env"]["DIALECTIC_THESIS_CONDITIONS"]) == []
 
 
+def test_build_spec_propagates_beam_flag_and_creds(monkeypatch):
+    """When gov-mcp has the dialectic-on-BEAM flag + lease creds, the reviewer
+    spawn env carries them so the reviewer's own writes route through BEAM."""
+    monkeypatch.setenv("UNITARES_DIALECTIC_BEAM_RESOLUTION", "1")
+    monkeypatch.setenv("LEASE_PLANE_BEARER_TOKEN", "tok-xyz")
+    monkeypatch.setenv("LEASE_PLANE_BASE_URL", "http://127.0.0.1:8788")
+    spec = od._build_spec("s", {"root_cause": "", "proposed_conditions": [], "reasoning": ""}, None)
+    env = spec["env"]
+    assert env["UNITARES_DIALECTIC_BEAM_RESOLUTION"] == "1"
+    assert env["LEASE_PLANE_BEARER_TOKEN"] == "tok-xyz"
+    assert env["LEASE_PLANE_BASE_URL"] == "http://127.0.0.1:8788"
+
+
+def test_build_spec_omits_beam_flag_when_parent_off(monkeypatch):
+    """Forward-only: flag absent in gov-mcp env => not in the reviewer spec
+    (reviewer falls back to Python). Keeps it flag-off-safe."""
+    monkeypatch.delenv("UNITARES_DIALECTIC_BEAM_RESOLUTION", raising=False)
+    monkeypatch.delenv("LEASE_PLANE_BEARER_TOKEN", raising=False)
+    spec = od._build_spec("s", {"root_cause": "", "proposed_conditions": [], "reasoning": ""}, None)
+    assert "UNITARES_DIALECTIC_BEAM_RESOLUTION" not in spec["env"]
+    assert "LEASE_PLANE_BEARER_TOKEN" not in spec["env"]
+
+
 @pytest.mark.parametrize("env_val,expected", [
     (None, "http://127.0.0.1:8767/mcp/"),                       # default has the path
     ("http://127.0.0.1:8767", "http://127.0.0.1:8767/mcp/"),    # bare base → append


### PR DESCRIPTION
Follow-up from the live e2e smoke test: orchestrator-spawned reviewer subprocesses didn't inherit `UNITARES_DIALECTIC_BEAM_RESOLUTION`, so their session-row writes fell back to Python while gov-mcp routed through BEAM.

`_build_spec` now forwards `UNITARES_DIALECTIC_BEAM_RESOLUTION` + `LEASE_PLANE_BEARER_TOKEN` + `LEASE_PLANE_BASE_URL` into the reviewer spawn env **when present** in gov-mcp's env. Forward-only ⇒ flag-off-safe (nothing forwarded when gov-mcp is off; reviewer stays on Python path). Correctness already held (BEAM/Python race is corruption-safe via B-4 + saga idempotency, verified live in the smoke test); this completes BEAM ownership of reviewer-driven sessions.

Tests: forwards flag+creds when parent has them; omits when off. Full suite green: **11055 passed**.

Deploy: gov-mcp only (the dispatch builds the spawn spec). Next orchestrated reviewer picks it up after redeploy.

https://claude.ai/code/session_011Qw3sfs6vCjFwrqmbgxMhD