### PR TITLE
revert(dialectic): drop #1185 reviewer-env flag forwarding (dead no-op)

### DIFF
--- a/src/mcp_handlers/dialectic/orchestrator_dispatch.py
+++ b/src/mcp_handlers/dialectic/orchestrator_dispatch.py
@@ -91,20 +91,12 @@ def _build_spec(session_id: str, thesis: Dict[str, Any], parent_agent_id: Option
     if parent_agent_id:
         env["UNITARES_PARENT_AGENT_ID"] = parent_agent_id
 
-    # Propagate the dialectic-on-BEAM routing flag + lease-plane creds so the
-    # spawned reviewer's OWN session-row writes (its antithesis phase advance,
-    # reviewer-slot claim, and any synthesis resolve it drives) route through
-    # BEAM too — matching the gov-mcp process. Forward-only: a key absent from
-    # the parent env is simply not set, so the reviewer falls back to the Python
-    # path. Stays flag-off-safe (nothing forwarded when gov-mcp is off).
-    for _key in (
-        "UNITARES_DIALECTIC_BEAM_RESOLUTION",
-        "LEASE_PLANE_BEARER_TOKEN",
-        "LEASE_PLANE_BASE_URL",
-    ):
-        _val = os.environ.get(_key)
-        if _val:
-            env[_key] = _val
+    # NB: we deliberately do NOT forward UNITARES_DIALECTIC_BEAM_RESOLUTION into
+    # the reviewer's env. The reviewer submits its antithesis/synthesis via the
+    # gov-mcp `dialectic` tool (client.call_tool), so those writes EXECUTE IN
+    # gov-mcp where the flag already applies — the reviewer process never does its
+    # own session-row writes. (Reverts #1185, which forwarded the flag on a wrong
+    # premise; it was a dead no-op.)
 
     return {
         "cmd": sys.executable,  # the MCP process's own interpreter has the deps

--- a/tests/test_dialectic_orchestrated_dispatch.py
+++ b/tests/test_dialectic_orchestrated_dispatch.py
@@ -54,27 +54,19 @@ def test_build_spec_omits_parent_when_absent():
     assert json.loads(spec["env"]["DIALECTIC_THESIS_CONDITIONS"]) == []
 
 
-def test_build_spec_propagates_beam_flag_and_creds(monkeypatch):
-    """When gov-mcp has the dialectic-on-BEAM flag + lease creds, the reviewer
-    spawn env carries them so the reviewer's own writes route through BEAM."""
+def test_build_spec_does_not_forward_beam_flag(monkeypatch):
+    """The reviewer submits via the gov-mcp `dialectic` tool, so its writes run in
+    gov-mcp (where the flag already applies) — the spawn env must NOT carry
+    UNITARES_DIALECTIC_BEAM_RESOLUTION / lease creds (reverts #1185's no-op
+    forwarding). Even with them set in the parent env, the spec omits them."""
     monkeypatch.setenv("UNITARES_DIALECTIC_BEAM_RESOLUTION", "1")
     monkeypatch.setenv("LEASE_PLANE_BEARER_TOKEN", "tok-xyz")
     monkeypatch.setenv("LEASE_PLANE_BASE_URL", "http://127.0.0.1:8788")
     spec = od._build_spec("s", {"root_cause": "", "proposed_conditions": [], "reasoning": ""}, None)
     env = spec["env"]
-    assert env["UNITARES_DIALECTIC_BEAM_RESOLUTION"] == "1"
-    assert env["LEASE_PLANE_BEARER_TOKEN"] == "tok-xyz"
-    assert env["LEASE_PLANE_BASE_URL"] == "http://127.0.0.1:8788"
-
-
-def test_build_spec_omits_beam_flag_when_parent_off(monkeypatch):
-    """Forward-only: flag absent in gov-mcp env => not in the reviewer spec
-    (reviewer falls back to Python). Keeps it flag-off-safe."""
-    monkeypatch.delenv("UNITARES_DIALECTIC_BEAM_RESOLUTION", raising=False)
-    monkeypatch.delenv("LEASE_PLANE_BEARER_TOKEN", raising=False)
-    spec = od._build_spec("s", {"root_cause": "", "proposed_conditions": [], "reasoning": ""}, None)
-    assert "UNITARES_DIALECTIC_BEAM_RESOLUTION" not in spec["env"]
-    assert "LEASE_PLANE_BEARER_TOKEN" not in spec["env"]
+    assert "UNITARES_DIALECTIC_BEAM_RESOLUTION" not in env
+    assert "LEASE_PLANE_BEARER_TOKEN" not in env
+    assert "LEASE_PLANE_BASE_URL" not in env
 
 
 @pytest.mark.parametrize("env_val,expected", [


### PR DESCRIPTION
#1185 forwarded `UNITARES_DIALECTIC_BEAM_RESOLUTION` + lease creds into the orchestrated-reviewer spawn env, on the premise the reviewer does its own session-row writes. It does not — `agents.dialectic_reviewer` submits via the gov-mcp `dialectic` tool, so those writes run in gov-mcp where the flag already applies. The forwarded env was never read; dead code with a misleading comment.

Removes the forwarding (+ a comment on why it's intentionally absent); replaces the two propagation tests with one guarding non-forwarding. Behavior-neutral. Full suite green: 11064.