### PR TITLE
feat(dialectic): emit dialectic_phase_changed on interactive transitions

### DIFF
--- a/src/mcp_handlers/dialectic/handlers.py
+++ b/src/mcp_handlers/dialectic/handlers.py
@@ -157,6 +157,19 @@ async def _emit_dialectic_event(event_type: str, session, **payload_extra) -> No
         logger.debug("dialectic event %s emit skipped: %s", event_type, e)
 
 
+async def _emit_phase_changed(session, prev_phase) -> None:
+    """Emit dialectic_phase_changed when an interactive submit advanced the phase
+    (thesis -> antithesis -> synthesis), for live intra-session progress. No-op if
+    the phase did not move (e.g. another synthesis round stays in SYNTHESIS).
+    Terminal phases (resolved/failed) are announced by dialectic_resolved, not here.
+    """
+    to_phase = getattr(getattr(session, "phase", None), "value", None)
+    if to_phase and to_phase != prev_phase:
+        await _emit_dialectic_event(
+            "dialectic_phase_changed", session, from_phase=prev_phase, to_phase=to_phase
+        )
+
+
 async def check_reviewer_stuck(session: DialecticSession) -> bool:
     """
     Check if reviewer is stuck (paused or hasn't responded after thesis submission).
@@ -1431,6 +1444,7 @@ async def handle_submit_thesis(arguments: Dict[str, Any]) -> Sequence[TextConten
         )
 
         # Submit to session
+        _prev_phase = session.phase.value
         result = session.submit_thesis(message, api_key)
 
         if result["success"]:
@@ -1452,6 +1466,9 @@ async def handle_submit_thesis(arguments: Dict[str, Any]) -> Sequence[TextConten
                     await pg_update_phase(session_id, session.phase.value)
             except Exception as e:
                 logger.warning(f"Could not update PostgreSQL after thesis: {e}")
+
+            # Live progress: thesis submitted -> phase advanced (-> antithesis).
+            await _emit_phase_changed(session, _prev_phase)
 
             # Persist to JSON (export snapshot)
             try:
@@ -1684,6 +1701,7 @@ async def handle_submit_antithesis(arguments: Dict[str, Any]) -> Sequence[TextCo
         )
 
         # Submit to session
+        _prev_phase = session.phase.value
         result = session.submit_antithesis(message, api_key)
 
         if result["success"]:
@@ -1720,6 +1738,9 @@ async def handle_submit_antithesis(arguments: Dict[str, Any]) -> Sequence[TextCo
                     await pg_update_phase(session_id, session.phase.value)
             except Exception as e:
                 logger.warning(f"Could not update PostgreSQL after antithesis: {e}")
+
+            # Live progress: antithesis submitted -> phase advanced (-> synthesis).
+            await _emit_phase_changed(session, _prev_phase)
 
             # Persist to JSON
             try:

--- a/tests/test_dialectic_broadcast_events.py
+++ b/tests/test_dialectic_broadcast_events.py
@@ -19,7 +19,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from src.mcp_handlers.dialectic.handlers import _emit_dialectic_event
+from src.mcp_handlers.dialectic.handlers import _emit_dialectic_event, _emit_phase_changed
 
 
 def _fake_session(**over):
@@ -104,3 +104,34 @@ async def test_emit_tolerates_a_minimal_session(monkeypatch):
     assert captured["event_type"] == "dialectic_opened"
     assert captured["payload"]["session_id"] == "s1"
     assert captured["agent_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_phase_changed_emits_on_transition(monkeypatch):
+    """dialectic_phase_changed fires with from/to when the phase actually moved."""
+    captured = {}
+    monkeypatch.setattr(
+        "src.mcp_handlers.dialectic.handlers.broadcaster_instance.broadcast_event",
+        AsyncMock(side_effect=lambda *a, **k: captured.update(k, event_type=a[0])),
+    )
+
+    session = _fake_session(phase=SimpleNamespace(value="antithesis"))
+    await _emit_phase_changed(session, "thesis")
+
+    assert captured["event_type"] == "dialectic_phase_changed"
+    assert captured["payload"]["from_phase"] == "thesis"
+    assert captured["payload"]["to_phase"] == "antithesis"
+
+
+@pytest.mark.asyncio
+async def test_phase_changed_noop_when_phase_unchanged(monkeypatch):
+    """No event when the phase did not move (e.g. another synthesis round)."""
+    mock = AsyncMock()
+    monkeypatch.setattr(
+        "src.mcp_handlers.dialectic.handlers.broadcaster_instance.broadcast_event", mock
+    )
+
+    session = _fake_session(phase=SimpleNamespace(value="synthesis"))
+    await _emit_phase_changed(session, "synthesis")
+
+    mock.assert_not_awaited()


### PR DESCRIPTION
## What

Adds the one deferred event from #1167 — **`dialectic_phase_changed`** — for live intra-session progress on the dialectic surface (#1250/#1251). Completes the event vocabulary.

Fires `dialectic_phase_changed` with `{from_phase, to_phase}` when an **interactive** submit advances the phase:
- `submit_thesis` → `thesis → antithesis`
- `submit_antithesis` → `antithesis → synthesis`

via a guarded `_emit_phase_changed` helper that **no-ops when the phase didn't move** (e.g. another synthesis round stays in SYNTHESIS).

## Scope (deliberate)

Only the interactive handlers are instrumented. The synthetic-reviewer and LLM-assisted paths run all phases to resolution within a single call — there's no real-time liveness to observe, and their outcome is already announced by `dialectic_resolved`. Terminal phases (resolved/failed) are `dialectic_resolved`, not phase_changed. So phase_changed = the genuine human-observable deliberation steps.

## Tests
- `test_phase_changed_emits_on_transition` (from/to payload) + `test_phase_changed_noop_when_phase_unchanged`.
- 608 dialectic tests green; ruff clean; no hang (local full dialectic run 12.6s).

## Refs
#1167 (this closes the last proposed event), #1251 (the other events), #1250 (consumer pane — already treats any `dialectic_*` as a doorbell, so it consumes this immediately).

https://claude.ai/code/session_01WQqbU1hSg1BiG8UJxp3tHt