### PR TITLE
feat(effects): effect-binding grant primitive — mint/verify (#1075 Phase 1, slice 1, INERT)

### DIFF
--- a/src/effect_grant.py
+++ b/src/effect_grant.py
@@ -1,0 +1,229 @@
+"""Effect-binding grant primitive (governed-effect Phase 1 — content-binding).
+
+Design: docs/proposals/governed-effect-effect-binding-v0.md (#1075).
+
+This is the **Option B** primitive: a server-minted, short-TTL, single-use
+grant that binds an authorization to an effect's *content*, so a captured
+forwarded credential cannot be retargeted to a different effect (T1) or
+replayed (T2, against a grant-only attacker). It does NOT close T3 (a
+bearer+token holder still authors freely) — see the design's threat model.
+
+What this module is / is NOT
+----------------------------
+- It is the **crypto primitive only**: mint + verify of the
+  ``gnt.v1.<payload_b64>.<sig_b64>`` envelope. It is single-sourced and
+  unit-tested here, and (this slice) wired into NOTHING — no endpoint mints
+  it, no veto path verifies it. It is inert until a later wiring slice.
+- ``verify_effect_grant`` does **not** consume the nonce. Single-use
+  enforcement is the *store's* job at wire-time (an atomic
+  ``INSERT ... ON CONFLICT DO NOTHING`` against ``consumed_nonces``); verify
+  returns the nonce so the caller can consume it atomically in the same
+  transaction as the veto. Putting consumption here would create a
+  SELECT-then-INSERT TOCTOU.
+
+Crypto stance (be honest — this is NOT the AIC)
+-----------------------------------------------
+The grant is a **symmetric HMAC** minted with the same fleet-wide secret as
+the ``continuity_token`` (``_get_continuity_secret``). It is *issuer-
+verifiable-only and copyable* — the exact property the AIC
+(``agent_identity_credential.py``) was written to escape. It is justified not
+by principled pedigree but by **thin authority**: a captured grant authorizes
+*one* effect, *once*, for *seconds*, content-bound. The asymmetric upgrade
+(Ed25519, per-agent enrolled key) is the design's Phase 2, not this.
+
+Domain separation
+------------------
+The signature covers the domain-separated bytes ``gnt.v1.<payload_b64>``
+(prefix included), mirroring the AIC's anti-confusion discipline. So even
+though the grant shares the HMAC secret with the ``v1.`` continuity_token, a
+grant and a token with identical payload bytes produce *different* signatures
+and can never be cross-verified against each other.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import secrets
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+# Single source for the HMAC secret — the design's "the secret it already
+# holds". Domain separation (the gnt.v1. prefix in the signed bytes) keeps
+# grants and continuity_tokens non-cross-verifiable despite the shared secret.
+from src.mcp_handlers.identity.session import _get_continuity_secret
+
+EFFECT_GRANT_VERSION = "gnt.v1"
+
+# Phase 1 grants are effect-freshness, not identity-rebind: seconds, not the
+# token's ~1h. A captured grant should be useless almost immediately.
+_DEFAULT_GRANT_TTL_SECONDS = 30
+_MIN_GRANT_TTL_SECONDS = 5
+
+
+def _b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode().rstrip("=")
+
+
+def _b64url_decode(data: str) -> bytes:
+    padding = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + padding)
+
+
+def _signing_input(payload_b64: str) -> bytes:
+    """Domain-separated bytes the HMAC covers: 'gnt.v1.<payload_b64>'.
+
+    Including the version prefix is what makes a grant non-cross-verifiable
+    against a same-secret continuity_token (whose signing input is the bare
+    payload_b64).
+    """
+    return f"{EFFECT_GRANT_VERSION}.{payload_b64}".encode()
+
+
+@dataclass(frozen=True)
+class EffectGrantVerification:
+    """Result of verify_effect_grant. Fail-closed: ok is False on any doubt.
+
+    ``nonce`` and ``exp`` are populated on a signature-valid grant (even one
+    that then fails a field/freshness check) so a caller can log them; act on
+    them only when ``ok`` is True. ``nonce`` is what the caller must atomically
+    consume at the store to enforce single-use.
+    """
+
+    ok: bool
+    reason: str
+    nonce: Optional[str] = None
+    exp: Optional[int] = None
+
+
+def mint_effect_grant(
+    *,
+    aid: str,
+    payload_sha256: str,
+    surface: str,
+    custody_mode: str,
+    idempotency_key: str,
+    ttl_seconds: int = _DEFAULT_GRANT_TTL_SECONDS,
+    nonce: Optional[str] = None,
+    _now: Optional[int] = None,
+) -> Optional[str]:
+    """Mint a single-use, content-bound effect grant.
+
+    The bound tuple (design §5) is
+    ``(aid, payload_sha256, surface, custody_mode, idempotency_key, nonce, exp)``
+    — note ``effect_id`` is deliberately absent (server-assigned after propose;
+    not the T1 anchor — content is). All fields are inside the signed payload,
+    so tampering any one breaks the HMAC.
+
+    Returns the ``gnt.v1.<payload_b64>.<sig_b64>`` string, or None if no secret
+    is configured (caller must treat None as fail-closed, never as "skip").
+    """
+    secret = _get_continuity_secret()
+    if not secret:
+        return None
+    if not (aid and payload_sha256 and surface and custody_mode and idempotency_key):
+        return None
+
+    now = int(time.time()) if _now is None else int(_now)
+    ttl = max(_MIN_GRANT_TTL_SECONDS, int(ttl_seconds))
+    grant_nonce = nonce or secrets.token_urlsafe(16)
+
+    payload = {
+        "v": 1,
+        "aid": str(aid),
+        "psha": str(payload_sha256),
+        "surf": str(surface),
+        "cust": str(custody_mode),
+        "idem": str(idempotency_key),
+        "nonce": grant_nonce,
+        "iat": now,
+        "exp": now + ttl,
+    }
+    payload_json = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+    payload_b64 = _b64url_encode(payload_json)
+    sig = hmac.new(secret, _signing_input(payload_b64), hashlib.sha256).digest()
+    return f"{EFFECT_GRANT_VERSION}.{payload_b64}.{_b64url_encode(sig)}"
+
+
+def verify_effect_grant(
+    grant: Optional[str],
+    *,
+    aid: str,
+    payload_sha256: str,
+    surface: str,
+    custody_mode: str,
+    idempotency_key: str,
+    _now: Optional[int] = None,
+) -> EffectGrantVerification:
+    """Verify a grant covers *exactly* the effect being cleared. Fail-closed.
+
+    Checks, in order, all required to pass:
+      1. parses as ``gnt.v1.<payload_b64>.<sig_b64>``;
+      2. HMAC over the domain-separated signing input matches (constant-time);
+      3. not expired (``exp`` vs now) — effect-freshness;
+      4. every bound field equals the caller's *expected* value taken from the
+         live envelope: ``aid`` (identity), ``psha`` (T1 content anchor),
+         ``surf``/``cust`` (content identity), ``idem`` (audit-trail binding).
+
+    Does NOT consume the nonce — returns it for the caller to consume atomically
+    at the store. A True ``ok`` means "this grant authorizes this exact effect";
+    single-use is still owed by the caller.
+    """
+    if not grant or not isinstance(grant, str):
+        return EffectGrantVerification(False, "grant_absent")
+    secret = _get_continuity_secret()
+    if not secret:
+        return EffectGrantVerification(False, "no_secret")
+
+    # The version token (gnt.v1) itself contains a dot, so parse the prefix
+    # literally rather than splitting on "." (payload_b64/sig_b64 are
+    # base64url and carry no dots). Mirrors the aic.v2. envelope discipline.
+    prefix = EFFECT_GRANT_VERSION + "."
+    if not grant.startswith(prefix):
+        return EffectGrantVerification(False, "wrong_version")
+    try:
+        payload_b64, sig_b64 = grant[len(prefix):].split(".", 1)
+    except ValueError:
+        return EffectGrantVerification(False, "malformed")
+
+    expected_sig = _b64url_encode(
+        hmac.new(secret, _signing_input(payload_b64), hashlib.sha256).digest()
+    )
+    if not hmac.compare_digest(expected_sig, sig_b64):
+        return EffectGrantVerification(False, "bad_signature")
+
+    try:
+        payload = json.loads(_b64url_decode(payload_b64).decode())
+        if not isinstance(payload, dict):
+            return EffectGrantVerification(False, "bad_payload")
+    except Exception:
+        return EffectGrantVerification(False, "bad_payload")
+
+    nonce = payload.get("nonce")
+    exp = payload.get("exp")
+    try:
+        exp_int = int(exp)
+    except (TypeError, ValueError):
+        return EffectGrantVerification(False, "bad_exp", nonce=nonce)
+
+    now = int(time.time()) if _now is None else int(_now)
+    if now >= exp_int:
+        return EffectGrantVerification(False, "expired", nonce=nonce, exp=exp_int)
+
+    # Field binding — each mismatch means the grant authorizes a *different*
+    # effect (or proposer, or key) than the one being cleared. T1 lives here.
+    expected = {
+        "aid": str(aid),
+        "psha": str(payload_sha256),
+        "surf": str(surface),
+        "cust": str(custody_mode),
+        "idem": str(idempotency_key),
+    }
+    for field, want in expected.items():
+        if str(payload.get(field)) != want:
+            return EffectGrantVerification(False, f"mismatch_{field}", nonce=nonce, exp=exp_int)
+
+    return EffectGrantVerification(True, "ok", nonce=nonce, exp=exp_int)

--- a/tests/test_effect_grant.py
+++ b/tests/test_effect_grant.py
@@ -1,0 +1,188 @@
+"""Unit tests for the effect-binding grant primitive (#1075 Phase 1, slice 1).
+
+Covers the threat-relevant properties the design (§3/§5) hangs on:
+  - round-trip mint -> verify for the exact effect (allow path);
+  - T1 retarget: a grant for one payload/surface/custody must not verify for
+    another;
+  - identity + idempotency binding (aid / idem mismatch -> fail);
+  - freshness (expired -> fail) — the basis for the seconds-TTL replay shrink;
+  - tamper resistance (mutated sig/payload -> fail);
+  - domain separation: a continuity_token shape and the grant cannot
+    cross-verify even under the shared secret;
+  - fail-closed when no secret is configured;
+  - the nonce is returned for the caller to consume (verify never consumes).
+
+The module is inert (wired into nothing); these tests are its whole contract.
+"""
+
+import importlib
+
+import pytest
+
+import src.effect_grant as eg
+
+
+_SECRET = b"test-fleet-secret-effect-grant"
+
+_FIELDS = dict(
+    aid="11111111-2222-3333-4444-555555555555",
+    payload_sha256="a" * 64,
+    surface="file://sandbox/x",
+    custody_mode="execute",
+    idempotency_key="idem-key-001",
+)
+
+
+@pytest.fixture(autouse=True)
+def _secret(monkeypatch):
+    """Pin a deterministic HMAC secret for every test."""
+    monkeypatch.setattr(eg, "_get_continuity_secret", lambda: _SECRET)
+
+
+def _mint(**overrides):
+    args = dict(_FIELDS)
+    args.update(overrides)
+    return eg.mint_effect_grant(**args)
+
+
+def _verify(grant, **overrides):
+    args = dict(_FIELDS)
+    args.update(overrides)
+    return eg.verify_effect_grant(grant, **args)
+
+
+# ── allow path ──────────────────────────────────────────────────────────────
+
+def test_roundtrip_allows_exact_effect():
+    grant = _mint()
+    assert grant and grant.startswith("gnt.v1.")
+    v = _verify(grant)
+    assert v.ok is True
+    assert v.reason == "ok"
+    assert v.nonce  # returned for the caller to consume
+    assert isinstance(v.exp, int)
+
+
+def test_each_mint_has_a_unique_nonce():
+    a = eg.verify_effect_grant(_mint(), **_FIELDS)
+    b = eg.verify_effect_grant(_mint(), **_FIELDS)
+    assert a.nonce and b.nonce and a.nonce != b.nonce
+
+
+# ── T1: retarget must fail (content anchor) ─────────────────────────────────
+
+@pytest.mark.parametrize("field,bad", [
+    ("payload_sha256", "b" * 64),
+    ("surface", "file://sandbox/OTHER"),
+    ("custody_mode", "record_only"),
+])
+def test_retarget_to_different_content_fails(field, bad):
+    grant = _mint()
+    v = _verify(grant, **{field: bad})
+    assert v.ok is False
+    assert v.reason.startswith("mismatch_")
+
+
+# ── identity + idempotency binding ──────────────────────────────────────────
+
+def test_mismatched_aid_fails():
+    grant = _mint()
+    v = _verify(grant, aid="99999999-0000-0000-0000-000000000000")
+    assert v.ok is False and v.reason == "mismatch_aid"
+
+
+def test_mismatched_idempotency_key_fails():
+    grant = _mint()
+    v = _verify(grant, idempotency_key="idem-key-ATTACKER")
+    assert v.ok is False and v.reason == "mismatch_idem"
+
+
+# ── freshness (the seconds-TTL replay shrink) ───────────────────────────────
+
+def test_expired_grant_fails():
+    grant = eg.mint_effect_grant(ttl_seconds=5, _now=1_000_000, **_FIELDS)
+    # verify well after exp
+    v = eg.verify_effect_grant(grant, _now=1_000_100, **_FIELDS)
+    assert v.ok is False and v.reason == "expired"
+
+
+def test_ttl_floor_enforced():
+    # ttl below the floor is clamped up, not honored as-is
+    grant = eg.mint_effect_grant(ttl_seconds=0, _now=1_000_000, **_FIELDS)
+    v = eg.verify_effect_grant(grant, _now=1_000_003, **_FIELDS)  # within floor
+    assert v.ok is True
+
+
+# ── tamper resistance ───────────────────────────────────────────────────────
+
+def test_tampered_signature_fails():
+    grant = _mint()
+    version, payload_b64, sig_b64 = grant.split(".", 2)
+    flipped = sig_b64[:-2] + ("AA" if not sig_b64.endswith("AA") else "BB")
+    v = _verify(f"{version}.{payload_b64}.{flipped}")
+    assert v.ok is False and v.reason == "bad_signature"
+
+
+def _split_grant(grant):
+    """Parse gnt.v1.<payload>.<sig> (the version token itself has a dot)."""
+    prefix = eg.EFFECT_GRANT_VERSION + "."
+    assert grant.startswith(prefix)
+    payload_b64, sig_b64 = grant[len(prefix):].split(".", 1)
+    return prefix, payload_b64, sig_b64
+
+
+def test_tampered_payload_fails():
+    prefix, _, sig_b64 = _split_grant(_mint())
+    _, other_payload_b64, _ = _split_grant(_mint(payload_sha256="b" * 64))
+    # swap in a different payload, keep the old signature -> HMAC mismatch
+    v = _verify(f"{prefix}{other_payload_b64}.{sig_b64}")
+    assert v.ok is False and v.reason == "bad_signature"
+
+
+@pytest.mark.parametrize("bad", ["", "not-a-grant", "gnt.v1.onlytwo", "v1.x.y"])
+def test_malformed_or_wrong_version_fails(bad):
+    v = _verify(bad)
+    assert v.ok is False
+    assert v.reason in ("grant_absent", "malformed", "wrong_version")
+
+
+# ── domain separation vs continuity_token ───────────────────────────────────
+
+def test_grant_does_not_cross_verify_as_continuity_token():
+    """A grant signs over 'gnt.v1.<payload>'; the continuity_token signs over
+    the bare '<payload>'. Even sharing the secret, the grant's sig must not
+    validate under the token's signing input."""
+    import hmac as _hmac
+    import hashlib as _hashlib
+
+    grant = _mint()
+    _, payload_b64, sig_b64 = grant.split(".", 2)
+    token_style_sig = eg._b64url_encode(
+        _hmac.new(_SECRET, payload_b64.encode(), _hashlib.sha256).digest()
+    )
+    assert token_style_sig != sig_b64  # prefix domain-separation holds
+
+
+def test_continuity_token_shape_is_rejected():
+    # a v1. token presented to the grant verifier fails on version, not by
+    # accident of signature
+    v = _verify("v1.eyJ2IjoxfQ.sig")
+    assert v.ok is False and v.reason == "wrong_version"
+
+
+# ── fail-closed on missing secret ───────────────────────────────────────────
+
+def test_mint_returns_none_without_secret(monkeypatch):
+    monkeypatch.setattr(eg, "_get_continuity_secret", lambda: None)
+    assert eg.mint_effect_grant(**_FIELDS) is None
+
+
+def test_verify_fails_closed_without_secret(monkeypatch):
+    grant = _mint()
+    monkeypatch.setattr(eg, "_get_continuity_secret", lambda: None)
+    v = eg.verify_effect_grant(grant, **_FIELDS)
+    assert v.ok is False and v.reason == "no_secret"
+
+
+def test_module_imports_clean():
+    importlib.reload(eg)


### PR DESCRIPTION
First slice of effect-binding **Phase 1** (content-binding) from the design doc (#1228 / `governed-effect-effect-binding-v0.md`). **Crypto primitive only — wired into nothing, inert until a later wiring slice.** Same dry-run-first, slice-by-slice discipline as the §5b/§6/§7 line.

## What ships
`src/effect_grant.py` — `mint_effect_grant` / `verify_effect_grant`:
- **`gnt.v1.<payload_b64>.<sig_b64>`** envelope, HMAC-SHA256 over the *domain-separated* signing input `gnt.v1.<payload_b64>` using the existing continuity secret. Domain separation ⇒ a grant and a same-secret `continuity_token` can **never** cross-verify (mirrors the `aic.v2.` discipline).
- Binds the design's **single authoritative tuple** `(aid, payload_sha256, surface, custody_mode, idempotency_key, nonce, exp)`. `effect_id` deliberately excluded (server-assigned after propose; content is the T1 anchor, not the handle).
- **Fail-closed** (any doubt → `ok=False` + reason); **does NOT consume the nonce** — single-use is the store's job at wire-time (atomic `INSERT ... ON CONFLICT`), so verify returns the nonce rather than introduce a SELECT-then-INSERT TOCTOU.

## Honest stance
Symmetric HMAC — **issuer-verifiable, copyable; NOT the AIC.** Justified by *thin authority* (one effect, once, seconds, content-bound). The asymmetric per-agent upgrade is **Phase 2**, not this.

## Closes / doesn't
This primitive is the basis for **T1 (retarget) closure + replay-window shrink**. It does **not** close T3 (a bearer+token holder still authors freely) — see the design's threat model.

## Verification
20 unit tests — allow path; T1 retarget (payload/surface/custody mismatch); aid + idempotency_key binding; freshness/expiry + TTL floor; tamper resistance; domain separation vs `continuity_token`; fail-closed on missing secret. Full gate **11129 passed / 22 skipped**, ruff clean, **confirmed imported by nothing in `src/`**.

## Next slices (not in this PR)
2) `consumed_nonces` table + propose-time grant-mint endpoint (gov-mcp), behind a flag. 3) lease-plane carry/forward + `binding_ok` at `/v1/effect-veto`. 4) wire + flag-flip (operator, dry-run-first). All fail-closed.

Design: #1228. Issue: #1075.

https://claude.ai/code/session_01RPGYhmjDU7uqjmA7vanh41