### PR TITLE
fix(orchestrator): reaping hardening — tree-kill + max-runtime backstop

### DIFF
--- a/elixir/agent_orchestrator/config/config.exs
+++ b/elixir/agent_orchestrator/config/config.exs
@@ -12,6 +12,12 @@ config :agent_orchestrator,
   # pure DB TTL row reaped by the lease plane's reaper, so a crashed orchestrator
   # self-heals within one TTL rather than leaking the surface forever.
   default_lease_ttl_s: 300,
+  # Wall-clock ceiling on a single agent's lifetime (30 min). No caller is
+  # obligated to DELETE a wedged agent, so this is the backstop that keeps a
+  # never-exiting child (and its subprocess tree) from leaking until restart.
+  # Generous — only fires on a genuinely stuck agent; per-spawn overridable via
+  # the spec's max_runtime_ms (nil/<=0 disables).
+  default_max_runtime_ms: 1_800_000,
   # AgentOrchestrator.ResultStore retention (closes the await-vs-fast-exit race,
   # #581). A finished runner retains its final result for this long so a late
   # await/snapshot survives process death; the sweep evicts expired rows and the

--- a/elixir/agent_orchestrator/lib/agent_orchestrator/agent_runner.ex
+++ b/elixir/agent_orchestrator/lib/agent_orchestrator/agent_runner.ex
@@ -31,6 +31,8 @@ defmodule AgentOrchestrator.AgentRunner do
         env: [{String.t(), String.t()}],   # extra env for the child (default [])
         cd: String.t() | nil,              # working dir
         max_output_lines: pos_integer(),   # buffer cap (default 1000)
+        max_runtime_ms: pos_integer(),     # wall-clock lifetime cap; self-reaps on expiry
+                                           # (default :default_max_runtime_ms; nil/<=0 disables)
         lease: nil | false | lease_cfg,    # default (absent/nil) = best-effort agent:/ presence;
                                            # false = no presence; map = override
         lease_client: module(),            # injectable, default LeasePlaneClient
@@ -141,6 +143,13 @@ defmodule AgentOrchestrator.AgentRunner do
 
   @default_max_lines 1000
   @line_max_bytes 65_536
+
+  # Default ceiling on a single agent's wall-clock lifetime (30 min). Generous —
+  # well past the slowest known consumer (orchestrated reviewer ~70s, council
+  # lanes ~120s) — so it only ever fires on a genuinely wedged agent. Per-spawn
+  # overridable via the spec's `max_runtime_ms` (nil / <= 0 disables it);
+  # config-overridable via :default_max_runtime_ms.
+  @default_max_runtime_ms 1_800_000
 
   # Lineage-provisioning env vars surfaced to the child (candidate
   # declarations — see "Lineage provisioning" in the moduledoc).
@@ -331,6 +340,13 @@ defmodule AgentOrchestrator.AgentRunner do
               "agent #{state.agent_id} started os_pid=#{os_pid} lease=#{lease_id || "none"} cmd=#{Map.get(spec, :cmd)}"
             )
 
+            # Arm the max-runtime backstop. No caller is obligated to DELETE a
+            # wedged agent (the live dialectic reviewer explicitly "leaves it
+            # async" on a 504), so without this an agent that never exits leaks
+            # its OS process + subprocess tree until the orchestrator restarts.
+            # The timer fires :max_runtime into our own mailbox; we self-reap.
+            maybe_arm_max_runtime(spec)
+
             {:ok, %{state | port: port, os_pid: os_pid}}
 
           {:error, reason} ->
@@ -393,6 +409,26 @@ defmodule AgentOrchestrator.AgentRunner do
       {:noreply, %{state | port: nil}}
     end
   end
+
+  # Max-runtime backstop fired and we are still running. Reap the whole tree
+  # (a wedged child won't exit on its own; kill_tree gets its MCP-subproc
+  # descendants too), then finalize with a synthetic terminal status so waiters
+  # get a definitive result instead of hanging on their own await. We kill +
+  # close here rather than leaving it to terminate/2 because finalize sets
+  # exit_status (→ terminate's reap guard would skip) and nils the port.
+  def handle_info(:max_runtime, %{exit_status: nil} = state) do
+    Logger.warning(
+      "agent #{state.agent_id} exceeded max runtime — reaping os_pid=#{inspect(state.os_pid)}"
+    )
+
+    if is_integer(state.os_pid), do: kill_tree(state.os_pid)
+    safe_close(state.port)
+    finalize(%{state | port: nil}, {:killed, :max_runtime})
+  end
+
+  # Already finalized (the agent exited before its deadline) — the stale timer
+  # is a no-op.
+  def handle_info(:max_runtime, state), do: {:noreply, state}
 
   def handle_info(_msg, state), do: {:noreply, state}
 
