### PR TITLE
feat(vigil): route the watcher demotion floor through governed file_write

### DIFF
--- a/agents/vigil/agent.py
+++ b/agents/vigil/agent.py
@@ -24,6 +24,7 @@ What it does each cycle:
 """
 
 import asyncio
+import functools
 
 import json
 import os
@@ -84,13 +85,17 @@ def _last_floor_recompute_iso() -> str | None:
 
 
 def maybe_recompute_watcher_floor(
-    *, max_age_hours: float = WATCHER_FLOOR_MAX_AGE_HOURS
+    *,
+    max_age_hours: float = WATCHER_FLOOR_MAX_AGE_HOURS,
+    governed_identity: dict | None = None,
 ) -> bool:
     """Trigger a watcher floor recompute if the last one is older than
     ``max_age_hours``. Returns True if a recompute fired.
 
-    Called from Vigil's run_cycle. Atomic write means a concurrent
-    surface hook can never see a half-written file.
+    Called from Vigil's run_cycle. When ``governed_identity`` is supplied the
+    floor is persisted through a governed ``file_write`` effect (the first real
+    consumer of that surface); it falls back to the local atomic write on any
+    failure, so a concurrent surface hook never sees a half-written file.
     """
     last_iso = _last_floor_recompute_iso()
     if last_iso:
@@ -103,7 +108,7 @@ def maybe_recompute_watcher_floor(
                 return False
         except (TypeError, ValueError):
             pass  # unparseable → recompute (safer to refresh than skip)
-    recompute_floor()
+    recompute_floor(governed_identity=governed_identity)
     return True
 
 
@@ -961,7 +966,23 @@ class VigilAgent(GovernanceAgent):
         # 24h staleness internally, so calling it every cycle is cheap.
         try:
             loop = asyncio.get_running_loop()
-            recomputed = await loop.run_in_executor(None, maybe_recompute_watcher_floor)
+            # Route the floor write through governed file_write (audited +
+            # rollback-tracked + lease-coordinated) using Vigil's own identity;
+            # save_floor_governed falls back to the atomic local write on any
+            # plane failure, so this can never lose the floor.
+            gov_id = None
+            if client.agent_uuid and client.continuity_token:
+                gov_id = {
+                    "proposer_uuid": client.agent_uuid,
+                    "continuity_token": client.continuity_token,
+                    "session_id": client.client_session_id or "",
+                }
+            recomputed = await loop.run_in_executor(
+                None,
+                functools.partial(
+                    maybe_recompute_watcher_floor, governed_identity=gov_id
+                ),
+            )
             if recomputed:
                 findings.append("watcher_floor: recomputed")
         except Exception as e:

--- a/agents/watcher/floor_state.py
+++ b/agents/watcher/floor_state.py
@@ -30,6 +30,7 @@ lowercase enum values — '|' won't collide with either.
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -41,6 +42,8 @@ from agents.watcher.calibration import BucketStats
 
 FLOOR_FILE_NAME = "pattern_floor.json"
 DEFAULT_STATE_DIR = watcher_state_dir()
+logger = logging.getLogger(__name__)
+
 _KEY_SEP = "|"
 
 
@@ -100,7 +103,13 @@ def save_floor(state: FloorState, *, state_dir: Path | None = None) -> None:
     target = target_dir / FLOOR_FILE_NAME
     tmp = target.with_suffix(f"{target.suffix}.tmp.{os.getpid()}.{time.monotonic_ns()}")
 
-    payload = {
+    with tmp.open("w") as fh:
+        json.dump(_floor_payload(state), fh, indent=2, sort_keys=True)
+    tmp.replace(target)
+
+
+def _floor_payload(state: FloorState) -> dict:
+    return {
         "updated_at": state.updated_at,
         "buckets": {
             f"{pattern}{_KEY_SEP}{file_class}": _bucket_to_dict(bucket)
@@ -108,9 +117,62 @@ def save_floor(state: FloorState, *, state_dir: Path | None = None) -> None:
         },
     }
 
-    with tmp.open("w") as fh:
-        json.dump(payload, fh, indent=2, sort_keys=True)
-    tmp.replace(target)
+
+def _floor_json(state: FloorState) -> str:
+    return json.dumps(_floor_payload(state), indent=2, sort_keys=True)
+
+
+def save_floor_governed(
+    state: FloorState,
+    *,
+    proposer_uuid: str,
+    continuity_token: str,
+    session_id: str,
+    state_dir: Path | None = None,
+    bearer_token: str | None = None,
+) -> bool:
+    """Persist the floor through a governed ``file_write`` effect — the write is
+    audited, rollback-tracked, and lease-coordinated (the lease plane enforces a
+    single writer, which is what the tmp+rename race guard approximated locally).
+
+    On ANY failure — plane down, veto, missing identity/bearer — this falls back
+    to the local atomic ``save_floor`` so the floor is never lost. Fail-open is
+    preserved end to end. Returns True only if the governed path committed.
+    """
+    import os
+
+    target = (state_dir or DEFAULT_STATE_DIR) / FLOOR_FILE_NAME
+    bearer = bearer_token or os.environ.get("LEASE_PLANE_BEARER_TOKEN")
+    try:
+        if bearer and proposer_uuid and continuity_token:
+            # The governed File.write fails (enoent) if the parent is absent —
+            # mkdir first, exactly as the atomic save_floor does.
+            target.parent.mkdir(parents=True, exist_ok=True)
+            from unitares_sdk.lease_plane.client import (
+                LeasePlaneClient,
+                LeasePlaneClientConfig,
+            )
+
+            client = LeasePlaneClient(LeasePlaneClientConfig(bearer_token=bearer))
+            resp = client.propose_file_write(
+                path=str(target),
+                content=_floor_json(state),
+                proposer_uuid=proposer_uuid,
+                continuity_token=continuity_token,
+                session_id=session_id,
+                idempotency_key=f"watcher-floor-{state.updated_at}",
+            )
+            if resp.get("ok"):
+                return True
+            logger.warning(
+                "governed floor write rejected (%s); atomic fallback",
+                resp.get("error"),
+            )
+    except Exception as exc:  # noqa: BLE001 — never lose the floor to a plane error
+        logger.warning("governed floor write failed (%s); atomic fallback", exc)
+
+    save_floor(state, state_dir=state_dir)
+    return False
 
 
 def load_floor(*, state_dir: Path | None = None) -> FloorState:
@@ -154,8 +216,14 @@ def recompute_floor(
     half_life_days: float = 30.0,
     min_weighted_n: float = 10.0,
     now: datetime | None = None,
+    governed_identity: dict | None = None,
 ) -> FloorState:
     """Read findings.jsonl, aggregate per-(pattern, file_class), persist.
