### PR TITLE
feat(doc-health): surface shipped-status docs sitting in active locations

### DIFF
--- a/scripts/diagnostics/check_doc_health.py
+++ b/scripts/diagnostics/check_doc_health.py
@@ -1,12 +1,20 @@
 #!/usr/bin/env python3
 """Check documentation health: dead refs, ghost tools, hardcoded IPs/counts.
 
+Also prints an advisory **demotion-candidate** list: planning/RFC docs whose own
+status says the work shipped but which still live in an active location
+(proposals/ outside resolved/, or the ontology/ identity tree). That list is
+triage, not a defect — it never affects the exit code; clear it by moving
+fully-shipped docs to proposals/resolved/ (or stubbing them out) on a real
+signal, rather than letting a subsystem's doc set sprawl.
+
 Usage:
     python3 scripts/diagnostics/check_doc_health.py [--strict]
 
 Exit codes:
-    0 — no warnings (or warnings only in non-strict mode)
-    1 — warnings found (strict mode only)
+    0 — no warnings (or warnings only in non-strict mode; the demotion advisory
+        never sets a non-zero code)
+    1 — warnings found (strict mode only) — demotion candidates excluded
 """
 
 import os
@@ -410,6 +418,100 @@ def check_hardcoded_counts(md_files: list[Path]) -> list[str]:
     return warnings
 
 
+# --- Check 5: Demotion candidates (shipped-status docs in an active location) ---
+#
+# A planning/RFC doc whose own status says the work shipped, but which still
+# lives in an "active" location (docs/proposals/ outside resolved/, or
+# docs/ontology/ which is the identity tree), is a demotion candidate: its
+# forward-looking body keeps reading as a plan after the thing landed, and the
+# subsystem's doc set sprawls. This does NOT auto-demote — it surfaces a triage
+# list the operator clears on a real signal (the 2026-06 BEAM/lease thread
+# reached ~21 docs this way). Advisory only: never affects the exit code,
+# because "should this move to resolved/" is a judgment call, not a defect.
+#
+# Heuristic, deliberately conservative — requires an explicit shipped marker in
+# the doc's own header region (first lines / frontmatter), so a doc that merely
+# mentions "deployed" deep in its body does not trip it. A doc that is shipped
+# AND still names remaining work is flagged as "partially shipped" (split the
+# done part out) rather than "fully shipped" (move it wholesale).
+
+# Anchor docs of docs/ontology/ — living canonical/ledger docs, not plans.
+_DEMOTION_SKIP_ONTOLOGY = {
+    "README.md", "identity.md", "plan.md", "paper-positioning.md", "glossary.md",
+}
+
+_SHIPPED_MARKERS = re.compile(
+    r'\b(shipped|deployed|landed|merged|in production|live in prod|'
+    r'enforcement shipped|complete[d]?|resolved|done)\b',
+    re.IGNORECASE,
+)
+# Signals the doc still tracks open work — distinguishes "fully shipped" (move
+# it) from "partially shipped" (split out the done part, keep the open part).
+_ACTIVE_REMAINING = re.compile(
+    r'\b(not started|remaining|in progress|in-flight|wip|todo|pending|'
+    r'proposed|design-gated|draft|next step|open question|phase [b-z] remains)\b',
+    re.IGNORECASE,
+)
+
+
+# A doc cited from this many places is a load-bearing reference (e.g. a
+# canonical contract spec like surface-lease-plane-v0.md, 13 inbound) — moving
+# it would break references, so it is not a demotion candidate even when its
+# status says "shipped." Tuned to keep genuine candidates (beam-coordination-
+# kernel.md, 7 inbound) while exempting the few living references above it.
+_DEMOTION_LIVING_REF_THRESHOLD = 10
+
+
+def check_demotion_candidates(md_files: list[Path]) -> list[str]:
+    refs = _collect_md_basename_refs()
+    warnings = []
+    for fpath in md_files:
+        rel = fpath.relative_to(REPO_ROOT)
+        parts = rel.parts
+        if not parts or parts[0] != "docs":
+            continue
+        # Scope: proposals/ (but not already-demoted resolved/) and ontology/.
+        in_proposals = "proposals" in parts and "resolved" not in parts
+        in_ontology = "ontology" in parts
+        if not (in_proposals or in_ontology):
+            continue
+        if rel.name == "README.md":
+            continue
+        # Living reference (cited widely by other docs) — not a stale plan to
+        # move. Count doc-to-doc citations only; code/test mentions of a
+        # filename don't make a planning doc a load-bearing reference.
+        inbound = {
+            m for m in refs.get(rel.name, set())
+            if m.startswith("docs/") and m.endswith(".md") and m != rel.as_posix()
+        }
+        if len(inbound) >= _DEMOTION_LIVING_REF_THRESHOLD:
+            continue
+        if _DATED_RECORD.search(rel.name):
+            # Dated point-in-time records are kept in place by design; a shipped
+            # status on a record is correct, not a demotion signal.
+            continue
+        if in_ontology and rel.name in _DEMOTION_SKIP_ONTOLOGY:
+            continue
+        # Status/header region only: frontmatter + the first prose lines, where
+        # docs put **Status:** / **Last Updated:** banners.
+        lines = fpath.read_text(errors="replace").splitlines()
+        header = "\n".join(lines[:15])
+        if not _SHIPPED_MARKERS.search(header):
+            continue
+        loc = "ontology/ (identity tree)" if in_ontology else "proposals/"
+        if _ACTIVE_REMAINING.search(header):
+            warnings.append(
+                f"  {rel}: partially shipped in {loc} — split the shipped part "
+                f"to resolved/ (or a stub) and keep only the open work forward-looking"
+            )
+        else:
+            warnings.append(
+                f"  {rel}: reads fully shipped in {loc} — consider moving to "
+                f"proposals/resolved/, or stub + point at the live canonical doc"
+            )
+    return warnings
+
+
 # --- Main ---
 
 def collect_md_files() -> list[Path]:
