### PR TITLE
feat(governed-effects): UNITARES profile spec + IR schema-parity guard (convergence step 2)

### DIFF
--- a/docs/proposals/governed-effect-unitares-profile-v0.md
+++ b/docs/proposals/governed-effect-unitares-profile-v0.md
@@ -1,0 +1,68 @@
+# UNITARES Profile of the Governed Effect IR (v0)
+
+**Status:** spec (convergence step 2). Companion to
+[`governed-effect-convergence-v0.md`](./governed-effect-convergence-v0.md) and the
+Governed-Effect Plane contract ([`governed-effect-plane-v0.md`](./governed-effect-plane-v0.md)).
+
+This defines the **UNITARES profile** of fermata's canonical Governed Effect IR:
+how this plane's effect envelope (`POST /v1/effects`, plane §3) maps onto fermata's
+IR, and the profile policy that sits *on top of* the portable IR. The pinned IR
+schema lives at `tests/fixtures/vendored/`; the parity test
+(`tests/test_governed_effect_ir_parity.py`) asserts this mapping produces valid IR.
+
+The portable core stays portable: nothing UNITARES-specific (identity tiers, the
+UNITARES effect types, lease custody) goes in the core IR — it all rides
+`profile: "unitares"` + the namespaced `profile_ext`.
+
+## Field mapping — plane envelope → fermata IR `Intent`
+
+| plane envelope field | fermata IR `Intent` field | notes |
+|---|---|---|
+| `idempotency_key` | `idempotency_key` | aligned 1:1 (both require it, both reject same-key-different-intent) |
+| `custody_mode` | `custody_mode` | aligned by convergence step 1 (fermata PR #55) — `record_only` \| `execute` |
+| `effect_type` | `adapter` + `operation` (core) **or** `adapter: "tool"` + `profile_ext.unitares_effect_type` (UNITARES types) | see effect-type table |
+| `surface` | `target` | e.g. `file:///abs` → `target` |
+| `payload` | `input` | mode-specific (plane §5); IR `input` is `additionalProperties: true` |
+| `proposer` `{agent_uuid, client_session_id}` | `profile_ext.proposer` | UNITARES identity proof — not a core IR concept |
+| `provenance` | `profile_ext.provenance` | harness/session/verification source |
+| `required_leases` | `profile_ext.required_leases` | lease-plane custody — UNITARES-specific, profile only |
+| (derived) | `required_capability` | e.g. `"file.write"` from effect_type |
+| (constant) | `profile: "unitares"` | declares the profile |
+
+## Effect-type mapping
+
+| plane `effect_type` | core IR? | `adapter` / `operation` | `profile_ext.unitares_effect_type` |
+|---|---|---|---|
+| `file_write` | yes | `file` / `write` | — |
+| `repo_commit` | yes | `file` / `write` (tree) | `repo_commit` |
+| `agent_spawn` | **no** (UNITARES) | `tool` / `spawn` | `agent_spawn` |
+| `resident_cycle` | **no** (UNITARES) | `tool` / `cycle` | `resident_cycle` |
+| `service_restart` | **no** (UNITARES) | `tool` / `restart` | `service_restart` |
+
+`file_write` is the portable overlap (it exists in fermata's adapters too).
+`agent_spawn`/`resident_cycle`/`service_restart` are UNITARES capabilities that
+the portable core does **not** know about — they map onto the generic `tool`
+adapter and carry their real type in `profile_ext`, exactly so the core IR never
+grows UNITARES-specific vocabulary.
+
+## Profile policy (beyond IR validation)
+
+The IR validates *shape*; the profile adds *policy* the IR is deliberately
+agnostic about (plane §2):
+
+- **`execute` requires re-verified tier `strong`.** `profile_ext.required_tier`
+  must be `strong` for `custody_mode: "execute"`.
+- **`record_only` requires tier `≥ medium`**, stamped re-verified (plane §7).
+- Identity tiers are a UNITARES concept; fermata's core uses capability/scope.
+  The profile is where the tier gate lives, never the core IR.
+
+These policy rules are profile-enforced (the parity test pins the `strong`-for-execute
+rule); they are NOT part of fermata's portable contract.
+
+## What this is not
+
+- Not a runtime mapper implementation. The mapping is specified here and encoded
+  in the parity test; a code mapper (and the runtime `record_only` behavior in
+  fermata) are later steps.
+- Not a change to the plane's internals — `EffectCustodian`, the lease plane, and
+  `effects.payloads` storage are unchanged. This is the contract-alignment layer.

--- a/tests/test_governed_effect_ir_parity.py
+++ b/tests/test_governed_effect_ir_parity.py
@@ -1,0 +1,152 @@
+"""Schema-parity guard: the Governed-Effect Plane envelope conforms to fermata's
+canonical Governed Effect IR, via the UNITARES profile mapping.
+
+This is the anti-drift artifact named in governed-effect-convergence-v0.md — the
+guard whose ABSENCE let the fermata seed and this plane diverge (state model,
+effect-type vocab, verification, identity coupling) while both claimed the same
+primitive. fermata owns the contract; this test holds the plane to it.
+
+The IR schema is a PINNED vendored copy at tests/vendored/ (post convergence
+step-1, fermata PR #55 — it has custody_mode). It is a read-only mirror so this
+test has no runtime dependency on the fermata package; fermata owns the contract.
+
+Refresh when fermata's IR changes:
+    git -C <fermata> show main:references/governed-effect-ir-v0.schema.json \
+        > tests/vendored/fermata-governed-effect-ir-v0.schema.json
+If a fermata IR bump breaks this test, that is the guard WORKING: the UNITARES
+profile mapping must be reconciled.
+
+Mapping spec: docs/proposals/governed-effect-unitares-profile-v0.md.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+_SCHEMA_PATH = (
+    Path(__file__).parent / "vendored"
+    / "fermata-governed-effect-ir-v0.schema.json"
+)
+
+
+@pytest.fixture(scope="module")
+def ir_validator() -> Draft202012Validator:
+    schema = json.loads(_SCHEMA_PATH.read_text())
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(schema)
+
+
+# --- the UNITARES profile mapping (executable spec) --------------------------
+# plane effect envelope (governed-effect-plane-v0.md §3) -> fermata IR Intent.
+# Kept here as the encoded spec; a runtime mapper module is a later step.
+_CORE_EFFECT_TYPES = {
+    "file_write": ("file", "write", "file.write"),
+    "repo_commit": ("file", "write", "repo.commit"),
+}
+_UNITARES_EFFECT_TYPES = {
+    "agent_spawn": ("tool", "spawn", "agent.spawn"),
+    "resident_cycle": ("tool", "cycle", "resident.cycle"),
+    "service_restart": ("tool", "restart", "service.restart"),
+}
+
+
+def plane_envelope_to_ir_intent(env: dict) -> dict:
+    et = env["effect_type"]
+    is_core = et in _CORE_EFFECT_TYPES
+    adapter, operation, capability = (_CORE_EFFECT_TYPES if is_core else _UNITARES_EFFECT_TYPES)[et]
+
+    profile_ext: dict = {
+        "proposer": env["proposer"],
+        "provenance": env.get("provenance", {}),
+        "required_leases": env.get("required_leases", []),
+        "required_tier": env["required_tier"],
+    }
+    if not is_core:
+        profile_ext["unitares_effect_type"] = et
+
+    return {
+        "intent_id": env["effect_id"],
+        "proposal_id": env["proposal_id"],
+        "adapter": adapter,
+        "operation": operation,
+        "target": env["surface"],
+        "input": env["payload"],
+        "required_capability": capability,
+        "idempotency_key": env["idempotency_key"],
+        "custody_mode": env["custody_mode"],
+        "profile": "unitares",
+        "profile_ext": profile_ext,
+    }
+
+
+def _envelope(effect_type: str, custody_mode: str, required_tier: str) -> dict:
+    return {
+        "effect_id": f"eff_{effect_type}_{custody_mode}",
+        "proposal_id": f"prop_{effect_type}_{custody_mode}",
+        "effect_type": effect_type,
+        "surface": "file:///abs/sandbox/note.txt",
+        "custody_mode": custody_mode,
+        "idempotency_key": "k-parity-001",
+        "proposer": {"agent_uuid": "u-1", "client_session_id": "agent-1"},
+        "provenance": {"harness": "claude", "session_id": "s-1"},
+        "payload": {"content": "x"},
+        "required_leases": [{"surface": "file:///abs/sandbox/note.txt", "ttl_s": 300}],
+        "required_tier": required_tier,
+    }
+
+
+PLANE_EFFECTS = [
+    _envelope("file_write", "record_only", "medium"),   # portable type, shadow
+    _envelope("file_write", "execute", "strong"),       # portable type, commit
+    _envelope("agent_spawn", "execute", "strong"),      # UNITARES-only type, commit
+    _envelope("resident_cycle", "record_only", "medium"),
+]
+
+
+# --- the guard ----------------------------------------------------------------
+
+def test_vendored_schema_is_the_converged_version():
+    """The pinned IR must be the post-convergence schema (custody_mode present),
+    or the whole parity check is meaningless."""
+    schema = json.loads(_SCHEMA_PATH.read_text())
+    assert "CustodyMode" in schema.get("$defs", {})
+    assert set(schema["$defs"]["CustodyMode"]["enum"]) == {"record_only", "execute"}
+
+
+@pytest.mark.parametrize("env", PLANE_EFFECTS, ids=lambda e: f'{e["effect_type"]}:{e["custody_mode"]}')
+def test_plane_effect_maps_to_valid_ir_intent(ir_validator, env):
+    """Every representative plane effect, mapped through the UNITARES profile,
+    is a VALID fermata IR Intent — the contract-conformance guarantee."""
+    intent = plane_envelope_to_ir_intent(env)
+    errors = sorted(ir_validator.iter_errors(intent), key=str)
+    assert not errors, f"{env['effect_type']}:{env['custody_mode']} -> {errors[0].message}"
+
+
+def test_profile_keeps_unitares_types_out_of_core():
+    """UNITARES-only effect types ride the generic `tool` adapter + profile_ext,
+    never as core IR vocabulary."""
+    intent = plane_envelope_to_ir_intent(_envelope("agent_spawn", "execute", "strong"))
+    assert intent["adapter"] == "tool"
+    assert intent["profile_ext"]["unitares_effect_type"] == "agent_spawn"
+    assert intent["profile"] == "unitares"
+
+
+def test_profile_policy_execute_requires_strong_tier():
+    """Profile policy (NOT IR shape): custody_mode=execute must carry tier=strong
+    (plane §2). The IR is agnostic; the profile enforces it."""
+    for env in PLANE_EFFECTS:
+        if env["custody_mode"] == "execute":
+            assert env["required_tier"] == "strong", (
+                f'{env["effect_type"]} execute must require strong tier'
+            )
+
+    # and a malformed execute-at-medium envelope is a profile violation
+    def violates(env: dict) -> bool:
+        return env["custody_mode"] == "execute" and env["required_tier"] != "strong"
+
+    assert violates(_envelope("file_write", "execute", "medium"))
+    assert not violates(_envelope("file_write", "execute", "strong"))

--- a/tests/vendored/fermata-governed-effect-ir-v0.schema.json
+++ b/tests/vendored/fermata-governed-effect-ir-v0.schema.json
@@ -1,0 +1,317 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/CIRWEL/fermata/main/references/governed-effect-ir-v0.schema.json",
+  "title": "Governed Effect IR v0",
+  "description": "Canonical records for a governed-effect runtime: agents may propose; only governed effects may commit.",
+  "oneOf": [
+    { "$ref": "#/$defs/Scope" },
+    { "$ref": "#/$defs/Proposal" },
+    { "$ref": "#/$defs/Intent" },
+    { "$ref": "#/$defs/EffectRecord" },
+    { "$ref": "#/$defs/Trace" }
+  ],
+  "$defs": {
+    "NonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "IsoTimestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "SpeechAct": {
+      "type": "string",
+      "enum": ["need", "claim", "doubt", "intend", "remember", "boundary"]
+    },
+    "EffectState": {
+      "type": "string",
+      "enum": ["proposal", "intent", "admissible", "verified", "approved", "committed", "rejected", "paused"]
+    },
+    "CustodyMode": {
+      "type": "string",
+      "enum": ["record_only", "execute"],
+      "description": "Explicit, up-front declaration of how the runtime handles the effect: record_only — the runtime validates and records but does NOT commit (the external actor commits; shadow/dry-run); execute — the runtime holds custody and commits. The core 8-state EffectState distinguishes these only by terminal state (reached committed or not); this names the intent BEFORE termination, so a record_only proposal is distinguishable from an execute one up front. Optional in the core IR (back-compat); a profile MAY require it."
+    },
+    "Resource": {
+      "type": "object",
+      "required": ["kind", "target"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "type": "string", "enum": ["file", "db", "message", "memory", "network", "tool"] },
+        "target": { "$ref": "#/$defs/NonEmptyString" },
+        "metadata": { "type": "object", "additionalProperties": true }
+      }
+    },
+    "Capability": {
+      "type": "object",
+      "required": ["name", "resource_kind", "mode"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "$ref": "#/$defs/NonEmptyString" },
+        "resource_kind": { "type": "string", "enum": ["file", "db", "message", "memory", "network", "tool"] },
+        "mode": { "$ref": "#/$defs/NonEmptyString" },
+        "allow": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/NonEmptyString" },
+          "default": []
+        },
+        "deny": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/NonEmptyString" },
+          "default": []
+        }
+      }
+    },
+    "PolicyRule": {
+      "type": "object",
+      "required": ["id", "effect", "condition"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "#/$defs/NonEmptyString" },
+        "effect": { "type": "string", "enum": ["allow", "deny", "pause", "require_approval", "require_evidence"] },
+        "condition": { "$ref": "#/$defs/NonEmptyString" },
+        "reason": { "type": "string" }
+      }
+    },
+    "ApprovalRule": {
+      "type": "object",
+      "required": ["authority", "condition"],
+      "additionalProperties": false,
+      "properties": {
+        "authority": { "type": "string", "enum": ["performer", "council", "runtime", "none"] },
+        "condition": { "$ref": "#/$defs/NonEmptyString" },
+        "expires_after_seconds": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "AuditSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "retain": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["trace", "dry_run", "approval", "input_hash", "output_hash", "actor", "scope", "adapter_ack", "verification"]
+          },
+          "default": ["trace", "actor", "scope"]
+        },
+        "redact": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/NonEmptyString" },
+          "default": []
+        }
+      }
+    },
+    "Scope": {
+      "type": "object",
+      "required": ["schema_version", "scope_id", "resources", "capabilities"],
+      "additionalProperties": false,
+      "properties": {
+        "schema_version": { "const": "0.1" },
+        "record_type": { "const": "scope" },
+        "scope_id": { "$ref": "#/$defs/NonEmptyString" },
+        "actor": { "type": "string" },
+        "resources": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Resource" },
+          "minItems": 1
+        },
+        "capabilities": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Capability" },
+          "minItems": 1
+        },
+        "policies": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/PolicyRule" },
+          "default": []
+        },
+        "approvals": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ApprovalRule" },
+          "default": []
+        },
+        "audit": { "$ref": "#/$defs/AuditSpec" }
+      }
+    },
+    "Intent": {
+      "type": "object",
+      "required": ["intent_id", "proposal_id", "adapter", "operation", "target", "input", "required_capability"],
+      "additionalProperties": false,
+      "properties": {
+        "intent_id": { "$ref": "#/$defs/NonEmptyString" },
+        "proposal_id": { "$ref": "#/$defs/NonEmptyString" },
+        "adapter": { "type": "string", "enum": ["file", "db", "message", "memory", "network", "tool"] },
+        "operation": { "$ref": "#/$defs/NonEmptyString" },
+        "target": { "$ref": "#/$defs/NonEmptyString" },
+        "input": { "type": "object", "additionalProperties": true },
+        "required_capability": { "$ref": "#/$defs/NonEmptyString" },
+        "idempotency_key": { "type": "string" },
+        "custody_mode": { "$ref": "#/$defs/CustodyMode" },
+        "profile": {
+          "$ref": "#/$defs/NonEmptyString",
+          "description": "Names a downstream profile of this IR (e.g. \"unitares\"). Core stays strict; profile-specific data goes in `profile_ext`."
+        },
+        "profile_ext": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Namespaced extension data for the declared `profile` — keeps profile-specific fields out of the strict core (e.g. a UNITARES profile attaches its tier requirement / UNITARES effect_type here)."
+        }
+      }
+    },
+    "Proposal": {
+      "type": "object",
+      "required": ["schema_version", "record_type", "proposal_id", "actor", "speech_act", "payload"],
+      "additionalProperties": false,
+      "properties": {
+        "schema_version": { "const": "0.1" },
+        "record_type": { "const": "proposal" },
+        "proposal_id": { "$ref": "#/$defs/NonEmptyString" },
+        "actor": { "$ref": "#/$defs/NonEmptyString" },
+        "speech_act": { "$ref": "#/$defs/SpeechAct" },
+        "reason": { "type": "string" },
+        "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+        "evidence": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/NonEmptyString" },
+          "default": []
+        },
+        "payload": { "type": "object", "additionalProperties": true },
+        "intent": { "$ref": "#/$defs/Intent" }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "speech_act": { "const": "intend" } },
+            "required": ["speech_act"]
+          },
+          "then": { "required": ["intent"] }
+        }
+      ]
+    },
+    "CheckResult": {
+      "type": "object",
+      "required": ["name", "result"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "$ref": "#/$defs/NonEmptyString" },
+        "result": { "type": "string", "enum": ["pass", "fail", "not_applicable", "unknown"] },
+        "detail": { "type": "object", "additionalProperties": true }
+      }
+    },
+    "ApprovalRecord": {
+      "type": "object",
+      "required": ["status", "authority"],
+      "additionalProperties": false,
+      "properties": {
+        "status": { "type": "string", "enum": ["not_required", "requested", "approved", "denied", "expired"] },
+        "authority": { "type": "string", "enum": ["performer", "council", "runtime", "none"] },
+        "approval_id": { "type": "string" },
+        "approver": { "type": "string" },
+        "decided_at": { "$ref": "#/$defs/IsoTimestamp" },
+        "expires_at": { "$ref": "#/$defs/IsoTimestamp" },
+        "scope_id": { "$ref": "#/$defs/NonEmptyString" },
+        "intent_id": { "$ref": "#/$defs/NonEmptyString" },
+        "intent_sha256": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" },
+        "reason": { "type": "string" }
+      }
+    },
+    "Acknowledgement": {
+      "type": "object",
+      "required": ["adapter", "target", "handle"],
+      "additionalProperties": true,
+      "properties": {
+        "adapter": { "type": "string" },
+        "target": { "$ref": "#/$defs/NonEmptyString" },
+        "handle": { "$ref": "#/$defs/NonEmptyString" },
+        "sha256": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" },
+        "bytes": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "Verification": {
+      "type": "object",
+      "required": ["status"],
+      "additionalProperties": true,
+      "properties": {
+        "status": { "type": "string", "enum": ["unverified", "verified", "failed", "not_applicable"] },
+        "method": { "type": "string" },
+        "detail": { "type": "object", "additionalProperties": true }
+      }
+    },
+    "EffectRecord": {
+      "type": "object",
+      "required": ["schema_version", "record_type", "effect_id", "state", "scope_id", "trace_id"],
+      "additionalProperties": false,
+      "properties": {
+        "schema_version": { "const": "0.1" },
+        "record_type": { "const": "effect" },
+        "effect_id": { "$ref": "#/$defs/NonEmptyString" },
+        "state": { "$ref": "#/$defs/EffectState" },
+        "intent_id": { "$ref": "#/$defs/NonEmptyString" },
+        "scope_id": { "$ref": "#/$defs/NonEmptyString" },
+        "trace_id": { "$ref": "#/$defs/NonEmptyString" },
+        "checks": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/CheckResult" },
+          "default": []
+        },
+        "approval": { "$ref": "#/$defs/ApprovalRecord" },
+        "acknowledgement": { "$ref": "#/$defs/Acknowledgement" },
+        "verification": { "$ref": "#/$defs/Verification" },
+        "rejection_reason": { "type": "string" },
+        "required_input": { "$ref": "#/$defs/NonEmptyString" },
+        "committed_at": { "$ref": "#/$defs/IsoTimestamp" },
+        "custody_mode": { "$ref": "#/$defs/CustodyMode" },
+        "profile": { "$ref": "#/$defs/NonEmptyString" },
+        "profile_ext": { "type": "object", "additionalProperties": true }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "state": { "const": "committed" } },
+            "required": ["state"]
+          },
+          "then": { "required": ["intent_id", "acknowledgement", "verification", "committed_at"] }
+        },
+        {
+          "if": {
+            "properties": { "state": { "const": "rejected" } },
+            "required": ["state"]
+          },
+          "then": { "required": ["rejection_reason"] }
+        },
+        {
+          "if": {
+            "properties": { "state": { "const": "paused" } },
+            "required": ["state"]
+          },
+          "then": { "required": ["intent_id", "required_input"] }
+        }
+      ]
+    },
+    "TraceEvent": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": true,
+      "properties": {
+        "type": { "$ref": "#/$defs/NonEmptyString" },
+        "at": { "$ref": "#/$defs/IsoTimestamp" }
+      }
+    },
+    "Trace": {
+      "type": "object",
+      "required": ["schema_version", "record_type", "trace_id", "events"],
+      "additionalProperties": false,
+      "properties": {
+        "schema_version": { "const": "0.1" },
+        "record_type": { "const": "trace" },
+        "trace_id": { "$ref": "#/$defs/NonEmptyString" },
+        "events": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/TraceEvent" },
+          "default": []
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Convergence step 2** — the UNITARES *profile* of fermata's Governed Effect IR + the anti-drift guard the convergence plan called for. Follows step 1 (fermata PR cirwel/fermata#55, the `custody_mode` + profile-hook contract change). Records: `docs/proposals/governed-effect-convergence-v0.md` (#1184).

## What this adds
- **`docs/proposals/governed-effect-unitares-profile-v0.md`** — the profile spec: the field mapping (plane effect envelope → fermata IR `Intent`), the effect-type mapping (portable `file_write` vs UNITARES-only `agent_spawn`/`resident_cycle`/`service_restart`, which ride the generic `tool` adapter + `profile_ext` so they never enter core IR vocabulary), and the profile *policy* the IR is agnostic about (`execute` requires re-verified `strong` tier).
- **`tests/test_governed_effect_ir_parity.py`** — the guard. Encodes the mapping and asserts every representative plane effect (record_only/execute × portable/UNITARES types) is a **valid fermata IR Intent**. This is precisely the test whose absence let the two contracts diverge. **7/7 pass.**
- **`tests/vendored/`** — a pinned, read-only copy of fermata's IR schema (post step-1, includes `custody_mode`), so the test has no runtime dependency on the fermata package. Refresh command + provenance are in the test's module docstring; a fermata IR bump breaking this test *is* the guard working.

## Boundaries (honest)
- **Contract layer only.** No change to the plane's `EffectCustodian`, lease plane, or `effects.payloads` storage.
- The mapping lives in the test as the executable spec; a runtime mapper module (and fermata's runtime `record_only` behavior) are later steps.
- Additive — no existing code touched.

Draft — contract-alignment on an active surface; maintainer is the merge gate. Depends on fermata#55 for the vendored schema's `custody_mode` (refresh the pin when #55 merges).

https://claude.ai/code/session_015daY142TcQtwBCz1FW37hr