### PR TITLE
feat(sdk): governed file-write consumer (LeasePlaneClient.propose_file_write)

### DIFF
--- a/agents/sdk/src/unitares_sdk/lease_plane/client.py
+++ b/agents/sdk/src/unitares_sdk/lease_plane/client.py
@@ -14,6 +14,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+import uuid
 from collections import deque
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
@@ -319,6 +320,53 @@ class LeasePlaneClient:
     def handoff_accept(self, request: HandoffAcceptRequest) -> SimpleResult:
         payload = self._request_json("POST", "/v1/lease/handoff/accept", request.model_dump(mode="json", exclude_none=True))
         return _parse_simple(payload)
+
+    def propose_file_write(
+        self,
+        *,
+        path: str,
+        content: str,
+        proposer_uuid: str,
+        continuity_token: str,
+        session_id: str,
+        ttl_s: int = 300,
+        idempotency_key: str | None = None,
+        encoding: str | None = None,
+    ) -> Mapping[str, Any]:
+        """Propose a governed ``file_write`` effect on the lease plane.
+
+        Instead of writing the file directly, the caller asks the plane to do
+        it under governance: the plane acquires the ``file://`` surface lease,
+        re-checks the §6 veto on the commit path, captures a rollback pre-image,
+        commits the bytes, and records a durable ``effect_id``. This is the
+        consumer side of governed file writes — a write that is audited,
+        rollback-tracked, and lease-coordinated rather than ad-hoc.
+
+        ``proposer_uuid``/``continuity_token`` are the caller's governance
+        identity (from ``onboard``); they are forwarded to the §6 veto and never
+        persisted. Returns the raw ``/v1/effects`` envelope: ``{"ok": true,
+        "effect_id": ..., "custody_mode": "execute", "result": {...}}`` on
+        success, or an error envelope (e.g. ``proposer_invalid`` 422,
+        ``governance_blocked`` 403, ``not_implemented`` 501 when the server
+        flags are off). The bytes are committed only on ``ok: true``.
+        """
+        fs_path = path[len("file://") :] if path.startswith("file://") else path
+        surface = f"file://{fs_path}"
+        payload: dict[str, Any] = {"path": fs_path, "content": content}
+        if encoding:
+            payload["encoding"] = encoding
+
+        body = {
+            "effect_type": "file_write",
+            "custody_mode": "execute",
+            "surface": surface,
+            "required_leases": [{"surface": surface, "ttl_s": ttl_s}],
+            "payload": payload,
+            "proposer": {"agent_uuid": proposer_uuid, "continuity_token": continuity_token},
+            "provenance": {"session_id": session_id},
+            "idempotency_key": idempotency_key or f"fw-{uuid.uuid4().hex}",
+        }
+        return self._request_json("POST", "/v1/effects", body)
 
     def health_check(self, *, timeout_s: float | None = None) -> HealthResult:
         """Liveness probe against the BEAM lease-plane (Wave 2 Phase C).

--- a/agents/sdk/tests/test_governed_file_write.py
+++ b/agents/sdk/tests/test_governed_file_write.py
@@ -1,0 +1,107 @@
+"""Tests for LeasePlaneClient.propose_file_write — the consumer side of governed
+file writes (route a write through the plane instead of writing directly)."""
+
+from __future__ import annotations
+
+from unitares_sdk.lease_plane.client import LeasePlaneClient, LeasePlaneClientConfig
+
+
+def _client(fake_transport):
+    return LeasePlaneClient(
+        LeasePlaneClientConfig(bearer_token="tok"), transport=fake_transport
+    )
+
+
+def test_propose_file_write_builds_the_governed_envelope():
+    captured: dict = {}
+
+    def fake_transport(request):
+        captured["req"] = request
+        return {
+            "ok": True,
+            "effect_id": "e-1",
+            "custody_mode": "execute",
+            "result": {"bytes_written": 3},
+            "protocol_version": "v1.0",
+        }
+
+    resp = _client(fake_transport).propose_file_write(
+        path="/tmp/governed.txt",
+        content="abc",
+        proposer_uuid="11111111-1111-1111-1111-111111111111",
+        continuity_token="ctok",
+        session_id="sess-1",
+        ttl_s=300,
+        idempotency_key="idem-1",
+    )
+
+    assert resp["ok"] is True
+    assert resp["effect_id"] == "e-1"
+
+    req = captured["req"]
+    assert req.method == "POST"
+    assert req.url.endswith("/v1/effects")
+    assert req.headers["Authorization"] == "Bearer tok"
+
+    body = req.json_body
+    assert body["effect_type"] == "file_write"
+    assert body["custody_mode"] == "execute"
+    assert body["surface"] == "file:///tmp/governed.txt"
+    assert body["required_leases"] == [
+        {"surface": "file:///tmp/governed.txt", "ttl_s": 300}
+    ]
+    assert body["payload"] == {"path": "/tmp/governed.txt", "content": "abc"}
+    # proposer identity is nested (matches the server's validate(); a flat
+    # proposer_agent_uuid would arrive as nil and crash before the veto).
+    assert body["proposer"] == {
+        "agent_uuid": "11111111-1111-1111-1111-111111111111",
+        "continuity_token": "ctok",
+    }
+    assert body["provenance"] == {"session_id": "sess-1"}
+    assert body["idempotency_key"] == "idem-1"
+
+
+def test_propose_file_write_strips_file_scheme_and_autogenerates_idempotency():
+    captured: dict = {}
+
+    def fake_transport(request):
+        captured["req"] = request
+        return {"ok": True, "effect_id": "e", "protocol_version": "v1.0"}
+
+    _client(fake_transport).propose_file_write(
+        path="file:///tmp/x",
+        content="y",
+        proposer_uuid="u",
+        continuity_token="c",
+        session_id="s",
+        encoding="base64",
+    )
+
+    body = captured["req"].json_body
+    # the scheme is stripped for the filesystem path but kept for the surface
+    assert body["payload"]["path"] == "/tmp/x"
+    assert body["payload"]["encoding"] == "base64"
+    assert body["surface"] == "file:///tmp/x"
+    # no idempotency_key supplied -> a stable-prefixed one is generated
+    assert body["idempotency_key"].startswith("fw-")
+
+
+def test_propose_file_write_surfaces_server_error_envelope():
+    def fake_transport(request):
+        return {
+            "ok": False,
+            "error": "governance_blocked",
+            "reason": "vetoed",
+            "protocol_version": "v1.0",
+        }
+
+    resp = _client(fake_transport).propose_file_write(
+        path="/tmp/x",
+        content="y",
+        proposer_uuid="u",
+        continuity_token="c",
+        session_id="s",
+    )
+    # the caller can see the governance verdict; nothing was committed
+    assert resp["ok"] is False
+    assert resp["error"] == "governance_blocked"


### PR DESCRIPTION
The **consumer side** of governed `file_write` — the first real way for fleet code to *use* the standing-live capability instead of writing files directly. This is the adoption play: the capability was supply with no demand until something routes its writes through the plane.

## What it does
`LeasePlaneClient.propose_file_write(path, content, proposer_uuid, continuity_token, session_id, ...)` routes a write through governance: the plane acquires the `file://` surface lease, the §6 veto runs on the commit path, a rollback pre-image is captured, the bytes commit, and a durable `effect_id` returns. The write is now **audited, rollback-tracked, and lease-coordinated** rather than ad-hoc.

## Why here
It lives on `LeasePlaneClient` (the existing `:8788` transport with the bearer + `_request_json`) because `/v1/effects` is the same boundary. It takes the caller's governance identity (`proposer_uuid` + `continuity_token` from `onboard`) and **nests it under `proposer`** exactly as the server's `validate()` expects — a flat field would arrive `nil` and be rejected before the veto. Returns the raw `/v1/effects` envelope; bytes commit only on `ok: true`.

## Verification
- **Live end-to-end** against the standing-live plane: a real governed commit (`ok=true`, `effect_id`, `bytes_written`) with the file written **by the plane**.
- Tests (3): envelope shape, `file://` scheme stripping + auto idempotency-key, server-error surfacing.

## Next (operator's pick)
Wiring a specific standing fleet writer (e.g. a resident agent's state file) to call this instead of `open(...).write` — that's a coupling decision (the writer gains a dependency on the plane), so it's surfaced rather than assumed.

Draft — consumer of an RCE-class surface; maintainer is the merge gate.