### PR TITLE
chore(scope-guard): flag Claude session-attribution links (commit msgs + PR body + files)

### DIFF
--- a/.github/workflows/repo-scope.yml
+++ b/.github/workflows/repo-scope.yml
@@ -49,10 +49,25 @@ jobs:
             echo "PR body register: allow-register marker present — skipping."
             exit 0
           fi
-          bad=$(printf '%s' "$PR_BODY" | grep -niE '/Users/cirwel|per your guidance|your overlay|you flagged|questions for [Kk]enny|live-verifier|council pass|council fold' || true)
+          bad=$(printf '%s' "$PR_BODY" | grep -niE '/Users/cirwel|per your guidance|your overlay|you flagged|questions for [Kk]enny|live-verifier|council pass|council fold|claude\.ai/code/session|Claude-Session:' || true)
           if [ -n "$bad" ]; then
-            echo "::error::PR body reads like a personal chat session or leaks an operator-local path. Rewrite third-person/imperative; move working notes out of the public record."
+            echo "::error::PR body reads like a personal chat session, leaks an operator-local path, or carries a Claude session-attribution link. Rewrite third-person/imperative; move working notes out of the public record."
             printf '%s\n' "$bad"
             exit 1
           fi
           echo "PR body register: clean"
+
+      # Commit messages aren't files or the PR body, so check them too — the
+      # Claude Code session-attribution trailer (Claude-Session: claude.ai/code/session)
+      # lands there by default and should not enter the public history.
+      - name: Lint PR commit messages for session-attribution links
+        if: github.event_name == 'pull_request'
+        run: |
+          base="${{ steps.base.outputs.ref }}"
+          bad=$(git log "${base}..HEAD" --format='%H %s%n%b' | grep -niE 'claude\.ai/code/session|Claude-Session:' || true)
+          if [ -n "$bad" ]; then
+            echo "::error::A PR commit message carries a Claude Code session link (claude.ai/code/session). Strip the Claude-Session trailer from commit messages."
+            printf '%s\n' "$bad"
+            exit 1
+          fi
+          echo "Commit messages: clean"

--- a/docs/REPO_SCOPE.md
+++ b/docs/REPO_SCOPE.md
@@ -33,6 +33,12 @@ agent (or no agent) against it.
   `~/projects/_notes-archive/<repo>/`; ship clean docs. A PR that legitimately
   discusses these patterns (this guard, a register cleanup, meta-docs) can opt
   the PR-body lint out with the HTML comment `<!-- scope-guard: allow-register -->`.
+- **Claude session-attribution links** — `claude.ai/code/session` / a
+  `Claude-Session:` trailer. The Claude Code harness appends these to commit
+  messages and PR bodies by default, but they tie the public repo to a private
+  session, signal AI authorship, and are dead links to anyone but the operator
+  (the commit-level analogue of `Co-Authored-By`, which this repo also omits).
+  The guard checks committed files, the PR body, **and the PR's commit messages**.
 
 ## Why a guard, not just this doc
 

--- a/scripts/dev/check-repo-scope.sh
+++ b/scripts/dev/check-repo-scope.sh
@@ -127,6 +127,9 @@ while IFS= read -r f; do
       if grep -nIE 'live-verifier|council pass|council fold|three-lane council' "$f" >/dev/null 2>&1; then
         report "$f" "Exposes the AI-review process (council/live-verifier) — internal deliberation, not product content. Keep working notes in ~/projects/_notes-archive and ship clean docs."
       fi
+      if grep -nIE 'claude\.ai/code/session|Claude-Session:' "$f" >/dev/null 2>&1; then
+        report "$f" "Contains a Claude Code session-attribution link (claude.ai/code/session) — it ties the public repo to a private session and signals AI authorship. Keep it out of committed content, commit messages, and PR bodies (cf. the no-Co-Authored-By convention)."
+      fi
       ;;
   esac
 done <<EOF


### PR DESCRIPTION
<!-- scope-guard: allow-register (this PR names the patterns it guards) -->

## Problem

The Claude Code harness appends a `Claude-Session: https://claude.ai/code/session_<id>` trailer to commit messages and PR bodies by default. In a **public** repo that:
- ties the history to a **private** session only the operator can open (dead link to everyone else),
- signals AI authorship on every commit/PR,
- is the commit-level analogue of `Co-Authored-By` — which this repo already omits by convention.

There is no Claude Code setting to disable it (confirmed against the docs; `includeCoAuthoredBy` does not cover it), so the guard is the enforcement.

## Fix

Extend the existing scope guard to flag `claude.ai/code/session` / `Claude-Session:`:
- **`check-repo-scope.sh` Rule 5** — in committed file content.
- **`repo-scope.yml`** — in the PR body, **plus a new step scanning the PR's commit messages** (`git log base..HEAD`). That's the trailer's main vector, which neither the file scan nor the body lint previously covered.
- **`REPO_SCOPE.md`** — documents it.

## Notes

- Diff-scoped, so existing history (~10 merged commits that carry the trailer) is not retro-flagged.
- Self-tested: catches the URL and the `Claude-Session:` trailer; ignores ordinary "claude code" prose; self-exempts the guard's own files.
- **This PR carries no `Claude-Session` trailer** — the first authored under the rule it adds.