### PR TITLE
fix(governed-effect): harden file_write execute error paths (no opaque 500s)

### DIFF
--- a/elixir/lease_plane/lib/unitares_lease_plane/governed_effect.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/governed_effect.ex
@@ -361,27 +361,41 @@ defmodule UnitaresLeasePlane.GovernedEffect do
   @min_execute_ttl_s 120
 
   defp execute_file_write(env) do
-    if min_ttl_ok?(env) do
-      digest = idempotency_digest(env)
+    cond do
+      # Validate the proposer BEFORE acquiring any lease — otherwise a nil or
+      # malformed uuid crashes uuid_to_binary inside Repo.acquire and surfaces as
+      # an opaque 500 instead of a clean client error.
+      not valid_proposer?(env) ->
+        {:error, :proposer_invalid}
 
-      case Repo.governed_effect_by_idempotency_key(env.idempotency_key, @execute_event_type) do
-        {:ok, %{idempotency_digest: ^digest, payload: stored}} ->
-          {:ok, execute_idempotent_body(stored)}
+      not min_ttl_ok?(env) ->
+        {:error, :lease_ttl_too_short}
 
-        {:ok, %{idempotency_digest: other}} when is_binary(other) ->
-          {:error, :idempotency_conflict}
+      true ->
+        digest = idempotency_digest(env)
 
-        {:ok, nil} ->
-          file_write_under_custody(env, digest)
+        case Repo.governed_effect_by_idempotency_key(env.idempotency_key, @execute_event_type) do
+          {:ok, %{idempotency_digest: ^digest, payload: stored}} ->
+            {:ok, execute_idempotent_body(stored)}
 
-        {:error, reason} ->
-          Logger.warning("governed_effect file_write idempotency lookup failed: #{inspect(reason)}")
-          {:error, :idempotency_lookup_failed}
-      end
-    else
-      {:error, :lease_ttl_too_short}
+          {:ok, %{idempotency_digest: other}} when is_binary(other) ->
+            {:error, :idempotency_conflict}
+
+          {:ok, nil} ->
+            file_write_under_custody(env, digest)
+
+          {:error, reason} ->
+            Logger.warning("governed_effect file_write idempotency lookup failed: #{inspect(reason)}")
+            {:error, :idempotency_lookup_failed}
+        end
     end
   end
+
+  @proposer_uuid_re ~r/\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\z/
+  defp valid_proposer?(%{proposer_agent_uuid: u}) when is_binary(u),
+    do: Regex.match?(@proposer_uuid_re, u)
+
+  defp valid_proposer?(_), do: false
 
   defp min_ttl_ok?(env) do
     Enum.all?(env.required_leases, fn l -> (lease_ttl(l) || 0) >= @min_execute_ttl_s end)

--- a/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
@@ -164,8 +164,41 @@ defmodule UnitaresLeasePlane.HTTPRouter do
           reason: "governance vetoed the effect or could not affirmatively clear it"
         })
 
+      {:error, :proposer_invalid} ->
+        json(conn, 422, %{
+          ok: false,
+          error: "proposer_invalid",
+          reason: "proposer.agent_uuid must be a valid UUID"
+        })
+
+      {:error, :lease_ttl_too_short} ->
+        json(conn, 422, %{
+          ok: false,
+          error: "lease_ttl_too_short",
+          reason: "every required lease must request ttl_s above the execute floor"
+        })
+
+      {:error, :lease_held} ->
+        json(conn, 409, %{
+          ok: false,
+          error: "lease_held",
+          reason: "a required surface is currently leased by another holder"
+        })
+
+      {:error, reason} when reason in [:lease_acquire_failed, :idempotency_lookup_failed] ->
+        json(conn, 503, %{
+          ok: false,
+          error: Atom.to_string(reason),
+          reason: "transient lease-plane error; nothing was committed"
+        })
+
       {:error, detail} when is_binary(detail) ->
         json(conn, 422, %{ok: false, error: "schema_invalid", detail: detail})
+
+      # Catch-all: an unmapped error atom must never crash the handler into a
+      # bare 500 — report it cleanly. Nothing is committed on any error path.
+      {:error, other} ->
+        json(conn, 500, %{ok: false, error: "internal", reason: inspect(other)})
     end
   end
 

--- a/elixir/lease_plane/test/governed_effect_test.exs
+++ b/elixir/lease_plane/test/governed_effect_test.exs
@@ -80,6 +80,27 @@ defmodule UnitaresLeasePlane.GovernedEffectTest do
       assert {:error, :execute_not_implemented} =
                GovernedEffect.handle(base(%{"custody_mode" => "execute"}))
     end
+
+    test "file_write execute with missing/invalid proposer rejects cleanly (no acquire crash)" do
+      Application.put_env(:lease_plane, :execute_file_write_enabled, true)
+
+      body =
+        base(%{
+          "custody_mode" => "execute",
+          "surface" => "file:///tmp/x",
+          "required_leases" => [%{"surface" => "file:///tmp/x", "ttl_s" => 300}],
+          "payload" => %{"path" => "/tmp/x", "content" => "y"}
+        })
+
+      # no proposer → must reject BEFORE Repo.acquire (which would crash on a nil
+      # uuid), and a malformed uuid is rejected the same way.
+      assert {:error, :proposer_invalid} = GovernedEffect.handle(body)
+
+      assert {:error, :proposer_invalid} =
+               GovernedEffect.handle(Map.put(body, "proposer", %{"agent_uuid" => "not-a-uuid"}))
+    after
+      Application.delete_env(:lease_plane, :execute_file_write_enabled)
+    end
   end
 
   describe "record_only result" do


### PR DESCRIPTION
Smooths the rough edges the live key-turn surfaced — all in the `file_write` execute path, none of which could write, but all of which returned opaque 500s instead of clean statuses.

## Changes
- **Proposer validated before lease acquire.** A nil/malformed `proposer.agent_uuid` crashed `uuid_to_binary` inside `Repo.acquire` (`FunctionClauseError` → 500). `execute_file_write` now checks a UUID-format guard first and returns `:proposer_invalid` before any custody starts. The §6 veto still runs on the commit path with the lease held — this only **adds an early validation**, it does not reorder the veto.
- **Router maps every error atom + a catch-all.** `proposer_invalid` / `lease_ttl_too_short` → **422**, `lease_held` → **409**, `lease_acquire_failed` / `idempotency_lookup_failed` → **503**, and an unmapped `{:error, atom}` → a clean **500** instead of crashing the handler.
- **Test:** `file_write` execute with missing *and* malformed proposer rejects cleanly (proves no acquire crash).

## Context
Found during the live key-turn verification (the `file_write` execute path is proven end-to-end incl. §5b rollback capture; flags reverted to default-off). This is pure error-path hardening — no behavior change on the happy path, 48 tests pass, flags remain off.

Draft — RCE-class surface; maintainer is the merge gate.