### PR TITLE
fix(governance): risk_attribution reports the actual verdict driver (not hardcoded self_reported)

### DIFF
--- a/src/monitor_decision.py
+++ b/src/monitor_decision.py
@@ -164,20 +164,21 @@ def make_decision(
             'action': 'pause',
             'sub_action': 'risk_pause',
             'reason': f'UNITARES high-risk verdict (risk_score={risk_score:.2f}) - safety pause suggested',
-            # Honest provenance: the verdict is driven by the signals the caller
-            # reported (ethical_drift, complexity, confidence), not by an
-            # independent measurement of behavior. Saying "the system detected
-            # high ethical risk" overclaimed — at current maturity the only
-            # non-self-attested signal (behavioral text model) does not carry
-            # this weight. See result['risk_attribution'] for the decomposition
-            # (dogfood 2026-06-13, P0).
+            # Honest provenance, regime-aware: which signal drove this verdict
+            # depends on warmup. Post-warmup, with Φ telemetry (the default), it
+            # is the independent behavioral assessment; pre-warmup it is the Φ
+            # cold-start prior (mostly server-derived). risk_attribution carries
+            # the exact primary_driver, so the guidance points there rather than
+            # asserting a single (now-stale) "self-attested" provenance
+            # (dogfood 2026-06-13 P0; driver-accuracy correction 2026-06-28).
             'guidance': (
-                'This is a safety check, not a failure. Based on the signals you '
-                'reported (ethical_drift, complexity, confidence), this check-in '
-                'scored high-risk. These inputs are self-attested — the verdict '
-                'reflects what you reported, not an independent measurement of '
-                'your behavior (see risk_attribution). Consider simplifying your '
-                'approach.'
+                'This is a safety check, not a failure. This check-in scored '
+                'high-risk. See risk_attribution for what drove it: once your '
+                'behavioral baseline is warm the verdict is an independent '
+                'assessment of your trajectory; before then it leans on the '
+                'signals you reported (ethical_drift, complexity, confidence). '
+                'Consider simplifying your approach or requesting a dialectic '
+                'review.'
             ),
             'critical': is_critical,
             'basin': basin,

--- a/src/monitor_result.py
+++ b/src/monitor_result.py
@@ -94,26 +94,55 @@ def _build_risk_attribution(
     continuity_metrics,
     behavioral_assessment,
     baseline_status: Dict = None,
+    *,
+    behavioral_confidence=None,
 ) -> Dict:
     """Decompose the risk/verdict by signal provenance.
 
-    The verdict path is a self-report integrity mechanism, not an
-    adversary-resistant monitor: risk is driven primarily by the
-    caller-supplied ``ethical_drift`` vector (it dominates the phi-based
-    score) plus self-reported complexity/confidence. The only
-    non-self-attested signal is the behavioral text model, and at current
-    maturity it does not carry enforcement weight (verification layer
-    reserved for v2). Surfacing the decomposition lets a reader see *what*
-    drove the verdict and how much of it is self-attested vs measured
-    (dogfood 2026-06-13, P0). All inputs here are already computed elsewhere
-    in the result; this only re-exposes them grouped by provenance.
+    Reports the *actual* verdict driver rather than a fixed label. With Φ
+    demoted to telemetry (the default, ``UNITARES_PHI_TELEMETRY_ONLY=1``), the
+    post-warmup verdict IS the independent behavioral assessment (z-scores vs
+    the agent's own baseline + absolute floors); the Φ path — fed by an
+    ethical-drift vector that is itself ~70%+ server-computed — is telemetry.
+    Pre-warmup (behavioral confidence < 0.3) the verdict falls back to the Φ
+    cold-start prior. The decomposition lets a reader see *what* drove the
+    verdict and how much of it is self-attested vs measured (dogfood
+    2026-06-13, P0; driver-accuracy correction 2026-06-28). All inputs here
+    are already computed elsewhere in the result; this only re-exposes them
+    grouped by provenance.
     """
-    self_reported: Dict = {
-        "provenance": "self_attested",
+    # Determine the ACTUAL verdict driver instead of hardcoding "self_reported".
+    # Mirrors resolve_verdict_risk (governance_monitor.py): with Φ telemetry
+    # (default) the warm behavioral verdict is authoritative; otherwise Φ floors;
+    # pre-warmup the verdict is the Φ cold-start prior.
+    from config.governance_config import (
+        GovernanceConfig as _GovConfig,
+        phi_telemetry_only as _phi_telemetry_only,
+    )
+
+    _behavioral_verdict = getattr(behavioral_assessment, "verdict", None)
+    _behavioral_warm = (
+        _GovConfig.BEHAVIORAL_VERDICT_ENABLED
+        and _behavioral_verdict is not None
+        and behavioral_confidence is not None
+        and behavioral_confidence >= 0.3
+    )
+    if _behavioral_warm and _phi_telemetry_only():
+        primary_driver = "behavioral_assessment"
+    elif _behavioral_warm:
+        primary_driver = "phi_floor"
+    else:
+        primary_driver = "phi_cold_start"
+
+    phi_drift: Dict = {
+        "provenance": "computed",
         "description": (
-            "Magnitude of the caller-supplied ethical_drift vector — the "
-            "dominant input to the phi-based risk score. Reported by the agent, "
-            "not independently verified."
+            "Norm of the ethical-drift vector that feeds the Φ telemetry. It is "
+            ">=70% server-derived (coherence deviation, complexity divergence, "
+            "calibration error, decision-consistency); the agent's self-reported "
+            "ethical_drift is blended at a capped 30% and only when nonzero — a "
+            "[0,0,0] report contributes nothing. Φ is telemetry by default, so "
+            "this drives the live verdict only pre-warmup (the cold-start prior)."
         ),
         "ethical_drift_norm": (
             float(drift_vector.norm)
@@ -140,12 +169,14 @@ def _build_risk_attribution(
         "provenance": "measured",
         "description": (
             "Per-agent behavioral EISV assessment (EMA z-scores vs this agent's "
-            "own baseline, plus tool-outcome signals) — the least self-attested "
-            "input. It IS combined into the verdict once the behavioral state is "
-            "warm (confidence >= 0.3): the enforcement pair takes the more-severe "
-            "verdict and the max risk, so it can escalate but not erase Φ. Before "
-            "warmup it is telemetry-only. A stronger verification/adversarial "
-            "weighting (the real fix for drift-discriminability) is reserved for v2."
+            "own baseline + absolute floors, plus tool-outcome signals) — the "
+            "least self-attested input. With Φ demoted to telemetry (default "
+            "UNITARES_PHI_TELEMETRY_ONLY=1), once warm (confidence >= 0.3) this IS "
+            "the verdict: it replaces the Φ floor and can de-escalate it. Before "
+            "warmup it is telemetry-only and the verdict falls back to the Φ "
+            "cold-start prior. (Under the non-default phi_telemetry=False it is "
+            "escalate-only and cannot lower a worse Φ.) Stronger "
+            "verification/adversarial weighting is reserved for v2."
         ),
         "risk": (
             float(behavioral_assessment.risk)
@@ -159,22 +190,34 @@ def _build_risk_attribution(
         ),
     }
 
+    if primary_driver == "behavioral_assessment":
+        note = (
+            "This verdict is the independent behavioral assessment (EMA residuals "
+            "vs this agent's own baseline + absolute floors). Φ and your reported "
+            "ethical_drift are telemetry here, not the driver."
+        )
+    elif primary_driver == "phi_floor":
+        note = (
+            "Behavioral is warm but Φ-telemetry is disabled (non-default): the "
+            "verdict is the more-severe of Φ and behavioral, with Φ flooring — "
+            "behavioral can escalate but not lower a worse Φ."
+        )
+    else:
+        note = (
+            "Behavioral baseline not yet warm (confidence < 0.3): the verdict uses "
+            "the Φ cold-start prior, computed mostly from server-derived signals "
+            "(complexity divergence, coherence, calibration). Your self-reported "
+            "ethical_drift contributes a capped <=30% blend only when nonzero; the "
+            "independent behavioral signal is not yet weighted."
+        )
+
     attribution = {
         "risk_score": metrics.get("risk_score"),
         "verdict": metrics.get("verdict"),
-        "primary_driver": "self_reported",
-        "note": (
-            "At current maturity this verdict is driven primarily by signals you "
-            "reported (ethical_drift, complexity, confidence). An agent that "
-            "under-reports ethical_drift lowers Φ-based risk regardless of its "
-            "actual behavior. The per-agent behavioral signal is the least "
-            "self-attested input; once warm (confidence >= 0.3) it is combined "
-            "into the verdict and can escalate it (more-severe verdict, max risk), "
-            "but it cannot lower a worse Φ and is not yet the primary driver — "
-            "stronger verification-weighted behavioral scoring is reserved for v2."
-        ),
+        "primary_driver": primary_driver,
+        "note": note,
         "sources": {
-            "self_reported": self_reported,
+            "phi_drift": phi_drift,
             "derived": derived,
             "behavioral": behavioral,
         },
@@ -206,7 +249,8 @@ def _build_risk_attribution(
                 "baseline-deviation terms that are ~0 during bootstrap and does "
                 "not track absolute drift magnitude. Treat risk_score (and any "
                 "margin-to-PAUSE derived from it) as non-discriminative until "
-                "baselined; rely on the reported ethical_drift norm directly."
+                "baselined; rely on the ethical_drift norm in sources.phi_drift "
+                "directly."
             ),
         }
 
@@ -307,6 +351,7 @@ def build_result(
         monitor._last_continuity_metrics,
         behavioral_assessment,
         baseline_status=_baseline_status,
+        behavioral_confidence=getattr(_beh, 'confidence', None),
     )
 
     if task_type_adjustment:

--- a/tests/test_governance_monitor.py
+++ b/tests/test_governance_monitor.py
@@ -1153,18 +1153,23 @@ class TestMakeDecision:
         assert decision['action'] == 'pause'
         assert decision['critical'] is not None
 
-    def test_high_risk_guidance_states_self_reported_provenance(self, monitor):
-        """Dogfood 2026-06-13 P0: guidance must not claim the system
-        "detected high ethical risk" — the verdict is driven by self-reported
-        signals, not an independent measurement. The copy must say so."""
+    def test_high_risk_guidance_states_honest_provenance(self, monitor):
+        """Dogfood 2026-06-13 P0 + driver-accuracy correction 2026-06-28:
+        guidance must not overclaim ("detected high ethical risk"), and must not
+        re-assert the stale "self-attested, not an independent measurement" copy
+        — post-warmup the verdict IS the independent behavioral assessment. The
+        regime-aware copy points to risk_attribution for the exact driver."""
         decision = monitor.make_decision(0.8, unitares_verdict='high-risk')
         guidance = decision['guidance'].lower()
         # The overclaiming copy is gone...
         assert 'detected high ethical risk' not in guidance
         assert 'protecting you' not in guidance
-        # ...replaced with honest provenance.
+        # ...and so is the stale blanket "not an independent measurement" claim.
+        assert 'not an independent measurement' not in guidance
+        # ...replaced with regime-aware honest provenance that defers to the
+        # risk_attribution decomposition.
+        assert 'risk_attribution' in guidance
         assert 'reported' in guidance
-        assert 'self-attested' in guidance
 
     def test_caution_verdict_low_risk(self, monitor):
         """Caution verdict with low risk should proceed."""

--- a/tests/test_monitor_result_novelty.py
+++ b/tests/test_monitor_result_novelty.py
@@ -174,10 +174,10 @@ def test_build_result_exposes_policy_and_unapplied_enforcement_layers():
 
 
 def test_risk_attribution_decomposes_by_provenance():
-    """Dogfood 2026-06-13 P0: the verdict is self-attested, not measured.
-    The result must expose WHAT drove the risk, grouped by provenance, so a
-    reader sees that risk is driven by self-reported ethical_drift while the
-    only non-self-attested signal (behavioral) is shown for comparison."""
+    """Dogfood 2026-06-13 P0 + driver-accuracy correction 2026-06-28: the result
+    must expose WHAT drove the risk, grouped by provenance. The Φ-drift norm is
+    a COMPUTED quantity (not labeled self-attested), and the driver is reported
+    honestly: cold-start (no warm behavioral signal) → the Φ cold-start prior."""
     from src.monitor_result import _build_risk_attribution
 
     drift = SimpleNamespace(norm=0.84)
@@ -185,17 +185,18 @@ def test_risk_attribution_decomposes_by_provenance():
     behavioral = SimpleNamespace(risk=0.006, verdict="safe")
     metrics = {"risk_score": 0.72, "verdict": "high-risk"}
 
+    # No behavioral_confidence passed → sub-warmup → Φ cold-start prior.
     attr = _build_risk_attribution(metrics, drift, cm, behavioral)
 
     assert attr["risk_score"] == 0.72
     assert attr["verdict"] == "high-risk"
-    assert attr["primary_driver"] == "self_reported"
-    assert attr["sources"]["self_reported"]["provenance"] == "self_attested"
-    assert attr["sources"]["self_reported"]["ethical_drift_norm"] == pytest.approx(0.84)
+    assert attr["primary_driver"] == "phi_cold_start"
+    # The drift norm is computed, not mislabeled self-attested.
+    assert attr["sources"]["phi_drift"]["provenance"] == "computed"
+    assert attr["sources"]["phi_drift"]["ethical_drift_norm"] == pytest.approx(0.84)
     assert attr["sources"]["derived"]["provenance"] == "derived"
     assert attr["sources"]["derived"]["complexity_divergence"] == pytest.approx(0.55)
-    # The non-self-attested signal is labeled "measured" and surfaced even
-    # though it disagrees with the self-reported verdict (0.006 vs high-risk).
+    # The least-self-attested signal is labeled "measured" and surfaced.
     assert attr["sources"]["behavioral"]["provenance"] == "measured"
     assert attr["sources"]["behavioral"]["risk"] == pytest.approx(0.006)
     assert attr["sources"]["behavioral"]["verdict"] == "safe"
@@ -209,7 +210,7 @@ def test_risk_attribution_handles_missing_signals():
     attr = _build_risk_attribution(
         {"risk_score": 0.26, "verdict": "safe"}, None, None, None
     )
-    assert attr["sources"]["self_reported"]["ethical_drift_norm"] is None
+    assert attr["sources"]["phi_drift"]["ethical_drift_norm"] is None
     assert attr["sources"]["derived"]["complexity_divergence"] is None
     assert attr["sources"]["behavioral"]["risk"] is None
     assert attr["sources"]["behavioral"]["verdict"] is None
@@ -285,7 +286,7 @@ def test_build_result_includes_risk_attribution():
     )
 
     assert "risk_attribution" in result
-    assert result["risk_attribution"]["sources"]["self_reported"]["ethical_drift_norm"] == pytest.approx(0.9)
+    assert result["risk_attribution"]["sources"]["phi_drift"]["ethical_drift_norm"] == pytest.approx(0.9)
     assert result["risk_attribution"]["sources"]["behavioral"]["risk"] == pytest.approx(0.006)
 
 

--- a/tests/test_risk_discriminability.py
+++ b/tests/test_risk_discriminability.py
@@ -38,3 +38,43 @@ def test_baselined_clears_caveat():
     assert disc["non_discriminative"] is False
     assert disc["updates_until_baseline"] == 0
     assert disc["note"] is None
+
+
+# --- primary_driver accuracy (correction 2026-06-28) -------------------------
+# The verdict driver must reflect the actual posture, not a hardcoded
+# "self_reported". With Φ telemetry (default UNITARES_PHI_TELEMETRY_ONLY=1) a
+# warm behavioral verdict is authoritative; cold-start falls back to the Φ prior.
+
+class _StubAssessment:
+    def __init__(self, verdict="safe", risk=0.1):
+        self.verdict = verdict
+        self.risk = risk
+
+
+def test_cold_start_driver_is_phi_not_self_reported(monkeypatch):
+    monkeypatch.setenv("UNITARES_PHI_TELEMETRY_ONLY", "1")
+    # No behavioral assessment / sub-warmup confidence → Φ cold-start prior.
+    attr = _build_risk_attribution(_metrics(), None, None, None, behavioral_confidence=0.1)
+    assert attr["primary_driver"] == "phi_cold_start"
+    # The legacy mislabel must be gone.
+    assert attr["primary_driver"] != "self_reported"
+    assert "self_reported" not in attr["sources"]
+    assert "phi_drift" in attr["sources"]
+
+
+def test_warm_driver_is_behavioral_under_phi_telemetry(monkeypatch):
+    monkeypatch.setenv("UNITARES_PHI_TELEMETRY_ONLY", "1")
+    attr = _build_risk_attribution(
+        _metrics(), None, None, _StubAssessment(verdict="high-risk", risk=0.8),
+        behavioral_confidence=0.5,
+    )
+    assert attr["primary_driver"] == "behavioral_assessment"
+
+
+def test_warm_driver_is_phi_floor_when_telemetry_off(monkeypatch):
+    monkeypatch.setenv("UNITARES_PHI_TELEMETRY_ONLY", "0")
+    attr = _build_risk_attribution(
+        _metrics(), None, None, _StubAssessment(verdict="caution", risk=0.5),
+        behavioral_confidence=0.5,
+    )
+    assert attr["primary_driver"] == "phi_floor"


### PR DESCRIPTION
Part 2 of 2 (code). Companion docs PR: #1222.

## Why
The in-band `risk_attribution` block self-described the verdict as **self-report-driven**, but that posture was superseded when Φ was demoted to telemetry-only (**default** `UNITARES_PHI_TELEMETRY_ONLY=1`). The strings were never updated — so the live API advertised the governance as *more self-reported / less independent than it actually runs*. (Surfaced by the operator's honesty-framing review.)

## What (verified against source)
- **`primary_driver` is computed, not hardcoded.** `behavioral_assessment` when the behavioral verdict is warm (confidence ≥ 0.3) under Φ-telemetry (default); `phi_floor` when telemetry is off (non-default); `phi_cold_start` pre-warmup. Mirrors `resolve_verdict_risk` (`governance_monitor.py:63-64`).
- **Drift norm relabeled** `sources.self_reported` → `sources.phi_drift` (provenance `computed`): ≥70% server-derived (`ethical_drift.py:301-389`); self-report is a capped ≤30% nonzero-gated blend (`monitor_drift.py:102-113`); `[0,0,0]` contributes nothing.
- **Behavioral source description** drops the stale "escalate but not erase Φ / not yet the primary driver" (non-default posture) and states the telemetry-default authority.
- **`monitor_decision` high-risk guidance** replaces "reflects what you reported, not an independent measurement" with regime-aware copy that defers to `risk_attribution`.
- `build_result` passes `behavioral_confidence` so the driver resolves.

## Contract change
`risk_attribution.sources.self_reported` → `sources.phi_drift`. Only consumer was a test (updated); no dashboard consumer found.

## Tests
Focused suites green — **488 tests** across the touched area (`test_risk_discriminability`, `test_monitor_result_novelty`, `test_governance_monitor`, `test_enrichments_mirror`, `test_response_formatter`, `test_monitor_decision_fast_trip`, `test_ethical_drift_signals`, `test_continuity_layer`); new `primary_driver` coverage (cold-start / warm-telemetry / phi-floor).

## Note on the full-suite run
A concurrent session was active in the same working tree during my full `test-cache` run (branch switched under me, master advanced, unrelated files appeared mid-run). One doc-contract test (`test_eisv_semantic_contract.py::test_landing_docs_link_the_proprioception_contract`) failed once in that run but **passes in isolation** — attributable to the concurrent activity / test-order, not to this change, which touches none of the docs it reads. CI on this branch is the clean gate.

Companion docs PR #1222 corrects the docs that inherited the framing.