@@ -453,19 +555,32 @@ def main():
     if counts:
         all_warnings.append(("Hardcoded counts (will go stale)", counts))
 
-    if not all_warnings:
+    # Advisory: surfaced for triage, never gates the exit code (demotion is a
+    # judgment call, not a defect). Printed separately from the warning total.
+    demotion = check_demotion_candidates(md_files)
+
+    if not all_warnings and not demotion:
         print("📄 Doc health: all clear")
         return 0
 
-    total = sum(len(w) for _, w in all_warnings)
-    print(f"📄 Doc health: {total} warning(s)")
-    for category, items in all_warnings:
-        print(f"\n  {category}:")
-        for item in items:
-            print(item)
-    print()
+    if all_warnings:
+        total = sum(len(w) for _, w in all_warnings)
+        print(f"📄 Doc health: {total} warning(s)")
+        for category, items in all_warnings:
+            print(f"\n  {category}:")
+            for item in items:
+                print(item)
+        print()
+    else:
+        print("📄 Doc health: all clear")
 
-    return 1 if strict else 0
+    if demotion:
+        print(f"📦 Demotion candidates ({len(demotion)}) — advisory, does not fail the check:")
+        for item in demotion:
+            print(item)
+        print()
+
+    return 1 if (strict and all_warnings) else 0
 
 
 if __name__ == "__main__":

