### PR TITLE
feat(governed-effect): crash-recovery reconciliation + boot scanner (slice 1b)

### DIFF
--- a/elixir/lease_plane/lib/unitares_lease_plane/application.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/application.ex
@@ -107,7 +107,13 @@ defmodule UnitaresLeasePlane.Application do
         UnitaresLeasePlane.HandoffServer,
         UnitaresLeasePlane.SurfaceRegistry,
         {Registry, keys: :unique, name: UnitaresLeasePlane.DialecticLivenessRegistry},
-        UnitaresLeasePlane.DialecticLivenessSupervisor
+        UnitaresLeasePlane.DialecticLivenessSupervisor,
+        # Governed-effect EXECUTE crash recovery (§5b). Runs its orphan scan in
+        # init/1 synchronously — placed AFTER Postgrex and BEFORE the HTTP
+        # listener so no new effect is accepted while a prior crash's orphans are
+        # unresolved. Fail-soft: a missing effects.* schema (pre-migration-052) or
+        # a DB error is logged and skipped, never crashes boot.
+        UnitaresLeasePlane.EffectRecovery
       ] ++ worker_children() ++ http_children()
 
     opts = [strategy: :one_for_one, name: UnitaresLeasePlane.Supervisor]

--- a/elixir/lease_plane/lib/unitares_lease_plane/effect_reconcile.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/effect_reconcile.ex
@@ -1,0 +1,127 @@
+defmodule UnitaresLeasePlane.EffectReconcile do
+  @moduledoc """
+  Crash-recovery reconciliation for governed-effect EXECUTE (§5b). This is the
+  safety-critical core: given an orphaned `effects.payloads` row (pre-image
+  captured, never committed), decide its fate by comparing the file's CURRENT
+  content hash against the recorded hashes — and act ONLY by writing a DB mark.
+
+  The corruption defense, by construction: this NEVER restores file bytes. The
+  three outcomes are commit-forward, tombstone, or quarantine — all DB-only — so
+  a competing writer that acquired the surface after the crash can never be
+  clobbered by recovery. (The council BLOCKER on the original "blindly restore
+  the pre-image" design is structurally eliminated here.)
+
+  Dispatch:
+    * current == payload_sha256         -> the write completed; commit-forward.
+    * current == pre_image_sha256, or
+      (current is nil AND NOT pre_image_existed) -> surface is at pre-image;
+        nothing was committed; tombstone (a same-key retry re-executes, §4).
+    * anything else (incl. a read error) -> surface is DIRTY (a competing write
+        or a partial write); quarantine — operator-first, retry unsafe. Never
+        touch the file.
+
+  `repo` is injectable (default `EffectRepo`) so the dispatch is unit-testable
+  with a fake repo and a real temp file.
+  """
+
+  alias UnitaresLeasePlane.EffectRepo
+
+  require Logger
+
+  @type outcome :: :committed | :tombstoned | {:quarantined, term()}
+
+  @doc "Reconcile one orphaned payload row. Returns the outcome (also logged)."
+  @spec reconcile_payload(map(), module()) :: outcome()
+  def reconcile_payload(payload, repo \\ EffectRepo) do
+    effect_id = payload.effect_id
+
+    case surface_path(payload) do
+      {:ok, path} ->
+        dispatch(payload, current_file_sha(path), repo)
+
+      {:error, reason} ->
+        # We cannot even locate the surface — cannot prove safety. Quarantine.
+        repo.quarantine(effect_id)
+        Logger.error("effect_reconcile: #{effect_id} unresolved surface (#{inspect(reason)}) — quarantined")
+        {:quarantined, {:surface, reason}}
+    end
+  end
+
+  defp dispatch(payload, {:ok, current_sha}, repo) do
+    effect_id = payload.effect_id
+
+    cond do
+      current_sha == payload.payload_sha256 ->
+        repo.mark_committed(effect_id)
+        Logger.warning("effect_reconcile: #{effect_id} write completed pre-crash — commit-forwarded")
+        :committed
+
+      at_pre_image?(payload, current_sha) ->
+        repo.tombstone(effect_id)
+        Logger.warning("effect_reconcile: #{effect_id} surface at pre-image — tombstoned (retry will re-execute)")
+        :tombstoned
+
+      true ->
+        repo.quarantine(effect_id)
+        Logger.error("effect_reconcile: #{effect_id} surface DIRTY (competing/partial write) — quarantined, NOT touched")
+        {:quarantined, :dirty}
+    end
+  end
+
+  defp dispatch(payload, {:error, reason}, repo) do
+    repo.quarantine(payload.effect_id)
+    Logger.error("effect_reconcile: #{payload.effect_id} file read failed (#{inspect(reason)}) — quarantined")
+    {:quarantined, {:read_error, reason}}
+  end
+
+  defp at_pre_image?(payload, current_sha) do
+    cond do
+      not is_nil(payload.pre_image_sha256) -> current_sha == payload.pre_image_sha256
+      # file did not exist pre-write AND does not exist now -> at pre-image
+      is_nil(current_sha) -> payload.pre_image_existed == false
+      true -> false
+    end
+  end
+
+  @doc """
+  SHA-256 (lowercase hex) of the file's current bytes, or `{:ok, nil}` when the
+  file does not exist (a legitimate pre-image-absent state). `{:error, _}` on any
+  other read failure — the caller quarantines.
+  """
+  @spec current_file_sha(String.t()) :: {:ok, String.t() | nil} | {:error, term()}
+  def current_file_sha(path) do
+    case File.read(path) do
+      {:ok, bytes} -> {:ok, sha256_hex(bytes)}
+      {:error, :enoent} -> {:ok, nil}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc false
+  def sha256_hex(bytes), do: :crypto.hash(:sha256, bytes) |> Base.encode16(case: :lower)
+
+  # required_leases is JSONB; Postgrex may hand it back as a decoded list or a
+  # raw string depending on type config. Take the first lease's surface and
+  # strip the file:// scheme to a filesystem path.
+  defp surface_path(payload) do
+    with {:ok, leases} <- decode_leases(Map.get(payload, :required_leases)),
+         [%{} = first | _] <- leases,
+         surface when is_binary(surface) <- Map.get(first, "surface") do
+      {:ok, strip_file_scheme(surface)}
+    else
+      _ -> {:error, :no_surface}
+    end
+  end
+
+  defp decode_leases(list) when is_list(list), do: {:ok, list}
+  defp decode_leases(bin) when is_binary(bin) do
+    case Jason.decode(bin) do
+      {:ok, list} when is_list(list) -> {:ok, list}
+      _ -> {:error, :bad_leases}
+    end
+  end
+  defp decode_leases(_), do: {:error, :bad_leases}
+
+  defp strip_file_scheme("file://" <> rest), do: rest
+  defp strip_file_scheme(other), do: other
+end

