### PR TITLE
docs: design-record banner on planning/RFC docs that read as live plans

### DIFF
--- a/docs/ontology/beam-coordination-kernel.md
+++ b/docs/ontology/beam-coordination-kernel.md
@@ -1,5 +1,7 @@
 # BEAM Coordination Kernel Plan
 
+> **Design record.** A planning / RFC document kept as design provenance; it captures intent at a point in time and may lag the running code. For current behavior see [`UNIFIED_ARCHITECTURE.md`](../UNIFIED_ARCHITECTURE.md) and the runtime sources it points to.
+
 **Created:** April 30, 2026
 **Last Updated:** June 28, 2026
 **Status:** Placement decided; lease-plane live; Sentinel Wave 1 shipped (`com.unitares.sentinel-beam`); **Wave 3a read-only handlers DEPLOYED (:8770, first inbound BEAM listener) and dialectic-on-BEAM merged (flags off, 2026-06-28)**. Remaining = Wave 3 write-path (3b/3c `handler_dispatch`, not started).

--- a/docs/ontology/r6-episode-fork-response-shape.md
+++ b/docs/ontology/r6-episode-fork-response-shape.md
@@ -1,5 +1,7 @@
 # R6 — Episode-fork vs identity-lineage-fork response-shape decision
 
+> **Design record.** A planning / RFC document kept as design provenance; it captures intent at a point in time and may lag the running code. For current behavior see [`UNIFIED_ARCHITECTURE.md`](../UNIFIED_ARCHITECTURE.md) and the runtime sources it points to.
+
 **Status:** Decision doc, revision pass 3, with 2026-05-05 v2.1 onboard-side field-shape decision and 2026-05-08 durable-provenance follow-up landed.
 **Scope:** A response-shape decision under plan row R6 (`docs/ontology/plan.md`). Promotes two fork-discrimination fields to plan row S22 for both `process_agent_update`'s thin `thread_context` and `onboard()`'s rich `thread_context`. As of 2026-05-08 those two fields also flow into the durable S22 write context persisted to `core.agent_state.state_json.provenance_context` and `knowledge.discoveries.provenance.s22_context`. Does NOT promote the broader candidate provenance envelope.
 **Companion to:** `harness-substrate-plurality.md` (R6 design + candidate envelope), `r6-h1-h5-dogfood-20260429.md` (dogfood pass; April 30 forcing observation).

--- a/docs/ontology/s1-continuity-token-retirement.md
+++ b/docs/ontology/s1-continuity-token-retirement.md
@@ -1,5 +1,7 @@
 # S1 — `continuity_token` retirement plan
 
+> **Design record.** A planning / RFC document kept as design provenance; it captures intent at a point in time and may lag the running code. For current behavior see [`UNIFIED_ARCHITECTURE.md`](../UNIFIED_ARCHITECTURE.md) and the runtime sources it points to.
+
 **Date:** 2026-04-24
 **Scope:** Plan doc for `continuity_token` retirement per `plan.md` §Track C C1. Inventories current roles of the token, identifies what S11 already accomplished, surfaces the Part-C coupling that makes naive retirement unsafe, and lays out a sequenced deprecation path with operator decision points.
 **Stance:** Descriptive + recommendation. No code changes in this pass.

--- a/docs/ontology/s8a-phase2-prep.md
+++ b/docs/ontology/s8a-phase2-prep.md
@@ -1,5 +1,7 @@
 # S8a Phase 2 — Prep (2026-04-29)
 
+> **Design record.** A planning / RFC document kept as design provenance; it captures intent at a point in time and may lag the running code. For current behavior see [`UNIFIED_ARCHITECTURE.md`](../UNIFIED_ARCHITECTURE.md) and the runtime sources it points to.
+
 **Companion to:** `docs/ontology/s8a-tag-discipline-audit.md` (Phase 1)
 **Status:** Prep diagnostic. Not a ratification artifact. Tomorrow's session (≥1-week-of-data trigger fires 2026-04-30) opens the actual Phase-2 PR using this as the data input.
 

--- a/docs/proposals/2026-06-24-wave-3-gate-framing.md
+++ b/docs/proposals/2026-06-24-wave-3-gate-framing.md
@@ -1,5 +1,7 @@
 # 2026-06-24 Wave-3 Gate — Framing Note
 
+> **Design record.** A planning / RFC document kept as design provenance; it captures intent at a point in time and may lag the running code. For current behavior see [`UNIFIED_ARCHITECTURE.md`](../UNIFIED_ARCHITECTURE.md) and the runtime sources it points to.
+
 **Created:** 2026-06-22
 **Status:** **RESOLVED 2026-06-24.** Both gate decisions are made (see RESOLUTION below). Body preserved as the framing that led here.
 **Scope:** Frames the single decision that resolves the largest cluster of open proposals at once. Does not relitigate destination A′ (operator-committed 2026-05-05); it asks whether the *Wave-3 forward build* still has a basis.

--- a/docs/proposals/beam-event-adapter-design-v0.md
+++ b/docs/proposals/beam-event-adapter-design-v0.md
@@ -1,5 +1,7 @@
 # BEAM Event-Adapter Design — v0
 
