### PR TITLE
fix(governed-effect): insert effects.payloads row before file_write commit

### DIFF
--- a/elixir/lease_plane/lib/unitares_lease_plane/file_write_executor.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/file_write_executor.ex
@@ -30,6 +30,18 @@ defmodule UnitaresLeasePlane.FileWriteExecutor do
   @impl true
   def reversible?, do: true
 
+  @doc """
+  Resolve a payload's bytes + content hash through the SAME path apply_effect
+  uses. The dispatch calls this to populate the durable effects.payloads row
+  BEFORE committing — record_pre_image is an UPDATE and needs the row to exist.
+  """
+  def resolved_payload(payload) do
+    case resolve_content(payload) do
+      {:ok, bytes} -> {:ok, bytes, sha256_hex(bytes)}
+      {:error, _} = err -> err
+    end
+  end
+
   @impl true
   def apply_effect(effect_id, payload, leases) do
     with {:ok, path} <- resolve_path(payload, leases),

--- a/elixir/lease_plane/lib/unitares_lease_plane/governed_effect.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/governed_effect.ex
@@ -53,6 +53,7 @@ defmodule UnitaresLeasePlane.GovernedEffect do
   require Logger
 
   alias UnitaresLeasePlane.Canonicalize
+  alias UnitaresLeasePlane.EffectRepo
   alias UnitaresLeasePlane.FileWriteExecutor
   alias UnitaresLeasePlane.GovernanceVetoClient
   alias UnitaresLeasePlane.OrchestratorClient
@@ -402,12 +403,30 @@ defmodule UnitaresLeasePlane.GovernedEffect do
           # §6 veto re-checked HERE, on the commit path, with the lease held.
           case GovernanceVetoClient.check(env) do
             :allow ->
-              result =
-                FileWriteExecutor.apply_effect(effect_id, env.payload, canon_leases)
+              # Insert the durable effects.payloads row BEFORE the commit so the
+              # executor's record_pre_image UPDATE (and crash recovery) have a row
+              # to act on. record_pre_image is UPDATE-only; without this the file
+              # would commit with no rollback/pre-image record.
+              case ensure_payload_row(effect_id, env, digest) do
+                :ok ->
+                  result =
+                    FileWriteExecutor.apply_effect(effect_id, env.payload, canon_leases)
 
-              {status, extra} = result_audit(result)
-              _ = persist_execute(env, execute_audit_payload(effect_id, env, digest, status, extra))
-              result_to_reply(result, effect_id)
+                  {status, extra} = result_audit(result)
+                  _ = persist_execute(env, execute_audit_payload(effect_id, env, digest, status, extra))
+                  result_to_reply(result, effect_id)
+
+                {:error, reason} ->
+                  _ =
+                    persist_execute(
+                      env,
+                      execute_audit_payload(effect_id, env, digest, "persist_failed", %{
+                        "error" => inspect(reason)
+                      })
+                    )
+
+                  {:error, :persist_failed}
+              end
 
             blocked ->
               payload =
@@ -429,6 +448,35 @@ defmodule UnitaresLeasePlane.GovernedEffect do
         Logger.warning("governed_effect file_write lease acquire failed: #{inspect(reason)}")
         {:error, :lease_acquire_failed}
     end
+  end
+
+  # Durable row for the commit path only — a dry-run writes nothing and needs no
+  # rollback row, so it would otherwise leave an orphan for recovery to reconcile.
+  defp ensure_payload_row(effect_id, env, digest) do
+    if file_write_commit_enabled?() do
+      case FileWriteExecutor.resolved_payload(env.payload) do
+        {:ok, bytes, sha} ->
+          EffectRepo.insert_effect_payload(%{
+            effect_id: effect_id,
+            effect_type: env.effect_type,
+            payload_bytes: bytes,
+            payload_sha256: sha,
+            required_leases: env.required_leases,
+            proposer_agent_uuid: env.proposer_agent_uuid,
+            idempotency_key: env.idempotency_key,
+            idempotency_digest: digest
+          })
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    else
+      :ok
+    end
+  end
+
+  defp file_write_commit_enabled? do
+    Application.get_env(:lease_plane, :execute_file_write_commit_enabled, false) == true
   end
 
   defp canonicalize_leases(leases) do


### PR DESCRIPTION
**Found by the first live `file_write` commit** (the dialectic's dry-run-first integration gate paid off). `record_pre_image` is UPDATE-only (`WHERE effect_id=.. AND rollback_state IS NULL`) — it needs the `effects.payloads` row to already exist. `execute_file_write` skipped the insert, so the UPDATE matched 0 rows (returned `:already`), the executor proceeded, and **the file committed with no durable pre-image / rollback / crash-recovery row** — defeating §5b. The `audit.events` trail was written correctly; only the `effects.payloads` row was missing.

## Why the unit tests missed it
`FakeRepo.record_pre_image` returns `:ok` regardless, masking the UPDATE-needs-existing-row semantics. The bug only shows against the real schema — caught by the live dry-run/commit gate, which is exactly what that gate is for.

## Fix
- `execute_file_write` now inserts the durable row (`EffectRepo.insert_effect_payload`, supplying the NOT-NULL `effect_type` / `idempotency_key` / `idempotency_digest` that only the dispatch holds) **before** `FileWriteExecutor.apply_effect`, and **only on the commit path** — a dry-run writes nothing and needs no rollback row, so it leaves no orphan for recovery.
- An insert failure **fails closed** (`persist_failed`) before any write.
- `FileWriteExecutor.resolved_payload/1` (new, public) routes the row's bytes+sha through the same content resolution `apply_effect` uses.

## Status
47 tests pass; both flags remain default-off. Re-verification is another live dry-run→commit cycle (confirm the `effects.payloads` row now appears with `committed_at` set) after merge+deploy.

Draft — RCE-class surface; maintainer is the merge gate.