--- a/tests/test_doc_health_dead_refs.py
+++ b/tests/test_doc_health_dead_refs.py
@@ -382,6 +382,108 @@ def test_dated_record_exempt_from_orphan_check(tmp_path, monkeypatch, doc_health
     assert doc_health.check_index_orphans([dated]) == []
 
 
+# --- check_demotion_candidates (shipped-status docs in active locations) -----
+
+
+def _demotion_for(tmp_path, monkeypatch, doc_health, rel, body):
+    """Write *body* to docs/<rel> and return demotion warnings for it."""
+    p = tmp_path / "docs" / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body)
+    monkeypatch.setattr(doc_health, "REPO_ROOT", tmp_path)
+    return doc_health.check_demotion_candidates([p])
+
+
+def test_fully_shipped_proposal_flagged(tmp_path, monkeypatch, doc_health):
+    """A proposal whose status says shipped, with no remaining work, is a candidate."""
+    warnings = _demotion_for(
+        tmp_path, monkeypatch, doc_health, "proposals/thing-v0.md",
+        "# Thing\n\n**Status:** shipped 2026-05-03 via PR #305. Enforcement deployed.\n",
+    )
+    assert len(warnings) == 1 and "fully shipped" in warnings[0]
+
+
+def test_partially_shipped_proposal_flagged_as_split(tmp_path, monkeypatch, doc_health):
+    """Shipped + named remaining work → 'partially shipped' (split, don't move whole)."""
+    warnings = _demotion_for(
+        tmp_path, monkeypatch, doc_health, "proposals/wave.md",
+        "# Wave\n\n**Status:** Wave 1 shipped; Wave 3 write-path not started.\n",
+    )
+    assert len(warnings) == 1 and "partially shipped" in warnings[0]
+
+
+def test_active_proposal_without_shipped_marker_not_flagged(tmp_path, monkeypatch, doc_health):
+    """A genuinely-active draft (no shipped marker in header) is not a candidate."""
+    warnings = _demotion_for(
+        tmp_path, monkeypatch, doc_health, "proposals/idea-v0.md",
+        "# Idea\n\n**Status:** draft, in progress. Proposed design under review.\n",
+    )
+    assert warnings == []
+
+
+def test_resolved_proposal_not_flagged(tmp_path, monkeypatch, doc_health):
+    """Already-demoted docs under proposals/resolved/ are not re-flagged."""
+    warnings = _demotion_for(
+        tmp_path, monkeypatch, doc_health, "proposals/resolved/old.md",
+        "# Old\n\n**Status:** shipped and complete.\n",
+    )
+    assert warnings == []
+
+
+def test_dated_record_with_shipped_status_not_flagged(tmp_path, monkeypatch, doc_health):
+    """A dated point-in-time record may say 'shipped' — it's a record, kept in place."""
+    warnings = _demotion_for(
+        tmp_path, monkeypatch, doc_health, "proposals/audit-2026-06-14.md",
+        "# Audit\n\n**Status:** shipped; deployed.\n",
+    )
+    assert warnings == []
+
+
+def test_ontology_anchor_not_flagged(tmp_path, monkeypatch, doc_health):
+    """ontology/ anchor docs (identity.md etc.) are living, not plans to demote."""
+    warnings = _demotion_for(
+        tmp_path, monkeypatch, doc_health, "ontology/identity.md",
+        "# Identity\n\nThe v2 ontology is deployed and complete in production.\n",
+    )
+    assert warnings == []
+
+
+def test_ontology_plan_flagged_with_location_hint(tmp_path, monkeypatch, doc_health):
+    """A shipped non-anchor doc in ontology/ is flagged, naming the identity tree."""
+    warnings = _demotion_for(
+        tmp_path, monkeypatch, doc_health, "ontology/coordination-plan.md",
+        "# Coordination Plan\n\n**Status:** lease plane live; Wave 1 shipped.\n",
+    )
+    assert len(warnings) == 1 and "ontology/ (identity tree)" in warnings[0]
+
+
+def test_widely_referenced_doc_exempt_as_living_reference(tmp_path, monkeypatch, doc_health):
+    """A doc cited by >= threshold other docs is a living reference, not a stale plan."""
+    target_rel = "proposals/contract-v0.md"
+    target = tmp_path / "docs" / target_rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("# Contract\n\n**Status:** shipped; the canonical spec.\n")
+    # Create threshold-many sibling docs that cite it by basename.
+    for i in range(doc_health._DEMOTION_LIVING_REF_THRESHOLD):
+        sib = tmp_path / "docs" / f"ref{i}.md"
+        sib.write_text("See [contract](contract-v0.md) for the spec.\n")
+    monkeypatch.setattr(doc_health, "REPO_ROOT", tmp_path)
+    assert doc_health.check_demotion_candidates([target]) == []
+
+
+def test_demotion_does_not_gate_strict_exit(tmp_path, monkeypatch, doc_health, capsys):
+    """A demotion candidate alone must NOT make even --strict exit non-zero."""
+    p = tmp_path / "docs" / "proposals" / "shipped-v0.md"
+    p.parent.mkdir(parents=True)
+    p.write_text("# X\n\n**Status:** shipped, deployed, complete.\n")
+    # Reference it from an index so it isn't also flagged as an orphan (which
+    # WOULD gate strict). We want a clean case: demotion candidate and nothing else.
+    (p.parent / "README.md").write_text("- [x](shipped-v0.md)\n")
+    monkeypatch.setattr(doc_health, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(doc_health.sys, "argv", ["check_doc_health.py", "--strict"])
+    assert doc_health.main() == 0
+
+
 def test_collect_md_files_skips_elixir_deps_and_build_dirs(tmp_path, monkeypatch, doc_health):
     """Vendored Elixir deps and Mix build output are not repo documentation."""
     (tmp_path / "docs").mkdir()


### PR DESCRIPTION
## Why

Stale-doc reports keep landing on the same shape: a planning/RFC doc whose work *shipped*, but which still reads as a forward plan because nobody demoted it once the thing landed. The BEAM/lease subsystem reached **~21 docs** this way. Chasing them one at a time is whack-a-mole; the durable fix is to **surface the list automatically and demote on a real signal**.

## What

Adds a `check_demotion_candidates` pass to `scripts/diagnostics/check_doc_health.py`. It flags docs under `docs/proposals/` (outside `resolved/`) and `docs/ontology/` whose **header status** declares the work shipped (`shipped`/`deployed`/`merged`/`complete`/`resolved`).

- **Advisory only — never gates the exit code** (even `--strict`). Demotion is a judgment call, not a defect; the check just prints a triage list.
- **`partially shipped`** (shipped + named remaining work) → "split the done part to `resolved/`, keep the open work forward-looking" vs **`fully shipped`** → "move wholesale / stub + point at the live doc."
- **Conservative, to keep signal high:**
  - shipped marker must be in the header region, not buried in the body;
  - exempts docs cited by ≥10 other docs (living references — e.g. the canonical `surface-lease-plane-v0.md` contract spec, 13 inbound — are not stale plans);
  - exempts `proposals/resolved/`, dated point-in-time records, and ontology anchors (`identity.md`, `plan.md`, `paper-positioning.md`, `glossary.md`, READMEs).

## Output today

```
📦 Demotion candidates (23) — advisory, does not fail the check:
  docs/ontology/beam-coordination-kernel.md: partially shipped in ontology/ (identity tree) — split ...
  docs/proposals/beam-wave-3a-read-only-handlers.md: reads fully shipped in proposals/ — consider moving ...
  ...
```

The example that prompted this (`beam-coordination-kernel.md`) is flagged; the living lease-plane contract spec is correctly **not**.

## Tests

+9 cases (fully/partially shipped, active-draft negative, resolved/ skip, dated-record skip, ontology anchor skip, ontology location hint, living-reference exemption, and a guard that the advisory never gates `--strict`). Full `tests/test_doc_health_dead_refs.py` suite: 33 passed.

Tooling only — no docs moved. This surfaces the worklist; demotion stays a human call.