### PR TITLE
chore(review): close cheap legibility/observability gaps from external review

### DIFF
--- a/docs/REVIEWER_GUIDE.md
+++ b/docs/REVIEWER_GUIDE.md
@@ -30,6 +30,28 @@ UNITARES is proprioceptive runtime state telemetry for long-lived AI-agent fleet
 - Not hardened against a motivated adversary gaming the EISV proxy. The design is adversarial-aware — outcomes can't be faked, baselines are self-relative — but enforcement leans lenient by intent and there has been no red-team. See [README → Scope and threat model](../README.md#scope-and-threat-model).
 - Not a claim of broad external adoption yet; the public deployment metrics describe a single-operator stress test.
 
+## Implementation status: what's live vs proposed
+
+A cold reader who greps the code and also reads `docs/proposals/` can easily
+mistake a *proposed* surface for vaporware, or conclude a *live* surface is
+"not implemented" because the README mentions it and the obvious file doesn't.
+This table is the authoritative shipped/proposed line. If it disagrees with
+runtime, trust [`dev/CANONICAL_SOURCES.md`](dev/CANONICAL_SOURCES.md) and the
+referenced files.
+
+| Surface | Status | Where to verify it's real |
+|---|---|---|
+| Check-in / EISV / verdict loop | **Live** | `src/behavioral_assessment.py`, `src/behavioral_state.py`; flow in [`UNIFIED_ARCHITECTURE.md`](UNIFIED_ARCHITECTURE.md) |
+| Self-relative (z-score vs own Welford baseline) scoring | **Live** | `behavioral_assessment.py` module docstring + `SIGMA_*` constants (provenance documented inline) |
+| Dialectic review (thesis / antithesis / synthesis, reviewer selection) | **Live** | `src/mcp_handlers/dialectic/handlers.py` — `submit_thesis` / `submit_antithesis` / `submit_synthesis` / `request_dialectic_review`, all in `TOOL_ORDER`. Not a stub. |
+| Knowledge graph (discoveries, edges, FTS) | **Live, advisory** | Committed schema `db/postgres/knowledge_schema.sql` + migration `002_knowledge_schema.sql`; tools `knowledge()`, `store_knowledge_graph`, `search_knowledge_graph`. AGE relational store is canonical; AGE graph is advisory. |
+| HTTP write/decision endpoints | **Live** | `src/http_api.py` — `POST /v1/effect-veto`, `POST /v1/tools/call`, `POST /api/findings`, `POST /v1/substrate/observe`. The **dashboard UI** is read-only by design; the **API** mutates. |
+| ODE / thermodynamic model | **Live but diagnostic only** | Runs in parallel; does **not** drive verdicts (behavioral path overrides). See [`EISV_COMPUTATION.md`](EISV_COMPUTATION.md). |
+| BEAM Wave 3a outbound proxy | **Live, optimization-only** | `src/wave3a_beam_proxy.py`. Python in-process dispatch is the authority; BEAM is a routed fast-path that **fails open to Python** on any error (500ms hard timeout). Routing is env-flag-gated (`src/wave3a_routing.py`). Observability: DB coordination events + `unitares_beam_proxy_*` Prometheus metrics. |
+
+If a capability is **not** in this table and only appears under `docs/proposals/`,
+treat it as proposed, not shipped.
+
 ## Fast path: three minutes
 
 ```bash

--- a/src/behavioral_assessment.py
+++ b/src/behavioral_assessment.py
@@ -80,10 +80,37 @@ BASIN_I_HEALTHY = 0.70   # == BASIN_HIGH.I_min
 BASIN_S_HEALTHY = 0.25   # == BASIN_HIGH.S_max
 BASIN_V_HEALTHY = 0.15   # == BASIN_HIGH.V_abs_max
 
-# Sigma thresholds for self-relative scoring
-SIGMA_MILD = 1.5      # noticeably different from self
-SIGMA_MODERATE = 2.0   # concerning
-SIGMA_SEVERE = 3.0     # severe deviation
+# Sigma thresholds for self-relative scoring.
+#
+# Provenance (be honest about what these are and are NOT):
+#   - These are the conventional Gaussian deviation landmarks — 1.5σ / 2σ / 3σ
+#     — NOT constants empirically tuned on a labelled dataset. There is no
+#     hidden fit behind the specific values; treat them as principled defaults,
+#     not validated optima.
+#   - They are defensible as *global* constants precisely because the signal
+#     they threshold is already per-agent-normalized: after warmup, scoring is
+#     a z-score of the agent's deviation from its OWN Welford baseline (see the
+#     module docstring), so "2.0" means "two of THIS agent's own standard
+#     deviations," not an absolute EISV cut. The per-agent adaptation lives in
+#     the baseline, not in these multipliers — which is why one set of σ
+#     landmarks can apply across agents without a one-size-fits-all absolute
+#     threshold.
+#   - Reference shape (2σ ≈ ~95th pct, 3σ ≈ ~99.7th pct under normality) is the
+#     intuition; the EISV residual distribution is not guaranteed Gaussian, so
+#     the percentile reading is a heuristic, not a calibrated false-positive
+#     rate.
+#
+# Known limitations / open calibration questions (do not silently treat these
+# as solved):
+#   - Applied UNIFORMLY across E/I/S/V and across all agent types; there is no
+#     per-dimension or per-task-type (convergent vs exploratory) variant.
+#   - No committed sensitivity analysis for how much verdict churn a ±10% move
+#     in any landmark produces.
+# Per-agent/per-class adaptation, when it lands, belongs in the baseline /
+# class-anchor calibration path, NOT by forking these constants.
+SIGMA_MILD = 1.5      # ~1.5σ from self — noticeably different from own baseline
+SIGMA_MODERATE = 2.0   # ~2σ — concerning (≈95th pct under normality, heuristic)
+SIGMA_SEVERE = 3.0     # ~3σ — severe (≈99.7th pct under normality, heuristic)
 
 
 def _basin_health_gate(state: BehavioralEISV) -> Dict[str, float]:

--- a/src/metrics_registry.py
+++ b/src/metrics_registry.py
@@ -59,6 +59,28 @@ DIALECTIC_SESSIONS_ACTIVE = Gauge(
     'Number of active dialectic sessions'
 )
 
+# Wave 3a BEAM-outbound proxy metrics (governance MCP -> BEAM listener).
+# The DB-backed coordination events + measurement rows in
+# src/wave3a_beam_proxy.py are the durable §4.2 audit channel; these two are
+# the live /metrics surface (Grafana) the audit channel does not expose:
+# per-tool call counts, latency, and fallback reason in real time.
+# `outcome` is "ok" on success or the ProxyResult.fallback_reason on failure
+# (timeout / non_200 / connect_error / decode_error / envelope_invalid / other).
+BEAM_PROXY_CALLS_TOTAL = Counter(
+    'unitares_beam_proxy_calls_total',
+    'Total BEAM proxy dispatch attempts by tool and outcome',
+    ['tool_name', 'outcome']
+)
+
+BEAM_PROXY_LATENCY = Histogram(
+    'unitares_beam_proxy_latency_seconds',
+    'BEAM proxy outbound call latency in seconds by tool and outcome',
+    ['tool_name', 'outcome'],
+    # Bucketed tight around the 500ms (§3.2) hard timeout budget so the
+    # timeout cliff and the sub-budget distribution are both legible.
+    buckets=(0.01, 0.025, 0.05, 0.1, 0.25, 0.4, 0.5, 0.75, 1.0)
+)
+
 # Server info (static)
 SERVER_INFO = Gauge(
     'unitares_server_info',

--- a/src/wave3a_beam_proxy.py
+++ b/src/wave3a_beam_proxy.py
@@ -191,6 +191,31 @@ async def _emit_event(event_type: str, payload: Dict[str, Any]) -> None:
         )
 
 
+def _record_proxy_metric(tool_name: str, outcome: str, elapsed_ms: int) -> None:
+    """Record the Prometheus call-count + latency for one proxy attempt.
+
+    Prometheus is the live ``/metrics`` surface (Grafana); the DB-backed
+    coordination events and ``measurement.wave_3a.request`` rows above remain
+    the durable §4.2 audit channel. This adds the missing real-time
+    observability dimension — calls / latency / fallback-reason per tool —
+    without touching that contract. ``outcome`` is ``"ok"`` on success or the
+    ``fallback_reason`` on any failure. Swallows all errors: a metrics failure
+    MUST NOT perturb the dispatch path (same discipline as ``_emit_event``).
+    """
+    try:
+        from src.metrics_registry import (
+            BEAM_PROXY_CALLS_TOTAL,
+            BEAM_PROXY_LATENCY,
+        )
+
+        BEAM_PROXY_CALLS_TOTAL.labels(tool_name=tool_name, outcome=outcome).inc()
+        BEAM_PROXY_LATENCY.labels(tool_name=tool_name, outcome=outcome).observe(
+            elapsed_ms / 1000.0
+        )
+    except Exception as exc:  # noqa: BLE001 — metrics are observability infra
+        logger.debug("[wave3a-proxy] metric record failed: %r", exc)
+
+
 def _spawn_emit(event_type: str, payload: Dict[str, Any]) -> None:
     """Fire-and-forget the event emit, keeping a strong task ref.
 
@@ -377,6 +402,7 @@ async def proxy_to_beam(
             tool_name,
             elapsed_ms,
         )
+        _record_proxy_metric(tool_name, "timeout", elapsed_ms)
         return ProxyResult(
             ok=False, fallback_reason="timeout", elapsed_ms=elapsed_ms
         )
@@ -398,6 +424,7 @@ async def proxy_to_beam(
             exc.response.status_code if exc.response else "?",
             elapsed_ms,
         )
+        _record_proxy_metric(tool_name, "non_200", elapsed_ms)
         return ProxyResult(
             ok=False, fallback_reason="non_200", elapsed_ms=elapsed_ms
         )
@@ -418,6 +445,7 @@ async def proxy_to_beam(
             type(exc).__name__,
             elapsed_ms,
         )
+        _record_proxy_metric(tool_name, "connect_error", elapsed_ms)
         return ProxyResult(
             ok=False, fallback_reason="connect_error", elapsed_ms=elapsed_ms
         )
@@ -442,6 +470,7 @@ async def proxy_to_beam(
             exc,
             elapsed_ms,
         )
+        _record_proxy_metric(tool_name, trigger, elapsed_ms)
         return ProxyResult(
             ok=False, fallback_reason=trigger, elapsed_ms=elapsed_ms
         )
@@ -465,6 +494,7 @@ async def proxy_to_beam(
             violation,
             elapsed_ms,
         )
+        _record_proxy_metric(tool_name, "envelope_invalid", elapsed_ms)
         return ProxyResult(
             ok=False,
             fallback_reason="envelope_invalid",
@@ -490,6 +520,7 @@ async def proxy_to_beam(
         payload_bytes=payload_bytes,
         beam_url=beam_url,
     )
+    _record_proxy_metric(tool_name, "ok", elapsed_ms)
     return ProxyResult(ok=True, response=body, elapsed_ms=elapsed_ms)
 
 

--- a/tests/test_tool_schema_validation.py
+++ b/tests/test_tool_schema_validation.py
@@ -14,7 +14,11 @@ from pathlib import Path
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
-from src.tool_schemas import get_tool_definitions
+from src.tool_schemas import (
+    get_tool_definitions,
+    get_pydantic_schemas,
+    TOOL_ORDER,
+)
 from src.mcp_handlers.decorators import (
     get_tool_registry,
     list_registered_tools,
@@ -81,6 +85,54 @@ class TestRegistryConsistency:
         with_hidden = list_registered_tools(include_hidden=True)
         assert len(with_hidden) >= len(default), (
             "Including hidden tools should not reduce the count"
+        )
+
+
+# ============================================================================
+# TOOL_ORDER <-> Pydantic schema sync (silent-drop drift gate)
+# ============================================================================
+
+class TestToolOrderSchemaSync:
+    """Hard gate against the silent tool-registration footgun.
+
+    ``get_tool_definitions()`` iterates ``TOOL_ORDER``; an entry with no
+    matching Pydantic ``*Params`` schema is ``print``-warned and ``continue``d,
+    so the tool silently vanishes from the advertised MCP surface for every
+    client — no exception, no CI failure, just a missing tool. The structural
+    tests below this class only inspect what survived that filter, so they
+    cannot catch the drop. This class asserts the invariant at the source.
+    """
+
+    def test_every_tool_order_entry_has_a_schema(self):
+        """Every name in TOOL_ORDER must resolve to a Pydantic schema.
+
+        A missing schema means the tool is silently dropped from the MCP
+        registry at boot (tool_schemas.py:get_tool_definitions warns + skips).
+        """
+        schemas = get_pydantic_schemas()
+        missing = [name for name in TOOL_ORDER if name not in schemas]
+        assert not missing, (
+            "TOOL_ORDER entries with no Pydantic *Params schema will be "
+            "SILENTLY DROPPED from the MCP tool surface at boot "
+            f"(tool_schemas.py prints a warning and continues): {missing}. "
+            "Add the matching *Params model in src/mcp_handlers/schemas/, or "
+            "remove the entry from TOOL_ORDER."
+        )
+
+    def test_no_duplicate_tool_order_entries(self):
+        """TOOL_ORDER must have no duplicate names (ordering/merge drift guard)."""
+        seen = set()
+        dupes = sorted({n for n in TOOL_ORDER if n in seen or seen.add(n)})
+        assert not dupes, f"Duplicate entries in TOOL_ORDER: {dupes}"
+
+    def test_every_tool_order_entry_is_advertised(self):
+        """Round-trip: every TOOL_ORDER name must survive into the built
+        tool list. Catches a drop from any cause, not just a missing schema."""
+        advertised = {t.name for t in get_tool_definitions()}
+        dropped = [name for name in TOOL_ORDER if name not in advertised]
+        assert not dropped, (
+            f"TOOL_ORDER entries that did not reach get_tool_definitions() "
+            f"output (silently dropped at boot): {dropped}"
         )
 
 


### PR DESCRIPTION
Four low-risk fixes triaged from an external code review. The review raised 10 weaknesses; **4 rested on misreadings of live code** (dialectic, KG, write endpoints, session derivation are all shipped). This PR takes the genuinely-real, cheap subset. No hot-path behavior change.

## What's in here

| # | Fix | Risk |
|---|---|---|
| obs | `unitares_beam_proxy_{calls_total,latency_seconds}` Prometheus metrics on the Wave 3a proxy (labeled `tool_name`+`outcome`) | observability-only, swallow-all helper |
| test | `TestToolOrderSchemaSync` — hard CI gate against the silent tool-registration drop | test-only |
| docs | Honest `SIGMA_*` threshold provenance in `behavioral_assessment.py` | comment-only |
| docs | "What's live vs proposed" status map in `REVIEWER_GUIDE.md` | docs-only |

### Why the BEAM metrics
The DB-backed coordination events + `measurement.wave_3a.request` rows remain the durable §4.2 audit channel. They are not on the live `/metrics` surface, so Grafana had no real-time calls/latency/fallback-reason view. These two metrics add exactly that, recorded via a helper that swallows all errors so a metrics failure can never perturb dispatch.

### Why the tool-schema gate
`get_tool_definitions()` iterates `TOOL_ORDER`; an entry with no Pydantic `*Params` schema is `print`-warned and `continue`d — silently dropped from the MCP surface at boot, no exception, no CI failure. Existing structural tests only inspect survivors, so they can't catch the drop. The new class asserts the invariant at the source. Verified it fires on injected drift.

### Why the docs
The reviewer concluded dialectic / KG / HTTP write endpoints were "not implemented" — all are live. That's a discoverability failure: RFCs in `docs/proposals/` read as shipped, shipped code read as absent. The status map grounds each surface in the file/endpoint that proves it.

## Not in scope (deliberately)
- `mcp_server.py` split (#1) — real but load-bearing single-writer; separate careful pass.
- fail-open vs fail-closed on full-assessment error (#9) — a design question, not a bug; deserves a deliberate answer.

## Gate
ruff clean; `test-cache.sh` → 11055 passed / 22 skipped; coverage 81.9% (>75%).

https://claude.ai/code/session_01BygDu5gT3LCGZbAuKfstVq