### PR TITLE
feat(effects): verify effect-binding at /v1/effect-veto (#1075 Phase 1, slice 3, INERT)

### DIFF
--- a/db/postgres/migrations/054_effects_consumed_nonces.sql
+++ b/db/postgres/migrations/054_effects_consumed_nonces.sql
@@ -1,0 +1,33 @@
+-- 054_effects_consumed_nonces.sql
+-- Single-use nonce ledger for effect-binding grants (#1075 Phase 1, slice 3).
+--
+-- Each gnt.v1 grant (src/effect_grant.py) carries a nonce. /v1/effect-veto
+-- consumes it exactly once via an atomic INSERT ... ON CONFLICT DO NOTHING
+-- (rowcount 1 = first use → allow; 0 = replay → veto). This closes the
+-- grant-only slice of T2 (replay) — a captured grant cannot be presented twice.
+--
+-- Retention rule (design §5): a nonce MUST be retained until at least its
+-- grant's exp, or a replay window opens between purge and expiry. We store
+-- grant_exp and purge on `grant_exp < now()` (a periodic sweep / opportunistic
+-- delete) — never a fixed retention shorter than exp. Purging an already-expired
+-- grant's nonce is safe because verify_effect_grant rejects it on exp anyway.
+--
+-- Lives in the existing `effects` schema (created by 052). MANUAL migration —
+-- do NOT auto-run. Apply with psql before the gov-mcp binary that references
+-- effects.consumed_nonces starts with UNITARES_GOVERNED_EFFECT_BINDING on.
+-- While the binding flag is off (default), the table is simply unused.
+
+CREATE TABLE IF NOT EXISTS effects.consumed_nonces (
+    nonce        TEXT PRIMARY KEY,
+    grant_exp    TIMESTAMPTZ NOT NULL,
+    consumed_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Supports the purge sweep (DELETE WHERE grant_exp < now()).
+CREATE INDEX IF NOT EXISTS idx_consumed_nonces_grant_exp
+    ON effects.consumed_nonces (grant_exp);
+
+COMMENT ON TABLE effects.consumed_nonces IS
+    'Single-use ledger for effect-binding grant nonces (#1075). One row per '
+    'consumed gnt.v1 grant; INSERT ... ON CONFLICT DO NOTHING enforces single '
+    'use at /v1/effect-veto. Purge on grant_exp < now().';

--- a/docs/FLAGS.md
+++ b/docs/FLAGS.md
@@ -12,7 +12,7 @@ For *consequential, flag-gated capabilities* and their **wake conditions**, see
 `docs/operations/dormant-capability-registry.md` (Theme 6) — this file is the flat
 index; that one is the curated decision record.
 
-**92 flags.**
+**95 flags.**
 
 | Flag | Default | Purpose | Read at |
 |---|---|---|---|
@@ -28,21 +28,22 @@ index; that one is the curated decision record.
 | `UNITARES_ANCHORS_DIR` | `(required)` | Return the anchors directory path | src/identity/substrate.py:92 |
 | `UNITARES_API_TOKEN` | `(required)` | Return continuity token support details for diagnostics. | src/mcp_handlers/identity/session.py:106, src/mcp_handlers/identity/session.py:169 |
 | `UNITARES_AUDIT_WRITE_JSONL` | `'1'` | read by __init__() | src/audit_log.py:110 |
-| `UNITARES_AUTOMATION_CENSUS_PATH` | `default_path` | GET /api/automations — automation census snapshot for the dashboard | src/http_api.py:1227 |
+| `UNITARES_AUTOMATION_CENSUS_PATH` | `default_path` | GET /api/automations — automation census snapshot for the dashboard | src/http_api.py:1393 |
 | `UNITARES_AUTOSELECT_REVIEWER` | `''` | Gate for reviewer auto-selection | src/mcp_handlers/dialectic/reviewer.py:98 |
 | `UNITARES_AUTO_DIALECTIC_RECOVERY` | `'1'` | Process governance update with authentication enforcement (async version) | src/agent_loop_detection.py:612 |
 | `UNITARES_BASELINE_CACHE_MAXLEN` | `'1000'` | — | governance_core/ethical_drift.py:55 |
 | `UNITARES_CALIBRATION_BACKEND` | `'postgres'` | Initialize calibration checker with confidence bins | src/calibration.py:106 |
-| `UNITARES_CLASS_CALIBRATION` | `''` | Merge a deployment-local per-class calibration overlay into the class-keyed dicts, if ``UNITARES_CLASS_CALIBRATION`` names a JSON file | config/governance_config.py:1027 |
+| `UNITARES_CLASS_CALIBRATION` | `''` | Merge a deployment-local per-class calibration overlay into the class-keyed dicts, if ``UNITARES_CLASS_CALIBRATION`` names a JSON file | config/governance_config.py:1036 |
 | `UNITARES_CONNECT_RETRIES` | `'1'` | read by __init__() | agents/sdk/src/unitares_sdk/client.py:107 |
 | `UNITARES_CONNECT_TIMEOUT` | `'10'` | read by __init__() | agents/sdk/src/unitares_sdk/client.py:105 |
 | `UNITARES_CONTINUITY_TOKEN_SECRET` | `(required)` | Return continuity token support details for diagnostics. | src/mcp_handlers/identity/session.py:94, src/mcp_handlers/identity/session.py:167 |
 | `UNITARES_DASHBOARD_DB_BUDGET_S` | `(required)` | Inner DB-read budget in seconds | src/mcp_handlers/admin/dashboard.py:34 |
+| `UNITARES_DIALECTIC_BEAM_RESOLUTION` | `'0'` | True iff the operator has flipped UNITARES_DIALECTIC_BEAM_RESOLUTION on. | src/mcp_handlers/dialectic/beam_resolve_client.py:28 |
 | `UNITARES_DIALECTIC_ORCHESTRATED_REVIEW` | `'0'` | Opt-in gate for routing reviews through the orchestrator (default OFF) | src/mcp_handlers/dialectic/orchestrator_dispatch.py:38 |
 | `UNITARES_DIALECTIC_REVIEWER_TIMEOUT` | `(required)` | Timeout budget for a structured dialectic reviewer call | src/mcp_handlers/support/llm_delegation.py:68 |
-| `UNITARES_DIALECTIC_REVIEW_BUDGET` | `(required)` | Wall-clock cap for the inline synthetic review (antithesis + synthesis) | src/mcp_handlers/dialectic/handlers.py:1128 |
+| `UNITARES_DIALECTIC_REVIEW_BUDGET` | `(required)` | Wall-clock cap for the inline synthetic review (antithesis + synthesis) | src/mcp_handlers/dialectic/handlers.py:1168 |
 | `UNITARES_DIALECTIC_REVIEW_MAX_TOKENS` | `'1024'` | Run the local heterogeneous model in THIS process (not via the server's call_model tool, whose 30s timeout is shorter than gemma4's 43–70s b | agents/dialectic_reviewer/reviewer.py:181 |
-| `UNITARES_DIALECTIC_SYNTHETIC_REVIEWER` | `'1'` | Whether submit_thesis auto-completes a no-live-reviewer session via the local synthetic reviewer instead of leaving it to hang at awaiting_f | src/mcp_handlers/dialectic/handlers.py:1118 |
+| `UNITARES_DIALECTIC_SYNTHETIC_REVIEWER` | `'1'` | Whether submit_thesis auto-completes a no-live-reviewer session via the local synthetic reviewer instead of leaving it to hang at awaiting_f | src/mcp_handlers/dialectic/handlers.py:1158 |
 | `UNITARES_DIALECTIC_WRITE_JSON_SNAPSHOT` | `'1'` | — | src/mcp_handlers/dialectic/session.py:70 |
 | `UNITARES_DISABLE_PLUGINS` | `(required)` | Load every registered ``governance_mcp.plugins`` entry point | src/plugin_loader.py:40 |
 | `UNITARES_EMBEDDING_MODEL` | `'minilm'` | Derive a config tag matching baseline filename suffix from env vars | src/embeddings.py:48, agents/vigil/agent.py:342 |
@@ -52,19 +53,21 @@ index; that one is the curated decision record.
 | `UNITARES_FINDINGS_URL` | `'http://localhost:8767/api/fi…` | — | agents/common/findings.py:21 |
 | `UNITARES_FIRST_RUN` | `(required)` | Resolve Watcher identity via proof-owned UUID-direct → fresh onboard | agents/watcher/agent.py:271, agents/sdk/src/unitares_sdk/agent.py:364 |
 | `UNITARES_GOVERNANCE_URL` | `(required)` | read by _governance_url() | src/mcp_handlers/dialectic/orchestrator_dispatch.py:53, agents/dialectic_reviewer/reviewer.py:242 |
-| `UNITARES_GROUNDING_APPLY` | `''` | Whether grounded E/I/S/coherence actually replace the ODE/heuristic values in the canonical metrics (UNITARES_GROUNDING_APPLY) | config/governance_config.py:1136 |
-| `UNITARES_GROUNDING_SHADOW` | `''` | Whether to shadow-compare grounded vs ungrounded canonical metrics each check-in (UNITARES_GROUNDING_SHADOW) | config/governance_config.py:1124 |
+| `UNITARES_GOVERNED_EFFECT_BINDING` | `(required)` | POST /v1/effect-grant — mint a single-use, content-bound effect grant | src/http_api.py:729, src/http_api.py:923 |
+| `UNITARES_GROUNDING_APPLY` | `''` | Whether grounded E/I/S/coherence actually replace the ODE/heuristic values in the canonical metrics (UNITARES_GROUNDING_APPLY) | config/governance_config.py:1151 |
+| `UNITARES_GROUNDING_SHADOW` | `''` | Whether to shadow-compare grounded vs ungrounded canonical metrics each check-in (UNITARES_GROUNDING_SHADOW) | config/governance_config.py:1139 |
 | `UNITARES_HEALTH_PROBE_INTERVAL_SECONDS` | `(required)` | Periodically run the deep health check and cache the result | src/background_tasks.py:526 |
-| `UNITARES_HTTP_API_TOKEN` | `(required)` | List all tools in OpenAI-compatible format Query params: mode: Tool mode filter - "minimal", "lite", "full" | src/http_api.py:436, src/http_api.py:485 (+34 more) |
-| `UNITARES_HTTP_CORS_ALLOW_ORIGIN` | `(required)` | Main entry point for governance MCP server. | src/mcp_server.py:841, src/mcp_server.py:883 |
-| `UNITARES_IDENTITY_STRICT` | `'log'` | Runtime accessor — respects env changes set after module load | config/governance_config.py:1189, config/governance_config.py:1198 |
-| `UNITARES_INCLUDE_API_KEY_IN_RESPONSES` | `(required)` | Include onboarding guidance, API key hints, welcome message. | src/mcp_handlers/updates/enrichments.py:533 |
+| `UNITARES_HTTP_API_TOKEN` | `(required)` | List all tools in OpenAI-compatible format Query params: mode: Tool mode filter - "minimal", "lite", "full" | src/http_api.py:435, src/http_api.py:484 (+35 more) |
+| `UNITARES_HTTP_CORS_ALLOW_ORIGIN` | `(required)` | Main entry point for governance MCP server. | src/mcp_server.py:454, src/mcp_server.py:496 |
+| `UNITARES_IDENTITY_STRICT` | `'log'` | Runtime accessor — respects env changes set after module load | config/governance_config.py:1204, config/governance_config.py:1213 |
+| `UNITARES_INCLUDE_API_KEY_IN_RESPONSES` | `(required)` | Include onboarding guidance, API key hints, welcome message. | src/mcp_handlers/updates/enrichments.py:540 |
 | `UNITARES_INTEGRATOR` | `'rk4'` | Returns the ODE integration method | governance_core/parameters.py:143 |
-| `UNITARES_IPUA_PIN_CHECK` | `'strict'` | Runtime accessor — respects env changes set after module load | config/governance_config.py:1311, config/governance_config.py:1322 |
+| `UNITARES_IPUA_PIN_CHECK` | `'strict'` | Runtime accessor — respects env changes set after module load | config/governance_config.py:1326, config/governance_config.py:1337 |
 | `UNITARES_I_DYNAMICS` | `'linear'` | Returns the I-channel dynamics mode | governance_core/parameters.py:160 |
-| `UNITARES_KG_PROACTIVE_EVERY` | `'0'` | Gate the proactive (steady-state) KG surface — cadence + warmup + length | src/mcp_handlers/updates/enrichments.py:1555 |
+| `UNITARES_KG_PROACTIVE_EVERY` | `'0'` | Gate the proactive (steady-state) KG surface — cadence + warmup + length | src/mcp_handlers/updates/enrichments.py:1575 |
+| `UNITARES_KG_SEARCH_TIMEOUT_S` | `'0.25'` | — | src/mcp_handlers/updates/enrichments.py:54 |
 | `UNITARES_KNOWLEDGE_BACKEND` | `'auto'` | Get global knowledge graph instance (singleton) | src/knowledge_graph.py:265, src/knowledge_graph.py:340 |
-| `UNITARES_LINEAGE_TRANSITIVE_ARCHIVAL` | `(required)` | Whether transitive succession-reachability DRIVES archival (vs shadow) | src/mcp_handlers/lifecycle/stuck.py:613 |
+| `UNITARES_LINEAGE_TRANSITIVE_ARCHIVAL` | `(required)` | Whether transitive succession-reachability DRIVES archival (vs shadow) | src/mcp_handlers/lifecycle/stuck.py:614 |
 | `UNITARES_LLM_MODEL` | `'gemma4:latest'` | Call a free/low-cost LLM for reasoning, generation, or analysis | src/mcp_handlers/support/model_inference.py:95, src/mcp_handlers/support/model_inference.py:150 (+2 more) |
 | `UNITARES_MCP_HOST` | `''` | Return the default socket bind address | src/mcp_listen_config.py:44 |
 | `UNITARES_METADATA_BACKEND` | `'postgres'` | — | src/agent_metadata_persistence.py:35 |
@@ -72,10 +75,10 @@ index; that one is the curated decision record.
 | `UNITARES_METRICS_URL` | `DEFAULT_URL` | read by main() | agents/chronicler/agent.py:215 |
 | `UNITARES_MIRROR_SIGNAL_EMIT` | `'1'` | Phase 0 mirror-effectiveness instrumentation (mirror-effectiveness-measurement-v0) | src/mcp_handlers/response_formatter.py:162 |
 | `UNITARES_NX_FAIL_CLOSED` | `''` | read by _nx_fail_closed_enabled() | src/mcp_handlers/identity/persistence.py:44 |
-| `UNITARES_OAUTH_AUTO_APPROVE` | `'true'` | — | src/mcp_server.py:194 |
-| `UNITARES_OAUTH_ISSUER_URL` | `(required)` | — | src/mcp_server.py:183 |
-| `UNITARES_OAUTH_RESOURCE_URL` | `(required)` | — | src/mcp_server.py:196 |
-| `UNITARES_OAUTH_SECRET` | `(required)` | — | src/mcp_server.py:193 |
+| `UNITARES_OAUTH_AUTO_APPROVE` | `'true'` | — | src/mcp_server.py:130 |
+| `UNITARES_OAUTH_ISSUER_URL` | `(required)` | — | src/mcp_server.py:119 |
+| `UNITARES_OAUTH_RESOURCE_URL` | `(required)` | — | src/mcp_server.py:132 |
+| `UNITARES_OAUTH_SECRET` | `(required)` | — | src/mcp_server.py:129 |
 | `UNITARES_OLLAMA_BASE` | `'http://localhost:11434'` | Native Ollama /api/chat endpoint (supports JSON-schema-constrained output via the `format` field) | src/mcp_handlers/support/llm_delegation.py:168 |
 | `UNITARES_OLLAMA_BASE_URL` | `'http://localhost:11434/v1'` | — | agents/dialectic_reviewer/reviewer.py:37 |
 | `UNITARES_PARAMS_JSON` | `(required)` | Returns the active dynamics parameters | governance_core/parameters.py:269 |
@@ -83,28 +86,28 @@ index; that one is the curated decision record.
 | `UNITARES_PARENT_AGENT_ID` | `(required)` | read by main() | agents/dialectic_reviewer/reviewer.py:243 |
 | `UNITARES_PAUSE_AUTO_EXPIRE_SECONDS` | `str(72 * 3600)` | — | config/governance_config.py:753 |
 | `UNITARES_PHASE5_EVIDENCE_WRITE` | `''` | Health check, CIRS emissions, PG record, outcome events | src/mcp_handlers/updates/phases.py:2049 |
-| `UNITARES_PHI_TELEMETRY_ONLY` | `'1'` | Whether Φ is demoted to telemetry (UNITARES_PHI_TELEMETRY_ONLY) | config/governance_config.py:1110 |
-| `UNITARES_PREFIX_BIND_FINGERPRINT` | `'off'` | Runtime accessor — respects env changes set after module load | config/governance_config.py:1273, config/governance_config.py:1282 |
+| `UNITARES_PHI_TELEMETRY_ONLY` | `'1'` | Whether Φ is demoted to telemetry (UNITARES_PHI_TELEMETRY_ONLY) | config/governance_config.py:1125 |
+| `UNITARES_PREFIX_BIND_FINGERPRINT` | `'off'` | Runtime accessor — respects env changes set after module load | config/governance_config.py:1288, config/governance_config.py:1297 |
 | `UNITARES_PROCESS_UPDATE_RESPONSE_MODE` | `'auto'` | Apply response mode filtering to fully-built response_data | src/mcp_handlers/response_formatter.py:238 |
 | `UNITARES_PROGRESS_FLAT_PROBE_INTERVAL_SECONDS` | `(required)` | Resident-progress telemetry probe | src/background_tasks.py:579 |
 | `UNITARES_PROXY_URL` | `(required)` | — | src/mcp_server_std.py:127 |
 | `UNITARES_REPO` | `str(Path(__file__).resolve().…` | read by main() | agents/vigil_hygiene/agent.py:364 |
 | `UNITARES_RERANKER_MODEL` | `'bge-m3'` | — | src/reranker.py:38 |
-| `UNITARES_RESIDENT_AGENTS` | `''` | Figure out which agent labels to treat as residents | src/http_api.py:2661 |
+| `UNITARES_RESIDENT_AGENTS` | `''` | Figure out which agent labels to treat as residents | src/http_api.py:2827 |
 | `UNITARES_SENSOR_COUPLING` | `(required)` | Whether sensor-derived EISV spring-couples into the ODE | governance_core/parameters.py:182, governance_core/parameters.py:204 |
-| `UNITARES_SESSION_FINGERPRINT_CHECK` | `'log'` | Runtime accessor — respects env changes set after module load | config/governance_config.py:1225, config/governance_config.py:1236 |
-| `UNITARES_SESSION_MIRROR_APPLY` | `''` | Whether the resolver READS the PostgreSQL session mirror as a source of truth (UNITARES_SESSION_MIRROR_APPLY) | config/governance_config.py:1160 |
-| `UNITARES_SESSION_MIRROR_SHADOW` | `''` | Whether to dual-write session/identity bindings into the PostgreSQL mirror tables (core.session_bindings, core.onboard_pins) alongside the R | config/governance_config.py:1150 |
+| `UNITARES_SESSION_FINGERPRINT_CHECK` | `'log'` | Runtime accessor — respects env changes set after module load | config/governance_config.py:1240, config/governance_config.py:1251 |
+| `UNITARES_SESSION_MIRROR_APPLY` | `''` | Whether the resolver READS the PostgreSQL session mirror as a source of truth (UNITARES_SESSION_MIRROR_APPLY) | config/governance_config.py:1175 |
+| `UNITARES_SESSION_MIRROR_SHADOW` | `''` | Whether to dual-write session/identity bindings into the PostgreSQL mirror tables (core.session_bindings, core.onboard_pins) alongside the R | config/governance_config.py:1165 |
 | `UNITARES_STDIO_PROXY_HTTP_BEARER_TOKEN` | `(required)` | — | src/mcp_server_std.py:131 |
 | `UNITARES_STDIO_PROXY_HTTP_URL` | `(required)` | — | src/mcp_server_std.py:126 |
 | `UNITARES_STDIO_PROXY_SSE_URL` | `(required)` | — | src/mcp_server_std.py:129 |
 | `UNITARES_STDIO_PROXY_STRICT` | `'1'` | — | src/mcp_server_std.py:130 |
 | `UNITARES_STDIO_PROXY_URL` | `(required)` | — | src/mcp_server_std.py:128 |
-| `UNITARES_S_SETPOINT` | `'1'` | Whether the per-class S setpoint is active (UNITARES_S_SETPOINT) | config/governance_config.py:1093 |
+| `UNITARES_S_SETPOINT` | `'1'` | Whether the per-class S setpoint is active (UNITARES_S_SETPOINT) | config/governance_config.py:1108 |
 | `UNITARES_TOOL_SCHEMA_STRIP_FIELD_DESCRIPTIONS` | `'0'` | Build the list of MCP Tool objects from Pydantic schemas + descriptions. | src/tool_schemas.py:234 |
 | `UNITARES_TOOL_SCHEMA_VERBOSITY` | `'short'` | Build the list of MCP Tool objects from Pydantic schemas + descriptions. | src/tool_schemas.py:231 |
 | `UNITARES_TOOL_USAGE_LOG` | `(required)` | read by __init__() | src/tool_usage_tracker.py:57 |
-| `UNITARES_TRACEMALLOC` | `''` | — | src/mcp_server.py:1208 |
-| `UNITARES_TRACEMALLOC_FRAMES` | `'5'` | — | src/mcp_server.py:1211 |
-| `UNITARES_UDS_SOCKET` | `(required)` | Main entry point for governance MCP server. | src/mcp_server.py:1134, agents/watcher/agent.py:238 (+2 more) |
+| `UNITARES_TRACEMALLOC` | `''` | — | src/mcp_server.py:821 |
+| `UNITARES_TRACEMALLOC_FRAMES` | `'5'` | — | src/mcp_server.py:824 |
+| `UNITARES_UDS_SOCKET` | `(required)` | Main entry point for governance MCP server. | src/mcp_server.py:747, agents/watcher/agent.py:238 (+2 more) |
 | `UNITARES_WATCHER_DATA_DIR` | `(required)` | Checkout-independent home for Watcher's local state (reader's view) | src/watcher_state_reader.py:55, agents/watcher/_util.py:52 |

--- a/elixir/lease_plane/lib/unitares_lease_plane/governance_veto_client.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/governance_veto_client.ex
@@ -67,10 +67,46 @@ defmodule UnitaresLeasePlane.GovernanceVetoClient do
       "effect_type" => Map.get(env, :effect_type)
     }
 
+    base
+    |> maybe_put_token(env)
+    |> maybe_put_binding(env)
+  end
+
+  defp maybe_put_token(body, env) do
     case Map.get(env, :proposer_continuity_token) do
-      t when is_binary(t) and t != "" -> Map.put(base, "proposer_continuity_token", t)
-      _ -> base
+      t when is_binary(t) and t != "" -> Map.put(body, "proposer_continuity_token", t)
+      _ -> body
     end
+  end
+
+  # §8 effect-binding (#1075): when the proposer carried a grant, forward it PLUS
+  # the content fields gov-mcp needs to verify the grant binds THIS effect
+  # (payload_sha256/custody_mode/idempotency_key; surface+effect_type already in
+  # base). When absent — today, always — the body is byte-identical to the §6/§7
+  # request, so this is a pure no-op until proposers start minting grants.
+  defp maybe_put_binding(body, env) do
+    case Map.get(env, :proposer_effect_grant) do
+      g when is_binary(g) and g != "" ->
+        body
+        |> Map.put("proposer_effect_grant", g)
+        |> Map.put("payload_sha256", payload_sha256(env))
+        |> Map.put("custody_mode", Map.get(env, :custody_mode))
+        |> Map.put("idempotency_key", Map.get(env, :idempotency_key))
+
+      _ ->
+        body
+    end
+  end
+
+  # Canonical payload hash — MUST match the proposer's mint-time payload_sha256
+  # so the grant's bound `psha` equals what gov-mcp verifies. Same computation as
+  # GovernedEffect.idempotency_digest's payload_hash: sha256 of the JSON-encoded
+  # payload, lowercase hex. (Cross-language canonicalization — Elixir Jason vs a
+  # Python proposer's json — is the slice-4 wiring integration item; a mismatch
+  # fails CLOSED at the veto, never open.)
+  defp payload_sha256(env) do
+    :crypto.hash(:sha256, Jason.encode!(Map.get(env, :payload, %{})))
+    |> Base.encode16(case: :lower)
   end
 
   defp parse(resp) do

--- a/elixir/lease_plane/lib/unitares_lease_plane/governed_effect.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/governed_effect.ex
@@ -138,6 +138,14 @@ defmodule UnitaresLeasePlane.GovernedEffect do
     # `inspect(env)`. Used only by the execute path (`GovernanceVetoClient`).
     proposer_continuity_token = nested_string(body, "proposer", "continuity_token")
 
+    # §8 effect-binding proof (#1075) — the proposer's single-use, content-bound
+    # grant, carried in the `proposer` object alongside the token. CREDENTIAL:
+    # forwarded transiently to the governance veto for §8 verification, then
+    # dropped. NEVER written to any audit_payload, response body, or log line
+    # (Invariant 1/7); keep it out of every `inspect(env)`. Optional — absent
+    # today (no proposer mints grants until the binding flag flips).
+    proposer_effect_grant = nested_string(body, "proposer", "effect_grant")
+
     cond do
       not (is_binary(idem) and byte_size(idem) > 0) ->
         {:error, "idempotency_key required (non-empty string)"}
@@ -172,7 +180,9 @@ defmodule UnitaresLeasePlane.GovernedEffect do
            proposer_agent_uuid: proposer_agent_uuid,
            provenance_session_id: provenance_session_id,
            # CREDENTIAL — transient, never persisted/logged (see comment above).
-           proposer_continuity_token: proposer_continuity_token
+           proposer_continuity_token: proposer_continuity_token,
+           # CREDENTIAL — transient §8 effect-binding proof (see comment above).
+           proposer_effect_grant: proposer_effect_grant
          }}
     end
   end
