### PR TITLE
feat(dialectic): persist + expose awaiting_facilitation in dialectic(list) (#1167 Ask 2)

### DIFF
--- a/db/postgres/migrations/053_dialectic_awaiting_facilitation.sql
+++ b/db/postgres/migrations/053_dialectic_awaiting_facilitation.sql
@@ -1,0 +1,27 @@
+-- 053_dialectic_awaiting_facilitation.sql
+-- Persist the `awaiting_facilitation` flag on dialectic sessions (#1167 Ask 2).
+--
+-- Today `awaiting_facilitation` is an in-memory attribute on the live
+-- DialecticSession object (src/dialectic_protocol.py), set when a reviewer is
+-- stuck and no auto-replacement was found (#1015 routes a rejected proposal
+-- here instead of auto-resuming). It is the highest-priority signal for the
+-- dialectic live-surface (badge / float-to-top), but `dialectic(action="list")`
+-- cannot see it because it lives only in memory and is lost on restart.
+--
+-- This column brings the persisted row to parity with the in-memory flag so
+-- the `list` API can surface it. The `get` path already exposes it via
+-- get_awaiting_facilitation_recovery.
+--
+-- MANUAL migration. Do NOT auto-run. Apply with psql before the server binary
+-- that SELECTs core.dialectic_sessions.awaiting_facilitation in
+-- list_all_sessions starts. Until applied, the new SELECT errors. Backfilled
+-- FALSE for existing rows (the live in-memory flag re-asserts on the next
+-- write at each session's reviewer-stuck / reassign site).
+
+ALTER TABLE core.dialectic_sessions
+    ADD COLUMN IF NOT EXISTS awaiting_facilitation BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN core.dialectic_sessions.awaiting_facilitation IS
+    'TRUE when the reviewer is stuck and no auto-replacement was found, routing '
+    'the session to human facilitation (#1015). Highest-priority surface signal. '
+    'Mirrors the in-memory DialecticSession.awaiting_facilitation flag (#1167).';

--- a/src/dialectic_db.py
+++ b/src/dialectic_db.py
@@ -223,6 +223,21 @@ class DialecticDB:
             """, status, session_id)
             return "UPDATE 1" in result
 
+    async def update_session_awaiting_facilitation(self, session_id: str, awaiting: bool) -> bool:
+        """Persist the awaiting_facilitation flag (#1167 Ask 2).
+
+        Mirrors the in-memory DialecticSession.awaiting_facilitation attribute so
+        dialectic(list) can surface stuck sessions (and they survive restarts).
+        """
+        await self._ensure_pool()
+        async with self._pool.acquire() as conn:
+            result = await conn.execute("""
+                UPDATE core.dialectic_sessions
+                SET awaiting_facilitation = $1, updated_at = now()
+                WHERE session_id = $2
+            """, awaiting, session_id)
+            return "UPDATE 1" in result
+
     async def resolve_session(
         self,
         session_id: str,
@@ -530,6 +545,11 @@ async def update_session_reviewer_async(session_id: str, reviewer_agent_id: str)
 async def update_session_status_async(session_id: str, status: str) -> bool:
     db = await get_dialectic_db()
     return await db.update_session_status(session_id, status)
+
+
+async def update_session_awaiting_facilitation_async(session_id: str, awaiting: bool) -> bool:
+    db = await get_dialectic_db()
+    return await db.update_session_awaiting_facilitation(session_id, awaiting)
 
 
 async def resolve_session_async(session_id: str, resolution: Dict[str, Any], status: str = "resolved") -> bool:

--- a/src/mcp_handlers/dialectic/handlers.py
+++ b/src/mcp_handlers/dialectic/handlers.py
@@ -105,6 +105,7 @@ from src.dialectic_db import (
     create_session_async as pg_create_session,
     update_session_phase_async as pg_update_phase,
     update_session_reviewer_async as pg_update_reviewer,
+    update_session_awaiting_facilitation_async as pg_update_awaiting_facilitation,
     add_message_async as pg_add_message,
     resolve_session_async as pg_resolve_session,
     get_all_sessions_by_agent_async as pg_get_all_sessions_by_agent,
@@ -489,6 +490,8 @@ async def _apply_reviewer_reassignment(
         # BEAM owns the reviewer write when flagged; else Python. (Slice 2.3)
         if await beam_update_reviewer(session_id, new_reviewer_id) is None:
             await pg_update_reviewer(session_id, new_reviewer_id)
+        # A reassigned reviewer clears the stuck/facilitation state (#1167 Ask 2).
+        await pg_update_awaiting_facilitation(session_id, False)
         await pg_add_message(
             session_id=session_id,
             agent_id="system",
@@ -767,6 +770,13 @@ async def handle_request_dialectic_review(arguments: Dict[str, Any]) -> Sequence
         # No independent reviewer yet; the antithesis is owed by a summoned or
         # operator-assigned reviewer, not by the paused agent itself.
         session.awaiting_facilitation = True
+        # Persist so dialectic(list) can float this to the top (#1167 Ask 2).
+        # Fail-soft: the session row already committed above; only the surface
+        # flag is at risk.
+        try:
+            await pg_update_awaiting_facilitation(session.session_id, True)
+        except Exception as e:
+            logger.error(f"Failed to persist awaiting_facilitation on create: {e}")
 
     # Build response based on reviewer assignment
     if auto_awaiting_reviewer:
@@ -922,6 +932,8 @@ async def handle_get_dialectic_session(arguments: Dict[str, Any]) -> Sequence[Te
                                 message_type="system",
                                 reasoning=f"Reviewer '{old_reviewer}' stuck. Awaiting human facilitation.",
                             )
+                            # Persist the flag so dialectic(list) surfaces it (#1167 Ask 2).
+                            await pg_update_awaiting_facilitation(session_id, True)
                         except Exception as e:
                             logger.error(f"Failed to persist facilitation status: {e}")
                         logger.info(f"[DIALECTIC] Session {session_id[:16]} awaiting human facilitation (reviewer {old_reviewer} stuck)")

--- a/src/mcp_handlers/dialectic/session.py
+++ b/src/mcp_handlers/dialectic/session.py
@@ -417,6 +417,7 @@ async def list_all_sessions(
                     ds.topic,
                     ds.created_at,
                     ds.resolution_json,
+                    ds.awaiting_facilitation,
                     COALESCE(mc.cnt, 0) as message_count,
                     (SELECT dm.agent_id
                      FROM core.dialectic_messages dm
@@ -469,6 +470,7 @@ async def list_all_sessions(
                     "topic": row["topic"] or "",
                     "created": created_at or "",
                     "message_count": row["message_count"] or 0,
+                    "awaiting_facilitation": bool(row["awaiting_facilitation"]) if "awaiting_facilitation" in row else False,
                 }
 
                 # Parse resolution if present

--- a/tests/test_dialectic_db.py
+++ b/tests/test_dialectic_db.py
@@ -703,6 +703,43 @@ class TestUpdateSessionStatus:
 
 
 # ============================================================================
+# DialecticDB.update_session_awaiting_facilitation (#1167 Ask 2)
+# ============================================================================
+
+class TestUpdateSessionAwaitingFacilitation:
+    @pytest.mark.asyncio
+    async def test_set_true_success(self, db):
+        """update_session_awaiting_facilitation persists the flag and returns True."""
+        instance, pool, conn = db
+        conn.execute = AsyncMock(return_value="UPDATE 1")
+
+        result = await instance.update_session_awaiting_facilitation("sess-001", True)
+        assert result is True
+        call_args = conn.execute.call_args[0]
+        assert call_args[1] is True
+        assert call_args[2] == "sess-001"
+
+    @pytest.mark.asyncio
+    async def test_clear_false_success(self, db):
+        """Clearing the flag passes False to the UPDATE."""
+        instance, pool, conn = db
+        conn.execute = AsyncMock(return_value="UPDATE 1")
+
+        result = await instance.update_session_awaiting_facilitation("sess-001", False)
+        assert result is True
+        assert conn.execute.call_args[0][1] is False
+
+    @pytest.mark.asyncio
+    async def test_not_found(self, db):
+        """Returns False when no row matched."""
+        instance, pool, conn = db
+        conn.execute = AsyncMock(return_value="UPDATE 0")
+
+        result = await instance.update_session_awaiting_facilitation("sess-gone", True)
+        assert result is False
+
+
+# ============================================================================
 # DialecticDB.resolve_session
 # ============================================================================
 

--- a/tests/test_dialectic_session_handlers.py
+++ b/tests/test_dialectic_session_handlers.py
@@ -966,6 +966,62 @@ class TestListAllSessions:
         assert result[0]["session_id"] == "pg_list_1"
         assert result[0]["phase"] == "thesis"
         assert result[0]["message_count"] == 2
+        # Backward-compatible: rows without the column default the flag to False.
+        assert result[0]["awaiting_facilitation"] is False
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_surfaces_awaiting_facilitation(self):
+        """#1167 Ask 2: dialectic(list) exposes the persisted awaiting_facilitation flag."""
+        from src.mcp_handlers.dialectic.session import list_all_sessions
+
+        now = datetime.now()
+        mock_rows = [
+            {
+                "session_id": "pg_stuck",
+                "phase": "antithesis",
+                "status": "active",
+                "session_type": "recovery",
+                "paused_agent_id": "agent_a",
+                "reviewer_agent_id": "agent_b",
+                "topic": "Stuck reviewer",
+                "created_at": now,
+                "resolution_json": None,
+                "awaiting_facilitation": True,
+                "message_count": 1,
+            },
+            {
+                "session_id": "pg_ok",
+                "phase": "thesis",
+                "status": "active",
+                "session_type": "recovery",
+                "paused_agent_id": "agent_c",
+                "reviewer_agent_id": "agent_d",
+                "topic": "Healthy",
+                "created_at": now,
+                "resolution_json": None,
+                "awaiting_facilitation": False,
+                "message_count": 0,
+            },
+        ]
+
+        mock_conn = AsyncMock()
+        mock_conn.fetch = AsyncMock(return_value=mock_rows)
+
+        mock_pool = AsyncMock()
+        mock_pool.acquire = MagicMock()
+        mock_pool.acquire.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        mock_db = AsyncMock()
+        mock_db._pool = mock_pool
+        mock_db._ensure_pool = AsyncMock()
+
+        with patch("src.dialectic_db.get_dialectic_db", new_callable=AsyncMock, return_value=mock_db):
+            result = await list_all_sessions()
+
+        by_id = {r["session_id"]: r for r in result}
+        assert by_id["pg_stuck"]["awaiting_facilitation"] is True
+        assert by_id["pg_ok"]["awaiting_facilitation"] is False
 
     @pytest.mark.asyncio
     async def test_list_sessions_postgres_with_resolution_string(self):


### PR DESCRIPTION
Implements **Ask 2** of #1167 — brings the persisted `core.dialectic_sessions` row to parity with the in-memory `DialecticSession.awaiting_facilitation` flag so `dialectic(action="list")` can surface stuck / human-facilitation sessions (the highest-priority signal for the live surface — badge / float-to-top) and they survive restarts. The `get` path already exposed it via `get_awaiting_facilitation_recovery`; this brings `list` to parity.

## Changes
- **migration 053** — `ADD COLUMN core.dialectic_sessions.awaiting_facilitation BOOLEAN NOT NULL DEFAULT FALSE`. **MANUAL** (house style, per 052): apply with psql **before** deploying the binary that SELECTs the column — until applied the new SELECT errors.
- **`dialectic_db`** — `update_session_awaiting_facilitation(+_async)`, following the existing `update_session_*` guarded-UPDATE pattern.
- **`handlers`** — persist at all three in-memory write-sites: set `True` on auto-awaiting-reviewer create and on reviewer-stuck-no-replacement; clear `False` on reviewer reassign. Fail-soft (session row already committed; only the surface flag is at risk).
- **`session.list_all_sessions`** — SELECT the column + expose per-summary, guarded so pre-migration / mocked rows default `False`.
- **tests** — db method (set/clear/not-found) + list surfacing.

## Out of scope
**Ask 1** (`dialectic_*` broadcast events) is intentionally left out — naming/shape is the dialectic-engine owner's call per the standing "sync the event vocabulary first" agreement.

## Verification
- Focused + full dialectic suites: **219 passed**; full gate **11080 passed / 21 skipped**, coverage 81.91%.
- `unitares_doctor.py` clean on this surface (schema/slot/column-drift pass). The one doctor FAIL (`docs/FLAGS.md` stale) is **pre-existing** and unrelated — this PR adds no flags.

## Deploy note
Single-writer migration surface: slot 053 is sequential, no drift. Apply 053 manually with the deploy.

https://claude.ai/code/session_01RPGYhmjDU7uqjmA7vanh41