--- a/elixir/lease_plane/lib/unitares_lease_plane/effect_recovery.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/effect_recovery.ex
@@ -1,0 +1,79 @@
+defmodule UnitaresLeasePlane.EffectRecovery do
+  @moduledoc """
+  Boot-time recovery for governed-effect EXECUTE (§5b). On startup, drains any
+  orphaned `effects.payloads` rows (pre-image captured, never committed) left by
+  a node crash, reconciling each by content hash via `EffectReconcile`.
+
+  Runs SYNCHRONOUSLY in `init/1` and is placed in the supervision tree BEFORE
+  the HTTP listener, so the plane never accepts a new effect while orphans from
+  a prior crash are unresolved. The in-process (`:transient` custodian restart)
+  recovery path is a separate slice; this covers the full-node-crash case.
+
+  FAIL-SOFT: boot must never crash from recovery. A missing `effects.*` schema
+  (the normal state until migration 052 is applied) or any query error is logged
+  and skipped — the scanner returns `{:ok, ...}` regardless. `repo` is injectable
+  for tests.
+  """
+
+  use GenServer
+
+  alias UnitaresLeasePlane.{EffectReconcile, EffectRepo}
+
+  require Logger
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
+  end
+
+  @impl true
+  def init(opts) do
+    repo = Keyword.get(opts, :repo, EffectRepo)
+    result = scan(repo)
+    {:ok, result}
+  end
+
+  @doc """
+  Run the orphan scan once. Returns a summary map. Never raises — a missing
+  table or any DB error degrades to `%{scanned: 0, skipped: reason}`.
+  """
+  @spec scan(module()) :: map()
+  def scan(repo \\ EffectRepo) do
+    case safe_orphans(repo) do
+      {:ok, []} ->
+        %{scanned: 0, recovered: 0}
+
+      {:ok, orphans} ->
+        outcomes = Enum.map(orphans, &reconcile_one(&1, repo))
+        counts = Enum.frequencies_by(outcomes, &outcome_kind/1)
+        Logger.warning("effect_recovery: drained #{length(orphans)} orphan(s) at boot: #{inspect(counts)}")
+        %{scanned: length(orphans), outcomes: counts}
+
+      {:skip, reason} ->
+        # Expected before migration 052 is applied, or on a transient DB error.
+        Logger.info("effect_recovery: orphan scan skipped (#{inspect(reason)})")
+        %{scanned: 0, skipped: reason}
+    end
+  end
+
+  defp safe_orphans(repo) do
+    case repo.orphaned_payloads() do
+      {:ok, rows} -> {:ok, rows}
+      {:error, reason} -> {:skip, reason}
+    end
+  rescue
+    e -> {:skip, {:exception, Exception.message(e)}}
+  end
+
+  defp reconcile_one(payload, repo) do
+    EffectReconcile.reconcile_payload(payload, repo)
+  rescue
+    e ->
+      Logger.error("effect_recovery: reconcile crashed for #{inspect(Map.get(payload, :effect_id))}: #{Exception.message(e)}")
+      {:quarantined, :reconcile_crash}
+  end
+
+  defp outcome_kind(:committed), do: :committed
+  defp outcome_kind(:tombstoned), do: :tombstoned
+  defp outcome_kind({:quarantined, _}), do: :quarantined
+  defp outcome_kind(_), do: :unknown
+end

