### PR TITLE
feat(dialectic): emit dialectic_* lifecycle events via broadcaster (#1167 Ask 1)

### DIFF
--- a/src/mcp_handlers/dialectic/handlers.py
+++ b/src/mcp_handlers/dialectic/handlers.py
@@ -55,6 +55,7 @@ async def _resolve_dialectic_agent_id(
         arguments, enforce_session_ownership=enforce_session_ownership
     )
 from src.logging_utils import get_logger
+from src.broadcaster import broadcaster_instance
 
 logger = get_logger(__name__)
 
@@ -120,6 +121,41 @@ from src.dialectic_db import (
 # ACTIVE: get_dialectic_session, list_dialectic_sessions, llm_assisted_dialectic
 # Still removed: request_exploration_session, nudge_dialectic_session, handle_self_recovery
 # ==============================================================================
+
+
+async def _emit_dialectic_event(event_type: str, session, **payload_extra) -> None:
+    """Best-effort broadcast of a dialectic lifecycle event (#1167 Ask 1).
+
+    Telemetry only — must never raise into the resolution path, so it mirrors the
+    knowledge handlers' guarded broadcast pattern. The broadcaster auto-persists to
+    audit.events and serves the WS firehose; the dashboard and the Phoenix dialectic
+    pane subscribe to any ``dialectic_*`` event as a doorbell to refetch
+    authoritative state. Names are the engine-owner-ratified set from #1167:
+    ``dialectic_opened``, ``dialectic_facilitation_needed``, ``dialectic_resolved``.
+
+    Emitted from the Python handler intentionally: when
+    UNITARES_DIALECTIC_BEAM_RESOLUTION is on, BEAM is an alternative *persistence*
+    backend, not an alternative control flow — this handler still runs, so a single
+    emit here covers both the BEAM and pg-fallback paths.
+    """
+    try:
+        phase = getattr(session, "phase", None)
+        payload = {
+            "session_id": getattr(session, "session_id", None),
+            "phase": getattr(phase, "value", phase),
+            "topic": getattr(session, "topic", None),
+            "session_type": getattr(session, "session_type", None),
+            "awaiting_facilitation": getattr(session, "awaiting_facilitation", False),
+        }
+        payload.update(payload_extra)
+        await broadcaster_instance.broadcast_event(
+            event_type,
+            agent_id=getattr(session, "paused_agent_id", None),
+            payload=payload,
+        )
+    except Exception as e:  # pragma: no cover - telemetry must not break the flow
+        logger.debug("dialectic event %s emit skipped: %s", event_type, e)
+
 
 async def check_reviewer_stuck(session: DialecticSession) -> bool:
     """
@@ -765,6 +801,7 @@ async def handle_request_dialectic_review(arguments: Dict[str, Any]) -> Sequence
 
     # Cache in-memory for quick access
     ACTIVE_SESSIONS[session.session_id] = session
+    await _emit_dialectic_event("dialectic_opened", session)
 
     if auto_awaiting_reviewer:
         # No independent reviewer yet; the antithesis is owed by a summoned or
@@ -777,6 +814,9 @@ async def handle_request_dialectic_review(arguments: Dict[str, Any]) -> Sequence
             await pg_update_awaiting_facilitation(session.session_id, True)
         except Exception as e:
             logger.error(f"Failed to persist awaiting_facilitation on create: {e}")
+        await _emit_dialectic_event(
+            "dialectic_facilitation_needed", session, reason="no_independent_reviewer"
+        )
 
     # Build response based on reviewer assignment
     if auto_awaiting_reviewer:
@@ -937,6 +977,9 @@ async def handle_get_dialectic_session(arguments: Dict[str, Any]) -> Sequence[Te
                         except Exception as e:
                             logger.error(f"Failed to persist facilitation status: {e}")
                         logger.info(f"[DIALECTIC] Session {session_id[:16]} awaiting human facilitation (reviewer {old_reviewer} stuck)")
+                        await _emit_dialectic_event(
+                            "dialectic_facilitation_needed", session, reason="reviewer_stuck"
+                        )
 
                     return success_response({
                         "success": False,
@@ -1317,6 +1360,7 @@ async def _run_synthetic_review(
             )
             session.awaiting_facilitation = False
             resolved = True
+            await _emit_dialectic_event("dialectic_resolved", session, action="resume")
         except Exception as e:
             logger.warning("[DIALECTIC] Synthetic resolution finalize failed: %s", e)
 
@@ -1942,6 +1986,12 @@ async def handle_submit_synthesis(arguments: Dict[str, Any]) -> Sequence[TextCon
                 for aid in (session.paused_agent_id, session.reviewer_agent_id):
                     if aid and aid in _SESSION_METADATA_CACHE:
                         del _SESSION_METADATA_CACHE[aid]
+
+                # Resolution is committed (BEAM or pg fallback above); announce the
+                # terminal outcome. session.phase is RESOLVED or FAILED here.
+                await _emit_dialectic_event(
+                    "dialectic_resolved", session, action=result.get("action")
+                )
     
                 await save_session(session)
     
@@ -2313,11 +2363,15 @@ async def handle_llm_assisted_dialectic(arguments: Dict[str, Any]) -> Sequence[T
                 status="resolved",
             )
             logger.info(f"LLM dialectic session {session_id} resolved via protocol")
+            await _emit_dialectic_event("dialectic_resolved", session, action="resume")
         else:
             session.awaiting_facilitation = True
             logger.info(
                 f"LLM dialectic session {session_id}: reviewer did not approve "
                 f"(recommendation={recommendation}); left unresolved for facilitation"
+            )
+            await _emit_dialectic_event(
+                "dialectic_facilitation_needed", session, reason="reviewer_did_not_approve"
             )
         # Store in ACTIVE_SESSIONS regardless so the verdict is recorded.
         ACTIVE_SESSIONS[session_id] = session

--- a/tests/test_dialectic_broadcast_events.py
+++ b/tests/test_dialectic_broadcast_events.py
@@ -1,0 +1,106 @@
+"""Contract for the dialectic lifecycle broadcast events (#1167 Ask 1).
+
+`_emit_dialectic_event` is the single guarded emit point the dialectic handlers
+use to surface session lifecycle to the broadcaster firehose (and thus the
+dashboard / Phoenix dialectic pane, which subscribe to any ``dialectic_*`` event).
+
+Two invariants matter and are pinned here:
+  1. The event reaches `broadcaster_instance.broadcast_event` with the ratified
+     type, the paused agent as `agent_id`, and a payload that carries
+     `session_id` + `awaiting_facilitation` (what the surface badges/sorts on).
+  2. It is telemetry: a failing broadcaster must NEVER raise into the resolution
+     path.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.mcp_handlers.dialectic.handlers import _emit_dialectic_event
+
+
+def _fake_session(**over):
+    base = dict(
+        session_id="sess-123",
+        phase=SimpleNamespace(value="resolved"),
+        topic="should we ship X",
+        session_type="discovery",
+        awaiting_facilitation=False,
+        paused_agent_id="agent-abc",
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+@pytest.mark.asyncio
+async def test_emit_passes_type_agent_and_payload(monkeypatch):
+    captured = {}
+
+    async def _capture(event_type, agent_id=None, payload=None):
+        captured.update(event_type=event_type, agent_id=agent_id, payload=payload)
+
+    monkeypatch.setattr(
+        "src.mcp_handlers.dialectic.handlers.broadcaster_instance.broadcast_event",
+        AsyncMock(side_effect=_capture),
+    )
+
+    await _emit_dialectic_event(
+        "dialectic_resolved", _fake_session(), action="resume"
+    )
+
+    assert captured["event_type"] == "dialectic_resolved"
+    assert captured["agent_id"] == "agent-abc"  # the paused agent, not the reviewer
+    payload = captured["payload"]
+    assert payload["session_id"] == "sess-123"
+    assert payload["phase"] == "resolved"  # enum-like .value unwrapped
+    assert payload["action"] == "resume"  # extra kwargs threaded through
+    assert payload["awaiting_facilitation"] is False
+
+
+@pytest.mark.asyncio
+async def test_facilitation_event_carries_reason(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        "src.mcp_handlers.dialectic.handlers.broadcaster_instance.broadcast_event",
+        AsyncMock(side_effect=lambda *a, **k: captured.update(k, event_type=a[0])),
+    )
+
+    await _emit_dialectic_event(
+        "dialectic_facilitation_needed",
+        _fake_session(awaiting_facilitation=True),
+        reason="reviewer_stuck",
+    )
+
+    assert captured["event_type"] == "dialectic_facilitation_needed"
+    assert captured["payload"]["reason"] == "reviewer_stuck"
+    assert captured["payload"]["awaiting_facilitation"] is True
+
+
+@pytest.mark.asyncio
+async def test_emit_never_raises_when_broadcaster_fails(monkeypatch):
+    monkeypatch.setattr(
+        "src.mcp_handlers.dialectic.handlers.broadcaster_instance.broadcast_event",
+        AsyncMock(side_effect=RuntimeError("ws down")),
+    )
+
+    # Must swallow — telemetry cannot break the resolution path.
+    await _emit_dialectic_event("dialectic_opened", _fake_session())
+
+
+@pytest.mark.asyncio
+async def test_emit_tolerates_a_minimal_session(monkeypatch):
+    """Defensive getattrs: a session missing optional fields must not crash."""
+    captured = {}
+    monkeypatch.setattr(
+        "src.mcp_handlers.dialectic.handlers.broadcaster_instance.broadcast_event",
+        AsyncMock(side_effect=lambda *a, **k: captured.update(k, event_type=a[0])),
+    )
+
+    await _emit_dialectic_event("dialectic_opened", SimpleNamespace(session_id="s1"))
+
+    assert captured["event_type"] == "dialectic_opened"
+    assert captured["payload"]["session_id"] == "s1"
+    assert captured["agent_id"] is None


### PR DESCRIPTION
## What

Wires the dialectic engine to the broadcaster firehose so the live dialectic surface has events to subscribe to — **closes the Ask-1 half of #1167** and unblocks B2 of the dialectic live surface (consumer is PR #1250, the Phoenix pane).

Adds one guarded helper `_emit_dialectic_event` (telemetry-only; **never raises into the resolution path**, mirroring the knowledge handlers' pattern) and emits the ratified event set at every live path:

| event | fires at |
|---|---|
| `dialectic_opened` | session create |
| `dialectic_facilitation_needed` | all 3 `awaiting_facilitation` transitions — no independent reviewer, reviewer stuck, LLM reviewer did not approve |
| `dialectic_resolved` | every terminal path — main multi-agent convergence, synthetic-reviewer, LLM-assisted |

## Why emit from Python (not BEAM)

Traced `UNITARES_DIALECTIC_BEAM_RESOLUTION` (`beam_resolve_client.py`): BEAM is an alternative **persistence backend**, not control flow. The Python handler still runs the orchestration and routes BEAM-first with `pg_*` fallback, so a single emit here covers **both** paths. There is no BEAM→Python callback, so Python is the only single point that covers both. Emits fire after the persistence decision (emit-after-persist), and `broadcast_event` auto-persists to `audit.events` + feeds the WS firehose for free.

## Scope (no silent cap)

`dialectic_phase_changed` (intra-session phase progress) is **deliberately deferred** — it's the scattered, lower-value site for a doorbell consumer, and instrumenting every phase-persist site on this hot surface isn't worth it yet. The name is reserved in #1167. The Phoenix pane treats **any** `dialectic_*` event as a doorbell to refetch, so the discrete lifecycle events above light it up today; phase-level liveness is a clean follow-up.

## Tests
- `tests/test_dialectic_broadcast_events.py` — payload contract (type / agent_id=paused agent / `session_id` + `awaiting_facilitation`) + the must-not-raise guarantee + minimal-session tolerance.
- 149 existing dialectic tests still green; AST + ruff clean.

## Refs
- #1167 (contract; this closes Ask 1 — Ask 2 / `awaiting_facilitation` in `list` is code-complete via migration 053).
- #1250 (consumer: Phoenix dialectic pane).

https://claude.ai/code/session_01WQqbU1hSg1BiG8UJxp3tHt