### PR TITLE
fix(dialectic): re-land save_session BEAM resolve/phase routing (#1189)

### DIFF
--- a/src/mcp_handlers/dialectic/session.py
+++ b/src/mcp_handlers/dialectic/session.py
@@ -172,16 +172,34 @@ async def save_session(session: DialecticSession) -> None:
     try:
         from src.dialectic_db import update_session_phase_async as pg_update_phase
         from src.dialectic_db import resolve_session_async as pg_resolve_session
+        from .beam_resolve_client import beam_resolve, beam_update_phase
         if session.phase in (DialecticPhase.RESOLVED, DialecticPhase.FAILED):
             resolution_dict = session.resolution.to_dict() if session.resolution else None
             status = session.phase.value if session.phase == DialecticPhase.RESOLVED else "failed"
-            await pg_resolve_session(
+            # save_session is the catch-all flush that resolves the session in the
+            # orchestrated-reviewer flow (verified 2026-06-28 by the pg_committed
+            # saga it produces: it, not the explicit handle_submit_synthesis sites,
+            # wrote the terminal row there). Route it through BEAM so the
+            # sole-writer invariant holds for that flow too; fail-safe fallback to
+            # Python keeps it flag-off-safe. (Re-land of #1189, accidentally
+            # reverted by #1190's stale-base "docs sweep" merge.)
+            beam_done = await beam_resolve(
                 session_id=session.session_id,
-                resolution=resolution_dict,
+                paused_agent_id=getattr(session, "paused_agent_id", None),
+                reviewer_agent_id=getattr(session, "reviewer_agent_id", None),
+                resolution=resolution_dict or {},
                 status=status,
             )
+            if beam_done is None:
+                await pg_resolve_session(
+                    session_id=session.session_id,
+                    resolution=resolution_dict,
+                    status=status,
+                )
         else:
-            await pg_update_phase(session.session_id, session.phase.value)
+            beam_ph = await beam_update_phase(session.session_id, session.phase.value)
+            if beam_ph is None:
+                await pg_update_phase(session.session_id, session.phase.value)
         logger.debug(f"Session {session.session_id} synced to PostgreSQL (phase={session.phase.value})")
     except Exception as e:
         logger.error(f"PostgreSQL sync failed for session {session.session_id}: {e}")

--- a/tests/test_dialectic_save_session_beam.py
+++ b/tests/test_dialectic_save_session_beam.py
@@ -21,6 +21,46 @@ from src.dialectic_protocol import DialecticPhase
 from src.mcp_handlers.dialectic import session as sess_mod
 
 
+def _resolved_session():
+    return SimpleNamespace(
+        session_id="sess-save-1",
+        phase=DialecticPhase.RESOLVED,
+        paused_agent_id="paused-1",
+        reviewer_agent_id="rev-1",
+        resolution=SimpleNamespace(to_dict=lambda: {"action": "resume"}),
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_session_routes_resolve_through_beam(monkeypatch):
+    """save_session (catch-all flush) routes its terminal resolve through BEAM —
+    the path that owns the orchestrated-reviewer-flow resolve."""
+    monkeypatch.setattr(sess_mod, "UNITARES_DIALECTIC_WRITE_JSON_SNAPSHOT", False, raising=False)
+    beam = AsyncMock(return_value={"ok": True, "status": "resolved"})
+    pg = AsyncMock()
+    with patch("src.mcp_handlers.dialectic.beam_resolve_client.beam_resolve", beam), \
+         patch("src.dialectic_db.resolve_session_async", pg):
+        await sess_mod.save_session(_resolved_session())
+
+    beam.assert_awaited_once()
+    assert beam.await_args.kwargs["status"] == "resolved"
+    assert beam.await_args.kwargs["reviewer_agent_id"] == "rev-1"
+    pg.assert_not_awaited()  # BEAM owned it -> no Python write
+
+
+@pytest.mark.asyncio
+async def test_save_session_falls_back_to_python_when_beam_declines(monkeypatch):
+    monkeypatch.setattr(sess_mod, "UNITARES_DIALECTIC_WRITE_JSON_SNAPSHOT", False, raising=False)
+    beam = AsyncMock(return_value=None)  # flag off / unreachable / etc.
+    pg = AsyncMock()
+    with patch("src.mcp_handlers.dialectic.beam_resolve_client.beam_resolve", beam), \
+         patch("src.dialectic_db.resolve_session_async", pg):
+        await sess_mod.save_session(_resolved_session())
+
+    beam.assert_awaited_once()
+    pg.assert_awaited_once()  # fail-safe fallback
+
+
 @pytest.mark.asyncio
 async def test_save_session_snapshot_serializes_datetime(monkeypatch, tmp_path):
     """A datetime nested in paused_agent_state must serialize (via default=str),


### PR DESCRIPTION
#1189 routed `save_session` (the catch-all flush that resolves orchestrated-reviewer-flow sessions) through BEAM with a fail-safe Python fallback. #1190's stale-base "docs staleness sweep" merge **accidentally reverted it** — its commit message never mentions the revert (same clobber class as the earlier mid-build merges) — so master's `save_session` went back to plain `pg_resolve_session`. The snapshot `default=str` fix (#1191) survived; this restores the routing on top of it.

`save_session` is what actually wrote the terminal row in the orchestrated flow (forensically confirmed; the `pg_committed` saga the BEAM route produces was the live proof). Without this, the sole-writer invariant does not hold for that flow. Idempotent (B-4 + saga), flag-off-safe (Python fallback when BEAM declines).

Tests: resolve routes through BEAM; falls back when BEAM declines (snapshot test retained). Full suite green: 11065. Deploy: gov-mcp.