--- a/elixir/lease_plane/test/effect_reconcile_test.exs
+++ b/elixir/lease_plane/test/effect_reconcile_test.exs
@@ -1,0 +1,126 @@
+defmodule UnitaresLeasePlane.EffectReconcileTest do
+  @moduledoc """
+  The crash-recovery reconciliation core (§5b) — the safety-critical dispatch.
+  Asserts the corruption defense holds: recovery NEVER writes the file, only a
+  DB mark (commit-forward / tombstone / quarantine), and a DIRTY surface (a
+  competing writer's bytes) is quarantined, never clobbered.
+
+  Uses a fake repo that records which mark was called (no DB) + real temp files.
+  """
+  use ExUnit.Case, async: true
+
+  alias UnitaresLeasePlane.{EffectReconcile, EffectRecovery}
+
+  defmodule FakeRepo do
+    def mark_committed(id), do: record({:mark_committed, id})
+    def tombstone(id), do: record({:tombstone, id})
+    def quarantine(id), do: record({:quarantine, id})
+    # used by EffectRecovery.scan tests; set the canned return via the proc dict
+    def orphaned_payloads, do: Process.get(:fake_orphans, {:ok, []})
+    defp record(msg), do: (send(self(), msg) && :ok)
+  end
+
+  defp sha(bytes), do: EffectReconcile.sha256_hex(bytes)
+
+  defp payload(path, opts) do
+    %{
+      effect_id: "eff-1",
+      payload_sha256: Keyword.fetch!(opts, :payload_sha256),
+      pre_image_sha256: Keyword.get(opts, :pre_image_sha256),
+      pre_image_existed: Keyword.get(opts, :pre_image_existed, true),
+      required_leases: [%{"surface" => "file://" <> path}]
+    }
+  end
+
+  @tag :tmp_dir
+  test "write completed pre-crash (file == payload bytes) -> commit-forward, file untouched", %{tmp_dir: dir} do
+    path = Path.join(dir, "note.txt")
+    new_bytes = "the committed content\n"
+    File.write!(path, new_bytes)
+
+    p = payload(path, payload_sha256: sha(new_bytes), pre_image_sha256: sha("old\n"))
+    assert EffectReconcile.reconcile_payload(p, FakeRepo) == :committed
+    assert_received {:mark_committed, "eff-1"}
+    # corruption defense: the file is NOT rewritten
+    assert File.read!(path) == new_bytes
+  end
+
+  @tag :tmp_dir
+  test "surface at pre-image (file == pre_image bytes) -> tombstone (retry re-executes)", %{tmp_dir: dir} do
+    path = Path.join(dir, "note.txt")
+    pre = "the original content\n"
+    File.write!(path, pre)
+
+    p = payload(path, payload_sha256: sha("would-have-written\n"), pre_image_sha256: sha(pre))
+    assert EffectReconcile.reconcile_payload(p, FakeRepo) == :tombstoned
+    assert_received {:tombstone, "eff-1"}
+    assert File.read!(path) == pre
+  end
+
+  @tag :tmp_dir
+  test "pre-image-absent and file absent -> tombstone", %{tmp_dir: dir} do
+    path = Path.join(dir, "never-created.txt")
+    refute File.exists?(path)
+
+    p = payload(path, payload_sha256: sha("x"), pre_image_sha256: nil, pre_image_existed: false)
+    assert EffectReconcile.reconcile_payload(p, FakeRepo) == :tombstoned
+    assert_received {:tombstone, "eff-1"}
+    refute File.exists?(path)
+  end
+
+  @tag :tmp_dir
+  test "DIRTY surface (competing writer's bytes, neither hash) -> quarantine, NEVER clobbered", %{tmp_dir: dir} do
+    path = Path.join(dir, "note.txt")
+    competing = "a DIFFERENT writer got here\n"
+    File.write!(path, competing)
+
+    p = payload(path, payload_sha256: sha("our-payload\n"), pre_image_sha256: sha("our-pre-image\n"))
+    assert EffectReconcile.reconcile_payload(p, FakeRepo) == {:quarantined, :dirty}
+    assert_received {:quarantine, "eff-1"}
+    # the competing writer's content is left exactly as-is
+    assert File.read!(path) == competing
+  end
+
+  test "unresolvable surface -> quarantine (cannot prove safety)" do
+    p = %{effect_id: "eff-x", payload_sha256: "a", pre_image_sha256: nil,
+          pre_image_existed: false, required_leases: []}
+    assert {:quarantined, {:surface, _}} = EffectReconcile.reconcile_payload(p, FakeRepo)
+    assert_received {:quarantine, "eff-x"}
+  end
+
+  test "required_leases as a raw JSON string is decoded" do
+    p = %{effect_id: "eff-j", payload_sha256: "a", pre_image_sha256: nil,
+          pre_image_existed: false, required_leases: ~s([{"surface":"file:///no/such/file"}])}
+    # file absent + pre_image_existed false -> tombstone
+    assert EffectReconcile.reconcile_payload(p, FakeRepo) == :tombstoned
+    assert_received {:tombstone, "eff-j"}
+  end
+
+  # --- EffectRecovery boot scanner (fail-soft) -------------------------------
+
+  test "recovery scan is FAIL-SOFT when the effects table is missing" do
+    Process.put(:fake_orphans, {:error, %{postgres: %{code: :undefined_table}}})
+    result = EffectRecovery.scan(FakeRepo)
+    assert %{scanned: 0, skipped: _} = result
+  end
+
+  test "recovery scan drains orphans and tallies outcomes" do
+    # one committed-forward, one tombstone (both via a temp file)
+    dir = System.tmp_dir!()
+    committed_path = Path.join(dir, "rec-committed-#{System.unique_integer([:positive])}.txt")
+    File.write!(committed_path, "done\n")
+
+    orphans = [
+      %{effect_id: "o1", payload_sha256: sha("done\n"), pre_image_sha256: nil,
+        pre_image_existed: false, required_leases: [%{"surface" => "file://" <> committed_path}]}
+    ]
+
+    Process.put(:fake_orphans, {:ok, orphans})
+    result = EffectRecovery.scan(FakeRepo)
+    assert result.scanned == 1
+    assert result.outcomes[:committed] == 1
+    assert_received {:mark_committed, "o1"}
+  after
+    Process.delete(:fake_orphans)
+  end
+end


