### PR TITLE
feat(grounding): Sentinel finding-adjudication → exogenous outcome channel (Stage-0 bridge half b, option A)

### DIFF
--- a/agents/common/resolution_outcome.py
+++ b/agents/common/resolution_outcome.py
@@ -1,0 +1,56 @@
+"""Shared builder: finding-resolution → exogenous ``outcome_event`` args.
+
+A resident's finding being adjudicated by an operator/human is ground truth from
+*outside* the governance loop (Invariant 4 clean — not the loop validating its
+own trajectory), so the resulting outcome carries
+``verification_source='external_signal'``. This is the exogenous-anchor channel
+the EISV residual falsifiability test needs (docs/proposals/eisv-maths-roadmap-v0.md
+§6.3 / Appendix B; docs/proposals/eisv-stage0-bridge-b-label-routing.md).
+
+Parameterized by ``finding_kind`` so each baselined resident maps to its own
+``outcome_type`` (``watcher_finding_*``, ``sentinel_finding_*``, …) while sharing
+identical precision/label semantics — which keeps their labels directly
+comparable. The ``outcome_event`` handler auto-snapshots EISV by ``agent_id``, so
+callers attribute the outcome to the **resident's own UUID** (not an operator's).
+
+This generalizes the Watcher-local ``build_resolution_outcome_args`` in
+``agents/watcher/agent.py``; Watcher can migrate onto this in a later DRY pass.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+def build_resolution_outcome_args(
+    finding_kind: str,
+    status: str,
+    fingerprint: str,
+    agent_uuid: str,
+    reason: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Map a finding resolution to an external-truth ``outcome_event`` payload.
+
+    A *confirmed* finding means the resident's analytical judgment was RIGHT (a
+    good outcome). Only a false-positive dismissal (``reason == "fp"``) means it
+    was WRONG (a bad outcome) — the sole true-negative in precision math. Other
+    dismissals (``out_of_scope``, ``wont_fix``, ``dup``, ``unclear``, ``stale``)
+    drop a *valid* finding that just won't be actioned, so the resident was still
+    right and the outcome is NOT bad.
+
+    ``finding_kind`` is the resident's finding family (e.g. ``"watcher_finding"``,
+    ``"sentinel_finding"``); it prefixes the outcome_type. ``agent_uuid`` must be
+    the resident's own UUID so the handler snapshots that resident's EISV.
+    """
+    confirmed = status == "confirmed"
+    is_bad = (not confirmed) and (reason == "fp")
+    return {
+        "agent_id": agent_uuid,
+        "outcome_type": f"{finding_kind}_confirmed" if confirmed else f"{finding_kind}_dismissed",
+        "is_bad": is_bad,
+        "verification_source": "external_signal",
+        "detail": {
+            "fingerprint": fingerprint,
+            "resolution": status,
+            "reason": reason or "",
+        },
+    }

--- a/agents/sentinel/agent.py
+++ b/agents/sentinel/agent.py
@@ -865,6 +865,40 @@ class SentinelAgent(GovernanceAgent):
 
 
 # ---------------------------------------------------------------------------
+# Finding adjudication → exogenous outcome (Stage-0 bridge half b, option A)
+# ---------------------------------------------------------------------------
+
+async def adjudicate_finding(
+    agent: "SentinelAgent",
+    client: GovernanceClient,
+    status: str,
+    fingerprint: str,
+    reason: str | None = None,
+) -> dict:
+    """Record an operator's adjudication of a Sentinel finding as an external-truth
+    ``outcome_event`` attributed to Sentinel's own (baselined) UUID.
+
+    The operator verdict is ground truth from outside the loop, so the outcome is
+    ``external_signal``; the handler auto-snapshots Sentinel's EISV by agent_id,
+    giving the residual-vs-Φ falsifiability test a second baselined-resident
+    channel beyond Watcher (docs/proposals/eisv-stage0-bridge-b-label-routing.md).
+    Option A: the outcome_event is the durable adjudication record — backlog /
+    audit.events status mutation is a deliberate follow-up.
+    """
+    from agents.common.resolution_outcome import build_resolution_outcome_args
+
+    await agent._ensure_identity(client)
+    if not agent.agent_uuid:
+        raise RuntimeError("Sentinel identity unresolved — refusing to attribute outcome")
+    args = build_resolution_outcome_args(
+        "sentinel_finding", status, fingerprint, agent.agent_uuid, reason
+    )
+    await client.call_tool("outcome_event", args)
+    log(f"recorded external-truth outcome ({status}) for sentinel finding {fingerprint}")
+    return args
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -875,6 +909,9 @@ async def main():
     parser.add_argument("--once", action="store_true", help="Run one analysis cycle and exit")
     parser.add_argument("--sitrep", action="store_true", help="Generate situation report and exit")
     parser.add_argument("--hours", type=float, default=6.0, help="Sitrep window (hours)")
