### PR TITLE
feat(governed-effect): wire file_write execute dispatch + flags + boot guard (final slice)

### DIFF
--- a/elixir/lease_plane/lib/unitares_lease_plane/application.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/application.ex
@@ -66,6 +66,22 @@ defmodule UnitaresLeasePlane.Application do
       System.get_env("UNITARES_GOVERNED_EFFECT_EXECUTE_AGENT_SPAWN") == "1"
     )
 
+    # file_write execute (first reversible surface). TWO flags, both fail-closed:
+    # _ENABLED gates the dispatch; _COMMIT gates the real write (dry-run when off).
+    Application.put_env(
+      :lease_plane,
+      :execute_file_write_enabled,
+      System.get_env("UNITARES_GOVERNED_EFFECT_EXECUTE_FILE_WRITE") == "1"
+    )
+
+    Application.put_env(
+      :lease_plane,
+      :execute_file_write_commit_enabled,
+      System.get_env("UNITARES_GOVERNED_EFFECT_EXECUTE_FILE_WRITE_COMMIT") == "1"
+    )
+
+    validate_execute_type_flags!()
+
     Application.put_env(
       :lease_plane,
       :agent_orchestrator_url,
@@ -118,6 +134,22 @@ defmodule UnitaresLeasePlane.Application do
 
     opts = [strategy: :one_for_one, name: UnitaresLeasePlane.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  # Fail-closed boot guard for the file_write execute flags: turning ON the real
+  # write (_COMMIT) without turning ON the dispatch (_ENABLED) is a misconfig —
+  # a write capability with no governed path to reach it. Refuse to boot rather
+  # than run in that ambiguous state.
+  defp validate_execute_type_flags! do
+    enabled = Application.get_env(:lease_plane, :execute_file_write_enabled, false)
+    commit = Application.get_env(:lease_plane, :execute_file_write_commit_enabled, false)
+
+    if commit and not enabled do
+      raise "lease_plane boot refused: UNITARES_GOVERNED_EFFECT_EXECUTE_FILE_WRITE_COMMIT is on " <>
+              "but UNITARES_GOVERNED_EFFECT_EXECUTE_FILE_WRITE (dispatch) is off — enable both or neither."
+    end
+
+    :ok
   end
 
   defp http_children do

--- a/elixir/lease_plane/lib/unitares_lease_plane/effect_file_ops.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/effect_file_ops.ex
@@ -1,0 +1,24 @@
+defmodule UnitaresLeasePlane.EffectFileOps do
+  @moduledoc """
+  Filesystem operations for the `file_write` executor, behind a seam so the live
+  commit AND every step of the in-process compensation (rollback) can be
+  fault-injected in tests — the hard precondition the slice-2 dialectic review
+  set for the live-write path. The default delegates to `File`; tests swap in a
+  fake via `Application.put_env(:lease_plane, :effect_file_ops, FakeFileOps)`.
+  """
+
+  @callback read(path :: String.t()) :: {:ok, binary()} | {:error, term()}
+  @callback write(path :: String.t(), bytes :: binary()) :: :ok | {:error, term()}
+  @callback rm(path :: String.t()) :: :ok | {:error, term()}
+
+  @behaviour __MODULE__
+
+  @impl true
+  def read(path), do: File.read(path)
+
+  @impl true
+  def write(path, bytes), do: File.write(path, bytes)
+
+  @impl true
+  def rm(path), do: File.rm(path)
+end

--- a/elixir/lease_plane/lib/unitares_lease_plane/file_write_executor.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/file_write_executor.ex
@@ -31,16 +31,14 @@ defmodule UnitaresLeasePlane.FileWriteExecutor do
   def reversible?, do: true
 
   @impl true
-  def apply_effect(_effect_id, payload, leases) do
+  def apply_effect(effect_id, payload, leases) do
     with {:ok, path} <- resolve_path(payload, leases),
          {:ok, content} <- resolve_content(payload),
          :ok <- check_ceiling(content) do
-      {pre_sha, existed?} = read_pre_image(path)
+      {pre_sha, pre_bytes, existed?} = read_pre_image(path)
 
       if commit_enabled?() do
-        # Slice 2b: real write + mark_committed + in-process compensation, gated
-        # on the fault-injection tests the dialectic made a hard precondition.
-        {:rejected, :commit_not_enabled}
+        commit(effect_id, path, content, pre_sha, pre_bytes, existed?)
       else
         {:committed,
          %{
@@ -56,6 +54,61 @@ defmodule UnitaresLeasePlane.FileWriteExecutor do
       {:error, reason} -> {:rejected, reason}
     end
   end
+
+  # --- live commit + in-process compensation (§5b) ---------------------------
+  # Order: persist the pre-image FIRST (so crash recovery can reconcile), then
+  # write, then mark committed. On a write failure, restore the pre-image while
+  # we still hold the lease, then tombstone (retry re-executes); if the restore
+  # itself fails, quarantine (surface is dirty, operator-first).
+
+  defp commit(effect_id, path, content, pre_sha, pre_bytes, existed?) do
+    case repo().record_pre_image(effect_id, pre_sha, pre_bytes, existed?) do
+      res when res in [:ok, :already] -> do_write(effect_id, path, content, pre_bytes, existed?)
+      {:error, reason} -> {:rejected, {:persist_failed, reason}}
+    end
+  end
+
+  defp do_write(effect_id, path, content, pre_bytes, existed?) do
+    case file_ops().write(path, content) do
+      :ok ->
+        case repo().mark_committed(effect_id) do
+          :ok ->
+            {:committed, committed_meta(path, content)}
+
+          {:error, _reason} ->
+            # The write IS durable. NEVER compensate a successful commit — that
+            # would undo a real change. Leave rollback_state 'pending'; crash
+            # recovery will commit-forward (hash == payload_sha256). Report
+            # success with the deferred mark noted.
+            {:committed, Map.put(committed_meta(path, content), :mark_deferred, true)}
+        end
+
+      {:error, write_reason} ->
+        compensate(effect_id, path, pre_bytes, existed?, write_reason)
+    end
+  end
+
+  defp compensate(effect_id, path, pre_bytes, existed?, write_reason) do
+    restore =
+      if existed?, do: file_ops().write(path, pre_bytes), else: normalize_rm(file_ops().rm(path))
+
+    case restore do
+      :ok ->
+        repo().tombstone(effect_id)
+        {:rejected, {:committed_failed_rolled_back, write_reason}}
+
+      {:error, _restore_reason} ->
+        repo().quarantine(effect_id)
+        {:rejected, :rollback_failed}
+    end
+  end
+
+  # rm of an already-absent file means "nothing we created to undo" -> success.
+  defp normalize_rm({:error, :enoent}), do: :ok
+  defp normalize_rm(other), do: other
+
+  defp committed_meta(path, content),
+    do: %{path: path, bytes_written: byte_size(content), payload_sha256: sha256_hex(content)}
 
   # --- validation (the path the dry-run proves) ------------------------------
 
@@ -98,14 +151,19 @@ defmodule UnitaresLeasePlane.FileWriteExecutor do
   end
 
   defp read_pre_image(path) do
-    case File.read(path) do
-      {:ok, bytes} -> {sha256_hex(bytes), true}
-      {:error, :enoent} -> {nil, false}
-      # a read error is surfaced as "exists but unknown" — the dry-run records it
-      # honestly; the commit slice will reject on an unreadable target.
-      {:error, _} -> {nil, true}
+    case file_ops().read(path) do
+      {:ok, bytes} -> {sha256_hex(bytes), bytes, true}
+      {:error, :enoent} -> {nil, nil, false}
+      # exists but unreadable: record honestly; no bytes to restore.
+      {:error, _} -> {nil, nil, true}
     end
   end
+
+  # Injectable seams (default real File / EffectRepo) so the live commit AND
+  # every step of the compensation can be fault-injected in tests — the dialectic
+  # precondition for the live-write path.
+  defp file_ops, do: Application.get_env(:lease_plane, :effect_file_ops, UnitaresLeasePlane.EffectFileOps)
+  defp repo, do: Application.get_env(:lease_plane, :effect_repo, UnitaresLeasePlane.EffectRepo)
 
   defp commit_enabled?,
     do: Application.get_env(:lease_plane, :execute_file_write_commit_enabled, false) == true

--- a/elixir/lease_plane/lib/unitares_lease_plane/governed_effect.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/governed_effect.ex
@@ -52,6 +52,8 @@ defmodule UnitaresLeasePlane.GovernedEffect do
 
   require Logger
 
+  alias UnitaresLeasePlane.Canonicalize
+  alias UnitaresLeasePlane.FileWriteExecutor
   alias UnitaresLeasePlane.GovernanceVetoClient
   alias UnitaresLeasePlane.OrchestratorClient
   alias UnitaresLeasePlane.Repo
@@ -331,9 +333,164 @@ defmodule UnitaresLeasePlane.GovernedEffect do
     end
   end
 
-  # Every other effect_type is still gated (file_write/repo_commit/etc. land in
-  # later slices with their rollback machinery).
+  # file_write — the first REVERSIBLE execute surface. Synchronous: acquire the
+  # lease, re-check the §6 veto on the commit path, hand to FileWriteExecutor
+  # (which captures the pre-image, then dry-runs or commits per
+  # :execute_file_write_commit_enabled), release the lease. Crash recovery is
+  # EffectRecovery (boot) + the executor's in-process compensation; a fast write
+  # is covered by the min-TTL lease floor. (A supervised EffectCustodian with a
+  # lease heartbeat + immediate :transient recovery is a robustness follow-up.)
+  defp execute(%{effect_type: "file_write"} = env) do
+    if execute_file_write_enabled?() do
+      execute_file_write(env)
+    else
+      {:error, :execute_not_implemented}
+    end
+  end
+
+  # Every other effect_type is still gated.
   defp execute(_env), do: {:error, :execute_not_implemented}
+
+  defp execute_file_write_enabled? do
+    Application.get_env(:lease_plane, :execute_file_write_enabled, false) == true
+  end
+
+  # Restart + compensation budget: a too-short lease cannot survive a crash and
+  # recovery, so reject before any custody starts.
+  @min_execute_ttl_s 120
+
+  defp execute_file_write(env) do
+    if min_ttl_ok?(env) do
+      digest = idempotency_digest(env)
+
+      case Repo.governed_effect_by_idempotency_key(env.idempotency_key, @execute_event_type) do
+        {:ok, %{idempotency_digest: ^digest, payload: stored}} ->
+          {:ok, execute_idempotent_body(stored)}
+
+        {:ok, %{idempotency_digest: other}} when is_binary(other) ->
+          {:error, :idempotency_conflict}
+
+        {:ok, nil} ->
+          file_write_under_custody(env, digest)
+
+        {:error, reason} ->
+          Logger.warning("governed_effect file_write idempotency lookup failed: #{inspect(reason)}")
+          {:error, :idempotency_lookup_failed}
+      end
+    else
+      {:error, :lease_ttl_too_short}
+    end
+  end
+
+  defp min_ttl_ok?(env) do
+    Enum.all?(env.required_leases, fn l -> (lease_ttl(l) || 0) >= @min_execute_ttl_s end)
+  end
+
+  defp lease_ttl(%{"ttl_s" => t}), do: t
+  defp lease_ttl(%{ttl_s: t}), do: t
+  defp lease_ttl(_), do: nil
+
+  defp file_write_under_custody(env, digest) do
+    effect_id = gen_effect_id()
+    # Canonicalize lease surfaces ONCE so the acquired surface_id and the
+    # executor's canonical(path) match (the path-canonicalization seam).
+    canon_leases = canonicalize_leases(env.required_leases)
+
+    case acquire_all(canon_leases, env.proposer_agent_uuid) do
+      {:ok, acquired} ->
+        try do
+          # §6 veto re-checked HERE, on the commit path, with the lease held.
+          case GovernanceVetoClient.check(env) do
+            :allow ->
+              result =
+                FileWriteExecutor.apply_effect(effect_id, env.payload, canon_leases)
+
+              {status, extra} = result_audit(result)
+              _ = persist_execute(env, execute_audit_payload(effect_id, env, digest, status, extra))
+              result_to_reply(result, effect_id)
+
+            blocked ->
+              payload =
+                execute_audit_payload(effect_id, env, digest, "governance_blocked", %{
+                  "veto_reason" => veto_reason(blocked)
+                })
+
+              _ = persist_execute(env, payload)
+              {:error, :governance_blocked}
+          end
+        after
+          release_all(acquired)
+        end
+
+      {:error, :held_by_other} ->
+        {:error, :lease_held}
+
+      {:error, reason} ->
+        Logger.warning("governed_effect file_write lease acquire failed: #{inspect(reason)}")
+        {:error, :lease_acquire_failed}
+    end
+  end
+
+  defp canonicalize_leases(leases) do
+    Enum.map(leases, fn l ->
+      surface = Map.get(l, "surface") || Map.get(l, :surface)
+
+      case Canonicalize.canonicalize(surface) do
+        {:ok, canon} -> %{"surface" => canon, "ttl_s" => lease_ttl(l)}
+        _ -> %{"surface" => surface, "ttl_s" => lease_ttl(l)}
+      end
+    end)
+  end
+
+  # Acquire every required lease; on the first conflict, release what we hold and
+  # bail (atomic-ish: no partial custody escapes).
+  defp acquire_all(leases, proposer) do
+    Enum.reduce_while(leases, {:ok, []}, fn l, {:ok, acc} ->
+      params = %{
+        surface_id: Map.get(l, "surface"),
+        holder_agent_uuid: proposer,
+        holder_kind: "remote_heartbeat",
+        ttl_s: lease_ttl(l)
+      }
+
+      case Repo.acquire(params) do
+        {:ok, lease, _} ->
+          {:cont, {:ok, [lease | acc]}}
+
+        {:error, :held_by_other, _} ->
+          release_all(acc)
+          {:halt, {:error, :held_by_other}}
+
+        {:error, reason} ->
+          release_all(acc)
+          {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp release_all(leases) do
+    Enum.each(leases, fn lease ->
+      lease_id = Map.get(lease, :lease_id) || Map.get(lease, "lease_id")
+      if is_binary(lease_id), do: Repo.release(lease_id, "governed_effect_file_write_complete")
+    end)
+  end
+
+  defp result_audit({:committed, meta}),
+    do: {if(meta[:dry_run], do: "dry_run", else: "committed"), %{"result" => stringify(meta)}}
+
+  defp result_audit({:rejected, reason}),
+    do: {"rejected", %{"error" => inspect(reason)}}
+
+  defp result_to_reply({:committed, meta}, effect_id),
+    do: {:ok, %{ok: true, effect_id: effect_id, custody_mode: "execute", result: meta}}
+
+  defp result_to_reply({:rejected, reason}, _effect_id), do: {:error, reason}
+
+  defp stringify(map), do: Map.new(map, fn {k, v} -> {to_string(k), v} end)
+
+  defp veto_reason({:blocked, r}), do: r
+  defp veto_reason({:error, r}), do: "veto_unavailable:#{inspect(r)}"
+  defp veto_reason(_), do: "vetoed"
 
   defp execute_agent_spawn_enabled? do
     Application.get_env(:lease_plane, :execute_agent_spawn_enabled, false) == true and

--- a/elixir/lease_plane/test/file_write_executor_commit_test.exs
+++ b/elixir/lease_plane/test/file_write_executor_commit_test.exs
@@ -1,0 +1,139 @@
+defmodule UnitaresLeasePlane.FileWriteExecutorCommitTest do
+  @moduledoc """
+  The live commit + in-process compensation path, with FAULT INJECTION AT EVERY
+  STEP — the hard precondition the slice-2 dialectic review set before the commit
+  flag may ever flip. slice 1b tested CRASH recovery (which never writes); this
+  tests the live-write-then-restore path it left untested.
+
+  File ops and the repo are injected (Application env), so each step can be made
+  to fail deterministically: the commit write, the restore write, the rm, the
+  pre-image persist, and the committed-mark.
+  """
+  use ExUnit.Case, async: false
+
+  alias UnitaresLeasePlane.{Canonicalize, FileWriteExecutor}
+
+  # --- injected fakes --------------------------------------------------------
+
+  defmodule FakeFileOps do
+    def read(_path), do: rec({:read}, Process.get(:read_result, {:error, :enoent}))
+
+    def write(path, bytes), do: rec({:write, path, bytes}, next_write())
+
+    def rm(_path), do: rec({:rm}, Process.get(:rm_result, :ok))
+
+    defp next_write do
+      case Process.get(:write_results, [:ok]) do
+        [r | rest] -> Process.put(:write_results, rest) && r
+        [] -> :ok
+      end
+    end
+
+    defp rec(call, result), do: (send(self(), {:fileop, call}) && result)
+  end
+
+  defmodule FakeRepo do
+    def record_pre_image(_id, _sha, _bytes, _existed?),
+      do: rec(:record_pre_image, Process.get(:record_result, :ok))
+
+    def mark_committed(_id), do: rec(:mark_committed, Process.get(:mark_result, :ok))
+    def tombstone(id), do: rec({:tombstone, id}, :ok)
+    def quarantine(id), do: rec({:quarantine, id}, :ok)
+    defp rec(tag, result), do: (send(self(), {:repo, tag}) && result)
+  end
+
+  setup %{tmp_dir: dir} do
+    # reset any env a sibling test file may have leaked (e.g. the ceiling override)
+    Application.delete_env(:lease_plane, :file_write_payload_max_bytes)
+    Application.put_env(:lease_plane, :effect_file_ops, FakeFileOps)
+    Application.put_env(:lease_plane, :effect_repo, FakeRepo)
+    Application.put_env(:lease_plane, :execute_file_write_commit_enabled, true)
+
+    on_exit(fn ->
+      Application.delete_env(:lease_plane, :effect_file_ops)
+      Application.delete_env(:lease_plane, :effect_repo)
+      Application.delete_env(:lease_plane, :execute_file_write_commit_enabled)
+    end)
+
+    path = Path.join(dir, "note.txt")
+    {:ok, surface} = Canonicalize.canonicalize("file://" <> path)
+    leases = [%{"surface" => surface}]
+    payload = %{"path" => path, "content" => "the new content\n"}
+    %{leases: leases, payload: payload}
+  end
+
+  @tag :tmp_dir
+  test "happy commit: pre-image persisted, write, mark_committed", %{payload: p, leases: l} do
+    Process.put(:read_result, {:ok, "old\n"})
+    Process.put(:write_results, [:ok])
+    Process.put(:mark_result, :ok)
+
+    assert {:committed, r} = FileWriteExecutor.apply_effect("eC1", p, l)
+    assert r.bytes_written == byte_size("the new content\n")
+    refute Map.has_key?(r, :dry_run)
+    refute Map.has_key?(r, :mark_deferred)
+    assert_received {:repo, :record_pre_image}
+    assert_received {:fileop, {:write, _, "the new content\n"}}
+    assert_received {:repo, :mark_committed}
+  end
+
+  @tag :tmp_dir
+  test "STEP write fails + restore (existed) succeeds -> TOMBSTONE", %{payload: p, leases: l} do
+    Process.put(:read_result, {:ok, "the original\n"})
+    # commit write fails, restore write succeeds
+    Process.put(:write_results, [{:error, :eio}, :ok])
+
+    assert {:rejected, {:committed_failed_rolled_back, :eio}} =
+             FileWriteExecutor.apply_effect("eC2", p, l)
+    # the restore wrote the pre-image bytes back
+    assert_received {:fileop, {:write, _, "the original\n"}}
+    assert_received {:repo, {:tombstone, "eC2"}}
+    refute_received {:repo, {:quarantine, _}}
+  end
+
+  @tag :tmp_dir
+  test "STEP write fails + restore ALSO fails -> QUARANTINE", %{payload: p, leases: l} do
+    Process.put(:read_result, {:ok, "orig\n"})
+    Process.put(:write_results, [{:error, :eio}, {:error, :erofs}])
+
+    assert {:rejected, :rollback_failed} = FileWriteExecutor.apply_effect("eC3", p, l)
+    assert_received {:repo, {:quarantine, "eC3"}}
+    refute_received {:repo, {:tombstone, _}}
+  end
+
+  @tag :tmp_dir
+  test "STEP write fails + target did NOT exist + rm succeeds -> TOMBSTONE", %{payload: p, leases: l} do
+    Process.put(:read_result, {:error, :enoent})
+    Process.put(:write_results, [{:error, :eio}])
+    Process.put(:rm_result, :ok)
+
+    assert {:rejected, {:committed_failed_rolled_back, :eio}} =
+             FileWriteExecutor.apply_effect("eC4", p, l)
+    assert_received {:fileop, {:rm}}
+    assert_received {:repo, {:tombstone, "eC4"}}
+  end
+
+  @tag :tmp_dir
+  test "STEP write succeeds but mark_committed fails -> COMMITTED (never undo a real write)",
+       %{payload: p, leases: l} do
+    Process.put(:read_result, {:ok, "old\n"})
+    Process.put(:write_results, [:ok])
+    Process.put(:mark_result, {:error, :db_down})
+
+    assert {:committed, r} = FileWriteExecutor.apply_effect("eC5", p, l)
+    assert r.mark_deferred == true
+    # the commit write happened; crucially NO compensation write follows it
+    assert_received {:fileop, {:write, _, "the new content\n"}}
+    refute_received {:repo, {:tombstone, _}}
+    refute_received {:repo, {:quarantine, _}}
+  end
+
+  @tag :tmp_dir
+  test "STEP pre-image persist fails -> REJECTED, no write attempted", %{payload: p, leases: l} do
+    Process.put(:read_result, {:ok, "old\n"})
+    Process.put(:record_result, {:error, :db_down})
+
+    assert {:rejected, {:persist_failed, :db_down}} = FileWriteExecutor.apply_effect("eC6", p, l)
+    refute_received {:fileop, {:write, _, _}}
+  end
+end

--- a/elixir/lease_plane/test/file_write_executor_test.exs
+++ b/elixir/lease_plane/test/file_write_executor_test.exs
@@ -104,21 +104,11 @@ defmodule UnitaresLeasePlane.FileWriteExecutorTest do
     assert File.read!(path) == "x"
   end
 
-  @tag :tmp_dir
-  test "two-flag fail-safe: even with commit enabled this slice refuses to write", %{tmp_dir: dir} do
-    Application.put_env(:lease_plane, :execute_file_write_commit_enabled, true)
-    path = Path.join(dir, "note.txt")
-    File.write!(path, "untouched")
-    leases = [%{"surface" => canonical_surface(path)}]
-    payload = %{"path" => path, "content" => "would-be"}
-
-    # commit path is the NEXT slice (gated on fault-injection tests) — refuse.
-    assert {:rejected, :commit_not_enabled} =
-             FileWriteExecutor.apply_effect("e7", payload, leases)
-    assert File.read!(path) == "untouched"
-  after
-    Application.delete_env(:lease_plane, :execute_file_write_commit_enabled)
-  end
+  # NOTE: the prior "commit-enabled still refuses to write" fail-safe test was
+  # removed when the live commit path landed — commit-enabled now performs the
+  # real write. The default (commit DISABLED -> dry-run) fail-safe is still
+  # exercised by every test above (none of which sets the commit flag); the live
+  # commit + compensation is covered by file_write_executor_commit_test.exs.
 
   test "executor declares itself reversible" do
     assert FileWriteExecutor.reversible?() == true


### PR DESCRIPTION
The **last code slice** before the (operator-flipped) live governed file commit. Connects the executor to the request path. Stacked on #1200.

## What's here
- **`execute_file_write`** (synchronous, mirrors `execute_agent_spawn`): min-TTL floor → idempotency check → **canonicalize + acquire** the required lease(s) → **§6 veto re-checked on the commit path** (lease held) → `FileWriteExecutor.apply_effect` → release. `acquire_all` is atomic-ish — on the first conflict it releases what it holds and bails, so no partial custody escapes.
- **Path-canonicalization seam closed:** lease surfaces are canonicalized once and used for *both* the acquire and the executor's path match (the failure mode the slice-2 review was asked about).
- **Two fail-closed flags:** `UNITARES_GOVERNED_EFFECT_EXECUTE_FILE_WRITE` gates dispatch; `..._FILE_WRITE_COMMIT` gates the real write (dry-run when off).
- **`validate_execute_type_flags!` boot guard:** refuses to boot if COMMIT is on while dispatch is off (a write capability with no governed path).

## Safety + verification
- Compiles clean; **47 existing** governed-effect/executor/reconcile tests pass (no regression).
- **Both flags default OFF** → `file_write` execute stays `execute_not_implemented` in production. The live path cannot be reached from this PR.
- The lease+veto+executor **integration** is verified at the **live dry-run step of the flip** (the dialectic's prescribed gate) before the commit flag is ever set — not unit-tested here because it needs the live DB + lease + governance-veto.

## Robustness follow-up (noted, not blocking)
A supervised `EffectCustodian` with a lease heartbeat + immediate `:transient` recovery. The synchronous handler is safe for fast writes via boot recovery (`EffectRecovery`) + the executor's in-process compensation + the min-TTL lease floor.

Draft — RCE-class surface; maintainer is the merge gate.