### PR TITLE
feat(observability): stamp live commit SHA so semver stops being load-bearing

### DIFF
--- a/src/agent_metadata_model.py
+++ b/src/agent_metadata_model.py
@@ -114,8 +114,12 @@ except ImportError:
             self.type = type
             self.text = text
 
-# Server version + build date - derived at startup, never hand-maintained
-from src.versioning import load_build_date_from_repo, load_version_from_file
+# Server version + build date + commit sha - derived at startup, never hand-maintained
+from src.versioning import (
+    load_build_date_from_repo,
+    load_build_sha_from_repo,
+    load_version_from_file,
+)
 
 def _load_version():
     """Load version from VERSION file (single source of truth)."""
@@ -123,6 +127,7 @@ def _load_version():
 
 SERVER_VERSION = _load_version()
 SERVER_BUILD_DATE = load_build_date_from_repo(project_root)
+SERVER_BUILD_SHA = load_build_sha_from_repo(project_root)
 
 
 def _normalize_http_proxy_base(url: str) -> str:

--- a/src/agent_state.py
+++ b/src/agent_state.py
@@ -26,6 +26,7 @@ from src.agent_metadata_model import (
     _load_version,
     SERVER_VERSION,
     SERVER_BUILD_DATE,
+    SERVER_BUILD_SHA,
     _normalize_http_proxy_base,
     _metadata_loading_lock,
     _metadata_loading,
@@ -125,7 +126,7 @@ from src.lock_cleanup import cleanup_stale_state_locks
 __all__ = [
     # Constants & config
     "project_root",
-    "SERVER_VERSION", "SERVER_BUILD_DATE",
+    "SERVER_VERSION", "SERVER_BUILD_DATE", "SERVER_BUILD_SHA",
     "PID_FILE", "LOCK_FILE", "MAX_KEEP_PROCESSES", "CURRENT_PID",
     "AIOFILES_AVAILABLE", "PSUTIL_AVAILABLE",
     "METADATA_FILE", "UNITARES_METADATA_BACKEND", "UNITARES_METADATA_WRITE_JSON_SNAPSHOT",

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -945,6 +945,7 @@ async def http_health(request):
     server_ready = request.state._http_api_server_ready_fn()
     server_start_time = request.state._http_api_server_start_time
     server_version = request.state._http_api_server_version
+    server_build_sha = getattr(request.state, "_http_api_server_build_sha", "unknown")
     has_streamable_http = request.state._http_api_has_streamable_http
     http_api_token = os.getenv("UNITARES_HTTP_API_TOKEN")
 
@@ -985,6 +986,7 @@ async def http_health(request):
     return JSONResponse({
         "status": "ok" if server_ready else "warming_up",
         "version": server_version,
+        "build_sha": server_build_sha,
         "uptime": {
             "seconds": int(uptime_seconds),
             "formatted": uptime_str,
@@ -1074,11 +1076,12 @@ async def http_metrics(request):
     # These are injected by register_http_routes via request.state
     server_start_time = request.state._http_api_server_start_time
     server_version = request.state._http_api_server_version
+    server_build_sha = getattr(request.state, "_http_api_server_build_sha", "unknown")
 
     try:
         # Update gauges with current values before generating output
         # Server info (static, set once)
-        SERVER_INFO.labels(version=server_version).set(1)
+        SERVER_INFO.labels(version=server_version, commit=server_build_sha).set(1)
 
         # Server uptime
         uptime_seconds = time.time() - server_start_time
@@ -3361,6 +3364,7 @@ def register_http_routes(
     server_version: str,
     has_streamable_http: bool,
     mcp_server_name: str = "governance-monitor-v1",
+    server_build_sha: str = "unknown",
 ):
     """
     Register all HTTP REST endpoints on the given Starlette ``app``.
@@ -3385,6 +3389,7 @@ def register_http_routes(
                 state["_http_api_server_ready_fn"] = server_ready_fn
                 state["_http_api_server_start_time"] = server_start_time
                 state["_http_api_server_version"] = server_version
+                state["_http_api_server_build_sha"] = server_build_sha
                 state["_http_api_has_streamable_http"] = has_streamable_http
                 state["_http_api_mcp_server_name"] = mcp_server_name
             await self.app(scope, receive, send)

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -60,7 +60,7 @@ from src.services.identity_continuity import (
     format_identity_continuity_startup_message,
     probe_identity_continuity_status,
 )
-from src.versioning import load_version_from_file
+from src.versioning import load_build_sha_from_repo, load_version_from_file
 logger = get_logger(__name__)
 
 # Server readiness flag - prevents "request before initialization" errors
@@ -100,6 +100,7 @@ def _load_version():
     return load_version_from_file(project_root)
 
 SERVER_VERSION = _load_version()
+SERVER_BUILD_SHA = load_build_sha_from_repo(project_root)
 
 
 # ============================================================================
@@ -503,6 +504,7 @@ async def main():
             server_version=SERVER_VERSION,
             has_streamable_http=HAS_STREAMABLE_HTTP,
             mcp_server_name=mcp.name,
+            server_build_sha=SERVER_BUILD_SHA,
         )
 
         # === Wave 3a probe endpoint (PR #1 scaffolding, see docs/proposals/

--- a/src/metrics_registry.py
+++ b/src/metrics_registry.py
@@ -89,7 +89,7 @@ BEAM_PROXY_LATENCY = Histogram(
 SERVER_INFO = Gauge(
     'unitares_server_info',
     'Server version info',
-    ['version']
+    ['version', 'commit']
 )
 
 # Server uptime and health metrics

--- a/src/versioning.py
+++ b/src/versioning.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 DEFAULT_VERSION_FALLBACK = "0.0.0"
 DEFAULT_BUILD_DATE_FALLBACK = "unknown"
+DEFAULT_BUILD_SHA_FALLBACK = "unknown"
 
 
 def load_version_from_file(project_root: Path) -> str:
@@ -57,3 +58,27 @@ def load_build_date_from_repo(project_root: Path) -> str:
         pass
 
     return DEFAULT_BUILD_DATE_FALLBACK
+
+
+def load_build_sha_from_repo(project_root: Path) -> str:
+    """Best-effort short commit SHA of the running build (``git rev-parse``).
+
+    This is the precise answer to "what code is live" — unlike the hand-typed
+    semver, it can't drift, so observability can key on it instead of the
+    version string. Returns ``"unknown"`` when ``.git`` is absent (sdist/wheel
+    install) or git is unavailable; never raises.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(project_root), "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        sha = out.stdout.strip()
+        if out.returncode == 0 and sha:
+            return sha
+    except Exception:
+        pass
+
+    return DEFAULT_BUILD_SHA_FALLBACK

--- a/tests/test_mcp_server_std.py
+++ b/tests/test_mcp_server_std.py
@@ -157,6 +157,27 @@ class TestLoadBuildDate:
 
 
 # ============================================================================
+# Test: load_build_sha_from_repo
+# ============================================================================
+
+class TestLoadBuildSha:
+    """Commit SHA is the drift-proof 'what's live' answer; semver is optional."""
+
+    def test_short_sha_at_real_repo(self):
+        import re
+        from src.agent_metadata_model import project_root
+        from src.versioning import load_build_sha_from_repo
+        result = load_build_sha_from_repo(project_root)
+        assert re.fullmatch(r"[0-9a-f]{7,40}", result), result
+
+    def test_unknown_when_git_unavailable(self, tmp_path):
+        from src.versioning import DEFAULT_BUILD_SHA_FALLBACK, load_build_sha_from_repo
+        with patch("src.versioning.subprocess.run", side_effect=Exception("no git")):
+            result = load_build_sha_from_repo(tmp_path)
+        assert result == DEFAULT_BUILD_SHA_FALLBACK
+
+
+# ============================================================================
 # Test: AgentMetadata dataclass
 # ============================================================================
 


### PR DESCRIPTION
## What

Surfaces the running build's **git commit SHA** so "what's live?" has a precise, drift-proof answer — the follow-up to the 2.14.0 release, where the hand-typed semver had frozen for 900+ commits.

## Why

The server's version string isn't a consumer contract (verified: nothing pins it; the SDK is versioned separately). Its only job is observability — and a hand-maintained string is a bad answer to "what commit is this." A derived SHA can't drift, so monitoring can key on it and the semver becomes optional decoration.

## Changes

- **`versioning.load_build_sha_from_repo()`** — `git rev-parse --short HEAD`, `"unknown"` fallback when `.git` is absent (sdist/wheel); never raises. Mirrors the build-date deriver.
- **`SERVER_BUILD_SHA`** exposed alongside `SERVER_VERSION` / `SERVER_BUILD_DATE` (agent_metadata_model, agent_state, mcp_server).
- **Prometheus** `unitares_server_info` gains a `commit` label → `unitares_server_info{version="2.14.0",commit="9a0ab3d4"}`. Standard `*_build_info` shape; dashboards / alerts / `deploy-status` can pin the SHA.
- **REST `/health`** gains a `build_sha` field (the common `curl /health` "what's live" check). `register_http_routes` takes `server_build_sha` (defaults `"unknown"`, so existing factory callers/tests are unaffected).
- Tests: `TestLoadBuildSha` (real-repo SHA + git-unavailable fallback).

## Scope boundary (deliberate)

The `get_server_info` admin JSON (`version`/`build_date`) is **not** touched. It's wave3a cross-runtime parity-locked against a golden the BEAM/Elixir handler must also satisfy — adding a field there requires the Elixir handler + golden regen, a separate and larger change. The wave3a parity test stays green.

## Verification

- Runtime: `version=2.14.0 build_date=2026-06-28 build_sha=9a0ab3d4`.
- `unitares_server_info{version,commit}` metric label accepted.
- 274 passed / 1 skipped across wave3a-parity + admin + server suites; health-endpoint suites green (additive field).

## Net effect

Combined with 2.14.0's derived build date, the service now answers "what's live" by SHA + date. The manual `VERSION` bump is no longer load-bearing — `2.14.0` can be the last hand-bump for the service; reserve deliberate semver for the published SDK / plugin marketplace.

https://claude.ai/code/session_01FRFApeYCerzdVDvAg8hhtE