### PR TITLE
feat(governed-effect): FileWriteExecutor dry-run path (slice 2, dry-run-first)

### DIFF
--- a/elixir/lease_plane/lib/unitares_lease_plane/file_write_executor.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/file_write_executor.ex
@@ -1,0 +1,120 @@
+defmodule UnitaresLeasePlane.FileWriteExecutor do
+  @moduledoc """
+  Executor for the `file_write` governed effect — the first REVERSIBLE execute
+  surface (§5a/§10). This slice is DRY-RUN ONLY: it proves the full validation
+  path (canonicalize the surface, confirm it matches a held lease, check the
+  payload ceiling, read the would-be rollback pre-image) and returns a dry-run
+  result WITHOUT writing a byte and WITHOUT any durable side effect.
+
+  Governed by the dialectic review of slice 2 (resolved 2026-06-28, action
+  `resume` with conditions): "dry-run-first — the FileWriteExecutor lands first
+  in a mode that captures the pre-image and returns a dry-run result WITHOUT
+  File.write, proving the lease+veto+pre-image path before any real byte is
+  committed." The live write + the in-process compensation path (with
+  fault-injection at every step of the live rollback) are the NEXT slice and are
+  a hard pre-flag-on gate per that resolution.
+
+  Two-flag fail-safe (defense in depth): `:execute_file_write_enabled` gates the
+  dispatch; `:execute_file_write_commit_enabled` (default false) gates whether a
+  real `File.write` is allowed. With commit disabled, `apply_effect/3` is a pure
+  validating dry-run even if the dispatch flag is on.
+  """
+
+  @behaviour UnitaresLeasePlane.EffectExecutor
+
+  alias UnitaresLeasePlane.Canonicalize
+
+  # Per-class payload ceiling for file_write; global hard backstop applied above.
+  @default_max_bytes 1_048_576
+
+  @impl true
+  def reversible?, do: true
+
+  @impl true
+  def apply_effect(_effect_id, payload, leases) do
+    with {:ok, path} <- resolve_path(payload, leases),
+         {:ok, content} <- resolve_content(payload),
+         :ok <- check_ceiling(content) do
+      {pre_sha, existed?} = read_pre_image(path)
+
+      if commit_enabled?() do
+        # Slice 2b: real write + mark_committed + in-process compensation, gated
+        # on the fault-injection tests the dialectic made a hard precondition.
+        {:rejected, :commit_not_enabled}
+      else
+        {:committed,
+         %{
+           dry_run: true,
+           path: path,
+           would_write_bytes: byte_size(content),
+           payload_sha256: sha256_hex(content),
+           pre_image_sha256: pre_sha,
+           pre_image_existed: existed?
+         }}
+      end
+    else
+      {:error, reason} -> {:rejected, reason}
+    end
+  end
+
+  # --- validation (the path the dry-run proves) ------------------------------
+
+  defp resolve_path(payload, leases) do
+    with raw when is_binary(raw) <- Map.get(payload, "path") || {:error, :path_required},
+         {:ok, canonical} <- Canonicalize.canonicalize("file://" <> raw),
+         true <- canonical in lease_surfaces(leases) || {:error, :surface_path_mismatch} do
+      {:ok, strip_scheme(canonical)}
+    else
+      {:error, reason} -> {:error, reason}
+      _ -> {:error, :surface_path_mismatch}
+    end
+  end
+
+  defp lease_surfaces(leases) do
+    for l <- leases, s = surface_of(l), is_binary(s), do: s
+  end
+
+  defp surface_of(%{"surface" => s}), do: s
+  defp surface_of(%{surface: s}), do: s
+  defp surface_of(_), do: nil
+
+  defp resolve_content(%{"content" => c} = payload) when is_binary(c) do
+    case Map.get(payload, "encoding") do
+      "base64" ->
+        case Base.decode64(c) do
+          {:ok, bytes} -> {:ok, bytes}
+          :error -> {:error, :bad_base64}
+        end
+
+      _ ->
+        {:ok, c}
+    end
+  end
+
+  defp resolve_content(_), do: {:error, :content_required}
+
+  defp check_ceiling(content) do
+    if byte_size(content) <= max_bytes(), do: :ok, else: {:error, :payload_too_large}
+  end
+
+  defp read_pre_image(path) do
+    case File.read(path) do
+      {:ok, bytes} -> {sha256_hex(bytes), true}
+      {:error, :enoent} -> {nil, false}
+      # a read error is surfaced as "exists but unknown" — the dry-run records it
+      # honestly; the commit slice will reject on an unreadable target.
+      {:error, _} -> {nil, true}
+    end
+  end
+
+  defp commit_enabled?,
+    do: Application.get_env(:lease_plane, :execute_file_write_commit_enabled, false) == true
+
+  defp max_bytes,
+    do: Application.get_env(:lease_plane, :file_write_payload_max_bytes, @default_max_bytes)
+
+  defp strip_scheme("file://" <> rest), do: rest
+  defp strip_scheme(other), do: other
+
+  defp sha256_hex(bytes), do: :crypto.hash(:sha256, bytes) |> Base.encode16(case: :lower)
+end

