### PR TITLE
docs(governance): make the fail-open + oscillation postures explicit

### DIFF
--- a/docs/UNIFIED_ARCHITECTURE.md
+++ b/docs/UNIFIED_ARCHITECTURE.md
@@ -79,6 +79,14 @@ The server returns a governance decision:
 
 Verdicts include `margin` (comfortable / tight / critical) indicating proximity to basin boundaries.
 
+#### Edge-regime postures: oscillation and assessment failure
+
+Two behaviors at the edges of the verdict path are deliberate and easy to miss when reading the code:
+
+**Oscillation / churn near a threshold.** There is no deadband on the risk cut itself — a single check-in crossing a threshold can change the action. Stability instead comes from two layers: (1) the EISV inputs are EMA-smoothed before scoring (`src/behavioral_state.py`, per-dimension α ≈ 0.08–0.15), and (2) a dedicated always-on oscillation governor, **CIRS** (`src/cirs.py`, `src/monitor_decision.py`), watches the *decision* stream over a sliding window (default `window=8`, `flip_threshold=3`, `oi_threshold=3.0`). When decisions flip-flop, CIRS `soft_dampen` nudges `safe → caution`, and sustained resonance triggers a `hard_block` (`sub_action=cirs_block`, "governance is flip-flopping — wait for state to settle"). So churn is handled by *escalation to a settle-pause*, not by a hold-band — a deliberate trade (it prevents flip spam but biases conservative near the boundary; see the false-pause history behind the basin-health gate, issue #689).
+
+**Assessment failure is fail-open.** If the assessment pipeline itself errors (DB/Redis outage, internal bug — distinct from the BEAM proxy, which fails open to in-process Python), the check-in handler returns an error response with **no `verdict`/`action` field** — it does not synthesize a `pause`. The agent proceeds. This is intentional for an advisory, non-guardrail system: fail-*closed* would let a transient infra blip mass-pause the whole fleet, and the anyio/asyncpg/Redis latency class (see `CLAUDE.md`) makes that a live risk. The normal pause gates (CIRS / void / coherence / high-risk / low-basin) are unaffected; this covers only the case where no verdict could be computed at all. See the design comment at `src/mcp_handlers/core.py` (`process_agent_update` handler).
+
 ### 5. Calibration
 
 The system tracks whether stated confidence matches outcomes. Ground truth comes from objective signals — test pass/fail, command exit codes, lint results. Over time this builds a calibration curve. Persistent overconfidence penalizes Information Integrity through entropy coupling.

--- a/src/mcp_handlers/core.py
+++ b/src/mcp_handlers/core.py
@@ -445,6 +445,17 @@ async def handle_process_agent_update(arguments: Dict[str, Any]) -> Sequence[Tex
                 }
             )]
     except Exception as e:
+        # FAIL-OPEN posture (deliberate). When the assessment pipeline itself
+        # errors (DB/Redis outage, internal bug), governance returns an error
+        # response with NO verdict/action field — it does NOT synthesize a
+        # `pause`. The agent therefore proceeds. This is correct for an
+        # advisory, non-guardrail system (see docs/REVIEWER_GUIDE.md "Failure &
+        # oscillation postures"): fail-CLOSED would let a transient infra blip
+        # mass-pause the whole fleet, and the anyio/asyncpg/Redis latency class
+        # documented in CLAUDE.md makes that a live risk, not a hypothetical.
+        # The verdict path's normal pauses (CIRS/void/coherence/high-risk/low
+        # basin in monitor_decision.py) are unaffected — this branch only covers
+        # the case where the assessment could not be computed at all.
         logger.error(f"Unexpected error in process_agent_update: {e}", exc_info=True)
         return [error_response(
             f"An unexpected error occurred: {str(e)}",


### PR DESCRIPTION
Closes the last two "unclear" items from the external review. **Comment + doc only — no behavior change.** Both behaviors are correct-but-implicit; a careful reviewer *and* a sub-agent I had trace the code both misread them, which is the tell that they needed documenting.

## Findings (verified against live code)

**Q: "Won't the verdict flip every check-in around a threshold? Is there hysteresis?"**
No deadband on the risk cut — but there **is** an always-on oscillation governor, **CIRS** (`src/cirs.py`, `src/monitor_decision.py`): a sliding window (`window=8`, `flip_threshold=3`, `oi_threshold=3.0`) over the *decision* stream. It `soft_dampen`s `safe→caution` while wobbling and `hard_block`s sustained resonance into a settle-pause (`sub_action=cirs_block`). So churn is handled by **escalation to a pause**, not a hold-band — a deliberate trade (prevents flip spam, biases conservative near the boundary; ties to the false-pause history behind #689). The review's "no hysteresis / churn possible" was wrong on the most important point.

**Q: "When the assessment errors — fail open or closed?"**
**Fail-open.** On a total assessment failure (DB/Redis outage, internal bug — distinct from the BEAM proxy, which already fails open to Python), the handler returns an error response with **no `verdict`/`action`** — it does not synthesize a pause, so the agent proceeds. Intentional for an advisory, non-guardrail system: fail-*closed* would let a transient infra blip mass-pause the whole fleet, and the anyio/asyncpg/Redis latency class (CLAUDE.md) makes that a live risk, not hypothetical.

## Changes
- `src/mcp_handlers/core.py` — design comment at the `process_agent_update` error path documenting the deliberate fail-open posture.
- `docs/UNIFIED_ARCHITECTURE.md` — "Edge-regime postures" subsection under Verdict, documenting both CIRS oscillation handling and the fail-open posture.

## Why no code fix
Neither behavior is a defect. The review framed them as gaps; verification shows they're deliberate, defensible postures that were simply undocumented. Same root cause as the rest of the triage — the system was hard to read *about itself*. If you later decide the oscillation bias-toward-pause or the fail-open default should change, those are genuine design calls, not bug fixes — flagging, not pre-empting.

Verification: ruff clean; core.py parses; 32 handler tests pass. Comment+doc, so no full-suite run (pre-push hook + CI gate it).

Third of the review-triage PRs (with #1205 cheap wins, #1208 mcp_server split); independent, no file overlap.

https://claude.ai/code/session_01BygDu5gT3LCGZbAuKfstVq