### PR TITLE
feat(governed-effect): storage foundation for file_write execute + §5b rollback (slice 1a)

### DIFF
--- a/db/postgres/migrations/052_effects_payloads.sql
+++ b/db/postgres/migrations/052_effects_payloads.sql
@@ -1,0 +1,55 @@
+-- 052_effects_payloads.sql
+-- Durable storage for the governed-effect EXECUTE half (Phase 4, §5b/§5/§10).
+--
+-- The first reversible execute surface (file_write) needs a place to hold the
+-- actual bytes the runtime commits AND the pre-image needed for rollback. The
+-- record_only path (#1065) stores nothing here — it rides audit.events. This
+-- table exists only for execute custody: pre-image capture, crash-recovery
+-- content-hash reconciliation, and tombstone/quarantine state.
+--
+-- MANUAL migration. Do NOT auto-run. Apply with psql before the new lease-plane
+-- binary that references effects.* starts. Until applied, EffectRepo queries
+-- error and the (flag-off) execute path stays execute_not_implemented.
+
+CREATE SCHEMA IF NOT EXISTS effects;
+
+CREATE TABLE IF NOT EXISTS effects.payloads (
+    effect_id          TEXT PRIMARY KEY,
+    effect_type        TEXT NOT NULL,
+    -- the scrubbed bytes the executor applies (per-class ceiling enforced in
+    -- Elixir before insert, never raw-logged). NULL until insert.
+    payload_bytes      BYTEA,
+    payload_sha256     TEXT NOT NULL,
+    -- §5b rollback: the file's bytes/hash BEFORE the write, captured by the
+    -- executor immediately before mutating. pre_image_existed=false means the
+    -- file did not exist (rollback = delete what we created).
+    pre_image_sha256   TEXT,
+    pre_image_bytes    BYTEA,
+    pre_image_existed  BOOLEAN NOT NULL DEFAULT FALSE,
+    -- rollback lifecycle. NULL = fresh or cleanly committed.
+    --   'pending'     — pre-image captured, mutation in flight (crash here →
+    --                   recovery reconciles by content hash).
+    --   'tombstoned'  — rolled back; a same-key retry MUST re-execute (§4/§5b).
+    --   'quarantined' — apply failed AND compensation failed; surface is dirty,
+    --                   operator-first, retry is unsafe.
+    rollback_state     TEXT CHECK (rollback_state IN ('pending', 'tombstoned', 'quarantined')),
+    committed_at       TIMESTAMPTZ,
+    -- stored for crash-recovery re-acquire (the surface lease(s) to re-hold
+    -- before any compensation).
+    required_leases    JSONB NOT NULL DEFAULT '[]',
+    proposer_agent_uuid TEXT,
+    idempotency_key    TEXT NOT NULL,
+    idempotency_digest TEXT NOT NULL,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Boot-time EffectRecovery scans only orphans: pre-image captured, never
+-- committed. Partial index keeps that scan cheap.
+CREATE INDEX IF NOT EXISTS idx_effects_payloads_orphans
+    ON effects.payloads (created_at)
+    WHERE rollback_state = 'pending' AND committed_at IS NULL;
+
+-- Register migration
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (52, 'effects_payloads', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/elixir/lease_plane/lib/unitares_lease_plane/effect_executor.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/effect_executor.ex
@@ -1,0 +1,29 @@
+defmodule UnitaresLeasePlane.EffectExecutor do
+  @moduledoc """
+  Behaviour for a per-`effect_type` executor on the governed-effect EXECUTE path
+  (§5a). The `EffectCustodian` GenServer acquires the required leases and clears
+  the governance veto, then hands off to `apply_effect/3`.
+
+  Contract for an implementation (e.g. `FileWriteExecutor`):
+
+    * `apply_effect/3` MUST capture the rollback pre-image (via
+      `EffectRepo.record_pre_image/4`) BEFORE mutating the surface, then mutate,
+      then `EffectRepo.mark_committed/1` AFTER the mutation is durable.
+    * On a mutation failure it MUST run its own in-process compensation (restore
+      the pre-image while it still holds the lease) and return `{:rejected, _}`;
+      if compensation also fails it MUST `EffectRepo.quarantine/1` and return
+      `{:rejected, :rollback_failed}`.
+    * It MUST NOT restore bytes across a process crash — crash recovery is the
+      custodian/`EffectRecovery`'s job and is by-construction non-mutating
+      (commit-forward / tombstone / quarantine by DB mark only).
+
+  `reversible?/0` declares whether the type supports rollback. An irreversible
+  type (e.g. `agent_spawn`) returns `false` and is promotable only under an
+  explicit no-rollback acknowledgment (§5b), never via this reversible path.
+  """
+
+  @callback apply_effect(effect_id :: String.t(), payload :: map(), leases :: [map()]) ::
+              {:committed, map()} | {:rejected, term()}
+
+  @callback reversible?() :: boolean()
+end

--- a/elixir/lease_plane/lib/unitares_lease_plane/effect_repo.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/effect_repo.ex
@@ -1,0 +1,154 @@
+defmodule UnitaresLeasePlane.EffectRepo do
+  @moduledoc """
+  Postgrex-backed durable store for the governed-effect EXECUTE half
+  (`effects.payloads`, migration 052). Not Ecto — same minimal-surface posture
+  as `Repo`. Scoped to execute custody: pre-image capture, crash-recovery
+  reconciliation, and tombstone/quarantine state. The `record_only` path does
+  NOT use this module (it rides `audit.events`).
+
+  All UPDATEs are written so a restarted custodian or the boot recovery scanner
+  can replay them safely (guarded `WHERE` clauses, idempotent marks).
+  """
+
+  alias UnitaresLeasePlane.DB
+
+  require Logger
+
+  @doc """
+  Insert the fresh effect-payload row (rollback_state NULL). Called at propose
+  time, before the custodian starts. ON CONFLICT DO NOTHING so a same-key retry
+  does not error.
+  """
+  @spec insert_effect_payload(map()) :: :ok | {:error, term()}
+  def insert_effect_payload(p) do
+    sql = """
+    INSERT INTO effects.payloads
+      (effect_id, effect_type, payload_bytes, payload_sha256, required_leases,
+       proposer_agent_uuid, idempotency_key, idempotency_digest)
+    VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8)
+    ON CONFLICT (effect_id) DO NOTHING
+    """
+
+    params = [
+      p.effect_id,
+      p.effect_type,
+      p.payload_bytes,
+      p.payload_sha256,
+      Jason.encode!(Map.get(p, :required_leases, [])),
+      Map.get(p, :proposer_agent_uuid),
+      p.idempotency_key,
+      p.idempotency_digest
+    ]
+
+    case Postgrex.query(DB, sql, params) do
+      {:ok, _} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Record the rollback pre-image and flip rollback_state -> 'pending'. The
+  `WHERE rollback_state IS NULL` guard makes a double-call (e.g. a restarted
+  custodian re-running apply) a no-op rather than clobbering a captured
+  pre-image. Returns `:ok` on the first capture, `:already` if the row had
+  already moved past NULL, `{:error, _}` on DB failure.
+  """
+  @spec record_pre_image(String.t(), String.t() | nil, binary() | nil, boolean()) ::
+          :ok | :already | {:error, term()}
+  def record_pre_image(effect_id, pre_image_sha256, pre_image_bytes, existed?) do
+    sql = """
+    UPDATE effects.payloads
+       SET rollback_state = 'pending',
+           pre_image_sha256 = $2,
+           pre_image_bytes = $3,
+           pre_image_existed = $4
+     WHERE effect_id = $1 AND rollback_state IS NULL
+    RETURNING effect_id
+    """
+
+    case Postgrex.query(DB, sql, [effect_id, pre_image_sha256, pre_image_bytes, existed?]) do
+      {:ok, %{num_rows: 1}} -> :ok
+      {:ok, %{num_rows: 0}} -> :already
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Mark the effect committed (clears rollback_state, sets committed_at).
+  Idempotent via `WHERE committed_at IS NULL` — safe to call from both the
+  happy path and a crash-recovery commit-forward.
+  """
+  @spec mark_committed(String.t()) :: :ok | {:error, term()}
+  def mark_committed(effect_id) do
+    sql = """
+    UPDATE effects.payloads
+       SET committed_at = now(), rollback_state = NULL
+     WHERE effect_id = $1 AND committed_at IS NULL
+    """
+
+    case Postgrex.query(DB, sql, [effect_id]) do
+      {:ok, _} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc "Tombstone a rolled-back effect so a same-key retry RE-EXECUTES (§4/§5b)."
+  @spec tombstone(String.t()) :: :ok | {:error, term()}
+  def tombstone(effect_id), do: set_state(effect_id, "tombstoned")
+
+  @doc "Quarantine an effect whose compensation failed — operator-first, retry unsafe."
+  @spec quarantine(String.t()) :: :ok | {:error, term()}
+  def quarantine(effect_id), do: set_state(effect_id, "quarantined")
+
+  defp set_state(effect_id, state) do
+    sql = "UPDATE effects.payloads SET rollback_state = $2 WHERE effect_id = $1"
+
+    case Postgrex.query(DB, sql, [effect_id, state]) do
+      {:ok, _} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc "Full row fetch for a single effect, or nil when absent."
+  @spec get_payload(String.t()) :: {:ok, map() | nil} | {:error, term()}
+  def get_payload(effect_id) do
+    sql = """
+    SELECT effect_id, effect_type, payload_sha256, pre_image_sha256,
+           pre_image_existed, rollback_state, committed_at, required_leases
+      FROM effects.payloads
+     WHERE effect_id = $1
+    """
+
+    case Postgrex.query(DB, sql, [effect_id]) do
+      {:ok, %{rows: []}} -> {:ok, nil}
+      {:ok, %{columns: cols, rows: [row]}} -> {:ok, row_to_map(cols, row)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Orphans for the boot recovery scanner: pre-image captured, never committed.
+  Backed by the partial index in migration 052.
+  """
+  @spec orphaned_payloads() :: {:ok, [map()]} | {:error, term()}
+  def orphaned_payloads do
+    sql = """
+    SELECT effect_id, effect_type, payload_sha256, pre_image_sha256,
+           pre_image_existed, rollback_state, committed_at, required_leases
+      FROM effects.payloads
+     WHERE rollback_state = 'pending' AND committed_at IS NULL
+    """
+
+    case Postgrex.query(DB, sql, []) do
+      {:ok, %{columns: cols, rows: rows}} -> {:ok, Enum.map(rows, &row_to_map(cols, &1))}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp row_to_map(cols, row) do
+    cols
+    |> Enum.map(&String.to_atom/1)
+    |> Enum.zip(row)
+    |> Map.new()
+  end
+end


### PR DESCRIPTION
Slice 1a of the `file_write` execute path — the next governed-effect frontier. The §6 veto already shipped (#1073) and `agent_spawn` execute is live, but §5b rollback was zero lines of Elixir. `file_write` is the first *reversible* execute surface, so it is where the rollback machinery actually gets exercised — the highest-stakes code in the system (a governed file commit plus a rollback that, done wrong, corrupts data or clobbers a competing writer).

This PR is INERT — additive storage and contract only. Nothing executes; no flag; compiles clean. The crash-recovery OTP state machine is deliberately a separate, focused slice rather than rushed in alongside the storage layer.

## What's here
- **migration 052 (MANUAL)** — `effects.payloads`: execute payload bytes, the rollback pre-image (sha + bytes), `rollback_state` (pending/tombstoned/quarantined), `committed_at`, `required_leases` for crash re-acquire. Partial index for the boot recovery scan. `record_only` is untouched (rides `audit.events`).
- **`EffectExecutor` behaviour** (§5a) — `apply_effect/3` + `reversible?/0`, with the pre-image-before-mutate and non-mutating-crash-recovery contract documented.
- **`EffectRepo`** — replay-safe queries: `record_pre_image` guarded on `rollback_state IS NULL`, `mark_committed` idempotent on `committed_at IS NULL`, `tombstone`/`quarantine`, `orphaned_payloads` for the boot scanner.

## Design (reviewed)
- **Corruption defense:** crash recovery never restores bytes — it only commit-forwards, tombstones, or quarantines by DB mark. Immune to the competing-writer clobber by construction.
- **Landmines for the next slice:** `restart: :transient` (not `:temporary`, or recovery never fires); tombstone-with-null-digest so a retry-after-rollback re-executes (not a silent no-op); veto re-checked on the commit path; min-TTL floor; a `validate_execute_type_flags!` boot guard.
- **Ground-truth:** `agent_spawn` execute is live (a real `committed` spawn 2026-06-25); §6 veto is live and fail-closed; `effects.payloads` was confirmed absent until this migration.

## Next slices (sequenced, dry-run-first)
- **1b** — `EffectCustodian` + `EffectRecovery` GenServers (`:transient` restart + boot scanner), tested with a fake executor (no real file writes).
- **2** — `FileWriteExecutor` behind a fail-closed `UNITARES_GOVERNED_EFFECT_EXECUTE_FILE_WRITE` flag, default off, dry-run-first.

Migration 052 is MANUAL — apply with `psql` before any binary referencing `effects.*`; the execute path stays `execute_not_implemented` until then.

Draft — RCE-class surface; maintainer is the merge gate.