### PR TITLE
fix(scope-guard): stop flagging the verb 'resume' as a career artifact

### DIFF
--- a/scripts/dev/check-repo-scope.sh
+++ b/scripts/dev/check-repo-scope.sh
@@ -89,7 +89,16 @@ while IFS= read -r f; do
   fi
 
   # Rule 2: career / personal artifacts by name or path segment.
-  if [[ "$bn" =~ [Rr]esume ]] || \
+  # "resume"/"cv" only count as a CV artifact when they're the trailing word of a
+  # *document* name (resume.pdf, kenny-resume.docx, cv.md) — NOT the verb "resume"
+  # buried in technical names (lifecycle/resume.py, identity-resume-v0.md), which
+  # were false-flagged before.
+  cv_artifact=0
+  case "${bn##*.}" in
+    py|js|ts|tsx|jsx|mjs|cjs|ex|exs|go|rs|rb|java|kt|c|cc|cpp|h|hpp|sh|bash|zsh|sql|yaml|yml|toml|json|lock|cfg|ini|env|mod|tf) ;;  # code/config — never a résumé
+    *) [[ "$bn" =~ (^|[-_])([Rr][eé]sum[eé]|[Cc][Vv])(\.[A-Za-z0-9]+)?$ ]] && cv_artifact=1 ;;
+  esac
+  if [[ "$cv_artifact" == 1 ]] || \
      [[ "$bn" =~ [Cc]over[-_]?[Ll]etter ]] || \
      [[ "/$f" =~ /[Cc]areer/ ]] || \
      [[ "/$f" =~ /[Jj]ob[-_][Aa]pplication ]] || \


### PR DESCRIPTION
## What

The scope guard's career-artifact rule matched `resume` *anywhere* in a basename, false-flagging legitimate session/lifecycle **resume** code as résumés:
- `src/mcp_handlers/lifecycle/resume.py`
- `docs/proposals/discord-thread-identity-resume-v0.md`

Tightened so `resume`/`cv` only count when they're the **trailing word of a non-code document name** (`resume.pdf`, `kenny-resume.docx`, `cv.md`). Code/config extensions are excluded outright. The cover-letter / `career/` / job-application / FRT rules are unchanged.

## Verified
- Now clear: `resume.py`, `discord-thread-identity-resume-v0.md`
- Still flagged: `resume.pdf`, `kenny-resume.docx`, `cv.md`, `Cover-Letter.docx`, `career/notes.md`, `frt_demo.md`

Surfaced by a full-repo `--files` scan (the guard is normally edit-triggered, so this had been masking 2 false positives in the latent-debt count).