--- a/elixir/lease_plane/test/file_write_executor_test.exs
+++ b/elixir/lease_plane/test/file_write_executor_test.exs
@@ -1,0 +1,126 @@
+defmodule UnitaresLeasePlane.FileWriteExecutorTest do
+  @moduledoc """
+  Slice 2 (dry-run-first, per the dialectic resolution of 2026-06-28): the
+  FileWriteExecutor validates the full lease+pre-image path but writes NO byte
+  and touches NO durable state. These tests assert exactly that — the target
+  file is never modified, and the result is honestly marked dry_run.
+  """
+  use ExUnit.Case, async: false
+
+  alias UnitaresLeasePlane.{Canonicalize, FileWriteExecutor}
+
+  defp sha(bytes), do: :crypto.hash(:sha256, bytes) |> Base.encode16(case: :lower)
+
+  defp canonical_surface(path) do
+    {:ok, surface} = Canonicalize.canonicalize("file://" <> path)
+    surface
+  end
+
+  setup do
+    # default state for the commit-disabled fail-safe
+    Application.delete_env(:lease_plane, :execute_file_write_commit_enabled)
+    Application.delete_env(:lease_plane, :file_write_payload_max_bytes)
+    :ok
+  end
+
+  @tag :tmp_dir
+  test "dry-run validates + reads pre-image but writes NOTHING", %{tmp_dir: dir} do
+    path = Path.join(dir, "note.txt")
+    existing = "the existing content\n"
+    File.write!(path, existing)
+
+    leases = [%{"surface" => canonical_surface(path)}]
+    payload = %{"path" => path, "content" => "the NEW content we would write\n"}
+
+    assert {:committed, r} = FileWriteExecutor.apply_effect("e1", payload, leases)
+    assert r.dry_run == true
+    assert r.would_write_bytes == byte_size("the NEW content we would write\n")
+    assert r.payload_sha256 == sha("the NEW content we would write\n")
+    assert r.pre_image_existed == true
+    assert r.pre_image_sha256 == sha(existing)
+    # the load-bearing assertion: the file is UNCHANGED
+    assert File.read!(path) == existing
+  end
+
+  @tag :tmp_dir
+  test "dry-run on an absent target -> pre_image_existed false, file still absent", %{tmp_dir: dir} do
+    path = Path.join(dir, "does-not-exist.txt")
+    leases = [%{"surface" => canonical_surface(path)}]
+    payload = %{"path" => path, "content" => "x"}
+
+    assert {:committed, r} = FileWriteExecutor.apply_effect("e2", payload, leases)
+    assert r.dry_run == true
+    assert r.pre_image_existed == false
+    assert r.pre_image_sha256 == nil
+    refute File.exists?(path)
+  end
+
+  @tag :tmp_dir
+  test "surface not among held leases -> rejected, never touched", %{tmp_dir: dir} do
+    path = Path.join(dir, "note.txt")
+    File.write!(path, "x")
+    # a lease for a DIFFERENT surface
+    leases = [%{"surface" => "file:///some/other/path"}]
+    payload = %{"path" => path, "content" => "y"}
+
+    assert {:rejected, :surface_path_mismatch} =
+             FileWriteExecutor.apply_effect("e3", payload, leases)
+    assert File.read!(path) == "x"
+  end
+
+  @tag :tmp_dir
+  test "base64 content is decoded for the size/hash", %{tmp_dir: dir} do
+    path = Path.join(dir, "note.txt")
+    File.write!(path, "")
+    raw = "hello bytes"
+    payload = %{"path" => path, "content" => Base.encode64(raw), "encoding" => "base64"}
+    leases = [%{"surface" => canonical_surface(path)}]
+
+    assert {:committed, r} = FileWriteExecutor.apply_effect("e4", payload, leases)
+    assert r.would_write_bytes == byte_size(raw)
+    assert r.payload_sha256 == sha(raw)
+  end
+
+  @tag :tmp_dir
+  test "payload over the ceiling is rejected before any work", %{tmp_dir: dir} do
+    Application.put_env(:lease_plane, :file_write_payload_max_bytes, 8)
+    path = Path.join(dir, "note.txt")
+    File.write!(path, "x")
+    leases = [%{"surface" => canonical_surface(path)}]
+    payload = %{"path" => path, "content" => "this is definitely longer than eight bytes"}
+
+    assert {:rejected, :payload_too_large} =
+             FileWriteExecutor.apply_effect("e5", payload, leases)
+    assert File.read!(path) == "x"
+  end
+
+  @tag :tmp_dir
+  test "missing content is rejected (path resolves, content absent)", %{tmp_dir: dir} do
+    path = Path.join(dir, "note.txt")
+    File.write!(path, "x")
+    leases = [%{"surface" => canonical_surface(path)}]
+    assert {:rejected, :content_required} =
+             FileWriteExecutor.apply_effect("e6", %{"path" => path}, leases)
+    assert File.read!(path) == "x"
+  end
+
+  @tag :tmp_dir
+  test "two-flag fail-safe: even with commit enabled this slice refuses to write", %{tmp_dir: dir} do
+    Application.put_env(:lease_plane, :execute_file_write_commit_enabled, true)
+    path = Path.join(dir, "note.txt")
+    File.write!(path, "untouched")
+    leases = [%{"surface" => canonical_surface(path)}]
+    payload = %{"path" => path, "content" => "would-be"}
+
+    # commit path is the NEXT slice (gated on fault-injection tests) — refuse.
+    assert {:rejected, :commit_not_enabled} =
+             FileWriteExecutor.apply_effect("e7", payload, leases)
+    assert File.read!(path) == "untouched"
+  after
+    Application.delete_env(:lease_plane, :execute_file_write_commit_enabled)
+  end
+
+  test "executor declares itself reversible" do
+    assert FileWriteExecutor.reversible?() == true
+  end
+end