+> **Design record.** A planning / RFC document kept as design provenance; it captures intent at a point in time and may lag the running code. For current behavior see [`UNIFIED_ARCHITECTURE.md`](../UNIFIED_ARCHITECTURE.md) and the runtime sources it points to.
+
 - **Created:** 2026-06-20
 - **Last Updated:** 2026-06-20
 - **Status:** Design note — DEFERRED to the 2026-06-24 Wave-3 gate read; no runtime code

--- a/docs/proposals/discord-thread-identity-resume-v0.md
+++ b/docs/proposals/discord-thread-identity-resume-v0.md
@@ -1,5 +1,7 @@
 # Discord BEAM thread identity — resume-per-thread (v0)
 
+> **Design record.** A planning / RFC document kept as design provenance; it captures intent at a point in time and may lag the running code. For current behavior see [`UNIFIED_ARCHITECTURE.md`](../UNIFIED_ARCHITECTURE.md) and the runtime sources it points to.
+
 **Created:** June 18, 2026
 **Status:** Orchestrator + reference-hook side merged (#834). The **fail-closed
 guard** (anchor honored only with an explicit orchestration marker) was mirrored

--- a/docs/proposals/stakes-keyed-gating-775.md
+++ b/docs/proposals/stakes-keyed-gating-775.md
@@ -1,5 +1,7 @@
 # Stakes-keyed gating (#775) — design of record
 
+> **Design record.** A planning / RFC document kept as design provenance; it captures intent at a point in time and may lag the running code. For current behavior see [`UNIFIED_ARCHITECTURE.md`](../UNIFIED_ARCHITECTURE.md) and the runtime sources it points to.
+
 **Status:** classification artifact LANDED + INERT; gate mechanism PARKED.
 **Issue:** #775 (spun from #752, step 3). Sibling: #776 (trust→friction, step 4).
 **Date:** 2026-06-28.

--- a/docs/proposals/track-b-implementation-blueprint.md
+++ b/docs/proposals/track-b-implementation-blueprint.md
@@ -1,5 +1,7 @@
 # Track B — Implementation blueprint (`operator_delegate` disclosure scope)
 
+> **Design record.** A planning / RFC document kept as design provenance; it captures intent at a point in time and may lag the running code. For current behavior see [`UNIFIED_ARCHITECTURE.md`](../UNIFIED_ARCHITECTURE.md) and the runtime sources it points to.
+
 - **Status:** Ready to apply against `CIRWEL/unitares` (this repo).
 - **Prereq:** Track A enforced (`UNITARES_IDENTITY_STRICT=strict`,
   `UNITARES_SESSION_FINGERPRINT_CHECK=strict`). Do not ship Track B first.

--- a/docs/proposals/worktree-isolation-vs-lease-default.md
+++ b/docs/proposals/worktree-isolation-vs-lease-default.md
@@ -16,6 +16,8 @@ stance: |
 
 # Worktree isolation as default; leases for the residue
 
+> **Design record.** A planning / RFC document kept as design provenance; it captures intent at a point in time and may lag the running code. For current behavior see [`UNIFIED_ARCHITECTURE.md`](../UNIFIED_ARCHITECTURE.md) and the runtime sources it points to.
+
 ## 0. What this note is and isn't
 
 This is **not** a proposal to remove or replace the Surface Lease Plane. The lease


### PR DESCRIPTION
## Why

Planning/RFC docs in `docs/ontology/` and `docs/proposals/` surface on deep links reading like current operating plans when they're point-in-time design records (prompting example: `docs/ontology/beam-coordination-kernel.md` — a 400-line "Plan" that's mostly shipped). A reader landing there has no signal it isn't the live source of truth.

## What

A uniform one-line banner under the title:

> **Design record.** A planning / RFC document kept as design provenance; it captures intent at a point in time and may lag the running code. For current behavior see [`UNIFIED_ARCHITECTURE.md`](../UNIFIED_ARCHITECTURE.md) and the runtime sources it points to.

- **In-place only** — no moves, no path/link changes. The "demote to `resolved/`" question stays open and operator-gated; this just fixes the deep-link "looks stale" problem at zero collision risk.
- **Doc-agnostic text** — no per-doc status claim, so it's accurate on every doc.
- **Idempotent**; trivial to add/remove per doc. 10 files, +2 lines each. Banner link verified to resolve from both `ontology/` and `proposals/`.
- Applied to the design-record set surfaced by the doc-health demotion check (#1206), **excluding** docs that already declare a prominent shipped/deployed/complete status at the top and the actively-primary Wave 3 RFC.

## Held back (deliberately)

Four further candidates — `agent-orchestrator-beam-v0`, `governed-effect-plane-v0`, `orchestrator-vouched-identity-v0`, `verification-weighted-verdict-v0` — carry pre-existing internal AI-review-process vocabulary that the scope guard blocks on any commit touching them. Bannering them would force allowlisting them as permanently-public, which cuts against the open public/private decision. Left untouched and surfaced here instead.