### PR TITLE
docs(architecture): fix ODE-as-engine diagram + stale KG schema, re-verify canonical map

### DIFF
--- a/docs/UNIFIED_ARCHITECTURE.md
+++ b/docs/UNIFIED_ARCHITECTURE.md
@@ -12,23 +12,28 @@ Status: canonical prose summary. If this file and runtime code disagree, trust [
 
   Do work                     HTTP POST /mcp/
   Report: what you did,      ------------------->
-    complexity, confidence    process_agent_update     EISV dynamics
-                                                      +----------+
-                                                      | dE/dt    |
-                                                      | dI/dt    |
-                                                      | dS/dt    |
-                                                      | dV/dt    |
-                                                      +----+-----+
-                                                           |
-                                                      coherence C(V)
-                                                      risk_score
-                                                      margin level
-                                                           |
-                              <---------------------------+
+    complexity, confidence    process_agent_update   Behavioral EISV
+                                                      +---------------------+
+                                                      | grounded signals    |
+                                                      |  (logs, tools,      |
+                                                      |   calibration)      |
+                                                      | -> EMA + z-score    |
+                                                      |    vs own baseline  |
+                                                      +----------+----------+
+                                                                 |       ODE / free-energy
+                                                            coherence    runs in parallel as a
+                                                            risk_score   diagnostic lens — it
+                                                            margin       does NOT drive verdicts
+                                                                 |
+                              <----------------------------------+
                               {"action": "proceed",
                                "margin": "comfortable",
                                "guidance": "..."}
 ```
+
+The engine is the **behavioral** path: observable work signals scored against
+the agent's own baseline. The ODE / free-energy formulation is a parallel
+research lens, not the verdict authority — see [§2](#2-eisv-evolution).
 
 ## The Governance Pipeline
 
@@ -49,7 +54,7 @@ At runtime, the reflective fields above (`complexity`, `confidence`) are not tru
 
 **Primary system: Behavioral EISV** — EMA (exponential moving average) observations from grounded behavioral signals. These signals are assembled from operational log analysis, continuity metrics, tool usage, calibration history, and outcome history; self-reports are one input, not the whole substrate. After ~30 check-ins, the system builds per-agent Welford baselines and assesses agents by z-score deviation from their own operating point rather than universal thresholds.
 
-**Secondary system: ODE (diagnostic only)** — coupled differential equations run in parallel but do not drive verdicts. The ODE provides a thermodynamic lens for analysis but behavioral verdicts override.
+**Secondary system: ODE (diagnostic only)** — coupled differential equations run in parallel but do not drive verdicts. The ODE provides a dynamical-systems lens for analysis but behavioral verdicts override.
 
 The grounding path lives in `src/dual_log/`, `src/behavioral_sensor.py`, `src/behavioral_state.py`, and `src/behavioral_assessment.py`. The ODE engine lives in `governance_core` (compiled package, unitares-core).
 
@@ -121,7 +126,9 @@ Agents contribute discoveries to a shared store. **PostgreSQL FTS is the canonic
 |  +- core.identities          |     All agent state, audit,
 |  +- core.agent_state         |     and knowledge lives here.
 |  +- audit.events             |
-|  +- core.discoveries (AGE)   |     There is no SQLite.
+|  +- knowledge.discoveries    |     relational KG record + FTS.
+|  +- discovery_embeddings     |     pgvector semantic search.
+|  +- governance_graph (AGE)   |     There is no SQLite.
 |  +- dialectic.*              |
 |  +- core.calibration         |
 |  +- core.tool_usage          |

--- a/docs/dev/CANONICAL_SOURCES.md
+++ b/docs/dev/CANONICAL_SOURCES.md
@@ -1,6 +1,6 @@
 # Canonical Sources
 
-**Last Updated:** 2026-04-11
+**Last Updated:** 2026-06-28 (re-verified: all listed runtime sources and thin-doc targets resolve)
 
 Use this page to resolve architecture disputes and doc drift.
 


### PR DESCRIPTION
## Why

The public architecture docs were flagged as feeling stale. On inspection the *content* is mostly current — the problem was narrower than a big merge:

1. **The headline diagram lied.** `UNIFIED_ARCHITECTURE.md` opened with an ASCII diagram showing `dE/dt, dI/dt, dS/dt, dV/dt` (the ODE) as **the engine** — directly contradicting its own §2 ("Primary system: Behavioral EISV … ODE diagnostic only") *and* `CANONICAL_SOURCES.md`'s own stale-risk pattern #3: *"descriptions implying ODE state directly drives verdicts."* The first thing a reviewer saw encoded the controller-era model the runtime moved past.
2. **Stale KG schema names** in the DB box: `core.discoveries (AGE)` — the real table is `knowledge.discoveries` (72 call sites in `src/`), with pgvector embeddings and the AGE graph `governance_graph` as separate representations.
3. **`CANONICAL_SOURCES.md` stamped 2026-04-11** — 2.5 months stale on the one doc whose job is to be the current authority map.

## What

- **`UNIFIED_ARCHITECTURE.md`**
  - Headline diagram redrawn: behavioral-EISV (grounded signals to EMA + z-score vs own baseline) is the engine; ODE/free-energy shown as a parallel diagnostic lens that does **not** drive verdicts. Added a one-line caption pointing to §2.
  - `thermodynamic lens` to `dynamical-systems lens` (consistency with established positioning).
  - DB box: `core.discoveries (AGE)` to `knowledge.discoveries` (relational+FTS) + `discovery_embeddings` (pgvector) + `governance_graph` (AGE).
- **`CANONICAL_SOURCES.md`**: re-stamped to 2026-06-28; **re-verified** all 9 listed runtime sources and 5 thin-doc targets resolve (none missing).

## Deliberately not done

- **No authority-map relabel.** `UNIFIED_ARCHITECTURE` and `DRIFT_LEDGER` already defer to `CANONICAL_SOURCES`, and the lease-plane proposal's "canonical" is scoped to its own subsystem contract. The hierarchy is coherent.
- **No body rewrites for verbosity.** The flagship doc's length is mostly substance (threat model, case study, in-flight pointers).
- **No content overlap with #1190** (the in-flight staleness sweep) — disjoint file set.

Docs-only; scope guard clean.