@@ -385,7 +395,10 @@ defmodule UnitaresLeasePlane.GovernedEffect do
             file_write_under_custody(env, digest)
 
           {:error, reason} ->
-            Logger.warning("governed_effect file_write idempotency lookup failed: #{inspect(reason)}")
+            Logger.warning(
+              "governed_effect file_write idempotency lookup failed: #{inspect(reason)}"
+            )
+
             {:error, :idempotency_lookup_failed}
         end
     end
@@ -427,7 +440,13 @@ defmodule UnitaresLeasePlane.GovernedEffect do
                     FileWriteExecutor.apply_effect(effect_id, env.payload, canon_leases)
 
                   {status, extra} = result_audit(result)
-                  _ = persist_execute(env, execute_audit_payload(effect_id, env, digest, status, extra))
+
+                  _ =
+                    persist_execute(
+                      env,
+                      execute_audit_payload(effect_id, env, digest, status, extra)
+                    )
+
                   result_to_reply(result, effect_id)
 
                 {:error, reason} ->

--- a/elixir/lease_plane/test/governed_effect_test.exs
+++ b/elixir/lease_plane/test/governed_effect_test.exs
@@ -292,6 +292,31 @@ defmodule UnitaresLeasePlane.GovernedEffectTest do
       refute row_text =~ "SECRET-s7-payload"
       refute row_text =~ "continuity_token"
     end