@@ -662,6 +698,25 @@ defmodule AgentOrchestrator.AgentRunner do
   defp maybe_opt(opts, _key, nil), do: opts
   defp maybe_opt(opts, _key, []), do: opts
   defp maybe_opt(opts, key, val), do: [{key, val} | opts]
+
+  # Arm the self-reap timer unless this spawn opted out. The message lands in our
+  # own mailbox after init returns, handled by handle_info(:max_runtime, ...).
+  defp maybe_arm_max_runtime(spec) do
+    case max_runtime_ms(spec) do
+      ms when is_integer(ms) and ms > 0 -> Process.send_after(self(), :max_runtime, ms)
+      _ -> :ok
+    end
+  end
+
+  # An explicit `max_runtime_ms` in the spec wins (an integer caps; nil / <= 0
+  # disables — the per-spawn escape hatch for a legitimately long agent). Absent,
+  # fall back to the configured/default ceiling.
+  defp max_runtime_ms(spec) do
+    case Map.fetch(spec, :max_runtime_ms) do
+      {:ok, v} -> v
+      :error -> Application.get_env(:agent_orchestrator, :default_max_runtime_ms, @default_max_runtime_ms)
+    end
+  end
 
   defp encode_env([]), do: []
 

--- a/elixir/agent_orchestrator/lib/agent_orchestrator/agent_runner.ex
+++ b/elixir/agent_orchestrator/lib/agent_orchestrator/agent_runner.ex
@@ -423,6 +423,17 @@ defmodule AgentOrchestrator.AgentRunner do
 
   @impl true
   def terminate(_reason, state) do
+    # Reap the whole process TREE when the child is still running at teardown
+    # (operator stop / app shutdown — exit_status still nil). `claude`/SDK
+    # children spawn their own subprocesses (MCP servers); closing the Port alone
+    # orphans those descendants — they reparent to init and pile up on the
+    # always-on orchestrator. This MUST run before safe_close: once the parent
+    # dies its children reparent and can no longer be found by walking the tree.
+    # Guarded on a NOT-yet-finalized state so we never signal a clean exit's
+    # os_pid, which by now could belong to an unrelated reused pid (the same
+    # guard AgentPort uses via its `exited` flag).
+    if is_nil(state.exit_status) and is_integer(state.os_pid), do: kill_tree(state.os_pid)
+
     # Idempotent with the exit-status path: release returns :not_found harmlessly
     # if already released. Closing the port here kills the child on operator stop.
     if state.port, do: safe_close(state.port)
@@ -697,6 +708,28 @@ defmodule AgentOrchestrator.AgentRunner do
     if Port.info(port) != nil, do: Port.close(port)
   catch
     :error, _ -> :ok
+  end
+
+  # Recursively SIGKILL a process and all its descendants, deepest first, so a
+  # reaped agent leaves no orphaned subprocesses (e.g. the MCP servers `claude`
+  # spawns). Best-effort and side-effecting; an already-dead pid just fails the
+  # kill harmlessly. Children are discovered via `pgrep -P` BEFORE the parent is
+  # signalled — once the parent dies its children reparent to init and can no
+  # longer be found by walking from it.
+  defp kill_tree(pid) do
+    children =
+      case System.cmd("pgrep", ["-P", "#{pid}"], stderr_to_stdout: true) do
+        {out, 0} -> out |> String.split() |> Enum.map(&String.to_integer/1)
+        _ -> []
+      end
+
+    Enum.each(children, &kill_tree/1)
+    System.cmd("kill", ["-KILL", "#{pid}"], stderr_to_stdout: true)
+    :ok
+  catch
+    # pgrep/kill are external; a malformed pid or a transient System.cmd failure
+    # must not crash terminate/2 (which would skip the lease release below it).
+    _, _ -> :ok
   end
 
   # RFC-4122 v4 UUID without a third-party dep. Version nibble forced to 4 and

--- a/elixir/agent_orchestrator/lib/agent_orchestrator/http_router.ex
+++ b/elixir/agent_orchestrator/lib/agent_orchestrator/http_router.ex
@@ -144,6 +144,7 @@ defmodule AgentOrchestrator.HTTPRouter do
          {:ok, env} <- fetch_env(body),
          {:ok, cd} <- fetch_string(body, "cd"),
          {:ok, max_lines} <- fetch_max_lines(body),
+         {:ok, max_runtime} <- fetch_max_runtime(body),
          {:ok, lease} <- fetch_lease(body),
          {:ok, lineage} <- fetch_lineage(body),
          {:ok, server_url} <- fetch_string(body, "server_url"),