### PR DESCRIPTION
Follows slice 1a (#1193, merged). Builds the safety-critical core of §5b rollback — the crash-recovery **reconciliation** — and the boot scanner that drains orphans from a node crash. Still INERT: nothing executes, no flag, not in the request path. The in-process custodian + `FileWriteExecutor` are slice 2.

This slice isolates the riskiest logic (the recovery dispatch — where a bug would corrupt data) so it can be unit-tested in full isolation.

## What's here
- **`EffectReconcile`** — given an orphaned `effects.payloads` row (pre-image captured, never committed), decide its fate by comparing the file's CURRENT content hash against the recorded hashes, acting ONLY by writing a DB mark:
  - `hash == payload_sha256` → commit-forward (the write completed pre-crash)
  - `hash == pre_image_sha256`, or (nil hash AND pre-image absent) → tombstone (a same-key retry re-executes)
  - anything else / read error → quarantine (operator-first)
  - **Corruption defense is structural:** recovery NEVER restores bytes, so a competing writer that acquired the surface after the crash cannot be clobbered.
- **`EffectRecovery`** — boot GenServer; runs the orphan scan synchronously in `init/1`, placed after Postgrex and before the HTTP listener. **Fail-soft:** a missing `effects.*` schema (the normal state until migration 052 is applied) or any DB error is logged and skipped, never crashes boot. Wired into `application.ex`.

## Tests (8, 0 failures)
All three reconcile branches with a fake repo + real temp files — including the DIRTY-surface case asserting the competing writer's bytes are left **untouched**; JSON-string lease decode; fail-soft scan on a missing table; orphan drain + outcome tally.

## Next (slice 2)
The in-process `EffectCustodian` (`restart: :transient`) + `FileWriteExecutor` behind a fail-closed flag, dry-run-first, wired into the execute dispatch.

Draft — RCE-class surface; maintainer is the merge gate.