### PR TITLE
docs: accuracy point-fixes — coverage gate, Redis re-label, stale claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Human evaluators start with the [Reviewer Guide](docs/REVIEWER_GUIDE.md).
 
 ## Stack & setup
 
-**Python 3.12+ · PostgreSQL + AGE + pgvector · Redis (optional).** Transports: MCP on `/mcp/` (Streamable HTTP) · REST on `/v1/tools/call` · Dashboard on `/dashboard`.
+**Python 3.12+ · PostgreSQL + AGE + pgvector · Redis.** Transports: MCP on `/mcp/` (Streamable HTTP) · REST on `/v1/tools/call` · Dashboard on `/dashboard`.
 
 <details>
 <summary><strong>Alternate ports, bare-metal, and thin clients</strong></summary>
@@ -210,7 +210,7 @@ POSTGRES_HOST_PORT=15432 REDIS_HOST_PORT=16379 GOVERNANCE_HOST_PORT=18767 docker
 UNITARES_DEMO_PORT=18767 make demo
 ```
 
-**Bare-metal** (lower overhead, what the maintainer runs in production): PostgreSQL 16+ with Apache AGE + pgvector compiled and installed (examples use PG 17), Redis optional.
+**Bare-metal** (lower overhead, what the maintainer runs in production): PostgreSQL 16+ with Apache AGE + pgvector compiled and installed (examples use PG 17). Redis: the server boots in degraded local-only mode without it, but production uses it as the primary session store.
 
 ```bash
 pip install -r requirements-full.txt

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ export UNITARES_KNOWLEDGE_BACKEND=age
 python src/mcp_server.py --port 8767
 ```
 
-`requirements-full.txt` is the default (server, tests, handler dev); `requirements-core.txt` is a 2-package subset (`mcp` + `numpy`) for thin stdio/proxy clients. DB bring-up: [db/postgres/README.md](db/postgres/README.md). Run signal-only without the math model: `export UNITARES_DISABLE_ODE=1`. Full port map: [`docs/operations/DEFINITIVE_PORTS.md`](docs/operations/DEFINITIVE_PORTS.md).
+`requirements-full.txt` is the default (server, tests, handler dev); `requirements-core.txt` is a minimal runtime subset (see the file) for thin stdio/proxy clients. DB bring-up: [db/postgres/README.md](db/postgres/README.md). Run signal-only without the math model: `export UNITARES_DISABLE_ODE=1`. Full port map: [`docs/operations/DEFINITIVE_PORTS.md`](docs/operations/DEFINITIVE_PORTS.md).
 
 </details>
 

--- a/docs/CANONICAL_COMPONENTS.md
+++ b/docs/CANONICAL_COMPONENTS.md
@@ -88,7 +88,7 @@ not** drive verdicts.
 |---|---|---|---|
 | **Coordination / lease plane** | BEAM (Elixir/OTP) kernel for single-writer coordination + liveness on shared surfaces (Plexus). Port 8788, bearer-gated. | `lease_plane.*`, the `dispatch_beam` client | **PARTIAL** — advisory-first rollout; Wave 3a first cutovers live |
 | **Resident agents** | Always-on governed agents | Vigil (cron janitorial) · Sentinel (continuous analytical) · Watcher (PostToolUse) · Steward (Pi→Mac) · Chronicler (daily) · Lumen (embodied Pi) | **LIVE** (launchd) |
-| **Substrate** | Durable truth | ONE Postgres = relational + Apache AGE 1.7 + pgvector; Redis optional | **MATURE** |
+| **Substrate** | Durable truth | ONE Postgres = relational + Apache AGE 1.7 + pgvector; Redis = de-facto primary session store (not optional), being migrated to PG-mirror | **MATURE** |
 | **Surfaces** | How agents/humans reach it | MCP `/mcp/` · REST `/v1/tools/call` · Dashboard `/dashboard` · SDK · governance plugin (Claude Code/Codex hooks) · host-adapter | **LIVE** |
 
 ---

--- a/docs/EISV_COMPUTATION.md
+++ b/docs/EISV_COMPUTATION.md
@@ -15,11 +15,11 @@ observables ──► observation blend ──► EMA state ──► residual /
  drift, tools)                                                               pause/reject
 ```
 