+
+    When ``governed_identity`` (``{proposer_uuid, continuity_token, session_id}``)
+    is supplied, the floor is persisted through a governed ``file_write`` effect
+    (audited + rollback-tracked + lease-coordinated), falling back to the atomic
+    local write on any failure. Without it, the local atomic write is used.
 
     Returns the new FloorState. Designed to be called nightly (cron) or
     from the ``--recompute-floor`` CLI for ad-hoc rebuilds.
@@ -190,5 +258,8 @@ def recompute_floor(
         updated_at=reference.strftime("%Y-%m-%dT%H:%M:%SZ"),
         buckets=buckets,
     )
-    save_floor(state, state_dir=state_dir)
+    if governed_identity:
+        save_floor_governed(state, state_dir=state_dir, **governed_identity)
+    else:
+        save_floor(state, state_dir=state_dir)
     return state

--- a/agents/watcher/tests/test_floor_governed.py
+++ b/agents/watcher/tests/test_floor_governed.py
@@ -1,0 +1,83 @@
+"""save_floor_governed — route the watcher floor through governed file_write,
+with a guaranteed atomic-local fallback so the floor is never lost (fail-open)."""
+
+from __future__ import annotations
+
+from agents.watcher.floor_state import FloorState, load_floor, save_floor_governed
+
+_PROPOSE = "unitares_sdk.lease_plane.client.LeasePlaneClient.propose_file_write"
+
+
+def _state() -> FloorState:
+    return FloorState(updated_at="2026-01-01T00:00:00Z", buckets={})
+
+
+def test_governed_path_commits_and_does_not_write_locally(monkeypatch, tmp_path):
+    captured: dict = {}
+
+    def fake_propose(self, **kwargs):
+        captured.update(kwargs)
+        return {"ok": True, "effect_id": "e1"}
+
+    monkeypatch.setattr(_PROPOSE, fake_propose)
+    monkeypatch.setenv("LEASE_PLANE_BEARER_TOKEN", "tok")
+
+    ok = save_floor_governed(
+        _state(),
+        proposer_uuid="u",
+        continuity_token="c",
+        session_id="s",
+        state_dir=tmp_path,
+    )
+
+    assert ok is True
+    assert captured["proposer_uuid"] == "u"
+    assert captured["path"].endswith("pattern_floor.json")
+    # the plane committed it — no local atomic fallback fired
+    assert not (tmp_path / "pattern_floor.json").exists()
+
+
+def test_governed_rejection_falls_back_to_atomic_write(monkeypatch, tmp_path):
+    monkeypatch.setattr(_PROPOSE, lambda self, **k: {"ok": False, "error": "governance_blocked"})
+    monkeypatch.setenv("LEASE_PLANE_BEARER_TOKEN", "tok")
+
+    ok = save_floor_governed(
+        _state(), proposer_uuid="u", continuity_token="c", session_id="s", state_dir=tmp_path
+    )
+
+    assert ok is False
+    # the floor is NEVER lost — the atomic local write happened
+    assert (tmp_path / "pattern_floor.json").exists()
+    assert load_floor(state_dir=tmp_path).updated_at == "2026-01-01T00:00:00Z"
+
+
+def test_governed_exception_falls_back(monkeypatch, tmp_path):
+    def boom(self, **k):
+        raise RuntimeError("plane down")
+
+    monkeypatch.setattr(_PROPOSE, boom)
+    monkeypatch.setenv("LEASE_PLANE_BEARER_TOKEN", "tok")
+
+    ok = save_floor_governed(
+        _state(), proposer_uuid="u", continuity_token="c", session_id="s", state_dir=tmp_path
+    )
+    assert ok is False
+    assert (tmp_path / "pattern_floor.json").exists()
+
+
+def test_missing_bearer_falls_back_without_calling_the_plane(monkeypatch, tmp_path):
+    called = {"n": 0}
+
+    def fake_propose(self, **k):
+        called["n"] += 1
+        return {"ok": True}
+
+    monkeypatch.setattr(_PROPOSE, fake_propose)
+    monkeypatch.delenv("LEASE_PLANE_BEARER_TOKEN", raising=False)
+
+    ok = save_floor_governed(
+        _state(), proposer_uuid="u", continuity_token="c", session_id="s", state_dir=tmp_path
+    )
+    assert ok is False
+    assert called["n"] == 0  # no bearer -> never even attempts the plane
+    assert (tmp_path / "pattern_floor.json").exists()


