### PR TITLE
docs: Redis is not optional — it's the de-facto primary session store

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ UNITARES governance MCP server. Information-theoretic governance framework for A
 
 - Python 3.12+, asyncio
 - PostgreSQL@17 + AGE 1.7.0 (Apache Graph Extension) via Homebrew
-- Redis (optional session cache)
+- Redis — de-facto primary session/identity store, **not optional** (boots in degraded local-only mode without it, but most live sessions exist only in Redis; see `docs/proposals/redis-retirement-v0.md`)
 - Pydantic v2 for parameter validation
 - MCP (Model Context Protocol) server
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ UNITARES governance MCP server. Information-theoretic governance framework for A
 
 - Python 3.12+, asyncio
 - PostgreSQL@17 + AGE 1.7.0 (Apache Graph Extension) via Homebrew
-- Redis (optional session cache)
+- Redis — de-facto primary session/identity store, **not optional** (boots in degraded local-only mode without it, but most live sessions exist only in Redis; see `docs/proposals/redis-retirement-v0.md`)
 - Pydantic v2 for parameter validation
 - MCP (Model Context Protocol) server
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@
 #
 # This brings up:
 #   - postgres-age      Postgres 17 + Apache AGE + pgvector  (port 5432)
-#   - redis             Session cache + locks                 (port 6379)
+#   - redis             De-facto primary session store + locks (port 6379)
 #   - governance-mcp    UNITARES governance server            (port 8767)
 #
 # All ports bind to 127.0.0.1 only. Override credentials via .env (copy

--- a/docs/manual/03-running-the-server.md
+++ b/docs/manual/03-running-the-server.md
@@ -22,7 +22,7 @@ A full UNITARES deployment is several bound services. All bind loopback by defau
 | Gateway MCP | `8768` | `/mcp/` | Reduced surface for weak external clients |
 | Lease plane | `8788` | `/v1/lease/*` (bearer-auth, fail-closed) | Elixir/OTP coordination for single-writer surfaces |
 | PostgreSQL + AGE | `5432` | `postgresql://…/governance` | Single source of truth |
-| Redis | `6379` | `redis://…/0` | Session cache (optional) |
+| Redis | `6379` | `redis://…/0` | Session/identity store — degrades to local-only without it, but de-facto primary for most live sessions (not optional) |
 
 Full port map: [`../operations/DEFINITIVE_PORTS.md`](../operations/DEFINITIVE_PORTS.md).
 

--- a/docs/manual/03-running-the-server.md
+++ b/docs/manual/03-running-the-server.md
@@ -21,7 +21,7 @@ A full UNITARES deployment is several bound services. All bind loopback by defau
 | Governance MCP | `8767` | `/mcp/` (Streamable HTTP), `/v1/tools/call` (REST), `/dashboard`, `/health` | Primary agent surface — check-ins, queries, verdicts |
 | Gateway MCP | `8768` | `/mcp/` | Reduced surface for weak external clients |
 | Lease plane | `8788` | `/v1/lease/*` (bearer-auth, fail-closed) | Elixir/OTP coordination for single-writer surfaces |
-| PostgreSQL + AGE | `5432` | `postgresql://…/governance` | Single source of truth |
+| PostgreSQL + AGE | `5432` | `postgresql://…/governance` | Canonical durable store — source of truth for governance data (live sessions/identity bindings are the exception: de-facto Redis-primary today, see `docs/proposals/redis-retirement-v0.md`) |
 | Redis | `6379` | `redis://…/0` | Session/identity store — degrades to local-only without it, but de-facto primary for most live sessions (not optional) |
 
 Full port map: [`../operations/DEFINITIVE_PORTS.md`](../operations/DEFINITIVE_PORTS.md).


### PR DESCRIPTION
## What

Corrects the "Redis (optional session cache)" framing across the contract + manual. Redis is **not** a disposable cache: ~most live sessions exist only in Redis (the default `persist=False` resolve path writes Redis + in-process only, not Postgres), so calling it "optional" misleads anyone estimating the cost of removing it. The server boots in degraded local-only mode without it — graceful degradation, not optionality.

| File | Was | Now |
|---|---|---|
| `CLAUDE.md` + `AGENTS.md` (shared-contract Stack) | "Redis (optional session cache)" | de-facto primary session/identity store, not optional |
| `docs/manual/03-running-the-server.md` | "Session cache (optional)" | session/identity store, de-facto primary, not optional |
| `docker-compose.yml` (comment) | "Session cache + locks" | de-facto primary session store + locks |

Shared-contract parity verified (`check-shared-contract.sh`). Points readers to `docs/proposals/redis-retirement-v0.md` for the full analysis.

## Deferred (collision)

`docs/UNIFIED_ARCHITECTURE.md:96` has the same "Session cache, optional" line but that file is owned by in-flight #1192 — flagged there to fix in place rather than collide.