### PR TITLE
scope-guard: enforce no-metered-model-cloud policy (Rule 6)

### DIFF
--- a/docs/REPO_SCOPE.md
+++ b/docs/REPO_SCOPE.md
@@ -34,6 +34,20 @@ agent (or no agent) against it.
   discusses these patterns (this guard, a register cleanup, meta-docs) can opt
   the PR-body lint out with the HTML comment `<!-- scope-guard: allow-register -->`.
 
+## Metered model-cloud dependencies
+
+The execution-cost policy (`CLAUDE.md` → *Execution-cost policy*) keeps this repo
+free / self-hosted: no dependency that requires a paid model API. The guard makes
+the policy's most concrete clauses executable, flagging only **unambiguously
+cloud-billed** signals in changed files: `anthropics/claude-code-action` in a
+`.github/workflows/` file, an `import`/`from anthropic` SDK import (no local
+equivalent exists), and a hardcoded `api.openai.com` / `api.anthropic.com`
+endpoint. It deliberately does **not** flag the sanctioned free paths — the
+`openai` client is allowed because it also drives a **local Ollama** server via a
+`base_url` override, and the agent orchestrator may spawn the `claude` CLI by
+design. A feature that genuinely needs a paid API should be a *deferred, opt-in*
+option (or live outside this repo), per the policy.
+
 ## Why a guard, not just this doc
 
 Memory and per-vendor instruction files (`CLAUDE.md`, `AGENTS.md`) do not

--- a/scripts/dev/check-repo-scope.sh
+++ b/scripts/dev/check-repo-scope.sh
@@ -138,6 +138,34 @@ while IFS= read -r f; do
       fi
       ;;
   esac
+
+  # Rule 6: net-new metered model-CLOUD dependency. The execution-cost policy
+  # (CLAUDE.md "No metered model-API dependencies ... rules out
+  # anthropics/claude-code-action and any CI/automation that calls a metered
+  # API") is written but was previously enforced only by humans reading it.
+  # PRECISE, near-zero-false-positive signals ONLY — we deliberately do NOT flag
+  # the sanctioned free paths: the `openai` client is allowed (it talks to LOCAL
+  # Ollama via a base_url override), and the orchestrator may spawn the `claude`
+  # CLI by design. We flag only the unambiguously cloud-billed ones.
+  if [[ "$f" == .github/workflows/*.yml || "$f" == .github/workflows/*.yaml ]]; then
+    if grep -nIE 'anthropics/claude-code-action' "$f" >/dev/null 2>&1; then
+      report "$f" "CI uses anthropics/claude-code-action — a metered model API. The execution-cost policy forbids metered deps; keep CI GITHUB_TOKEN-only / local Ollama."
+    fi
+  fi
+  case "$bn" in
+    *.py)
+      if grep -nIE '^[[:space:]]*(import|from)[[:space:]]+anthropic([[:space:].]|$)' "$f" >/dev/null 2>&1; then
+        report "$f" "Imports the anthropic SDK — there is no local equivalent, so this is a metered Anthropic API dependency. Forbidden by the execution-cost policy (use a local model via the openai client, or make it a deferred opt-in outside the repo)."
+      fi
+      ;;
+  esac
+  case "$bn" in
+    *.py|*.sh|*.bash|*.yml|*.yaml|*.toml)
+      if grep -nIE 'api\.(openai|anthropic)\.com' "$f" >/dev/null 2>&1; then
+        report "$f" "Targets a metered model cloud endpoint (api.openai.com / api.anthropic.com) — point at a local/self-hosted base_url, or make it a deferred opt-in per the execution-cost policy."
+      fi
+      ;;
+  esac
 done <<EOF
 $FILES
 EOF


### PR DESCRIPTION
Makes the **execution-cost policy** (CLAUDE.md: *No metered model-API dependencies ... rules out `anthropics/claude-code-action` and any CI/automation that calls a metered API*) executable. It was written but enforced only by humans — a claude-dependent resident nearly landed in `agents/` this week before a human caught it.

## What it flags (precise, near-zero-FP, changed files only)
- `anthropics/claude-code-action` in a `.github/workflows/` file
- an `import`/`from anthropic` SDK import (no local equivalent → always metered)
- a hardcoded `api.openai.com` / `api.anthropic.com` endpoint

## What it deliberately does NOT flag (sanctioned free paths)
- the `openai` client — it drives a **local Ollama** server via `base_url` (already used in `model_inference.py`, `llm_delegation.py`, `dialectic_reviewer`)
- the orchestrator spawning the `claude` CLI — by design

## Verification
3 violating fixtures flagged (action / anthropic SDK / cloud endpoint); the local-Ollama-via-openai fixture stays clean; existing repo passes `--base origin/master`. Runs in the existing pre-commit hook + `repo-scope.yml` CI. Doc in `docs/REPO_SCOPE.md`.

Scope note: this is the *cleanly-machineable* half of the boundary. The broader 'operator/claude-dependent tooling' boundary stays a judgment call (the litmus) because the repo legitimately uses local-LLM-via-openai and orchestrator-spawned-claude.