+
+    test "§8: a forwarded effect_grant never leaks into the persisted record" do
+      key = tracked_key()
+      set_execute_flag(true, "http://127.0.0.1:8789", "http://127.0.0.1:1")
+
+      assert {:error, :governance_blocked} =
+               GovernedEffect.handle(
+                 base(%{
+                   "idempotency_key" => key,
+                   "custody_mode" => "execute",
+                   "effect_type" => "agent_spawn",
+                   "proposer" => %{
+                     "agent_uuid" => "00000000-0000-0000-0000-0000000000aa",
+                     "effect_grant" => "gnt.v1.SECRET-s8-grant-payload.SECRET-s8-sig"
+                   },
+                   "payload" => %{"cmd" => "echo", "args" => ["hi"]}
+                 })
+               )
+
+      assert [row] = execute_rows(key)
+      assert row["status"] == "governance_blocked"
+      row_text = Jason.encode!(row)
+      refute row_text =~ "SECRET-s8-grant-payload"
+      refute row_text =~ "effect_grant"
+    end
   end
 
   describe "§7 GovernanceVetoClient body forwarding" do
@@ -333,6 +358,65 @@ defmodule UnitaresLeasePlane.GovernedEffectTest do
         })
 
       refute Map.has_key?(body, "proposer_continuity_token")