+    parser.add_argument("--resolve", metavar="FINGERPRINT", help="Adjudicate a finding as CONFIRMED (Sentinel was right) → external-truth outcome")
+    parser.add_argument("--dismiss", metavar="FINGERPRINT", help="Adjudicate a finding as DISMISSED → external-truth outcome (use --reason fp for a false positive)")
+    parser.add_argument("--reason", default=None, help="Dismissal reason; 'fp' marks a false positive (the only 'bad' outcome for Sentinel)")
     parser.add_argument("--url", default=GOV_MCP_URL, help="MCP URL")
     parser.add_argument("--ws-url", default=GOV_WS_URL, help="WebSocket URL")
     parser.add_argument("--interval", type=int, default=ANALYSIS_INTERVAL, help="Analysis interval (seconds)")
@@ -885,6 +922,18 @@ async def main():
         ws_url=args.ws_url,
         analysis_interval=args.interval,
     )
+
+    if args.resolve or args.dismiss:
+        status = "confirmed" if args.resolve else "dismissed"
+        fingerprint = args.resolve or args.dismiss
+        async with GovernanceClient(
+            mcp_url=agent.mcp_url,
+            timeout=agent.timeout,
+            connect_timeout=agent.connect_timeout,
+            connect_retries=agent.connect_retries,
+        ) as client:
+            await adjudicate_finding(agent, client, status, fingerprint, args.reason)
+        return
 
     if args.sitrep:
         await agent.run_sitrep(args.hours)

--- a/tests/test_resolution_outcome.py
+++ b/tests/test_resolution_outcome.py
@@ -1,0 +1,80 @@
+"""Shared resolution → exogenous outcome builder + Sentinel adjudication wiring.
+
+Pins the precision semantics (confirmed=good, fp-dismissal=bad, other-dismissal
+=not-bad) and that the Sentinel CLI path attributes the external-truth outcome to
+Sentinel's OWN UUID so the handler snapshots Sentinel's EISV — the second
+baselined-resident channel for the residual falsifiability test.
+"""
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from agents.common.resolution_outcome import build_resolution_outcome_args
+
+
+def test_confirmed_is_good_outcome():
+    a = build_resolution_outcome_args("sentinel_finding", "confirmed", "fp123", "uuid-1")
+    assert a["agent_id"] == "uuid-1"
+    assert a["outcome_type"] == "sentinel_finding_confirmed"
+    assert a["is_bad"] is False
+    assert a["verification_source"] == "external_signal"
+    assert a["detail"] == {"fingerprint": "fp123", "resolution": "confirmed", "reason": ""}
+
+
+def test_false_positive_dismissal_is_bad():
+    a = build_resolution_outcome_args("sentinel_finding", "dismissed", "fp123", "uuid-1", reason="fp")
+    assert a["outcome_type"] == "sentinel_finding_dismissed"
+    assert a["is_bad"] is True
+    assert a["detail"]["reason"] == "fp"
+
+
+def test_non_fp_dismissal_is_not_bad():
+    for reason in ("out_of_scope", "wont_fix", "dup", "stale", "unclear", None):
+        a = build_resolution_outcome_args("sentinel_finding", "dismissed", "fp", "uuid", reason=reason)
+        assert a["is_bad"] is False, reason
+        assert a["outcome_type"] == "sentinel_finding_dismissed"
+
+
+def test_finding_kind_parameterizes_outcome_type():
+    w = build_resolution_outcome_args("watcher_finding", "confirmed", "fp", "u")
+    assert w["outcome_type"] == "watcher_finding_confirmed"
+    s = build_resolution_outcome_args("sentinel_finding", "dismissed", "fp", "u", reason="fp")
+    assert s["outcome_type"] == "sentinel_finding_dismissed"
+
+
+@pytest.mark.asyncio
+async def test_adjudicate_finding_posts_outcome_attributed_to_sentinel():
+    from agents.sentinel.agent import adjudicate_finding
+
+    agent = SimpleNamespace(agent_uuid="sentinel-uuid", _ensure_identity=AsyncMock())
+    client = SimpleNamespace(call_tool=AsyncMock())
+
+    args = await adjudicate_finding(agent, client, "dismissed", "fp-xyz", reason="fp")
+
+    agent._ensure_identity.assert_awaited_once_with(client)
+    client.call_tool.assert_awaited_once()
+    tool, payload = client.call_tool.await_args.args
+    assert tool == "outcome_event"
+    assert payload["agent_id"] == "sentinel-uuid"
+    assert payload["outcome_type"] == "sentinel_finding_dismissed"
+    assert payload["is_bad"] is True
+    assert payload["verification_source"] == "external_signal"
+    assert args == payload
+
+
+@pytest.mark.asyncio
+async def test_adjudicate_finding_refuses_without_identity():
+    from agents.sentinel.agent import adjudicate_finding
+
+    agent = SimpleNamespace(agent_uuid=None, _ensure_identity=AsyncMock())
+    client = SimpleNamespace(call_tool=AsyncMock())
+
+    with pytest.raises(RuntimeError):
+        await adjudicate_finding(agent, client, "confirmed", "fp", None)
+    client.call_tool.assert_not_awaited()


