### PR TITLE
fix(dialectic): route save_session resolve through BEAM (the real reviewer-flow gap)

### DIFF
--- a/src/mcp_handlers/dialectic/session.py
+++ b/src/mcp_handlers/dialectic/session.py
@@ -172,16 +172,32 @@ async def save_session(session: DialecticSession) -> None:
     try:
         from src.dialectic_db import update_session_phase_async as pg_update_phase
         from src.dialectic_db import resolve_session_async as pg_resolve_session
+        from .beam_resolve_client import beam_resolve, beam_update_phase
         if session.phase in (DialecticPhase.RESOLVED, DialecticPhase.FAILED):
             resolution_dict = session.resolution.to_dict() if session.resolution else None
             status = session.phase.value if session.phase == DialecticPhase.RESOLVED else "failed"
-            await pg_resolve_session(
+            # save_session is the catch-all flush that resolves the session in the
+            # orchestrated-reviewer flow (verified 2026-06-28: it, not the explicit
+            # handle_submit_synthesis sites, wrote the terminal row there). Route it
+            # through BEAM so the sole-writer invariant holds for that flow too;
+            # fail-safe fallback to Python keeps it flag-off-safe.
+            beam_done = await beam_resolve(
                 session_id=session.session_id,
-                resolution=resolution_dict,
+                paused_agent_id=getattr(session, "paused_agent_id", None),
+                reviewer_agent_id=getattr(session, "reviewer_agent_id", None),
+                resolution=resolution_dict or {},
                 status=status,
             )
+            if beam_done is None:
+                await pg_resolve_session(
+                    session_id=session.session_id,
+                    resolution=resolution_dict,
+                    status=status,
+                )
         else:
-            await pg_update_phase(session.session_id, session.phase.value)
+            beam_ph = await beam_update_phase(session.session_id, session.phase.value)
+            if beam_ph is None:
+                await pg_update_phase(session.session_id, session.phase.value)
         logger.debug(f"Session {session.session_id} synced to PostgreSQL (phase={session.phase.value})")
     except Exception as e:
         logger.error(f"PostgreSQL sync failed for session {session.session_id}: {e}")

--- a/tests/test_dialectic_save_session_beam.py
+++ b/tests/test_dialectic_save_session_beam.py
@@ -1,0 +1,57 @@
+"""
+save_session is the catch-all flush that resolves a dialectic session in the
+orchestrated-reviewer flow (forensically confirmed 2026-06-28: it, not the
+explicit handle_submit_synthesis sites, wrote the terminal row there). These
+tests pin that its resolve routes through BEAM with a fail-safe Python fallback.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from src.dialectic_protocol import DialecticPhase
+from src.mcp_handlers.dialectic import session as sess_mod
+
+
+def _resolved_session():
+    return SimpleNamespace(
+        session_id="sess-save-1",
+        phase=DialecticPhase.RESOLVED,
+        paused_agent_id="paused-1",
+        reviewer_agent_id="rev-1",
+        resolution=SimpleNamespace(to_dict=lambda: {"action": "resume"}),
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_session_routes_resolve_through_beam(monkeypatch):
+    monkeypatch.setattr(sess_mod, "UNITARES_DIALECTIC_WRITE_JSON_SNAPSHOT", False, raising=False)
+    beam = AsyncMock(return_value={"ok": True, "status": "resolved"})
+    pg = AsyncMock()
+    with patch("src.mcp_handlers.dialectic.beam_resolve_client.beam_resolve", beam), \
+         patch("src.dialectic_db.resolve_session_async", pg):
+        await sess_mod.save_session(_resolved_session())
+
+    beam.assert_awaited_once()
+    assert beam.await_args.kwargs["status"] == "resolved"
+    assert beam.await_args.kwargs["reviewer_agent_id"] == "rev-1"
+    pg.assert_not_awaited()  # BEAM owned it -> no Python write
+
+
+@pytest.mark.asyncio
+async def test_save_session_falls_back_to_python_when_beam_declines(monkeypatch):
+    monkeypatch.setattr(sess_mod, "UNITARES_DIALECTIC_WRITE_JSON_SNAPSHOT", False, raising=False)
+    beam = AsyncMock(return_value=None)  # flag off / unreachable / etc.
+    pg = AsyncMock()
+    with patch("src.mcp_handlers.dialectic.beam_resolve_client.beam_resolve", beam), \
+         patch("src.dialectic_db.resolve_session_async", pg):
+        await sess_mod.save_session(_resolved_session())
+
+    beam.assert_awaited_once()
+    pg.assert_awaited_once()  # fail-safe fallback


### PR DESCRIPTION
Live forensics found the orchestrated-reviewer dialectic flow resolves via `save_session` (the catch-all flush), which wrote the terminal row through `pg_resolve_session` **unrouted** — the gov-mcp log showed `Resolved session` with no `beam_resolve` before it. The explicit `handle_submit_synthesis` sites were already routed; `save_session` was the miss.

This is the **actual** fix (PR #1185's env-propagation was a no-op — the reviewer submits via gov-mcp, so its writes already run in the flag-on process; propagating the flag to its env changes nothing).

`save_session` now routes its resolve + phase-advance through BEAM with fail-safe Python fallback. Flag-off-safe; idempotent (B-4 + saga) even if an explicit site also resolved.

Tests: routes through BEAM; falls back when BEAM declines. Full suite green: **11064 passed**.

Deploy: gov-mcp. After deploy I'll live-verify a reviewer-driven resolve leaves a `pg_committed` saga (the thing round-1 lacked).

https://claude.ai/code/session_011Qw3sfs6vCjFwrqmbgxMhD