### PR DESCRIPTION
The first execute slice for `file_write`, built **dry-run-first** per the dialectic resolution of slice 2 (`action=resume` with conditions). The executor validates the FULL path — canonicalize the surface, confirm it matches a held lease, check the payload ceiling, read the would-be rollback pre-image — and returns a dry-run result **without writing a byte and without any durable side effect.**

## What's here
- **`FileWriteExecutor`** implements the `EffectExecutor` behaviour (`apply_effect/3`, `reversible?/0`).
- **Two-flag fail-safe (defense in depth):** `:execute_file_write_enabled` gates dispatch; `:execute_file_write_commit_enabled` (default **false**) gates real writes. With commit disabled, `apply_effect` is a pure validating dry-run *even if* dispatch is on.
- The live `File.write` + the in-process compensation path is the **next slice**, and is gated on **fault-injection tests covering failure at every step of the live rollback** — the hard precondition set by the slice-2 dialectic review (slice 1b only tested *crash* recovery, which never writes; the live-write-then-restore path is the untested gap).

## Tests (8, 0 failures)
Dry-run reads the pre-image but leaves the target **unchanged**; absent-target handling; surface-not-in-held-leases rejection; base64 decode; payload ceiling; missing content; the **two-flag fail-safe** (commit-enabled still refuses to write this slice); `reversible? == true`.

## Boundary
INERT: no flag set in production, not yet wired into the execute dispatch (that wiring + the in-process `EffectCustodian` come with the live-write slice).

Draft — RCE-class surface; maintainer is the merge gate.