### PR DESCRIPTION
## Why
The EISV residual falsifiability test needs *baselined residents* carrying *externally-verified* outcomes. Today only **Watcher** does — it drives all **17** current joinable rows (live, up from 0). The overlap floor for an emitted AUC is ≥20, and the labels are single-resident + skewed. A second resident channel is the lever (`docs/proposals/eisv-stage0-bridge-b-label-routing.md`, P3).

Sentinel is richly baselined (**5,224** state rows, live) but its findings live in `audit.events` with **no resolve/dismiss path**, so it produced zero externally-verified outcomes. This adds that channel — **option A** (outcome-only; the operator verdict is the durable record).

## What
- **`agents/common/resolution_outcome.py`** — shared, parameterized `build_resolution_outcome_args(finding_kind, status, fingerprint, agent_uuid, reason)`. Semantics match Watcher exactly so labels are comparable: confirmed = good, false-positive dismissal (`reason="fp"`) = bad, other dismissals = not-bad; `verification_source="external_signal"`; attributed to the **resident's own UUID** so the `outcome_event` handler snapshots *that resident's* EISV. (Generalizes Watcher's local copy — Watcher can DRY onto it in a follow-up; left untouched here.)
- **Sentinel CLI** — `--resolve <fp>` / `--dismiss <fp> [--reason fp]`. Resolves Sentinel's persistent identity via the SDK base-agent path (`_ensure_identity`, `refuse_fresh_onboard=True` → no ghost) and posts the outcome attributed to Sentinel's UUID. The testable `adjudicate_finding()` refuses to attribute if identity is unresolved.

## Scope / honesty
- **Option A only:** the `outcome_event` is the durable adjudication record. It does **not** mutate the finding's status in `audit.events` / `/v1/sentinel/backlog` — that's a deliberate follow-up (option B).
- **Invariant 4 preserved:** the label is an operator/human verdict (exogenous), never the loop validating its own trajectory.
- **Forward-only + accrual:** like Watcher, this accrues as operators adjudicate; it doesn't backfill. Volume ramps; per-class power is a ramp, not a switch.

## Tests
6 new (`tests/test_resolution_outcome.py`): builder precision semantics + finding_kind parameterization + the Sentinel wiring (attributes to Sentinel UUID; refuses without identity). 22 existing Sentinel tests green. CI is the full gate.

https://claude.ai/code/session_01VpnQBh6B7ZoUbWe2V319G5