### PR TITLE
fix(dialectic): clear awaiting_facilitation on main-path resolution

### DIFF
--- a/src/mcp_handlers/dialectic/handlers.py
+++ b/src/mcp_handlers/dialectic/handlers.py
@@ -1987,6 +1987,18 @@ async def handle_submit_synthesis(arguments: Dict[str, Any]) -> Sequence[TextCon
                     if aid and aid in _SESSION_METADATA_CACHE:
                         del _SESSION_METADATA_CACHE[aid]
 
+                # A terminal session no longer needs human facilitation. The
+                # synthetic-success (~submit_synthetic) and reviewer-reassignment
+                # paths already clear this flag, but the main multi-agent resolve
+                # did not — leaving a stale awaiting_facilitation=true on a resolved
+                # session, which the live surface wrongly badges / floats to top.
+                if getattr(session, "awaiting_facilitation", False):
+                    session.awaiting_facilitation = False
+                    try:
+                        await pg_update_awaiting_facilitation(session.session_id, False)
+                    except Exception as e:
+                        logger.warning(f"Could not clear awaiting_facilitation on resolve: {e}")
+
                 # Resolution is committed (BEAM or pg fallback above); announce the
                 # terminal outcome. session.phase is RESOLVED or FAILED here.
                 await _emit_dialectic_event(

--- a/tests/test_dialectic_handlers.py
+++ b/tests/test_dialectic_handlers.py
@@ -1070,6 +1070,48 @@ class TestHandleSubmitSynthesis:
         assert data.get("action") == "resume"
 
     @pytest.mark.asyncio
+    async def test_convergence_clears_awaiting_facilitation(
+        self, mock_server, mock_pg_add_message, mock_pg_update_phase,
+        mock_save_session, mock_pg_resolve_session, mock_context_agent,
+    ):
+        """A session that was awaiting facilitation must clear the flag — and
+        persist the clear — when the main multi-agent path resolves. Otherwise the
+        live surface keeps badging / floating a resolved session. Regression for
+        the gap the synthetic-success and reassignment paths already covered."""
+        from src.mcp_handlers.dialectic.handlers import handle_submit_synthesis
+
+        session = _make_session(phase=DialecticPhase.SYNTHESIS)
+        session.synthesis_round = 1
+        session.awaiting_facilitation = True  # flagged earlier in its life
+
+        mock_result = {"success": True, "converged": True, "phase": "resolved"}
+        mock_resolution = MagicMock()
+        mock_resolution.to_dict.return_value = {"action": "resume", "conditions": ["Lower threshold"]}
+
+        with patch(f"{DIALECTIC}.load_session", new_callable=AsyncMock, return_value=session), \
+             patch.object(session, "submit_synthesis", return_value=mock_result), \
+             patch.object(session, "finalize_resolution", return_value=mock_resolution), \
+             patch.object(session, "check_hard_limits", return_value=(True, None)), \
+             patch(f"{DIALECTIC}.execute_resolution", new_callable=AsyncMock,
+                   return_value={"resumed": True}), \
+             patch(f"{DIALECTIC}.pg_update_awaiting_facilitation",
+                   new_callable=AsyncMock) as mock_clear, \
+             mock_pg_add_message, mock_pg_update_phase, mock_save_session, \
+             mock_pg_resolve_session, mock_context_agent:
+            result = await handle_submit_synthesis({
+                "session_id": session.session_id,
+                "agent_id": "agent-paused",
+                "proposed_conditions": ["Lower threshold"],
+                "agrees": True,
+                "api_key": "key",
+            })
+
+        data = parse_result(result)
+        assert data.get("converged") is True
+        assert session.awaiting_facilitation is False  # in-memory flag cleared
+        mock_clear.assert_awaited_with(session.session_id, False)  # and persisted
+
+    @pytest.mark.asyncio
     async def test_convergence_safety_violation(
         self, mock_server, mock_pg_add_message, mock_pg_update_phase,
         mock_save_session, mock_pg_resolve_session, mock_context_agent,


### PR DESCRIPTION
## What

A dialectic session flagged `awaiting_facilitation` that resolves via the **main multi-agent convergence path** kept a stale `awaiting_facilitation=true`. The synthetic-success (`~submit_synthetic`) and reviewer-reassignment paths already clear it, but the main resolve block (`handlers.py`) did not — so the live dialectic surface (#1250) **wrongly badges / floats a resolved session to the top**.

## How found

Surfaced while verifying the #1251 deploy end-to-end: I opened a real test session, drove it through a genuine orchestrated reviewer to `resolved`, and the resolved row carried `awaiting_facilitation=true`. (Cleared that one row manually; this is the code fix.)

## Fix

Clear the flag — in-memory **and** persisted via `pg_update_awaiting_facilitation` — in the convergence block, co-located with the `dialectic_resolved` emit so the event payload reflects it too. Runs for every terminal outcome of the convergence block (resume / safety-block / exec-fail), and is a no-op when the flag was never set.

## Test

`test_convergence_clears_awaiting_facilitation` drives the converge path with the flag pre-set and asserts it clears in-memory and persists `False`. 85 dialectic tests green; ruff clean.

## Refs
- #1251 (the emit events whose deploy-verification surfaced this), #1250 (the consumer that mis-renders the stale flag), #1167 (contract).

https://claude.ai/code/session_01WQqbU1hSg1BiG8UJxp3tHt