### PR DESCRIPTION
**The first real production consumer of governed `file_write`** — the adoption side. The capability was supply with no demand until something routed a genuine write through it. Vigil's periodic floor recompute now persists `pattern_floor.json` via a governed effect (audited + rollback-tracked + lease-coordinated) instead of an ad-hoc write.

## Why the floor is the right first consumer
- **Fail-open by design:** a missing/corrupt floor → "no demotion fires, surface findings", so a governed-write failure *cannot* break Watcher's core job.
- **Overwrite semantics** (matches `file_write`), **low frequency** (Vigil 30-min cron, age-gated), and Vigil **already holds a governance identity**.
- The lease plane's single-writer lease is a stronger version of what the local tmp+rename race-guard approximated.

## What it does
- `floor_state.save_floor_governed`: `propose_file_write` with the proposer identity (mkdir parent first); on **any** failure — plane down, veto, missing identity/bearer — falls back to the atomic `save_floor`. **The floor is never lost** (fail-open end to end). `recompute_floor` gains an optional `governed_identity` that routes the save.
- `vigil`: `maybe_recompute_watcher_floor` threads `governed_identity`; `run_cycle` builds it from `client.{agent_uuid, continuity_token, client_session_id}`.

## Verification
- **Live** against the standing-live plane: governed commit returned `True` with a committed `effects.payloads` row. The **fallback also proved itself** when an early run errored (floor written anyway, loads back clean).
- Tests (4): governed commit (no local fallback) / reject → fallback / exception → fallback / missing-bearer → fallback-without-calling-plane. **25** floor + demotion tests pass (no regression).

## Minor follow-up (noted, not blocking)
The executor's `{:rejected, {:committed_failed_rolled_back, _}}` surfaces as a catch-all 500 rather than a cleaner status — worth mapping later. The rollback itself is correct.

Draft — consumer of an RCE-class surface; maintainer is the merge gate.