### PR TITLE
Fix AI-facing response mode aliases

### DIFF
--- a/src/mcp_handlers/response_formatter.py
+++ b/src/mcp_handlers/response_formatter.py
@@ -94,12 +94,17 @@ def _copy_passthrough_fields(response_data: dict, result: dict, fields: tuple) -
             result[field] = value
 
 
-def _coerce_response_mode(value: Any) -> str:
+def canonical_response_mode(value: Any) -> str:
     """Return the canonical spelling for one response mode value."""
     mode = str(value or "auto").strip().lower()
     if not mode:
         mode = "auto"
     return _RESPONSE_MODE_ALIASES.get(mode, mode)
+
+
+def _coerce_response_mode(value: Any) -> str:
+    """Compatibility wrapper for older tests/internal imports."""
+    return canonical_response_mode(value)
 
 
 def _auto_response_mode(response_data: dict) -> str:
@@ -138,7 +143,7 @@ def _auto_response_mode(response_data: dict) -> str:
 
 def _resolve_response_mode(raw_mode: Any, response_data: dict) -> str:
     """Normalize aliases and resolve auto into the actual response shape."""
-    mode = _coerce_response_mode(raw_mode)
+    mode = canonical_response_mode(raw_mode)
     if mode == "auto":
         return _auto_response_mode(response_data)
     if mode in _SUPPORTED_RESPONSE_MODES:
