### PR TITLE
feat(effects): /v1/effect-grant propose-time mint endpoint (#1075 Phase 1, slice 2, INERT)

### DIFF
--- a/src/effect_grant.py
+++ b/src/effect_grant.py
@@ -1,0 +1,229 @@
+"""Effect-binding grant primitive (governed-effect Phase 1 — content-binding).
+
+Design: docs/proposals/governed-effect-effect-binding-v0.md (#1075).
+
+This is the **Option B** primitive: a server-minted, short-TTL, single-use
+grant that binds an authorization to an effect's *content*, so a captured
+forwarded credential cannot be retargeted to a different effect (T1) or
+replayed (T2, against a grant-only attacker). It does NOT close T3 (a
+bearer+token holder still authors freely) — see the design's threat model.
+
+What this module is / is NOT
+----------------------------
+- It is the **crypto primitive only**: mint + verify of the
+  ``gnt.v1.<payload_b64>.<sig_b64>`` envelope. It is single-sourced and
+  unit-tested here, and (this slice) wired into NOTHING — no endpoint mints
+  it, no veto path verifies it. It is inert until a later wiring slice.
+- ``verify_effect_grant`` does **not** consume the nonce. Single-use
+  enforcement is the *store's* job at wire-time (an atomic
+  ``INSERT ... ON CONFLICT DO NOTHING`` against ``consumed_nonces``); verify
+  returns the nonce so the caller can consume it atomically in the same
+  transaction as the veto. Putting consumption here would create a
+  SELECT-then-INSERT TOCTOU.
+
+Crypto stance (be honest — this is NOT the AIC)
+-----------------------------------------------
+The grant is a **symmetric HMAC** minted with the same fleet-wide secret as
+the ``continuity_token`` (``_get_continuity_secret``). It is *issuer-
+verifiable-only and copyable* — the exact property the AIC
+(``agent_identity_credential.py``) was written to escape. It is justified not
+by principled pedigree but by **thin authority**: a captured grant authorizes
+*one* effect, *once*, for *seconds*, content-bound. The asymmetric upgrade
+(Ed25519, per-agent enrolled key) is the design's Phase 2, not this.
+
+Domain separation
+------------------
+The signature covers the domain-separated bytes ``gnt.v1.<payload_b64>``
+(prefix included), mirroring the AIC's anti-confusion discipline. So even
+though the grant shares the HMAC secret with the ``v1.`` continuity_token, a
+grant and a token with identical payload bytes produce *different* signatures
+and can never be cross-verified against each other.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import secrets
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+# Single source for the HMAC secret — the design's "the secret it already
+# holds". Domain separation (the gnt.v1. prefix in the signed bytes) keeps
+# grants and continuity_tokens non-cross-verifiable despite the shared secret.
+from src.mcp_handlers.identity.session import _get_continuity_secret
+
+EFFECT_GRANT_VERSION = "gnt.v1"
+
+# Phase 1 grants are effect-freshness, not identity-rebind: seconds, not the
+# token's ~1h. A captured grant should be useless almost immediately.
+_DEFAULT_GRANT_TTL_SECONDS = 30
+_MIN_GRANT_TTL_SECONDS = 5
+
+
+def _b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode().rstrip("=")
+
+
+def _b64url_decode(data: str) -> bytes:
+    padding = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + padding)
+
+
+def _signing_input(payload_b64: str) -> bytes:
+    """Domain-separated bytes the HMAC covers: 'gnt.v1.<payload_b64>'.
+
+    Including the version prefix is what makes a grant non-cross-verifiable
+    against a same-secret continuity_token (whose signing input is the bare
+    payload_b64).
+    """
+    return f"{EFFECT_GRANT_VERSION}.{payload_b64}".encode()
+
+
+@dataclass(frozen=True)
+class EffectGrantVerification:
+    """Result of verify_effect_grant. Fail-closed: ok is False on any doubt.
+
+    ``nonce`` and ``exp`` are populated on a signature-valid grant (even one
+    that then fails a field/freshness check) so a caller can log them; act on
+    them only when ``ok`` is True. ``nonce`` is what the caller must atomically
+    consume at the store to enforce single-use.
+    """
+
+    ok: bool
+    reason: str
+    nonce: Optional[str] = None
+    exp: Optional[int] = None
+
+
+def mint_effect_grant(
+    *,
+    aid: str,
+    payload_sha256: str,
+    surface: str,
+    custody_mode: str,
+    idempotency_key: str,
+    ttl_seconds: int = _DEFAULT_GRANT_TTL_SECONDS,
+    nonce: Optional[str] = None,
+    _now: Optional[int] = None,
+) -> Optional[str]:
+    """Mint a single-use, content-bound effect grant.
+
+    The bound tuple (design §5) is
+    ``(aid, payload_sha256, surface, custody_mode, idempotency_key, nonce, exp)``
+    — note ``effect_id`` is deliberately absent (server-assigned after propose;
+    not the T1 anchor — content is). All fields are inside the signed payload,
+    so tampering any one breaks the HMAC.
+
+    Returns the ``gnt.v1.<payload_b64>.<sig_b64>`` string, or None if no secret
+    is configured (caller must treat None as fail-closed, never as "skip").
+    """
+    secret = _get_continuity_secret()
+    if not secret:
+        return None
+    if not (aid and payload_sha256 and surface and custody_mode and idempotency_key):
+        return None
+
+    now = int(time.time()) if _now is None else int(_now)
+    ttl = max(_MIN_GRANT_TTL_SECONDS, int(ttl_seconds))
+    grant_nonce = nonce or secrets.token_urlsafe(16)
+
+    payload = {
+        "v": 1,
+        "aid": str(aid),
+        "psha": str(payload_sha256),
+        "surf": str(surface),
+        "cust": str(custody_mode),
+        "idem": str(idempotency_key),
+        "nonce": grant_nonce,
+        "iat": now,
+        "exp": now + ttl,
+    }
+    payload_json = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+    payload_b64 = _b64url_encode(payload_json)
+    sig = hmac.new(secret, _signing_input(payload_b64), hashlib.sha256).digest()
+    return f"{EFFECT_GRANT_VERSION}.{payload_b64}.{_b64url_encode(sig)}"
+
+
+def verify_effect_grant(
+    grant: Optional[str],
+    *,
+    aid: str,
+    payload_sha256: str,
+    surface: str,
+    custody_mode: str,
+    idempotency_key: str,
+    _now: Optional[int] = None,
+) -> EffectGrantVerification:
+    """Verify a grant covers *exactly* the effect being cleared. Fail-closed.
+
+    Checks, in order, all required to pass:
+      1. parses as ``gnt.v1.<payload_b64>.<sig_b64>``;
+      2. HMAC over the domain-separated signing input matches (constant-time);
+      3. not expired (``exp`` vs now) — effect-freshness;
+      4. every bound field equals the caller's *expected* value taken from the
+         live envelope: ``aid`` (identity), ``psha`` (T1 content anchor),
+         ``surf``/``cust`` (content identity), ``idem`` (audit-trail binding).
+
+    Does NOT consume the nonce — returns it for the caller to consume atomically
+    at the store. A True ``ok`` means "this grant authorizes this exact effect";
+    single-use is still owed by the caller.
+    """
+    if not grant or not isinstance(grant, str):
+        return EffectGrantVerification(False, "grant_absent")
+    secret = _get_continuity_secret()
+    if not secret:
+        return EffectGrantVerification(False, "no_secret")
+
+    # The version token (gnt.v1) itself contains a dot, so parse the prefix
+    # literally rather than splitting on "." (payload_b64/sig_b64 are
+    # base64url and carry no dots). Mirrors the aic.v2. envelope discipline.
+    prefix = EFFECT_GRANT_VERSION + "."
+    if not grant.startswith(prefix):
+        return EffectGrantVerification(False, "wrong_version")
+    try:
+        payload_b64, sig_b64 = grant[len(prefix):].split(".", 1)
+    except ValueError:
+        return EffectGrantVerification(False, "malformed")
+
+    expected_sig = _b64url_encode(
+        hmac.new(secret, _signing_input(payload_b64), hashlib.sha256).digest()
+    )
+    if not hmac.compare_digest(expected_sig, sig_b64):
+        return EffectGrantVerification(False, "bad_signature")
+
+    try:
+        payload = json.loads(_b64url_decode(payload_b64).decode())
+        if not isinstance(payload, dict):
+            return EffectGrantVerification(False, "bad_payload")
+    except Exception:
+        return EffectGrantVerification(False, "bad_payload")
+
+    nonce = payload.get("nonce")
+    exp = payload.get("exp")
+    try:
+        exp_int = int(exp)
+    except (TypeError, ValueError):
+        return EffectGrantVerification(False, "bad_exp", nonce=nonce)
+
+    now = int(time.time()) if _now is None else int(_now)
+    if now >= exp_int:
+        return EffectGrantVerification(False, "expired", nonce=nonce, exp=exp_int)
+
+    # Field binding — each mismatch means the grant authorizes a *different*
+    # effect (or proposer, or key) than the one being cleared. T1 lives here.
+    expected = {
+        "aid": str(aid),
+        "psha": str(payload_sha256),
+        "surf": str(surface),
+        "cust": str(custody_mode),
+        "idem": str(idempotency_key),
+    }
+    for field, want in expected.items():
+        if str(payload.get(field)) != want:
+            return EffectGrantVerification(False, f"mismatch_{field}", nonce=nonce, exp=exp_int)
+
+    return EffectGrantVerification(True, "ok", nonce=nonce, exp=exp_int)

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -693,6 +693,111 @@ async def http_call_tool(request):
         }, status_code=500)
 
 
+async def http_effect_grant(request):
+    """POST /v1/effect-grant — mint a single-use, content-bound effect grant.
+
+    Phase 1 of effect-binding (governed-effect-effect-binding-v0 §4-B / #1075).
+    A proposer calls this BEFORE submitting an effect to the lease plane: it
+    presents its continuity_token plus the effect's content fields; gov-mcp
+    re-certifies the token to ``strong`` (the §7 path) and, if strong, mints a
+    ``gnt.v1`` grant bound to (aid, payload_sha256, surface, custody_mode,
+    idempotency_key, nonce, exp). The proposer then carries the grant in the
+    effect envelope's ``proposer`` object; the lease plane forwards it to
+    ``/v1/effect-veto``, which verifies it covers THIS exact effect (a later
+    slice).
+
+    Closes T1 (retarget) + the grant-only slice of T2 (replay) — NOT T3 (a
+    bearer+token holder can still mint grants for effects it authors). See the
+    design's threat model.
+
+    INERT by default: gated on ``UNITARES_GOVERNED_EFFECT_BINDING``; off → 501.
+    Nothing forwards or verifies the grant yet (wiring is a later slice).
+
+    Request:  ``{"proposer_agent_uuid", "proposer_continuity_token",
+                 "payload_sha256", "surface", "custody_mode",
+                 "idempotency_key", "ttl_seconds"?}``
+    Response: ``{"ok": true, "grant": "gnt.v1...."}`` — the grant is issued TO
+              the caller (like onboard's continuity_token); never logged.
+    """
+    http_api_token = os.getenv("UNITARES_HTTP_API_TOKEN")
+    if not _check_http_auth(request, http_api_token=http_api_token):
+        return JSONResponse({"ok": False, "error": "unauthorized"}, status_code=401)
+
+    # Inert unless explicitly enabled. Fail-closed: off → not implemented, so a
+    # premature caller is refused rather than silently issued a grant nothing
+    # verifies yet.
+    if not _http_bool(os.getenv("UNITARES_GOVERNED_EFFECT_BINDING")):
+        return JSONResponse(
+            {"ok": False, "error": "binding_not_enabled",
+             "detail": "effect-binding grant minting is disabled (Phase 1, inert)"},
+            status_code=501,
+        )
+
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    if not isinstance(body, dict):
+        body = {}
+
+    proposer = body.get("proposer_agent_uuid") or body.get("agent_id")
+    fields = {
+        "proposer_agent_uuid": proposer,
+        "payload_sha256": body.get("payload_sha256"),
+        "surface": body.get("surface"),
+        "custody_mode": body.get("custody_mode"),
+        "idempotency_key": body.get("idempotency_key"),
+    }
+    missing = [k for k, v in fields.items() if not (isinstance(v, str) and v)]
+    if missing:
+        return JSONResponse(
+            {"ok": False, "error": "schema_invalid",
+             "detail": f"required string fields missing: {', '.join(missing)}"},
+            status_code=422,
+        )
+
+    # A grant is only minted for a proposer that re-certifies as a STRONG
+    # identity — the same §7 gate the veto enforces (the grant asserts
+    # aid=proposer). Fail-closed: no/invalid/expired/mismatched token → no
+    # grant. The token is consumed for verification only, never logged.
+    from src.mcp_handlers.identity.session import recertify_strong_tier
+    if not recertify_strong_tier(body.get("proposer_continuity_token"), proposer):
+        return JSONResponse(
+            {"ok": False, "error": "tier_recert_failed",
+             "detail": "proposer did not re-certify as a strong identity"},
+            status_code=403,
+        )
+
+    # Optional caller TTL; the primitive clamps to its floor. Default applies if
+    # absent or unparseable.
+    mint_kwargs = {}
+    ttl_raw = body.get("ttl_seconds")
+    if ttl_raw is not None:
+        try:
+            mint_kwargs["ttl_seconds"] = int(ttl_raw)
+        except (TypeError, ValueError):
+            pass
+
+    from src.effect_grant import mint_effect_grant
+    grant = mint_effect_grant(
+        aid=proposer,
+        payload_sha256=fields["payload_sha256"],
+        surface=fields["surface"],
+        custody_mode=fields["custody_mode"],
+        idempotency_key=fields["idempotency_key"],
+        **mint_kwargs,
+    )
+    if not grant:
+        # No HMAC secret configured — cannot mint. Fail closed.
+        return JSONResponse(
+            {"ok": False, "error": "grant_mint_unavailable",
+             "detail": "no signing secret configured"},
+            status_code=503,
+        )
+
+    return JSONResponse({"ok": True, "grant": grant})
+
+
 async def http_effect_veto(request):
     """POST /v1/effect-veto — governance veto for a proposed governed effect.
 
@@ -3304,6 +3409,7 @@ def register_http_routes(
     app.routes.append(Route("/", http_dashboard_redesign, methods=["GET"]))  # Root also serves the redesign
     app.routes.append(Route("/v1/tools", http_list_tools, methods=["GET"]))
     app.routes.append(Route("/v1/tools/call", http_call_tool, methods=["POST"]))
+    app.routes.append(Route("/v1/effect-grant", http_effect_grant, methods=["POST"]))
     app.routes.append(Route("/v1/effect-veto", http_effect_veto, methods=["POST"]))
     app.routes.append(Route("/health", http_health, methods=["GET"]))
     app.routes.append(Route("/health/live", http_health_live, methods=["GET"]))

--- a/tests/test_effect_grant.py
+++ b/tests/test_effect_grant.py
@@ -1,0 +1,188 @@
+"""Unit tests for the effect-binding grant primitive (#1075 Phase 1, slice 1).
+
+Covers the threat-relevant properties the design (§3/§5) hangs on:
+  - round-trip mint -> verify for the exact effect (allow path);
+  - T1 retarget: a grant for one payload/surface/custody must not verify for
+    another;
+  - identity + idempotency binding (aid / idem mismatch -> fail);
+  - freshness (expired -> fail) — the basis for the seconds-TTL replay shrink;
+  - tamper resistance (mutated sig/payload -> fail);
+  - domain separation: a continuity_token shape and the grant cannot
+    cross-verify even under the shared secret;
+  - fail-closed when no secret is configured;
+  - the nonce is returned for the caller to consume (verify never consumes).
+
+The module is inert (wired into nothing); these tests are its whole contract.
+"""
+
+import importlib
+
+import pytest
+
+import src.effect_grant as eg
+
+
+_SECRET = b"test-fleet-secret-effect-grant"
+
+_FIELDS = dict(
+    aid="11111111-2222-3333-4444-555555555555",
+    payload_sha256="a" * 64,
+    surface="file://sandbox/x",
+    custody_mode="execute",
+    idempotency_key="idem-key-001",
+)
+
+
+@pytest.fixture(autouse=True)
+def _secret(monkeypatch):
+    """Pin a deterministic HMAC secret for every test."""
+    monkeypatch.setattr(eg, "_get_continuity_secret", lambda: _SECRET)
+
+
+def _mint(**overrides):
+    args = dict(_FIELDS)
+    args.update(overrides)
+    return eg.mint_effect_grant(**args)
+
+
+def _verify(grant, **overrides):
+    args = dict(_FIELDS)
+    args.update(overrides)
+    return eg.verify_effect_grant(grant, **args)
+
+
+# ── allow path ──────────────────────────────────────────────────────────────
+
+def test_roundtrip_allows_exact_effect():
+    grant = _mint()
+    assert grant and grant.startswith("gnt.v1.")
+    v = _verify(grant)
+    assert v.ok is True
+    assert v.reason == "ok"
+    assert v.nonce  # returned for the caller to consume
+    assert isinstance(v.exp, int)
+
+
+def test_each_mint_has_a_unique_nonce():
+    a = eg.verify_effect_grant(_mint(), **_FIELDS)
+    b = eg.verify_effect_grant(_mint(), **_FIELDS)
+    assert a.nonce and b.nonce and a.nonce != b.nonce
+
+
+# ── T1: retarget must fail (content anchor) ─────────────────────────────────
+
+@pytest.mark.parametrize("field,bad", [
+    ("payload_sha256", "b" * 64),
+    ("surface", "file://sandbox/OTHER"),
+    ("custody_mode", "record_only"),
+])
+def test_retarget_to_different_content_fails(field, bad):
+    grant = _mint()
+    v = _verify(grant, **{field: bad})
+    assert v.ok is False
+    assert v.reason.startswith("mismatch_")
+
+
+# ── identity + idempotency binding ──────────────────────────────────────────
+
+def test_mismatched_aid_fails():
+    grant = _mint()
+    v = _verify(grant, aid="99999999-0000-0000-0000-000000000000")
+    assert v.ok is False and v.reason == "mismatch_aid"
+
+
+def test_mismatched_idempotency_key_fails():
+    grant = _mint()
+    v = _verify(grant, idempotency_key="idem-key-ATTACKER")
+    assert v.ok is False and v.reason == "mismatch_idem"
+
+
+# ── freshness (the seconds-TTL replay shrink) ───────────────────────────────
+
+def test_expired_grant_fails():
+    grant = eg.mint_effect_grant(ttl_seconds=5, _now=1_000_000, **_FIELDS)
+    # verify well after exp
+    v = eg.verify_effect_grant(grant, _now=1_000_100, **_FIELDS)
+    assert v.ok is False and v.reason == "expired"
+
+
+def test_ttl_floor_enforced():
+    # ttl below the floor is clamped up, not honored as-is
+    grant = eg.mint_effect_grant(ttl_seconds=0, _now=1_000_000, **_FIELDS)
+    v = eg.verify_effect_grant(grant, _now=1_000_003, **_FIELDS)  # within floor
+    assert v.ok is True
+
+
+# ── tamper resistance ───────────────────────────────────────────────────────
+
+def test_tampered_signature_fails():
+    grant = _mint()
+    version, payload_b64, sig_b64 = grant.split(".", 2)
+    flipped = sig_b64[:-2] + ("AA" if not sig_b64.endswith("AA") else "BB")
+    v = _verify(f"{version}.{payload_b64}.{flipped}")
+    assert v.ok is False and v.reason == "bad_signature"
+
+
+def _split_grant(grant):
+    """Parse gnt.v1.<payload>.<sig> (the version token itself has a dot)."""
+    prefix = eg.EFFECT_GRANT_VERSION + "."
+    assert grant.startswith(prefix)
+    payload_b64, sig_b64 = grant[len(prefix):].split(".", 1)
+    return prefix, payload_b64, sig_b64
+
+
+def test_tampered_payload_fails():
+    prefix, _, sig_b64 = _split_grant(_mint())
+    _, other_payload_b64, _ = _split_grant(_mint(payload_sha256="b" * 64))
+    # swap in a different payload, keep the old signature -> HMAC mismatch
+    v = _verify(f"{prefix}{other_payload_b64}.{sig_b64}")
+    assert v.ok is False and v.reason == "bad_signature"
+
+
+@pytest.mark.parametrize("bad", ["", "not-a-grant", "gnt.v1.onlytwo", "v1.x.y"])
+def test_malformed_or_wrong_version_fails(bad):
+    v = _verify(bad)
+    assert v.ok is False
+    assert v.reason in ("grant_absent", "malformed", "wrong_version")
+
+
+# ── domain separation vs continuity_token ───────────────────────────────────
+
+def test_grant_does_not_cross_verify_as_continuity_token():
+    """A grant signs over 'gnt.v1.<payload>'; the continuity_token signs over
+    the bare '<payload>'. Even sharing the secret, the grant's sig must not
+    validate under the token's signing input."""
+    import hmac as _hmac
+    import hashlib as _hashlib
+
+    grant = _mint()
+    _, payload_b64, sig_b64 = grant.split(".", 2)
+    token_style_sig = eg._b64url_encode(
+        _hmac.new(_SECRET, payload_b64.encode(), _hashlib.sha256).digest()
+    )
+    assert token_style_sig != sig_b64  # prefix domain-separation holds
+
+
+def test_continuity_token_shape_is_rejected():
+    # a v1. token presented to the grant verifier fails on version, not by
+    # accident of signature
+    v = _verify("v1.eyJ2IjoxfQ.sig")
+    assert v.ok is False and v.reason == "wrong_version"
+
+
+# ── fail-closed on missing secret ───────────────────────────────────────────
+
+def test_mint_returns_none_without_secret(monkeypatch):
+    monkeypatch.setattr(eg, "_get_continuity_secret", lambda: None)
+    assert eg.mint_effect_grant(**_FIELDS) is None
+
+
+def test_verify_fails_closed_without_secret(monkeypatch):
+    grant = _mint()
+    monkeypatch.setattr(eg, "_get_continuity_secret", lambda: None)
+    v = eg.verify_effect_grant(grant, **_FIELDS)
+    assert v.ok is False and v.reason == "no_secret"
+
+
+def test_module_imports_clean():
+    importlib.reload(eg)

--- a/tests/test_http_api_effect_grant.py
+++ b/tests/test_http_api_effect_grant.py
@@ -1,0 +1,151 @@
+"""Proof-tests for POST /v1/effect-grant (effect-binding Phase 1 mint endpoint).
+
+The endpoint mints a single-use, content-bound grant ONLY for a proposer that
+re-certifies as a `strong` identity (the §7 gate), and ONLY when the binding
+feature flag is on (inert/501 otherwise). Proven here so neither can be a silent
+no-op:
+
+  - flag OFF  → 501 (inert by default; a premature caller is refused).
+  - no/aid-mismatch token → 403 (no grant for a non-strong proposer).
+  - missing content field → 422.
+  - valid strong token + all fields → 200 with a grant that VERIFIES for that
+    exact effect (round-trip through the real primitive) and FAILS for a
+    different payload (T1 holds at the endpoint boundary).
+
+Tokens are minted with the real `create_continuity_token` under a test HMAC
+secret, so the §7 path is exercised end-to-end (real HMAC + exp).
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from src.http_api import http_effect_grant
+from src.effect_grant import verify_effect_grant
+from src.mcp_handlers.identity import session as session_mod
+
+PROPOSER = "00000000-0000-0000-0000-0000000000aa"
+OTHER_UUID = "00000000-0000-0000-0000-0000000000bb"
+TEST_SECRET = "test-continuity-secret-0123456789abcdef"
+
+_FIELDS = {
+    "payload_sha256": "a" * 64,
+    "surface": "file://sandbox/x",
+    "custody_mode": "execute",
+    "idempotency_key": "idem-key-001",
+}
+
+
+@pytest.fixture(autouse=True)
+def _env():
+    """Shared secret for mint+verify, binding flag ON, ambient bearers cleared."""
+    with patch.dict(
+        os.environ,
+        {
+            "UNITARES_CONTINUITY_TOKEN_SECRET": TEST_SECRET,
+            "UNITARES_GOVERNED_EFFECT_BINDING": "1",
+            "UNITARES_MCP_BEARER_TOKENS": "",
+            "UNITARES_HTTP_API_TOKEN": "",
+        },
+    ):
+        yield
+
+
+def _token(aid=PROPOSER):
+    return session_mod.create_continuity_token(aid, f"sid-{aid[:8]}")
+
+
+def _client():
+    app = Starlette(routes=[Route("/v1/effect-grant", http_effect_grant, methods=["POST"])])
+    return TestClient(app)
+
+
+def _post(body):
+    return _client().post("/v1/effect-grant", json=body)
+
+
+def _full_body(token="__valid__", **overrides):
+    body = {"proposer_agent_uuid": PROPOSER, **_FIELDS}
+    if token == "__valid__":
+        token = _token()
+    if token is not None:
+        body["proposer_continuity_token"] = token
+    body.update(overrides)
+    return body
+
+
+# ── inert by default ─────────────────────────────────────────────────────────
+
+def test_disabled_flag_returns_501():
+    with patch.dict(os.environ, {"UNITARES_GOVERNED_EFFECT_BINDING": "0"}):
+        r = _post(_full_body())
+    assert r.status_code == 501
+    assert r.json()["error"] == "binding_not_enabled"
+
+
+# ── §7 gate: a grant is only minted for a strong-recertified proposer ─────────
+
+def test_no_token_is_refused():
+    r = _post(_full_body(token=None))
+    assert r.status_code == 403
+    assert r.json()["error"] == "tier_recert_failed"
+
+
+def test_aid_mismatch_token_is_refused():
+    # a valid token whose aid != the claimed proposer must not yield a grant
+    r = _post(_full_body(token=_token(aid=OTHER_UUID)))
+    assert r.status_code == 403
+    assert r.json()["error"] == "tier_recert_failed"
+
+
+# ── schema ───────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("drop", ["payload_sha256", "surface", "custody_mode", "idempotency_key"])
+def test_missing_content_field_is_422(drop):
+    body = _full_body()
+    body.pop(drop)
+    r = _post(body)
+    assert r.status_code == 422
+    assert r.json()["error"] == "schema_invalid"
+    assert drop in r.json()["detail"]
+
+
+# ── allow path: minted grant verifies for THIS effect, not another (T1) ──────
+
+def test_strong_proposer_gets_a_grant_that_verifies():
+    r = _post(_full_body())
+    assert r.status_code == 200
+    grant = r.json()["grant"]
+    assert grant.startswith("gnt.v1.")
+
+    # round-trip through the real primitive: the grant authorizes exactly the
+    # effect it was minted for, bound to the proposer.
+    v = verify_effect_grant(grant, aid=PROPOSER, **_FIELDS)
+    assert v.ok is True
+    assert v.nonce
+
+    # T1 at the boundary: the same grant must NOT verify for a different payload
+    bad = verify_effect_grant(grant, aid=PROPOSER, **{**_FIELDS, "payload_sha256": "b" * 64})
+    assert bad.ok is False
+
+
+def test_custom_ttl_is_honored_within_floor():
+    r = _post(_full_body(ttl_seconds=120))
+    assert r.status_code == 200
+    grant = r.json()["grant"]
+    v = verify_effect_grant(grant, aid=PROPOSER, **_FIELDS)
+    assert v.ok is True
+
+
+# ── fail-closed when minting is impossible ───────────────────────────────────
+
+def test_mint_returning_none_is_503():
+    # valid token (so §7 passes) but the primitive can't mint → fail closed
+    with patch("src.effect_grant.mint_effect_grant", return_value=None):
+        r = _post(_full_body())
+    assert r.status_code == 503
+    assert r.json()["error"] == "grant_mint_unavailable"


### PR DESCRIPTION
Slice 2 of effect-binding **Phase 1**, **stacked on slice 1 (#1237)**. Adds the gov-mcp endpoint a proposer calls *before* submitting an effect — the mint half of the design (`governed-effect-effect-binding-v0` §4-B / #1228). **Still inert.**

> **Base is the slice-1 branch, not master** — review/merge #1237 first. (The diff shows only slice-2 files once #1237 lands.)

## What ships
`POST /v1/effect-grant` (`http_effect_grant` in `src/http_api.py`): presents `continuity_token` + content fields → re-certifies the token to `strong` (reuses `recertify_strong_tier`, the **§7** gate) → mints a `gnt.v1` grant via `mint_effect_grant` bound to `(aid, payload_sha256, surface, custody_mode, idempotency_key, nonce, exp)`.

## Inert by default — two independent reasons it cannot touch prod
1. gated on `UNITARES_GOVERNED_EFFECT_BINDING` (not in any plist → off → **501**);
2. **nothing forwards or verifies the grant yet** — the lease-plane carry/forward + the `binding_ok` check at `/v1/effect-veto` are **slice 3**. Route registered, feature off, no caller.

## Fail-closed throughout
flag off → 501 · missing content field → 422 · proposer not strong (no/invalid/expired/aid-mismatch token) → 403 (no grant) · no signing secret → 503. Token verified transiently, never logged; grant issued to the caller in the body (like onboard's continuity_token), never logged.

## Scope
Closes **T1** (retarget) + grant-only slice of **T2** (replay) once wired — **not T3** (a bearer+token holder can still mint grants for effects it authors), the documented residual.

## Verification
10 endpoint tests: flag-off 501; no/aid-mismatch token 403; missing field 422; strong proposer gets a grant that **round-trip verifies for that exact effect and fails for a different payload** (T1 at the boundary); custom TTL; mint-None 503. Full gate **11139 passed / 22 skipped**, ruff clean, confirmed off in prod + no caller.

## Remaining slices
3) `consumed_nonces` migration + lease-plane carry/forward + `binding_ok` at `/v1/effect-veto` (with atomic nonce-consume). 4) wire + flag-flip (operator, dry-run-first).

Design: #1228 · Issue: #1075 · Slice 1: #1237.

https://claude.ai/code/session_01RPGYhmjDU7uqjmA7vanh41