@@ -152,6 +153,7 @@ defmodule AgentOrchestrator.HTTPRouter do
         %{cmd: cmd, args: args, env: env}
         |> put_opt(:cd, cd)
         |> put_opt(:max_output_lines, max_lines)
+        |> put_opt(:max_runtime_ms, max_runtime)
         |> put_opt(:lineage, lineage)
         |> put_opt(:server_url, server_url)
         |> put_opt(:client_session_id, client_session_id)
@@ -212,6 +214,18 @@ defmodule AgentOrchestrator.HTTPRouter do
       nil -> {:ok, nil}
       n when is_integer(n) and n > 0 -> {:ok, n}
       _ -> {:error, "max_output_lines must be a positive integer"}
+    end
+  end
+
+  # Absent => omit (runner applies its configured default ceiling). A positive
+  # integer overrides the lifetime cap for this spawn. HTTP callers can raise the
+  # cap for a legitimately long agent; the in-VM API additionally accepts nil to
+  # disable, which is not exposed here (the control surface should stay bounded).
+  defp fetch_max_runtime(body) do
+    case Map.get(body, "max_runtime_ms") do
+      nil -> {:ok, nil}
+      n when is_integer(n) and n > 0 -> {:ok, n}
+      _ -> {:error, "max_runtime_ms must be a positive integer"}
     end
   end
 

--- a/elixir/agent_orchestrator/test/agent_orchestrator_test.exs
+++ b/elixir/agent_orchestrator/test/agent_orchestrator_test.exs
@@ -548,4 +548,63 @@ defmodule AgentOrchestratorTest do
       assert :ok = AgentOrchestrator.stop(id)
     end
   end
+
+  describe "tree reaping on stop" do
+    test "stop reaps the agent's descendant subprocesses, not just the direct child" do
+      # A child runtime like `claude` forks its own subprocesses (MCP servers).
+      # Closing the Port alone kills only the direct child; the descendants
+      # reparent to init and pile up on the always-on orchestrator. terminate/2
+      # must walk the tree and SIGKILL the descendants too. Model that here with
+      # a shell that backgrounds a long-lived grandchild, prints its pid, then
+      # blocks — stopping the agent must leave no live grandchild.
+      {:ok, id, _pid} =
+        AgentOrchestrator.run(%{
+          cmd: "sh",
+          args: ["-c", "sleep 300 & echo CHILD_PID=$! ; sleep 300"],
+          lease: false
+        })
+
+      child_pid =
+        eventually_value(fn ->
+          with {:ok, %{output: lines}} <- AgentOrchestrator.snapshot(id) do
+            Enum.find_value(lines, fn line ->
+              case Regex.run(~r/CHILD_PID=(\d+)/, line) do
+                [_, pid] -> String.to_integer(pid)
+                _ -> nil
+              end
+            end)
+          else
+            _ -> nil
+          end
+        end)
+
+      assert is_integer(child_pid), "expected the backgrounded grandchild's pid in output"
+      assert os_process_alive?(child_pid), "grandchild should be alive before stop"
+
+      assert :ok = AgentOrchestrator.stop(id, :test_reap)
+
+      # The grandchild must die — kill_tree reaped it. Poll: a SIGKILLed process
+      # is a zombie until init reaps the reparented orphan.
+      assert eventually(fn -> not os_process_alive?(child_pid) end, 200),
+             "grandchild #{child_pid} survived stop — tree was not reaped"
+    end
+  end
+
+  # Like eventually/2 but returns the first truthy value the probe yields (or nil
+  # after exhausting retries), for polling a value into existence rather than a
+  # boolean condition.
+  defp eventually_value(fun, retries \\ 100) do
+    case fun.() do
+      nil -> if retries <= 0, do: nil, else: Process.sleep(10) && eventually_value(fun, retries - 1)
+      val -> val
+    end
+  end
+
+  # True iff an OS pid currently exists (signal 0 probes without delivering).
+  defp os_process_alive?(os_pid) do
+    case System.cmd("kill", ["-0", "#{os_pid}"], stderr_to_stdout: true) do
+      {_, 0} -> true
+      _ -> false
+    end
+  end
 end

--- a/elixir/agent_orchestrator/test/agent_orchestrator_test.exs
+++ b/elixir/agent_orchestrator/test/agent_orchestrator_test.exs
@@ -590,6 +590,61 @@ defmodule AgentOrchestratorTest do
     end
   end
 