@@ -275,7 +280,7 @@ def format_response(
 
 def _format_standard(response_data: dict, task_type: str, saved_trust_tier: Any = None) -> dict:
     """Build standard (interpreted) response."""
-    from governance_state import GovernanceState
+    from src.governance_state import GovernanceState
     from governance_core import State, Theta, DEFAULT_THETA
 
     metrics = response_data.get("metrics", {}) if isinstance(response_data.get("metrics"), dict) else {}

--- a/src/mcp_handlers/updates/pipeline.py
+++ b/src/mcp_handlers/updates/pipeline.py
@@ -14,10 +14,12 @@ Usage:
 """
 
 import inspect
+import os
 import time
 from typing import Callable, List, NamedTuple
 
 from src.logging_utils import get_logger
+from src.mcp_handlers.response_formatter import canonical_response_mode
 
 logger = get_logger(__name__)
 
@@ -31,6 +33,29 @@ class _EnrichmentEntry(NamedTuple):
 
 
 _ENRICHMENTS: List[_EnrichmentEntry] = []
+
+
+def _requested_response_mode(ctx) -> str:
+    """Return the canonical caller-requested mode before response data exists.
+
+    This mirrors the formatter's request priority for the one mode that matters
+    before formatting: legacy `minimal`, whose response-shaping enrichments can
+    be skipped safely. `auto` cannot be resolved until response_data exists, so
+    it stays `auto` here and runs all enrichments.
+    """
+    arguments = getattr(ctx, "arguments", None) or {}
+    raw_mode = arguments.get("response_mode")
+
+    if not raw_mode:
+        meta = getattr(ctx, "meta", None)
+        preferences = getattr(meta, "preferences", None)
+        if isinstance(preferences, dict):
+            raw_mode = preferences.get("verbosity")
+
+    if not raw_mode:
+        raw_mode = os.getenv("UNITARES_PROCESS_UPDATE_RESPONSE_MODE", "auto")
+
+    return canonical_response_mode(raw_mode)
 
 
 def enrichment(order: int, *, lite_safe: bool = False):
@@ -63,7 +88,7 @@ async def run_enrichment_pipeline(ctx) -> None:
     runs serially today; this instrumentation is the prerequisite for
     deciding which enrichments are safe to parallelize.
     """
-    is_minimal = (getattr(ctx, "arguments", None) or {}).get("response_mode") == "minimal"
+    is_minimal = _requested_response_mode(ctx) == "minimal"
     timings: List[tuple[str, int]] = []
     for entry in _ENRICHMENTS:
         if is_minimal and entry.lite_safe:

--- a/tests/test_enrichment_pipeline.py
+++ b/tests/test_enrichment_pipeline.py
@@ -1,7 +1,7 @@
 """Tests for the enrichment pipeline registry and runner."""
 
 import asyncio
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -175,6 +175,105 @@ class TestLiteModeSkipping:
         try:
             ctx = MagicMock()
             ctx.arguments = {"response_mode": "minimal"}
+            await run_enrichment_pipeline(ctx)
+            assert call_log == ["cheap"]
+        finally:
+            _ENRICHMENTS.clear()
+            _ENRICHMENTS.extend(original)
+
+    @pytest.mark.asyncio
+    async def test_lite_alias_runs_lite_safe_enrichments(self):
+        """response_mode='lite' is compact, not the legacy skinny path."""
+        from src.mcp_handlers.updates.pipeline import (
+            _EnrichmentEntry,
+            _ENRICHMENTS,
+        )
+
+        call_log = []
+
+        def heavy(ctx):
+            call_log.append("heavy")
+
+        def cheap(ctx):
+            call_log.append("cheap")
+
+        original = list(_ENRICHMENTS)
+        _ENRICHMENTS.clear()
+        _ENRICHMENTS.extend([
+            _EnrichmentEntry(fn=cheap, order=1, name="cheap", is_async=False, lite_safe=False),
+            _EnrichmentEntry(fn=heavy, order=2, name="heavy", is_async=False, lite_safe=True),
+        ])
+
+        try:
+            ctx = MagicMock()
+            ctx.arguments = {"response_mode": "lite"}
+            await run_enrichment_pipeline(ctx)
+            assert call_log == ["cheap", "heavy"]
+        finally:
+            _ENRICHMENTS.clear()
+            _ENRICHMENTS.extend(original)
+
+    @pytest.mark.asyncio
+    async def test_lite_safe_skipped_when_env_default_is_minimal(self):
+        """The skinny path also applies when minimal is selected by default."""
+        from src.mcp_handlers.updates.pipeline import (
+            _EnrichmentEntry,
+            _ENRICHMENTS,
+        )
+
+        call_log = []
+
+        def heavy(ctx):
+            call_log.append("heavy")
+
+        def cheap(ctx):
+            call_log.append("cheap")
+
+        original = list(_ENRICHMENTS)
+        _ENRICHMENTS.clear()
+        _ENRICHMENTS.extend([
+            _EnrichmentEntry(fn=cheap, order=1, name="cheap", is_async=False, lite_safe=False),
+            _EnrichmentEntry(fn=heavy, order=2, name="heavy", is_async=False, lite_safe=True),
+        ])
+
+        try:
+            ctx = MagicMock()
+            ctx.arguments = {}
+            with patch.dict("os.environ", {"UNITARES_PROCESS_UPDATE_RESPONSE_MODE": "minimal"}):
+                await run_enrichment_pipeline(ctx)
+            assert call_log == ["cheap"]
+        finally:
+            _ENRICHMENTS.clear()
+            _ENRICHMENTS.extend(original)
+
+    @pytest.mark.asyncio
+    async def test_lite_safe_skipped_when_agent_prefers_minimal(self):
+        """Agent verbosity preferences use the same canonical response contract."""
+        from src.mcp_handlers.updates.pipeline import (
+            _EnrichmentEntry,
+            _ENRICHMENTS,
+        )
+
+        call_log = []
+
+        def heavy(ctx):
+            call_log.append("heavy")
+
+        def cheap(ctx):
+            call_log.append("cheap")
+
+        original = list(_ENRICHMENTS)
+        _ENRICHMENTS.clear()
+        _ENRICHMENTS.extend([
+            _EnrichmentEntry(fn=cheap, order=1, name="cheap", is_async=False, lite_safe=False),
+            _EnrichmentEntry(fn=heavy, order=2, name="heavy", is_async=False, lite_safe=True),
+        ])
+
+        try:
+            ctx = MagicMock()
+            ctx.arguments = {}
+            ctx.meta = MagicMock()
+            ctx.meta.preferences = {"verbosity": "minimal"}
             await run_enrichment_pipeline(ctx)
             assert call_log == ["cheap"]
         finally:

--- a/tests/test_response_formatter.py
+++ b/tests/test_response_formatter.py
@@ -426,6 +426,13 @@ class TestFormatResponse:
         result = format_response(data, {"response_mode": "verbose"})
         assert set(result.keys()) == original_keys
 
+    def test_interpreted_alias_for_standard_uses_real_import(self):
+        data = _sample_response()
+        result = format_response(data, {"response_mode": "interpreted"})
+        assert result["_mode"] == "standard"
+        assert "state" in result
+        assert result["decision"] == "continue"
+
     def test_auto_mode_healthy_becomes_compact_for_disembodied(self):
         data = _sample_response()
         data["health_status"] = "healthy"
@@ -1118,20 +1125,6 @@ class TestEmitMirrorSignalRecords:
 # Task 2: prediction_id + warnings pass-through (spec §6 + §2)
 # ============================================================================
 
-def _make_governance_state_mocks():
-    """Create sys.modules stubs for governance_state + governance_core."""
-    mock_gs_instance = MagicMock()
-    mock_gs_instance.interpret_state.return_value = {"summary": "mocked"}
-    mock_gs_module = MagicMock()
-    mock_gs_module.GovernanceState = MagicMock(return_value=mock_gs_instance)
-
-    mock_core_module = MagicMock()
-    mock_core_module.State = MagicMock()
-    mock_core_module.Theta = MagicMock()
-    mock_core_module.DEFAULT_THETA = MagicMock()
-    return mock_gs_module, mock_core_module
-
-
 def _policy_enforcement_fields():
     return {
         "policy_evaluation": {
@@ -1150,22 +1143,14 @@ def _policy_enforcement_fields():
 class TestFormatStandardPreservesPredictionId:
     """_format_standard must pass prediction_id and warnings through (spec §6 + §2).
 
-    _format_standard does local imports (from governance_state import ...) so we
-    must inject into sys.modules. Same strategy as other tests in this suite that
-    call format_response with auto→standard routing (those mock _format_standard
-    wholesale; we mock the deps so we can actually exercise the body).
+    Exercise the real local imports so the legacy `standard` / `interpreted`
+    path cannot regress to a missing top-level module.
     """
 
     def _call_format_standard(self, response_data):
-        """Call _format_standard with all required module-level deps mocked."""
-        import sys
+        """Call _format_standard with the real local modules."""
         from src.mcp_handlers.response_formatter import _format_standard
-        gs_mock, core_mock = _make_governance_state_mocks()
-        with patch.dict(sys.modules, {
-            "governance_state": gs_mock,
-            "governance_core": core_mock,
-        }):
-            return _format_standard(response_data, task_type="general")
+        return _format_standard(response_data, task_type="general")
 
     def test_prediction_id_passes_through(self):
         response_data = {


### PR DESCRIPTION
## Summary
- make process_agent_update response_mode alias canonicalization reusable
- fix legacy standard/interpreted mode by importing src.governance_state correctly
- make minimal-mode enrichment skipping honor env/default and agent preferences while keeping lite as compact

## Tests
- python3 -m pytest tests/test_response_formatter.py tests/test_pydantic_schemas.py tests/test_enrichment_pipeline.py tests/test_response_base.py tests/test_identity_payloads.py -q
- python3 -m pytest tests/test_response_formatter.py tests/test_enrichment_pipeline.py -q
- ./scripts/dev/test-cache.sh (rebased tree: 11113 passed, 22 skipped, coverage 81.87%)
- pre-push smoke hook (138 passed, 10350 deselected)