### PR TITLE
test(governed-effect): real-DB contract tests for effects.payloads (stop fakes hiding bugs)

### DIFF
--- a/elixir/lease_plane/test/effect_repo_contract_test.exs
+++ b/elixir/lease_plane/test/effect_repo_contract_test.exs
@@ -1,0 +1,87 @@
+defmodule UnitaresLeasePlane.EffectRepoContractTest do
+  @moduledoc """
+  Real-DB contract tests for the effects.payloads write path.
+
+  These exist because the file_write commit bug (#1204) — a committed file with
+  NO durable row — PASSED its unit tests: the FakeRepo's record_pre_image
+  returned :ok regardless, hiding that the REAL record_pre_image is an UPDATE
+  that needs the row to already exist. A real-DB test cannot lie about that.
+  """
+  use ExUnit.Case, async: false
+
+  alias UnitaresLeasePlane.EffectRepo
+
+  setup do
+    # Skip cleanly (don't error) if migration 052 hasn't reached this test DB.
+    case Postgrex.query(UnitaresLeasePlane.DB, "SELECT to_regclass('effects.payloads')", []) do
+      {:ok, %{rows: [[nil]]}} ->
+        {:skip, "effects.payloads absent — migration 052 not applied to the test DB"}
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp eid(suffix), do: "ge-contract-#{suffix}-#{System.unique_integer([:positive])}"
+
+  defp cleanup(id) do
+    on_exit(fn ->
+      Postgrex.query(UnitaresLeasePlane.DB, "DELETE FROM effects.payloads WHERE effect_id = $1", [id])
+    end)
+  end
+
+  defp insert(id) do
+    EffectRepo.insert_effect_payload(%{
+      effect_id: id,
+      effect_type: "file_write",
+      payload_bytes: "content",
+      payload_sha256: "psha",
+      required_leases: [],
+      proposer_agent_uuid: nil,
+      idempotency_key: "k-#{id}",
+      idempotency_digest: "d-#{id}"
+    })
+  end
+
+  test "record_pre_image is UPDATE-only: a never-inserted effect is :already and creates NO row" do
+    id = eid("noinsert")
+    cleanup(id)
+
+    # THE BUG-CATCHER. The dispatch MUST insert the row first; skipping the insert
+    # means record_pre_image touches nothing, and a subsequent commit would be
+    # untracked — exactly #1204, which the FakeRepo's blanket :ok masked.
+    assert EffectRepo.record_pre_image(id, "sha", "bytes", true) == :already
+    assert {:ok, nil} = EffectRepo.get_payload(id)
+  end
+
+  test "full contract: insert -> record_pre_image -> mark_committed = a tracked, committed row" do
+    id = eid("full")
+    cleanup(id)
+
+    assert :ok = insert(id)
+    assert {:ok, row} = EffectRepo.get_payload(id)
+    refute row[:committed_at]
+    refute row[:rollback_state]
+
+    assert :ok = EffectRepo.record_pre_image(id, "presha", "prebytes", true)
+    assert {:ok, row2} = EffectRepo.get_payload(id)
+    assert row2[:rollback_state] == "pending"
+    assert row2[:pre_image_sha256] == "presha"
+
+    assert :ok = EffectRepo.mark_committed(id)
+    assert {:ok, row3} = EffectRepo.get_payload(id)
+    assert row3[:committed_at]
+    # mark_committed deliberately nulls rollback_state (committed = resolved)
+    refute row3[:rollback_state]
+  end
+
+  test "record_pre_image is idempotent: a second call after the pre-image is :already" do
+    id = eid("idem")
+    cleanup(id)
+
+    assert :ok = insert(id)
+    assert :ok = EffectRepo.record_pre_image(id, "s", "b", false)
+    # rollback_state is no longer NULL -> the WHERE matches 0 rows -> :already
+    assert :already = EffectRepo.record_pre_image(id, "s2", "b2", false)
+  end
+end

--- a/elixir/lease_plane/test/file_write_executor_commit_test.exs
+++ b/elixir/lease_plane/test/file_write_executor_commit_test.exs
@@ -32,6 +32,12 @@ defmodule UnitaresLeasePlane.FileWriteExecutorCommitTest do
     defp rec(call, result), do: (send(self(), {:fileop, call}) && result)
   end
 
+  # NOTE: this fake is deliberately lenient — it exercises the EXECUTOR's commit
+  # logic in isolation (write / mark / compensation), assuming the durable row
+  # already exists (the DISPATCH inserts it). It does NOT model the real
+  # UPDATE-only semantics of record_pre_image; that contract — and the #1204
+  # "committed file, no durable row" bug it once hid — is pinned by the real-DB
+  # effect_repo_contract_test.exs.
   defmodule FakeRepo do
     def record_pre_image(_id, _sha, _bytes, _existed?),
       do: rec(:record_pre_image, Process.get(:record_result, :ok))


### PR DESCRIPTION
The `file_write` commit bug (#1204 — a committed file with **no durable row**) *passed its unit tests*. Why: the `FakeRepo`'s `record_pre_image` returned `:ok` regardless, hiding that the **real** `record_pre_image` is an UPDATE that needs the row to already exist. A real-DB test can't lie about that — so this adds one.

## What's here
- **`effect_repo_contract_test.exs`** (3 tests, real DB):
  - **The bug-catcher:** `record_pre_image` on a never-inserted effect is `:already` and creates **no row** — exactly the contract #1204 violated.
  - Full path: `insert → record_pre_image → mark_committed` leaves a tracked, committed row (with `pre_image` set, then `committed_at` set + `rollback_state` nulled).
  - `record_pre_image` is idempotent (`:already` after the pre-image).
  - **Skips cleanly** if migration 052 hasn't reached the test DB (no CI breakage).
- **`file_write_executor_commit_test.exs`**: a note that its `FakeRepo` is *deliberately lenient* (tests executor logic in isolation) and a pointer to the contract test for the real semantics — so no future reader mistakes the fake's `:ok` for the contract.

43 governed-effect / executor / contract tests pass.

Draft — maintainer is the merge gate.