### PR TITLE
perf(checkin): timeout-guard the KG search in enrich_mirror_signals (the check-in tail)

### DIFF
--- a/src/mcp_handlers/updates/enrichments.py
+++ b/src/mcp_handlers/updates/enrichments.py
@@ -45,6 +45,13 @@ _RELATED_DISCOVERY_RELEVANCE_FLOOR = 0.1
 #   3. Novelty — session-scoped dedup (Redis) so a given discovery is surfaced
 #      at most once per session; what reaches the agent is always new to it.
 _KG_PROACTIVE_FLOOR = 0.35
+# KG-search timeout for the mirror-signals enrichment. The KG semantic/full-text
+# search is the dominant check-in tail: per-enrichment telemetry (2026-06-28,
+# n=2133) put enrich_mirror_signals at p99=281ms / max=2624ms while every other
+# enrichment was <16ms mean — the cost is this anyio-amplified KG I/O (see
+# CLAUDE.md "Substrate Tax"). KG surfacing is advisory, so a slow search degrades
+# to "no surfacing this turn" (return []) instead of blocking the response.
+_KG_SEARCH_TIMEOUT = float(os.getenv("UNITARES_KG_SEARCH_TIMEOUT_S", "0.25"))
 # Session-scope TTL for the per-agent set of already-surfaced discovery_ids.
 _KG_SURFACED_TTL_SECONDS = 86400
 
@@ -1489,13 +1496,26 @@ async def _search_kg_by_checkin_text(
         from src.knowledge_graph import get_knowledge_graph
         graph = await get_knowledge_graph()
 
-        # Try semantic search first, fall back to full-text
+        # Try semantic search first, fall back to full-text. Both are wrapped in
+        # a tight timeout: KG search is the dominant check-in tail (anyio-amplified
+        # I/O), and surfacing is advisory — a slow/contended search degrades to
+        # "no surfacing this turn" rather than blocking the response up to seconds.
         results = []
         try:
-            results = await graph.semantic_search(response_text, limit=3)
+            results = await asyncio.wait_for(
+                graph.semantic_search(response_text, limit=3), timeout=_KG_SEARCH_TIMEOUT
+            )
+        except asyncio.TimeoutError:
+            logger.debug("KG semantic_search exceeded %.0fms budget; skipping surfacing", _KG_SEARCH_TIMEOUT * 1000)
+            return []
         except (AttributeError, NotImplementedError):
             try:
-                results = await graph.full_text_search(response_text, limit=3)
+                results = await asyncio.wait_for(
+                    graph.full_text_search(response_text, limit=3), timeout=_KG_SEARCH_TIMEOUT
+                )
+            except asyncio.TimeoutError:
+                logger.debug("KG full_text_search exceeded %.0fms budget; skipping surfacing", _KG_SEARCH_TIMEOUT * 1000)
+                return []
             except (AttributeError, NotImplementedError):
                 pass
 

--- a/tests/test_enrichments_mirror.py
+++ b/tests/test_enrichments_mirror.py
@@ -21,7 +21,38 @@ from src.mcp_handlers.updates.enrichments import (
     _should_search_kg_by_checkin_text,
     _proactive_kg_due,
     _dedupe_surfaced_kg,
+    _search_kg_by_checkin_text,
 )
+
+
+@pytest.mark.asyncio
+async def test_kg_search_times_out_to_empty(monkeypatch):
+    """A slow/contended KG search must degrade to [] within the budget, not block
+    the response. KG search is the dominant check-in tail (anyio-amplified I/O);
+    surfacing is advisory."""
+    import asyncio, time
+    import src.mcp_handlers.updates.enrichments as enr
+
+    async def _hang(*a, **k):
+        await asyncio.sleep(5)  # far exceeds the budget
+        return [("x", 1.0)]
+
+    graph = MagicMock()
+    graph.semantic_search = _hang
+    graph.full_text_search = _hang
+
+    monkeypatch.setattr(enr, "_KG_SEARCH_TIMEOUT", 0.05, raising=False)
+    import src.knowledge_graph as kg_mod
+    monkeypatch.setattr(kg_mod, "get_knowledge_graph", AsyncMock(return_value=graph))
+
+    ctx = _make_ctx(response_text="a real check-in long enough to pass the >=10 char gate")
+
+    t0 = time.perf_counter()
+    result = await _search_kg_by_checkin_text(ctx)
+    elapsed = time.perf_counter() - t0
+
+    assert result == []              # degraded to no surfacing
+    assert elapsed < 1.0             # did NOT wait for the 5s hang
 
 
 # ============================================================================


### PR DESCRIPTION
Per-enrichment telemetry (2026-06-28, n=2133 live check-ins via `[enrichment_phases]`): `enrich_mirror_signals` is **p99=281ms / max=2624ms / mean=70ms — ~90% of all enrichment time**, while every other enrichment is <16ms mean. The cost is the KG semantic/full-text search (`_search_kg_by_checkin_text`) — the anyio-amplified I/O described in CLAUDE.md "Substrate Tax" — awaited unbounded in the response path.

KG surfacing is advisory (the optional `_mirror_kg_results` field), so both search calls are wrapped in `asyncio.wait_for` with a tight budget (`UNITARES_KG_SEARCH_TIMEOUT_S`, default 0.25s): a slow/contended search degrades to "no surfacing this turn" (`return []`) instead of blocking the response up to ~2.6s. Matches the established substrate-tax mitigation pattern; one change at the helper covers both call sites (reactive + proactive).

This is the targeted fix for the bottleneck the wave-3 telemetry identified — no BEAM port needed (the handler-port migration was shelved; see `docs/handoffs/wave-3-checkin-phase-telemetry-2026-06-28.md`). Test: a 5s-hang search returns `[]` within the budget. Focused enrichment/pipeline/KG suites green (157).