+    end
+  end
+
+  describe "§8 effect-binding body forwarding (#1075)" do
+    alias UnitaresLeasePlane.GovernanceVetoClient
+
+    test "the grant + content fields are forwarded when a grant is present" do
+      body =
+        GovernanceVetoClient.build_veto_body(%{
+          proposer_agent_uuid: "00000000-0000-0000-0000-0000000000aa",
+          surface: "file://sandbox/x",
+          effect_type: "file_write",
+          custody_mode: "execute",
+          idempotency_key: "idem-001",
+          payload: %{"path" => "sandbox/x", "bytes" => "hi"},
+          proposer_effect_grant: "gnt.v1.payload.sig"
+        })
+
+      assert body["proposer_effect_grant"] == "gnt.v1.payload.sig"
+      assert body["custody_mode"] == "execute"
+      assert body["idempotency_key"] == "idem-001"
+      # payload_sha256 must equal the idempotency payload_hash (sha256 of the
+      # JSON-encoded payload, lowercase hex) so the grant's psha verifies.
+      expected =
+        :crypto.hash(:sha256, Jason.encode!(%{"path" => "sandbox/x", "bytes" => "hi"}))
+        |> Base.encode16(case: :lower)
+
+      assert body["payload_sha256"] == expected
+    end
+
+    test "no binding keys are added when the grant is absent or blank (byte-identical)" do
+      for grant <- [nil, ""] do
+        env = %{
+          proposer_agent_uuid: "00000000-0000-0000-0000-0000000000aa",
+          surface: "file://sandbox/x",
+          effect_type: "file_write",
+          custody_mode: "execute",
+          idempotency_key: "idem-001",
+          payload: %{"a" => 1},
+          proposer_effect_grant: grant
+        }
+
+        body = GovernanceVetoClient.build_veto_body(env)
+
+        for k <- ~w(proposer_effect_grant payload_sha256 custody_mode idempotency_key) do
+          refute Map.has_key?(body, k),
+                 "grant=#{inspect(grant)} should add no binding key #{k}"
+        end
+      end
+
+      # and when the env never carried the grant key at all
+      body =
+        GovernanceVetoClient.build_veto_body(%{
+          proposer_agent_uuid: "00000000-0000-0000-0000-0000000000aa",
+          surface: "file://sandbox/x",
+          effect_type: "file_write"
+        })
+
+      refute Map.has_key?(body, "proposer_effect_grant")
     end
   end
 

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -798,6 +798,53 @@ async def http_effect_grant(request):
     return JSONResponse({"ok": True, "grant": grant})
 
 
