### PR TITLE
fix(governed-effect): map executor rejections to clean HTTP statuses

### DIFF
--- a/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
@@ -192,6 +192,47 @@ defmodule UnitaresLeasePlane.HTTPRouter do
           reason: "transient lease-plane error; nothing was committed"
         })
 
+      # Executor validation rejections — client errors (bad payload/path), not 500s.
+      {:error, reason}
+      when reason in [
+             :path_required,
+             :surface_path_mismatch,
+             :content_required,
+             :bad_base64,
+             :payload_too_large
+           ] ->
+        json(conn, 422, %{
+          ok: false,
+          error: Atom.to_string(reason),
+          reason: "effect rejected at validation; nothing was written"
+        })
+
+      # The write could not be applied but was cleanly rolled back — the surface
+      # is unchanged. Distinct from the quarantine case below.
+      {:error, {:committed_failed_rolled_back, write_reason}} ->
+        json(conn, 422, %{
+          ok: false,
+          error: "effect_write_failed",
+          reason: "the write could not be applied and was rolled back: #{inspect(write_reason)}"
+        })
+
+      # Pre-image persist failed before any write attempt — durable record missing.
+      {:error, {:persist_failed, persist_reason}} ->
+        json(conn, 503, %{
+          ok: false,
+          error: "persist_failed",
+          reason: "could not durably record the effect; nothing was written: #{inspect(persist_reason)}"
+        })
+
+      # Write failed AND the rollback also failed — the surface is quarantined and
+      # needs operator review. A genuine 500, but reported, not a bare catch-all.
+      {:error, :rollback_failed} ->
+        json(conn, 500, %{
+          ok: false,
+          error: "rollback_failed",
+          reason: "write failed and the rollback also failed; the surface is quarantined for operator review"
+        })
+
       {:error, detail} when is_binary(detail) ->
         json(conn, 422, %{ok: false, error: "schema_invalid", detail: detail})
 


### PR DESCRIPTION
The `file_write` executor's rejection reasons were falling through `/v1/effects` to the catch-all **500 "internal"** — client errors masquerading as server errors. Surfaced by the Vigil floor consumer (#1242): a missing parent dir got rejected as a 500 instead of a clean status.

## Mapped now
- **validation** (`path_required`, `surface_path_mismatch`, `content_required`, `bad_base64`, `payload_too_large`) → **422** (client error, nothing written)
- `{:committed_failed_rolled_back, _}` → **422 `effect_write_failed`** (write couldn't apply, cleanly rolled back, surface unchanged)
- `{:persist_failed, _}` **tuple** → **503** (only the bare atom was mapped; the executor returns the tuple, which hit the catch-all)
- `:rollback_failed` → **500 `rollback_failed`** (write *and* rollback failed → surface quarantined for operator review — a real 500, but *reported*, not bare)

The catch-all stays as the backstop for genuinely-unexpected reasons. 40 lease-plane tests pass.

Draft — RCE-class surface; maintainer is the merge gate.