### PR TITLE
feat(dashboard): enumerate per-check detail in System Health panel

### DIFF
--- a/dashboard/redesign/data.js
+++ b/dashboard/redesign/data.js
@@ -352,6 +352,9 @@
           lastCycleAgeS: vg.stats.last_cycle_age_seconds, avgCoherence: vg.stats.avg_coherence_window,
           eisv: vg.cycles && vg.cycles[0] ? vg.cycles[0] : null };
         if (h) out.health = { status: h.status, version: h.version, checks: h.status_breakdown || {},
+          // Per-check detail — the 12 named checks /health/deep already returns,
+          // so the panel can name what's degraded instead of only counting.
+          items: h.checks || {}, operator: h.operator_summary || {},
           breakers: { governance: (h.circuit_breakers && h.circuit_breakers.governance || {}).trips_24h || 0, redis: (h.circuit_breakers && h.circuit_breakers.redis || {}).trips_24h || 0 },
           calibration: (h.checks && h.checks.calibration || {}).status, redis: h.redis_present, continuity: h.identity_continuity_mode };
         // Chronicler has no dedicated summary endpoint — pull its live state from

--- a/dashboard/redesign/sections/residents.js
+++ b/dashboard/redesign/sections/residents.js
@@ -86,11 +86,55 @@
       ${e.E != null ? `<div style="margin-top:var(--space-3);display:flex;gap:var(--space-5);font-family:var(--font-mono);font-size:var(--text-sm);color:var(--ink-2)"><span>E ${e.E.toFixed(2)}</span><span>I ${e.I.toFixed(2)}</span><span>S ${e.S.toFixed(2)}</span><span>V ${e.V.toFixed(2)}</span></div>` : ""}</div>`;
   }
 
+  // Map a per-check status string to a pip color. Anything other than the
+  // known-good/known-soft states reads as a hard failure.
+  function healthColor(st) {
+    return st === "healthy" ? "var(--ok)"
+      : st === "warning" ? "var(--warn)"
+      : st === "deprecated" ? "var(--muted)"
+      : "var(--danger)"; // error / unavailable / unknown
+  }
+  // Pick the single most operator-useful field a check exposes, so each row
+  // says something beyond its name. Order = most-to-least diagnostic.
+  function healthDetail(c) {
+    if (!c || typeof c !== "object") return "";
+    if (c.latency_ms != null) return Math.round(c.latency_ms) + "ms";
+    if (c.note) return String(c.note);
+    if (c.init_error) return String(c.init_error);
+    if (c.pending_updates) return c.pending_updates + " pending";
+    if (c.mode) return String(c.mode);
+    if (c.backend) return String(c.backend);
+    return "";
+  }
+
   function health(h) {
     if (!h) return "";
     const ch = h.checks || {};
-    return `<div class="panel">${head("System Health", h.status === "healthy" ? "healthy" : "silent", "v" + esc(h.version || "") + " · continuity " + esc(h.continuity || "—"))}
-      ${statRow([stat("checks ok", ch.healthy || 0, "var(--ok)"), stat("warnings", ch.warning || 0, (ch.warning ? "var(--warn)" : "var(--muted)")), stat("breaker trips 24h", (h.breakers || {}).governance || 0, "var(--ok)"), stat("calibration", h.calibration || "—", "var(--ok)")])}</div>`;
+    const items = h.items || {};
+    const op = h.operator || {};
+    // Sort non-healthy checks to the top so a degraded one is never buried.
+    const rank = (st) => (st === "healthy" ? 2 : st === "deprecated" ? 1 : 0);
+    const rows = Object.keys(items).sort((a, b) => rank(items[a] && items[a].status) - rank(items[b] && items[b].status))
+      .map((name) => {
+        const c = items[name] || {}, st = c.status || "unknown", det = healthDetail(c);
+        return `<div style="display:flex;gap:var(--space-3);align-items:baseline;font-size:var(--text-sm);padding:var(--space-1) 0">
+          <span class="dot-pip" style="background:${healthColor(st)};flex:none;align-self:center"></span>
+          <span style="font-family:var(--font-mono);color:var(--ink-2);flex:none">${esc(name)}</span>
+          <span class="spring"></span>
+          ${det ? `<span class="fresh" style="flex:none">${esc(det)}</span>` : ""}
+          <span style="color:${healthColor(st)};flex:none;text-transform:uppercase;font-size:var(--text-xs);letter-spacing:var(--tracking-label)">${esc(st)}</span></div>`;
+      }).join("");
+    // Operator banner: only when something is actually failing/degraded.
+    const fails = (op.failing_checks || []).concat(op.degraded_checks || []);
+    const banner = fails.length
+      ? `<div style="margin:var(--space-3) 0;padding:var(--space-2) var(--space-3);border-left:2px solid var(--warn);background:var(--surface-2);font-size:var(--text-sm);color:var(--ink-2)">
+           <b>${fails.length}</b> need${fails.length === 1 ? "s" : ""} attention: <span style="font-family:var(--font-mono)">${esc(fails.join(", "))}</span>${op.first_action && op.first_action !== "No action needed." ? ` — ${esc(op.first_action)}` : ""}</div>`
+      : "";
+    const allOk = h.status === "healthy" && !fails.length;
+    return `<div class="panel">${head("System Health", allOk ? "healthy" : "silent", "v" + esc(h.version || "") + " · continuity " + esc(h.continuity || "—"))}
+      ${statRow([stat("checks ok", ch.healthy || 0, "var(--ok)"), stat("warnings", ch.warning || 0, (ch.warning ? "var(--warn)" : "var(--muted)")), stat("errors", ch.error || 0, (ch.error ? "var(--danger)" : "var(--muted)")), stat("breaker trips 24h", (h.breakers || {}).governance || 0, "var(--ok)")])}
+      ${banner}
+      ${rows ? `<div style="margin-top:var(--space-3)">${rows}</div>` : ""}</div>`;
   }
 
   async function load() {

--- a/dashboard/redesign/snapshot.js
+++ b/dashboard/redesign/snapshot.js
@@ -128,7 +128,12 @@ window.SNAPSHOT = {
     vigil: { cycles24h:42, writesWindow:30, lastVerdict:"proceed", lastCycleAgeS:890, avgCoherence:0.489,
       eisv:{E:0.750,I:0.766,S:0.159,V:-0.017,coherence:0.489} },
     chronicler: { status:"silent", silenceH:18.6, note:"daily resident past its 1h check-in threshold" },
-    health: { status:"healthy", version:"2.13.0", checks:{ healthy:12, warning:0, error:0 },
+    health: { status:"healthy", version:"2.14.0", checks:{ healthy:12, warning:0, error:0 },
+      items:{ primary_db:{status:"healthy",latency_ms:3}, audit_db:{status:"healthy",latency_ms:4}, redis_cache:{status:"healthy",mode:"connected"},
+        lease_plane:{status:"healthy"}, knowledge_graph:{status:"healthy"}, pi_connectivity:{status:"healthy"},
+        identity_continuity:{status:"healthy",mode:"redis"}, calibration:{status:"healthy",pending_updates:0}, calibration_db:{status:"healthy"},
+        telemetry:{status:"healthy"}, agent_metadata:{status:"healthy"}, data_directory:{status:"healthy"} },
+      operator:{ overall_status:"healthy", failing_checks:[], degraded_checks:[], first_action:"No action needed." },
       breakers:{ governance:0, redis:0 }, calibration:"healthy", dbPool:{ size:8, idle:4, max:25 }, redis:true, continuity:"redis" },
   },
   research: {


### PR DESCRIPTION
## What

The System Health panel on the Residents view collapsed `/health/deep` to four roll-up numbers (`12 checks ok · 0 warnings · …`) and threw away the per-check detail the endpoint already returns. You could see *that* something was off but never *which* check — the gap Kenny flagged ("doesn't say what is okay and what is not okay").

This surfaces the **12 named checks individually**: each row gets a status-colored pip, the check name, its most diagnostic field (`latency_ms` / `note` / `mode` / `pending_updates`), and its per-check status. Non-healthy checks sort to the top, and `operator_summary.failing_checks` / `degraded_checks` drive an attention banner with `first_action`. The roll-up row keeps checks-ok / warnings and now also shows errors.

## Scope

Pure front-end — `/health/deep` already returns all of this:
- `data.js` — pass through `health.items` (`h.checks`) and `health.operator` (`h.operator_summary`)
- `sections/residents.js` — `health()` renders the per-check list + banner
- `snapshot.js` — offline fallback updated to the same shape

## Verified

Rendered locally against the snapshot fallback (live data has the identical shape, confirmed against the running server's `/health/deep`): all 12 checks list with pips, latencies (`primary_db 3ms`, `audit_db 4ms`), `redis_cache connected`, `identity_continuity redis`, and per-check status.

> Note: separate follow-ups discussed but not in this PR — Sentinel panel reading the durable `/v1/sentinel/backlog` instead of the volatile in-memory ring (shows `0/0/0` after restart), and Chronicler not emitting EISV/events.

https://claude.ai/code/session_0124JwLQNcBihZq683GT7ueR