+async def _check_effect_binding(body: dict, proposer: str):
+    """§8 effect-binding: verify the forwarded grant covers THIS effect, then
+    consume its nonce exactly once (#1075 Phase 1). Returns (binding_ok, reason).
+
+    Called only when UNITARES_GOVERNED_EFFECT_BINDING is on. Fail-closed: a
+    missing/invalid/expired/mismatched grant, a replayed nonce, or a store error
+    → (False, reason). On a valid grant the nonce is consumed atomically
+    (INSERT ... ON CONFLICT DO NOTHING in one statement — no SELECT-then-INSERT
+    TOCTOU); a second presentation of the same grant finds the row present →
+    replay → vetoed. The grant is a credential: verified transiently, never
+    logged.
+    """
+    grant = body.get("proposer_effect_grant")
+    if not grant or not isinstance(grant, str):
+        return False, "binding_absent"
+    from src.effect_grant import verify_effect_grant
+    v = verify_effect_grant(
+        grant,
+        aid=proposer,
+        payload_sha256=str(body.get("payload_sha256") or ""),
+        surface=str(body.get("surface") or ""),
+        custody_mode=str(body.get("custody_mode") or ""),
+        idempotency_key=str(body.get("idempotency_key") or ""),
+    )
+    if not v.ok:
+        return False, f"binding_{v.reason}"
+    try:
+        from src.db import get_db
+        db = get_db()
+        async with db.acquire() as conn:
+            result = await conn.execute(
+                """
+                INSERT INTO effects.consumed_nonces (nonce, grant_exp)
+                VALUES ($1, to_timestamp($2))
+                ON CONFLICT (nonce) DO NOTHING
+                """,
+                v.nonce, int(v.exp),
+            )
+    except Exception as e:  # noqa: BLE001 — store failure → fail closed
+        logger.warning("effect-binding nonce consume failed: %s", e)
+        return False, "binding_store_unavailable"
+    # asyncpg returns a command tag like "INSERT 0 1" (1 row) or "INSERT 0 0".
+    if str(result).split()[-1] != "1":
+        return False, "binding_replayed"
+    return True, None
+
+
 async def http_effect_veto(request):
     """POST /v1/effect-veto — governance veto for a proposed governed effect.
 
@@ -866,6 +913,16 @@ async def http_effect_veto(request):
     tier = "strong" if tier_ok else "unverified"
     tier_reason = None if tier_ok else "tier_recert_failed:not_strong_identity"
 
+    # §8 effect-binding (governed-effect-effect-binding-v0 §5 / #1075). ADDITIVE,
+    # flag-gated: when UNITARES_GOVERNED_EFFECT_BINDING is off (default), this is
+    # a no-op (binding_ok=True) and the live §6/§7 veto is byte-identical. When
+    # on, the forwarded grant must cover THIS exact effect and its nonce must be
+    # unconsumed — otherwise binding_ok is False and the effect is vetoed. Like
+    # §7, this gate applies on EVERY exit path below.
+    binding_ok, binding_reason = True, None
+    if _http_bool(os.getenv("UNITARES_GOVERNED_EFFECT_BINDING")):
+        binding_ok, binding_reason = await _check_effect_binding(body, proposer)
+
     try:
         from src.db import get_db
         db = get_db()
@@ -900,12 +957,14 @@ async def http_effect_veto(request):
         # no/invalid token → vetoed. This is the intended composition —
         # "a strong, never-flagged identity may spawn; a weak/unverified one
         # may not" — not an emergent property of the old early return.
+        unknown_reasons = [r for r in (tier_reason, binding_reason) if r]
         return JSONResponse({
             "ok": True,
-            "vetoed": not tier_ok,
+            "vetoed": not (tier_ok and binding_ok),
             "verdict": None, "action": None, "risk_score": None,
             "tier": tier, "tier_ok": tier_ok,
-            "reason": (tier_reason if not tier_ok else "no_governance_state"),
+            "binding_ok": binding_ok,
+            "reason": (" ; ".join(unknown_reasons) if unknown_reasons else "no_governance_state"),
         })
 
     verdict = row["verdict"]
@@ -913,8 +972,8 @@ async def http_effect_veto(request):
     risk_score = row["risk_score"]
     block_verdict = verdict == "high-risk"
     block_action = action is not None and action not in ("approve", "guide")
-    # §6 verdict/action gate OR §7 tier gate — either trips the veto.
-    vetoed = bool(block_verdict or block_action or (not tier_ok))
+    # §6 verdict/action OR §7 tier OR §8 effect-binding — any trips the veto.
+    vetoed = bool(block_verdict or block_action or (not tier_ok) or (not binding_ok))
 
     if vetoed:
         reasons = []
@@ -922,7 +981,9 @@ async def http_effect_veto(request):
             reasons.append(f"verdict={verdict} action={action}")
         if not tier_ok:
             reasons.append(tier_reason)
-        reason = " ; ".join(reasons)
+        if not binding_ok:
+            reasons.append(binding_reason)
+        reason = " ; ".join(r for r in reasons if r)
     else:
         reason = None
 
@@ -934,6 +995,7 @@ async def http_effect_veto(request):
         "risk_score": risk_score,
         "tier": tier,
         "tier_ok": tier_ok,
+        "binding_ok": binding_ok,
         "reason": reason,
     })
 

--- a/tests/test_http_api_effect_veto_binding.py
+++ b/tests/test_http_api_effect_veto_binding.py
@@ -1,0 +1,173 @@
+"""Proof-tests for the §8 effect-binding gate at POST /v1/effect-veto (#1075).
+
+§8 is ADDITIVE and flag-gated (UNITARES_GOVERNED_EFFECT_BINDING):
+  - flag OFF (default) → binding_ok defaults True, the live §6/§7 veto is
+    byte-identical (covered by test_http_api_effect_veto.py, which sets no flag);
+  - flag ON → the forwarded grant must cover THIS exact effect AND its nonce must
+    be unconsumed, else the effect is vetoed.
+
+Proven here so neither half is a silent no-op:
+  - valid grant + fresh nonce → allowed (binding_ok True);
+  - replayed nonce (INSERT ... ON CONFLICT hit) → vetoed (binding_replayed);
+  - no grant → vetoed (binding_absent);
+  - grant for a different payload → vetoed (binding_mismatch_psha);
+  - nonce-store error → vetoed (binding_store_unavailable), fail-closed.
+
+Governance row is None (unknown proposer → §6 fails open) so §7+§8 are isolated.
+Tokens + grants are minted with the real primitives under a test HMAC secret.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from src.http_api import http_effect_veto
+from src.effect_grant import mint_effect_grant
+from src.mcp_handlers.identity import session as session_mod
+
+PROPOSER = "00000000-0000-0000-0000-0000000000aa"
+TEST_SECRET = "test-continuity-secret-0123456789abcdef"
+
+_CONTENT = {
+    "payload_sha256": "a" * 64,
+    "surface": "file://sandbox/x",
+    "custody_mode": "execute",
+    "idempotency_key": "idem-key-001",
+}
+
+
+@pytest.fixture(autouse=True)
+def _env():
+    with patch.dict(
+        os.environ,
+        {
+            "UNITARES_CONTINUITY_TOKEN_SECRET": TEST_SECRET,
+            "UNITARES_GOVERNED_EFFECT_BINDING": "1",
+            "UNITARES_MCP_BEARER_TOKENS": "",
+            "UNITARES_HTTP_API_TOKEN": "",
+        },
+    ):
+        yield
+
+
+def _token(aid=PROPOSER):
+    return session_mod.create_continuity_token(aid, f"sid-{aid[:8]}")
+
+
+def _grant(**overrides):
+    fields = {**_CONTENT, **overrides}
+    return mint_effect_grant(aid=PROPOSER, **fields)
+
+
+class _FakeConn:
+    def __init__(self, row, insert_result, execute_exc):
+        self._row = row
+        self._insert = insert_result
+        self._execute_exc = execute_exc
+
+    async def fetchrow(self, *_a, **_k):
+        return self._row
+
+    async def execute(self, *_a, **_k):
+        if self._execute_exc:
+            raise self._execute_exc
+        return self._insert
+
+
+class _FakeAcquire:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *_a):
+        return False
+
+
+class _FakeDB:
+    def __init__(self, row=None, insert_result="INSERT 0 1", execute_exc=None):
+        self._conn = _FakeConn(row, insert_result, execute_exc)
+
+    def acquire(self):
+        return _FakeAcquire(self._conn)
+
+
+def _post(body, *, insert_result="INSERT 0 1", execute_exc=None):
+    with patch("src.db.get_db", return_value=_FakeDB(None, insert_result, execute_exc)):
+        app = Starlette(routes=[Route("/v1/effect-veto", http_effect_veto, methods=["POST"])])
+        return TestClient(app).post("/v1/effect-veto", json=body)
+
+
+def _body(grant="__valid__", **content_overrides):
+    body = {
+        "proposer_agent_uuid": PROPOSER,
+        "proposer_continuity_token": _token(),
+        **_CONTENT,
+        **content_overrides,
+    }
+    if grant == "__valid__":
+        grant = _grant()
+    if grant is not None:
+        body["proposer_effect_grant"] = grant
+    return body
+
+
+# ── allow: valid grant + fresh nonce ─────────────────────────────────────────
+
+def test_valid_grant_fresh_nonce_is_allowed():
+    r = _post(_body())
+    assert r.status_code == 200
+    j = r.json()
+    assert j["binding_ok"] is True
+    assert j["vetoed"] is False
+
+
+# ── replay: nonce already consumed ───────────────────────────────────────────
+
+def test_replayed_nonce_is_vetoed():
+    r = _post(_body(), insert_result="INSERT 0 0")  # ON CONFLICT hit → 0 rows
+    j = r.json()
+    assert j["binding_ok"] is False
+    assert j["vetoed"] is True
+    assert j["reason"] == "binding_replayed"
+
+
+# ── absent / mismatched / store-error → vetoed (fail-closed) ─────────────────
+
+def test_no_grant_is_vetoed():
+    r = _post(_body(grant=None))
+    j = r.json()
+    assert j["binding_ok"] is False and j["vetoed"] is True
+    assert j["reason"] == "binding_absent"
+
+
+def test_grant_for_different_payload_is_vetoed():
+    # grant minted for payload A, effect declares payload B → T1 mismatch
+    mismatched = _grant(payload_sha256="b" * 64)
+    r = _post(_body(grant=mismatched))
+    j = r.json()
+    assert j["binding_ok"] is False and j["vetoed"] is True
+    assert j["reason"] == "binding_mismatch_psha"
+
+
+def test_nonce_store_error_fails_closed():
+    r = _post(_body(), execute_exc=RuntimeError("db down"))
+    j = r.json()
+    assert j["binding_ok"] is False and j["vetoed"] is True
+    assert j["reason"] == "binding_store_unavailable"
+
+
+# ── flag off → §8 is a no-op (live veto unchanged) ───────────────────────────
+
+def test_flag_off_is_noop_even_without_grant():
+    with patch.dict(os.environ, {"UNITARES_GOVERNED_EFFECT_BINDING": "0"}):
+        r = _post(_body(grant=None))
+    j = r.json()
+    # no grant, but binding disabled → not vetoed on §8 grounds; tier still ok
+    assert j["binding_ok"] is True
+    assert j["vetoed"] is False


