### PR TITLE
feat(grounding): snapshot EISV onto outcome events that arrive without one (Stage-0 bridge half a)

### DIFF
--- a/docs/proposals/eisv-stage0-bridge-b-label-routing.md
+++ b/docs/proposals/eisv-stage0-bridge-b-label-routing.md
@@ -6,6 +6,19 @@ _Companion to `eisv-maths-roadmap-v0.md` (§6.3 falsifiability gate, §7 anchor 
 
 `agents/watcher/agent.py:343` (`build_resolution_outcome_args`) already maps a Watcher finding resolution to an `external_signal` outcome attributed to **Watcher's own UUID** — confirmed = good outcome, false-positive dismissal = bad. With PR #1210 the handler now auto-snapshots Watcher's EISV onto that row. So for Watcher, the pipe exists. The disjointness in Appendix B (0 joinable rows, recon 2026-06-25) predates this wiring landing at volume. The remaining work is to make the join actually populate, with the right semantics, across more than one resident.
 
+## Live floor (2026-06-28) — the disjointness is thawing
+
+`stage_b_viability.py` queries run live against the governance DB:
+
+| metric | 2026-06-25 | 2026-06-28 |
+|---|---|---|
+| `external_signal` outcomes | 1,632 | 1,693 |
+| …carrying EISV | 2 | 20 |
+| …joinable to a prior baselined state (**OVERLAP**) | **0** | **17** |
+| baselined agents with external outcomes | 0 | 1 (Watcher) |
+
+The 17 joinable rows are *exactly* the `watcher_finding_*` outcomes (16 dismissed + 1 confirmed), all EISV-bearing, all attributed to Watcher's baselined UUID via the inline-recorder snapshot. So the channel works — but the probe floor is **overlap ≥ 20** before it emits an AUC, and the labels are single-resident and skewed (only fp-dismissals are `is_bad`, so the bad-label count is ~1). **The binding constraint is no longer the snapshot — it's breadth and volume.** Reprioritize: P3 (more baselined-resident channels) is now the lever to cross the floor and diversify labels; P2 (temporal binding) is a correctness refinement on rows that already join.
+
 ## The real gaps (the half-(b) work)
 
 1. **Baseline verification (blocking).** A label only yields a *residual* if the attributed UUID has a non-synthetic EISV baseline. Confirm Watcher (and each target resident) has `core.agent_state.synthetic = false` rows — i.e. it checks in often enough to build a Welford baseline. If a resident emits findings but never syncs EISV, the snapshot is null and the row still doesn't join. **Verify first; if absent, ensure the resident check-ins land before anything else.**
@@ -22,7 +35,7 @@ _Companion to `eisv-maths-roadmap-v0.md` (§6.3 falsifiability gate, §7 anchor 
 
 ## Phased plan
 
-- **P1 — verify + measure.** Confirm Watcher/Sentinel UUIDs are baselined; run `stage_b_viability.py` to see whether PR #1210 alone moved overlap off zero for Watcher's recent resolves. Establishes the live floor.
+- **P1 — verify + measure. ✅ DONE 2026-06-28.** Live overlap = **17** (Watcher channel), up from 0; floor is ≥20. Watcher is baselined; the task_* population is not. See "Live floor" above.
 - **P2 — temporal binding.** Register-at-emission / consume-at-adjudication for Watcher (and Sentinel). Smallest correctness fix; makes the residual-at-emission the thing being tested.
 - **P3 — breadth.** Sentinel + dialectic + operator-correction channels, tiered.
 - **P4 — wire `test_failed`.** The most objective bad anchor (1 event in 79k today); route CI/test failures to the responsible agent.

--- a/docs/proposals/eisv-stage0-bridge-b-label-routing.md
+++ b/docs/proposals/eisv-stage0-bridge-b-label-routing.md
@@ -1,0 +1,33 @@
+# EISV Stage-0 population bridge — half (b): routing external labels to baselined residents
+
+_Companion to `eisv-maths-roadmap-v0.md` (§6.3 falsifiability gate, §7 anchor registry, Appendix B disjointness). Half (a) — snapshot EISV onto outcome rows that arrive without one — shipped in PR #1210. This specs half (b): make **baselined resident** agents actually carry **externally-verified** outcomes, so the residual-vs-Φ test has a non-empty join. L2/L3 — needs a deliberate motion, not a silent edit._
+
+## Finding: half (b) is partially built, not absent
+
+`agents/watcher/agent.py:343` (`build_resolution_outcome_args`) already maps a Watcher finding resolution to an `external_signal` outcome attributed to **Watcher's own UUID** — confirmed = good outcome, false-positive dismissal = bad. With PR #1210 the handler now auto-snapshots Watcher's EISV onto that row. So for Watcher, the pipe exists. The disjointness in Appendix B (0 joinable rows, recon 2026-06-25) predates this wiring landing at volume. The remaining work is to make the join actually populate, with the right semantics, across more than one resident.
+
+## The real gaps (the half-(b) work)
+
+1. **Baseline verification (blocking).** A label only yields a *residual* if the attributed UUID has a non-synthetic EISV baseline. Confirm Watcher (and each target resident) has `core.agent_state.synthetic = false` rows — i.e. it checks in often enough to build a Welford baseline. If a resident emits findings but never syncs EISV, the snapshot is null and the row still doesn't join. **Verify first; if absent, ensure the resident check-ins land before anything else.**
+
+2. **Temporal binding (correctness).** Today the outcome snapshots EISV at *adjudication* time (operator resolves hours/days later). The falsifiability hypothesis is "the residual **when the work was produced** predicts whether it was good" — so the snapshot should bind to EISV at **finding-emission**, not resolution. Reuse the existing two-phase prediction registry (`register_tactical_prediction` / `consume_prediction`, `src/monitor_prediction.py`): register a prediction carrying EISV+confidence **when the finding is emitted**; the resolve/dismiss **consumes** that prediction, so the outcome row binds the emission-time residual. Without this, half (a)'s resolve-time snapshot tests the wrong moment.
+
+3. **Breadth across residents (power).** Watcher alone is low-volume. Wire the analogous exogenous channels, each attributed to the baselined resident's UUID, tiered per §7:
+   - **Sentinel** finding adjudication (findings already durable in `audit.events`) — `external_signal`.
+   - **Dialectic verdicts** — schema already lists these as exogenous (`schemas/core.py:415`); attribute the resolution outcome to the participating resident.
+   - **Operator corrections** — `gold` tier (highest informativeness), when Kenny overrides a resident's output.
+   Invariant 4 holds throughout: every anchor is exogenous; never the loop validating its own trajectory (`server_observation` stays excluded).
+
+4. **Accrual honesty.** Even fully wired, this is forward-only and low-rate (~hundreds of bad labels, class-uneven). `stage_b_viability.py` will report overlap > 0 first, then a noisy AUC that tightens as labels accrue. Per-class power (esp. rare classes) is a ramp, not a switch — say so; don't claim B's justification before the labels support it.
+
+## Phased plan
+
+- **P1 — verify + measure.** Confirm Watcher/Sentinel UUIDs are baselined; run `stage_b_viability.py` to see whether PR #1210 alone moved overlap off zero for Watcher's recent resolves. Establishes the live floor.
+- **P2 — temporal binding.** Register-at-emission / consume-at-adjudication for Watcher (and Sentinel). Smallest correctness fix; makes the residual-at-emission the thing being tested.
+- **P3 — breadth.** Sentinel + dialectic + operator-correction channels, tiered.
+- **P4 — wire `test_failed`.** The most objective bad anchor (1 event in 79k today); route CI/test failures to the responsible agent.
+- **Gate:** B's §6.3 justification is claimable only once `stage_b_viability.py` reports a residual-vs-Φ AUC margin with adequate (per-class) power — and a clean negative result is a valid, publishable outcome.
+
+## Non-goals
+
+No suspicion/trust gating on the live path (§7a — informativeness, not intent). No backfill (emission-time state is gone for past rows). No new table — `audit.outcome_events` + the prediction registry already carry this.

--- a/src/db/mixins/tool_usage.py
+++ b/src/db/mixins/tool_usage.py
@@ -82,6 +82,33 @@ class ToolUsageMixin:
         """
         from src.outcome_corroboration import enrich_detail_with_corroboration
         from config.governance_config import GovernanceConfig
+
+        # --- EISV outcome-snapshot bridge (Stage-0 population bridge; roadmap §4a / Appendix B) ---
+        # External-signal / test outcomes arrive through callers that do not carry an EISV
+        # snapshot, so eisv_* land NULL and the row can never join an agent's state for the
+        # residual-vs-Phi falsifiability test (§6.3). When no EISV was supplied and the agent
+        # has a real (non-synthetic) measured state, snapshot it at outcome time. Fires only
+        # when every channel is None — never overrides an explicit snapshot — and self-limits
+        # to agents already in the EISV system (get_latest_eisv_by_agent_id excludes bootstrap
+        # rows and returns None otherwise, so non-instrumented agents stay NULL, never faked).
+        if (
+            eisv_e is None and eisv_i is None and eisv_s is None and eisv_v is None
+            and eisv_phi is None and eisv_verdict is None
+            and eisv_coherence is None and eisv_regime is None
+        ):
+            try:
+                _snap = await self.get_latest_eisv_by_agent_id(agent_id)
+            except Exception:
+                _snap = None
+            if _snap:
+                eisv_e, eisv_i, eisv_s, eisv_v = (
+                    _snap.get("E"), _snap.get("I"), _snap.get("S"), _snap.get("V"),
+                )
+                eisv_phi, eisv_verdict = _snap.get("phi"), _snap.get("verdict")
+                eisv_coherence, eisv_regime = _snap.get("coherence"), _snap.get("regime")
+                detail = dict(detail or {})
+                detail["eisv_snapshot_source"] = "outcome_bridge"
+
         corroborated_detail = enrich_detail_with_corroboration(
             detail,
             outcome_type=outcome_type,

--- a/tests/test_outcome_events_verification_source.py
+++ b/tests/test_outcome_events_verification_source.py
@@ -343,3 +343,77 @@ async def test_inline_outcome_response_echoes_corroboration_metadata():
     assert persisted_detail["corroboration_grade"] == "claim_only"
     assert persisted_detail["eprocess_eligible"] is False
     assert persisted_detail["hard_exogenous"] is False
+
+
+# --- EISV outcome-snapshot bridge (Stage-0 population bridge; roadmap §6.3 falsifiability) ---
+# External-signal/test outcomes arrive with no EISV, so eisv_* land NULL and the row can
+# never join an agent's state for the residual-vs-Phi falsifiability test. These pin the
+# bridge that snapshots the agent's latest measured EISV at outcome time.
+
+@pytest.mark.asyncio
+async def test_bridge_snapshots_eisv_when_caller_supplies_none():
+    """An external_signal outcome with no EISV gets the agent's latest measured
+    state snapshotted, so the row becomes joinable for the falsifiability test."""
+    conn = _FakeOutcomeConn(["bridged-id"])
+    db = _OutcomeMixinHarness(conn)
+    db.get_latest_eisv_by_agent_id = AsyncMock(return_value={
+        "E": 0.70, "I": 0.60, "S": 0.20, "V": 0.0,
+        "phi": 0.50, "verdict": "continue", "coherence": 0.55, "regime": "EXPLORATION",
+    })
+
+    result = await db.record_outcome_event(
+        agent_id="agent-1",
+        outcome_type="test_failed",
+        is_bad=True,
+        verification_source="external_signal",
+    )
+
+    assert result == "bridged-id"
+    db.get_latest_eisv_by_agent_id.assert_awaited_once_with("agent-1")
+    args = conn.calls[0][1]
+    assert args[5] == 0.70   # eisv_e
+    assert args[9] == 0.50   # eisv_phi
+    detail = json.loads(args[13])
+    assert detail["eisv_snapshot_source"] == "outcome_bridge"
+
+
+@pytest.mark.asyncio
+async def test_bridge_no_op_when_agent_has_no_measured_state():
+    """Non-instrumented agents (no real EISV) stay NULL — the bridge never fabricates."""
+    conn = _FakeOutcomeConn(["null-id"])
+    db = _OutcomeMixinHarness(conn)
+    db.get_latest_eisv_by_agent_id = AsyncMock(return_value=None)
+
+    result = await db.record_outcome_event(
+        agent_id="ephemeral-agent",
+        outcome_type="test_failed",
+        is_bad=True,
+        verification_source="external_signal",
+    )
+
+    assert result == "null-id"
+    args = conn.calls[0][1]
+    assert args[5] is None  # eisv_e stays null
+    detail = json.loads(args[13])
+    assert "eisv_snapshot_source" not in detail
+
+
+@pytest.mark.asyncio
+async def test_bridge_does_not_override_explicit_eisv():
+    """When a caller already carries an EISV snapshot, the bridge stays out of the way."""
+    conn = _FakeOutcomeConn(["explicit-id"])
+    db = _OutcomeMixinHarness(conn)
+    db.get_latest_eisv_by_agent_id = AsyncMock(return_value={"E": 0.99})
+
+    result = await db.record_outcome_event(
+        agent_id="agent-1",
+        outcome_type="task_completed",
+        is_bad=False,
+        eisv_e=0.42,
+        verification_source="server_observation",
+    )
+
+    assert result == "explicit-id"
+    db.get_latest_eisv_by_agent_id.assert_not_awaited()
+    args = conn.calls[0][1]
+    assert args[5] == 0.42  # explicit value preserved, not overridden


### PR DESCRIPTION
## Why
The EISV residual falsifiability test (`docs/proposals/eisv-maths-roadmap-v0.md` §6.3) — *does the per-agent residual predict externally-verified bad outcomes better than absolute Φ?* — is **structurally uncomputable today**. Per Appendix B, the labelled (`external_signal`) population and the EISV population are disjoint: 1,632 anchored outcomes, but **0** joinable to a prior baselined state. The agents we can ground have no residual; the agents with residuals get only self-referential outcomes.

One root cause: `external_signal` / test outcomes are written through `record_outcome_event` callers that carry **no EISV**, so `eisv_*` land NULL — the row can never join the agent's state.

## What
A snapshot fallback at the single DB chokepoint (`record_outcome_event`): when no EISV channel is supplied **and** the agent has a real (non-synthetic) measured state, snapshot it at outcome time.

- Fires **only** when every EISV channel is `None` — never overrides an explicit snapshot.
- **Self-limits to instrumented agents** — `get_latest_eisv_by_agent_id` already excludes bootstrap/synthetic rows and returns `None` otherwise, so non-instrumented agents stay NULL. **Nothing is fabricated.**
- Bridged rows are marked `detail.eisv_snapshot_source = "outcome_bridge"` for analysis.
- No migration — `eisv_*` columns already exist on `audit.outcome_events`.

## Scope / honesty
- **Forward-only.** Past rows can't be backfilled — the EISV state at the outcome moment is gone. The Stage-B residual gate becomes computable as labelled + instrumented overlap accrues.
- This is **population-bridge half (a)**. Half **(b)** — ensuring baselined resident agents actually *receive* external task/test labels — is the deeper remaining constraint and is **not** in this PR. Alone, (a) does not flip the falsifier to computable; it removes the NULL-EISV blocker so the join can populate once (b) lands.
- The missing `test_failed` anchor wiring (1 event in 79k) is also separate.

## Tests
3 new pins in `test_outcome_events_verification_source.py`: fires-and-snapshots, no-op-when-no-measured-state, never-overrides-explicit. Full `record_outcome_event` caller blast radius green locally (66 passed). CI is the full gate.

https://claude.ai/code/session_01VpnQBh6B7ZoUbWe2V319G5