+  describe "max-runtime backstop" do
+    test "self-reaps the agent and its descendant tree when max_runtime elapses (no caller delete)" do
+      # A wedged agent that never exits would otherwise leak its OS process +
+      # subprocess tree until the orchestrator restarts — no caller is obligated
+      # to DELETE it. The max-runtime timer must reap it on its own.
+      {:ok, id, _pid} =
+        AgentOrchestrator.run(%{
+          cmd: "sh",
+          args: ["-c", "sleep 300 & echo CHILD_PID=$! ; sleep 300"],
+          max_runtime_ms: 400,
+          lease: false
+        })
+
+      child_pid =
+        eventually_value(fn ->
+          with {:ok, %{output: lines}} <- AgentOrchestrator.snapshot(id) do
+            Enum.find_value(lines, fn line ->
+              case Regex.run(~r/CHILD_PID=(\d+)/, line) do
+                [_, pid] -> String.to_integer(pid)
+                _ -> nil
+              end
+            end)
+          else
+            _ -> nil
+          end
+        end)
+
+      assert is_integer(child_pid)
+      assert os_process_alive?(child_pid), "grandchild should be alive before the deadline"
+
+      # We never stop or await it — the orchestrator's own timer must reap.
+      assert eventually(fn -> not os_process_alive?(child_pid) end, 200),
+             "grandchild #{child_pid} survived the max-runtime deadline — not reaped"
+
+      # And the result is retained with the synthetic terminal status.
+      assert {:ok, %{running: false, exit_status: {:killed, :max_runtime}}} =
+               AgentOrchestrator.snapshot(id)
+    end
+
+    test "max_runtime_ms: nil disables the cap (long agent keeps running)" do
+      {:ok, id, _pid} =
+        AgentOrchestrator.run(%{
+          cmd: "sleep",
+          args: ["300"],
+          max_runtime_ms: nil,
+          lease: false
+        })
+
+      # No timer armed → still running after a window that a tiny cap would reap in.
+      Process.sleep(150)
+      assert {:ok, %{running: true}} = AgentOrchestrator.snapshot(id)
+      assert :ok = AgentOrchestrator.stop(id, :test_cleanup)
+    end
+  end
+
   # Like eventually/2 but returns the first truthy value the probe yields (or nil
   # after exhausting retries), for polling a value into existence rather than a
   # boolean condition.


### PR DESCRIPTION
Two coupled fixes that make the always-on orchestrator reap spawned agents cleanly and reliably. Both already matter for its **live** consumers (the dialectic reviewer and governed-effect `agent_spawn`, which launch `claude`/python that fork MCP subprocesses), and together they unblock routing `dispatch_beam`'s fire-and-collect council lanes through the orchestrator without losing the reaping `AgentPort` gives those lanes today.

## 1. `kill_tree` on stop (commit 1)
`AgentRunner.terminate/2` only `Port.close`'d the **direct** child, so a runtime that forks subprocesses (`claude` → MCP servers) orphaned the descendants — they reparent to init and pile up on the always-on service. Ports `dispatch_beam`'s proven `kill_tree` (`pgrep -P` deepest-first), run **before** `safe_close` and **guarded on `exit_status == nil`** so a clean exit's possibly-reused `os_pid` is never signalled (same guard `AgentPort` uses via its `exited` flag). `catch`-wrapped so an external `pgrep`/`kill` hiccup can't crash `terminate/2` and skip the lease release.

## 2. max-runtime backstop (commit 2)
**No caller anywhere DELETEs a running orchestrator agent** — the reviewer dispatch literally "leaves it async" on a `504`, and the "slower reap" its comment cites only resolves the dialectic *session row*, never the BEAM agent or its `claude` process. So a wedged agent leaked until restart. `AgentRunner` now arms a `:max_runtime` timer on spawn (default **30 min**, `config :default_max_runtime_ms`, per-spawn `max_runtime_ms`; `nil`/`<=0` disables). On expiry it `kill_tree`s, closes the port, and finalizes with a synthetic `{:killed, :max_runtime}` status so waiters get a definitive result. Exposed over `POST /v1/agents` (positive-int override; HTTP can't disable, keeping the control surface bounded). 30 min is well past the slowest known consumer (reviewer ~70s, council ~120s), so it only fires on a genuinely stuck agent.

## Tests / checks
New `tree reaping on stop` + `max-runtime backstop` cases (tree reaped via both explicit stop and deadline; `nil` disables). **71 tests green** (was 68), `mix compile --warnings-as-errors` clean.

> Did **not** run `mix format` — the file has many pre-existing non-mix-format lines (formatting isn't gated here); a reformat would bury the change in unrelated churn. New code matches the surrounding style.

Claude-Session: https://claude.ai/code/session_01PnBTA8r3FnBo9v6zxkr6vs