### PR DESCRIPTION
Slice 3 of effect-binding **Phase 1** — the verify half (slices 1 #1237 + 2 #1240 already merged to master). The lease plane forwards the grant and `/v1/effect-veto` verifies it covers THIS exact effect + consumes its nonce once. **Inert — the live §6/§7 veto is byte-identical until `UNITARES_GOVERNED_EFFECT_BINDING` flips on.**

**Python:** migration **054** `effects.consumed_nonces` (single-use ledger, `INSERT ... ON CONFLICT DO NOTHING`, retention ≥ grant exp). §8 `binding_ok` gate in `http_effect_veto`: flag **off (default) → no-op** (live veto unchanged); **on →** `verify_effect_grant` must cover `(aid, payload_sha256, surface, custody_mode, idempotency_key)` **and** the nonce must be unconsumed, else vetoed. Both exit paths (like §7). Atomic single-statement consume (no SELECT-then-INSERT TOCTOU); store error fails closed. New `binding_ok` response field.

**Elixir:** `validate/1` extracts `proposer.effect_grant` (transient credential, never persisted/logged); `build_veto_body` forwards the grant + content fields **only when present** → byte-identical today → pure no-op. `payload_sha256` reuses the idempotency payload-hash; cross-language canonicalization is the **slice-4 integration item** (a mismatch fails **closed**, never open).

**Inert 3 ways:** flag in no plist (off → §8 no-op) · no proposer mints grants · migration unapplied. Live execute surface unchanged.

**Scope:** closes **T1** (retarget) + grant-only **T2** (replay). **Not T3** — that needs Phase 2 (enrollment / orchestrator-vouched delegation). Per #1075 this was demand-gated; banked inert.

**Verify:** Python 6 §8 cases (valid+fresh allow; replayed nonce; absent; T1 payload-mismatch; store-error fail-closed; flag-off no-op) + 13 veto regression unchanged. Elixir +4 (forward with content fields; byte-identical when absent; grant never leaks into the persisted record) — full lease suite **276 tests + 14 properties, 0 failures**. Full Python gate **11145 passed**; ruff clean; doctor migration slot/drift clean. `docs/FLAGS.md` regenerated (also swept a pre-existing stale `UNITARES_SESSION_MIRROR_SHADOW` entry — generated artifact).

**Slice 4 (operator, NOT here):** apply 054 → **lease-plane-first** deploy (forwards harmlessly while gov ignores) → **then** gov-mcp `UNITARES_GOVERNED_EFFECT_BINDING=1`, dry-run-first. Lease-first ordering avoids a deploy-window fail-closed block.

Design #1228 · Issue #1075 · Slices #1237 → #1240 → this.

https://claude.ai/code/session_01RPGYhmjDU7uqjmA7vanh41