-The dynamical-systems / thermodynamic model (`governance_core/`, the ODE) runs **in parallel and does not drive verdicts** by default (`governance_monitor.py:1013-1017`: *"The ODE engine runs in parallel but does NOT drive verdicts… Primary verdicts come from behavioral assessment (EMA + z-score deviations)."*). It supplies the phi objective, regime detection, and historical continuity — the research lens, not the control loop.
+The dynamical-systems / thermodynamic model (`governance_core/`, the ODE) runs **in parallel and does not drive verdicts** by default (`governance_monitor.py`, the "does NOT drive verdicts" guard comment: *"The ODE engine runs in parallel but does NOT drive verdicts… Primary verdicts come from behavioral assessment (EMA + z-score deviations)."*). It supplies the phi objective, regime detection, and historical continuity — the research lens, not the control loop.
 
 ## Step 1 — Observations (`src/behavioral_sensor.py`)
 
-For non-embodied agents (the common case), three observations are computed from governance observables. Embodied agents (e.g. the Raspberry-Pi deployment) instead supply hardware `sensor_eisv` directly (`governance_monitor.py:967-972`).
+For non-embodied agents (the common case), three observations are computed from governance observables. Embodied agents (e.g. the Raspberry-Pi deployment) instead supply hardware `sensor_eisv` directly (`governance_monitor.py`, the `sensor_eisv` embodied-agent path).
 
 **E_obs** — productive capacity (`_compute_E`):
 ```
@@ -56,14 +56,14 @@ State is an EMA of the observations (α ramps from ~0.5 during bootstrap to a co
 E = (1−α)·E + α·E_obs        I = (1−α)·I + α·I_obs        S = (1−α)·S + α·S_obs
 ```
 
-**V is not an independent dimension.** It is the EMA-smoothed E−I imbalance (`behavioral_state.py:174-176`):
+**V is not an independent dimension.** It is the EMA-smoothed E−I imbalance (`behavioral_state.py`, `_raw_valence()` fed into the `update()` EMA):
 ```
 raw_v = E − I
 V     = (1−α_V)·V + α_V·raw_v
 ```
 So "four-dimensional state vector" is really three observed axes (E, I, S) plus a derived imbalance readout (V). V is surfaced separately because its **sign** is operationally actionable — positive = running hot (energetic but claims outrun results), negative = running careful (coherent but low progress) — not because it carries independent information.
 
-(If you grep the codebase you will find a second `_compute_V` — a slope-plus-level formula — in `behavioral_sensor.py`. It is **unused on the verdict path**: `governance_monitor.py:1002` passes only E/I/S observations to `behavioral_state.update()`, which recomputes V as the EMA of E−I above. The live V is the one described here.)
+(If you grep the codebase you will find a second `_compute_V` — a slope-plus-level formula — in `behavioral_sensor.py`. It is **unused on the verdict path**: `governance_monitor.py` passes only E/I/S observations to `self._behavioral_state.update()`, which recomputes V as the EMA of E−I above. The live V is the one described here.)
 
 ## Step 3 — Residuals: proprioception, not prosecution
 

--- a/docs/PRODUCTION_SNAPSHOT.md
+++ b/docs/PRODUCTION_SNAPSHOT.md
@@ -3,8 +3,9 @@
 Frozen public snapshot from June 16, 2026 (single-operator — the author's own
 traffic). Headline: **3.7M+ governance events processed · ≈714K in the last 7
 days**. Running continuously since November 2025 and dogfooded — the agents
