### PR TITLE
feat(identity): make the #807 prefix-echo over-claim countable (proof_origin telemetry)

### DIFF
--- a/src/audit_log.py
+++ b/src/audit_log.py
@@ -463,6 +463,8 @@ class AuditLogger:
         token_iat: Optional[int] = None,
         token_exp: Optional[int] = None,
         token_age_seconds: Optional[int] = None,
+        proof_origin: Optional[str] = None,
+        csid_transport_injected: Optional[bool] = None,
     ) -> None:
         """Record one observation per onboard/resume identity resolution.
 
@@ -476,6 +478,13 @@ class AuditLogger:
         token was presented at resume. ``agent_uuid`` may be None when the
         resolution did not bind to a known agent (e.g., onboard that minted
         a fresh identity has it set; pre-bind diagnostics may not).
+
+        ``proof_origin`` ("caller_asserted" | "server_inferred") and
+        ``csid_transport_injected`` make the #807 over-claim countable: how
+        many tokenless prefix-echo resolves stamp the strong/``caller_proven``
+        label (caller_proven = proof_origin == "caller_asserted") versus the
+        honestly-weaker transport-injected ones. Lets a burn-in size the
+        cross-process subset without changing any tier or write gate.
         """
         entry = AuditEntry(
             timestamp=datetime.now().isoformat(),
@@ -491,6 +500,8 @@ class AuditLogger:
                 "token_iat": token_iat,
                 "token_exp": token_exp,
                 "token_age_seconds": token_age_seconds,
+                "proof_origin": proof_origin,
+                "csid_transport_injected": csid_transport_injected,
             },
         )
         self._write_entry(entry)

--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -2579,6 +2579,8 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
             get_session_resolution_source,
             get_pin_match_scope,
             get_shadow_pin_observation,
+            get_session_proof_origin,
+            get_csid_transport_injected,
         )
         _ires_token = arguments.get("continuity_token")
         _ires_iat: Optional[int] = None
@@ -2601,6 +2603,8 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
             token_iat=_ires_iat,
             token_exp=_ires_exp,
             token_age_seconds=_ires_age,
+            proof_origin=get_session_proof_origin(),
+            csid_transport_injected=get_csid_transport_injected(),
         )
     except Exception as _ires_err:  # pragma: no cover — defensive
         logger.debug(f"[IRES] identity_resolution_observed write failed (non-fatal): {_ires_err}")

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -125,6 +125,8 @@ class TestLogIdentityResolutionObserved:
             token_iat=1700_000_000,
             token_exp=1700_003_600,
             token_age_seconds=900,
+            proof_origin="server_inferred",
+            csid_transport_injected=False,
         )
         entries = _read_jsonl(logger.log_file)
         assert len(entries) == 1
@@ -139,6 +141,37 @@ class TestLogIdentityResolutionObserved:
         assert d["token_iat"] == 1700_000_000
         assert d["token_exp"] == 1700_003_600
         assert d["token_age_seconds"] == 900
+        assert d["proof_origin"] == "server_inferred"
+        assert d["csid_transport_injected"] is False
+
+    def test_records_proof_origin_for_prefix_echo_overclaim(self, tmp_path):
+        """#807: the tokenless prefix-echo over-claim must be countable — record
+        proof_origin + csid_transport_injected so a burn-in can size how many
+        explicit_client_session_id* resolves stamp the strong/caller_proven
+        label vs. the honestly-weaker transport-injected ones."""
+        logger = _make_logger(tmp_path)
+        logger.log_identity_resolution_observed(
+            agent_uuid="agent-prefix-echo",
+            resolution_source="explicit_client_session_id_scoped",
+            proof_origin="caller_asserted",
+            csid_transport_injected=False,
+        )
+        d = _read_jsonl(logger.log_file)[0]["details"]
+        assert d["resolution_source"] == "explicit_client_session_id_scoped"
+        # caller_proven is derivable: proof_origin == "caller_asserted"
+        assert d["proof_origin"] == "caller_asserted"
+        assert d["csid_transport_injected"] is False
+
+    def test_new_fields_default_none(self, tmp_path):
+        """Back-compat: callers that omit the new fields get None, not a crash."""
+        logger = _make_logger(tmp_path)
+        logger.log_identity_resolution_observed(
+            agent_uuid="agent-legacy",
+            resolution_source="ip_ua_fingerprint",
+        )
+        d = _read_jsonl(logger.log_file)[0]["details"]
+        assert d["proof_origin"] is None
+        assert d["csid_transport_injected"] is None
 
     def test_accepts_none_agent_uuid(self, tmp_path):
         """Resolutions that don't bind to an agent (pre-bind diagnostic paths)


### PR DESCRIPTION
Implements **option (b)** from the #807 burn-in — instrument the discriminator so the over-claim becomes countable, **without** any tier or write-gating change (that policy decision stays open and human-owned).

## Why
The [#807 burn-in](https://github.com/cirwel/unitares/issues/807#issuecomment-4827910726) (strict window, 2026-06-28) found tokenless prefix-echo (`explicit_client_session_id*`) is the **dominant** write-capable resolution path (~649/month; PATH 0 token-resume at **0** adoption). But `identity_resolution_observed` recorded only `resolution_source` — **not** whether the resolve actually stamped the strong/`caller_proven` label the issue flags. So the over-claim was not measurable and "evidence-driven at #425 default" had no evidence.

## Change (purely additive)
Two fields on the observation event:
- **`proof_origin`** (`caller_asserted` | `server_inferred`) — `caller_proven == (proof_origin == "caller_asserted")`, so a burn-in can count strong-stamped prefix-echo resolves vs. the honestly-weaker transport-injected ones.
- **`csid_transport_injected`** (bool) — the flag that already demotes the stamp (`src/mcp_handlers/identity/session.py:677`).

Both already live in request context (`get_session_proof_origin` / `get_csid_transport_injected`); this threads them into the existing best-effort audit write. **No tier change, no write gate change, no migration** (JSONB `details`). Fail-soft.

## Effect
Re-running the burn-in after a window now directly sizes the cross-process over-claim subset — converting #807 from "blocked on missing telemetry" to "decision-ready." Canonical query to run after a burn-in window:

```sql
SELECT payload->>resolution_source AS src,
       payload->>proof_origin       AS proof_origin,
       payload->>csid_transport_injected AS transport_injected,
       count(*)
FROM audit.events
WHERE event_type=identity_resolution_observed
  AND ts >= now() - interval 7 days
  AND payload->>resolution_source LIKE explicit_client_session_id%
GROUP BY 1,2,3 ORDER BY 4 DESC;
-- caller_asserted + transport_injected=false on a prefix-echo source
-- = the strong/caller_proven over-claim population #807 cares about.
```

## Scope
Does **not** decide the tier policy — accept-and-relabel **(a)** vs. drive-token-adoption-then-downrate **(c)** stays open on #807. Identity is a coupled single-writer surface; scanned open PRs first (only #1221, a threat-model doc — no overlap).

## Verification
- `test_audit_log.py` extended (over-claim case + back-compat None defaults) + `test_identity_handlers.py`: **196 passed** focused; full gate **11097 passed / 22 skipped**, coverage 81.89%.

https://claude.ai/code/session_01RPGYhmjDU7uqjmA7vanh41