### PR TITLE
docs(demo): correct quick_demo narrative — it does not pause in 7 steps

### DIFF
--- a/scripts/demo/quick_demo.py
+++ b/scripts/demo/quick_demo.py
@@ -17,8 +17,15 @@ What you'll see:
 - The agent onboards (fresh UUID + thread).
 - Seven check-ins simulate clean work → calibration drift → confusion.
 - Each step prints the verdict, the reason, and the four-channel state.
-- risk_score climbs from ~0.27 as drift accumulates; when it crosses the
-  high-risk gate the agent is paused and further check-ins are refused.
+- The graded proprioceptive signal moves in the drift direction: entropy S
+  rises, integrity I slips, valence V swings, and the decision margin tightens
+  (settling → tight) as the calibration miss and confusion accumulate.
+- The verdict stays `proceed` across this short run. Governance gates on a
+  smoothed risk (mean-of-10), which a seven-step synthetic trajectory does not
+  push over the pause threshold — by design, to avoid false pauses on normal
+  work. A `proceed` whose margin has gone `tight` is the signal here, not a
+  pause. Sustained or higher-severity drift can cross the gate and pause; the
+  code still handles that AGENT_PAUSED reply, you just won't trip it in 7 steps.
 
 No Postgres reads, no dashboard required — everything you see comes back
 in the check-in response shape that any client would receive.


### PR DESCRIPTION
## Honesty fix for the public demo narrative

Surfaced while building the testing-gaps integration test (#1215): `scripts/demo/quick_demo.py` — the artifact `make demo` runs and the README Quick Start points at — **describes a pause that does not happen**.

### The claim vs live behavior
The docstring said:
> risk_score climbs from ~0.27 as drift accumulates; when it crosses the high-risk gate the agent is paused and further check-ins are refused.

Running it live (repeatedly, stable):
```
step 1: proceed (settling)  risk=0.25
step 3: proceed (tight)     risk=0.24   S 0.19->0.27
step 4: proceed (tight)     risk=0.16
... all 7 steps proceed; risk stays 0.10-0.25, never crosses the 0.70 gate
```
The agent **never pauses**. Governance gates on a smoothed mean-of-10 risk, which a seven-step synthetic trajectory cannot push over threshold — deliberately, to avoid false pauses on normal work (the documented growth-not-punish posture).

### The fix
Docstring only — rewrites the "what you'll see" bullet to describe what actually happens: the **graded** signal moves in the drift direction (S rises, I slips, V swings, margin tightens `settling -> tight`) while the verdict stays `proceed`. A `proceed` whose margin has gone `tight` is the signal, not a pause. The defensive `AGENT_PAUSED` handling in the loop is unchanged — a real agent can still pause; this demo just won't trip it in 7 steps.

No code behavior changed; demo still runs; `ruff` clean.