-building UNITARES run under it. Every number here is verifiable on a fresh clone;
-see the [Reviewer Guide](REVIEWER_GUIDE.md#falsifiability-grade-eisv-yourself-dont-trust-this-doc).
+building UNITARES run under it. The falsifiability checks run on a fresh clone;
+the live deployment metrics below need governance-DB access to reproduce — see
+the [Reviewer Guide](REVIEWER_GUIDE.md#falsifiability-grade-eisv-yourself-dont-trust-this-doc).
 
 ## Full metrics table
 
@@ -16,7 +17,7 @@ see the [Reviewer Guide](REVIEWER_GUIDE.md#falsifiability-grade-eisv-yourself-do
 | Governance events processed | 3,748,000+ (≈714K in the last 7 days) |
 | Knowledge graph discoveries | 1,054 |
 | V operating range | Active agents often within [-0.1, 0.1] |
-| Tests | 8,500+ collected · smoke/pre-push subset plus 25% min coverage gate |
+| Tests | 8,500+ collected · smoke/pre-push subset plus 75% min coverage gate |
 
 *What these numbers show:* the pipeline holds up under sustained volume. *What
 they don't show:* product-market traction. External adoption is the open question.

--- a/docs/UNIFIED_ARCHITECTURE.md
+++ b/docs/UNIFIED_ARCHITECTURE.md
@@ -106,7 +106,7 @@ Agents and operators interact through several bound services. All bind to `127.0
 | Gateway MCP | `8768` | `/mcp/` | Reduced surface for weak external clients |
 | Lease plane | `8788` | `/v1/lease/*` (bearer-auth, fail-closed) | Elixir/OTP coordination layer for single-writer surfaces — runbook in [`operations/lease-plane-operator-runbook.md`](operations/lease-plane-operator-runbook.md) |
 | PostgreSQL@17 + AGE | `5432` | `postgresql://…/governance` | Single source of truth |
-| Redis | `6379` | `redis://…/0` | Session cache, optional |
+| Redis | `6379` | `redis://…/0` | De-facto primary session/identity store — not optional; most live sessions exist only here. Being migrated to a Postgres-mirror model (`docs/proposals/redis-retirement-v0.md`) |
 
 ## Recovery: Circuit Breaker + Dialectic
 
@@ -141,8 +141,8 @@ Agents contribute discoveries to a shared store. **PostgreSQL FTS is the canonic
 |  +- core.calibration         |
 |  +- core.tool_usage          |
 |                              |
-|  Redis (port 6379)           |     Session cache only.
-|  audit_log.jsonl (raw)       |     Falls back gracefully without Redis.
+|  Redis (port 6379)           |     De-facto primary session store —
+|  audit_log.jsonl (raw)       |     not optional; degraded local-only without it.
 +------------------------------+
 ```
 

--- a/scripts/dev/refresh_snapshot.py
+++ b/scripts/dev/refresh_snapshot.py
@@ -29,18 +29,31 @@ import os
 import re
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 
 DEFAULT_DB_URL = os.environ.get(
     "GOVERNANCE_DATABASE_URL",
     "postgresql://postgres:postgres@localhost:5432/governance",
 )
 
+
+def _cov_fail_under(default: int = 75) -> int:
+    """Read the coverage gate from the canonical test runner so this snapshot
+    cannot quote a stale number (it read 25 while the real gate was 75)."""
+    runner = Path(__file__).resolve().parents[2] / "scripts" / "dev" / "test-cache.sh"
+    try:
+        m = re.search(r"cov-fail-under=(\d+)", runner.read_text(encoding="utf-8"))
+    except OSError:
+        return default
+    return int(m.group(1)) if m else default
+
+
 # Non-DB rows: preserved as-is by --write, emitted verbatim by the print path.
 STATIC_ROWS = [
     ("V operating range", "Active agents often within [-0.1, 0.1]"),
     (
         "Tests",
-        "8,500+ collected · smoke/pre-push subset plus 25% min coverage gate",
+        f"8,500+ collected · smoke/pre-push subset plus {_cov_fail_under()}% min coverage gate",
     ),
 ]
 

--- a/tests/test_refresh_snapshot.py
+++ b/tests/test_refresh_snapshot.py
@@ -79,7 +79,7 @@ def test_apply_to_readme_updates_db_rows_and_leaves_static(mod, snap):
         "| Governance events processed | 351,000+ (≈94K in the last 7 days) |\n"
         "| Knowledge graph discoveries | 860 |\n"
         "| V operating range | Active agents often within [-0.1, 0.1] |\n"
-        "| Tests | 8,500+ collected · smoke/pre-push subset plus 25% min coverage gate |\n"
+        "| Tests | 8,500+ collected · smoke/pre-push subset plus 75% min coverage gate |\n"
     )
     updated = mod.apply_to_readme(original, snap, "June 16, 2026")
     assert "**3.7M+ governance events processed · ≈714K in the last 7 days**." in updated
@@ -87,7 +87,7 @@ def test_apply_to_readme_updates_db_rows_and_leaves_static(mod, snap):
     assert "| Knowledge graph discoveries | 1,054 |" in updated
     # Non-DB rows are untouched.
     assert "| V operating range | Active agents often within [-0.1, 0.1] |" in updated
-    assert "| Tests | 8,500+ collected · smoke/pre-push subset plus 25% min coverage gate |" in updated
+    assert "| Tests | 8,500+ collected · smoke/pre-push subset plus 75% min coverage gate |" in updated
     # Old numbers are gone.
     assert "351,000+" not in updated
     assert "| Knowledge graph discoveries | 860 |" not in updated


### PR DESCRIPTION
Accuracy fixes from the docs audit — same single-source principle as the flag/port generators (#1255), but these are point corrections rather than new generators.

## Changes

- **Coverage gate (was wrong):** `PRODUCTION_SNAPSHOT.md` said *"25% min coverage gate"*; the real gate is **75%** (`--cov-fail-under=75` in `test-cache.sh` + CI). `refresh_snapshot.py` now derives the number from the canonical test runner instead of hardcoding it, so a future gate change can't re-stale the snapshot. Committed doc corrected to 75%.
- **Overclaim (was misleading):** *"Every number here is verifiable on a fresh clone"* is false for the live-DB deployment metrics (they need governance-DB access). Reworded to scope fresh-clone reproducibility to the falsifiability checks — consistent with what the Reviewer Guide already says.
- **README deps (was wrong + drift-prone):** `requirements-core.txt` described as *"a 2-package subset (`mcp` + `numpy`)"*; it actually pins **3** (`mcp`, `numpy`, `PyYAML`). De-enumerated to "a minimal runtime subset (see the file)" so it can't drift on the next dependency change.

## Verification

- `refresh_snapshot._cov_fail_under()` → 75 (read from `test-cache.sh`).
- `tests/test_refresh_snapshot.py` → 7 passed (fixture % aligned to 75 for consistency; round-trip semantics unchanged).
- `check_doc_drift.py` → pass; ruff clean.
- Independent of #1255 (no file overlap).

## Redis re-label (added)

Docs called Redis "session cache, optional / falls back gracefully" — false (~94% of live sessions exist only in Redis). Corrected to the calibrated truth in CLAUDE.md: **de-facto primary session store, not optional, being migrated to PG-mirror** (`redis-retirement-v0`). Deliberately *not* a spotlight — framed as a tracked liability, not a feature. Touches `UNIFIED_ARCHITECTURE`, `CANONICAL_COMPONENTS`, `README`. Trust-contract's "#425 pending" line left for the identity single-writer owner (dated forensic record + sensitive surface).


## EISV citations (added)

`EISV_COMPUTATION.md` cited 4 source locations by line number — all drifted since written (substance correct). Re-pointed at durable symbols (the "does NOT drive verdicts" guard, the `sensor_eisv` path, `_raw_valence()`/`update()`, the `_behavioral_state.update()` call) so they can't drift on the next code edit.
