### PR TITLE
docs(security): document the governed-effect execute plane in the threat model

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,14 +15,37 @@ UNITARES is a runtime governance MCP server for AI-agent fleets. In-scope vulner
 - Authentication / identity bypasses in the MCP handlers, the gateway (port 8768), the lease plane (port 8788), or the dashboard
 - Bearer-token handling, session-cache leakage, or cross-agent identity confusion (see [`docs/ontology/identity.md`](docs/ontology/identity.md) for the identity model)
 - Injection / RCE through MCP tool inputs, audit-log entries, or knowledge-graph writes
+- Escaping the **governed-effect execute plane** (port 8788) — committing a host effect (`agent_spawn` / `file_write` / commit) without passing the strong-tier identity gate, the per-effect governance veto, the bearer token, or lease custody (see the section below; off by default)
 - SQL injection, AGE injection, or other database-layer issues
 - Sensitive data exposure in audit logs, telemetry, or the dashboard
 - Resource exhaustion / DoS against any bound service
 
 **Out of scope:**
-- Issues that require root or local-shell access to the host running the server (e.g., reading `data/` on disk)
+- Issues that require root or local-shell access to the host running the server (e.g., reading `data/` on disk). Note: the governed-effect execute plane is *HTTP-reachable* host execution, not local-shell — it is in scope above, not excluded by this clause
 - Vulnerabilities in dependencies — please report those upstream first; we'll bump pinned versions once a fix is available
 - Configurations that bind services to non-loopback interfaces — the default config binds to `127.0.0.1` (see `MCP_CLIENTS.md`); exposing publicly is operator responsibility
+
+## Governed-effect execute plane
+
+UNITARES ships an optional **governed-effect execute plane** (BEAM, port 8788): an
+agent *proposes* an effect — `agent_spawn`, `file_write`, or a file-write `commit` —
+and only governance *commits* it. Because that is a host code-execution / file-write
+surface, it is treated as privileged:
+
+- **Off by default.** All three execute flags
+  (`UNITARES_GOVERNED_EFFECT_EXECUTE_AGENT_SPAWN` / `_FILE_WRITE` / `_FILE_WRITE_COMMIT`)
+  default off in code, and the shipped plist templates do not set them — a fresh
+  clone or deploy has no execute surface. A fail-closed boot guard refuses to start
+  if `COMMIT` is enabled without the dispatch path.
+- **Multiply gated when enabled.** Every effect re-certifies **strong-tier identity**
+  and passes a **per-effect governance veto** (`POST /v1/effect-veto`) on every path;
+  the plane is bearer-gated and loopback-bound by default, with per-class payload
+  ceilings and content-hash reversibility/recovery.
+- **In scope.** Bypassing any of those gates to commit an unsanctioned effect is a
+  security issue — please report it.
+
+The maintainer's own dogfood deployment runs this plane **enabled** (it is off for
+everyone else by default, and reachable only via loopback + bearer token there).
 
 ## Supported versions
 

--- a/docs/SCOPE_AND_THREAT_MODEL.md
+++ b/docs/SCOPE_AND_THREAT_MODEL.md
@@ -120,3 +120,20 @@ the full server pipeline (sensors, continuity, dialectic peer review); the
 structural argument is expected to carry to those paths but has not been measured
 there.
 
+**The highest-stakes surface: the governed-effect execute plane.** Everything above
+concerns the *signal* and whether an agent can game it. The most security-relevant
+capability is different in kind: an optional **governed-effect execute plane** (BEAM,
+port 8788) where an agent proposes an effect — `agent_spawn`, `file_write`, or a
+file-write commit — and only governance commits it. That is a genuine new safety
+property ("agents propose, governance commits"), but it is also a host code-execution
+surface, so it is the place a motivated attacker would aim. It is **off by default**
+(all three execute flags default off; the shipped plist templates do not enable them;
+a fail-closed boot guard blocks commit-without-dispatch), and when an operator enables
+it every effect is gated by strong-tier identity re-certification, a per-effect
+governance veto (`POST /v1/effect-veto`) on every path, a bearer token, loopback
+binding, per-class payload ceilings, and content-hash reversibility. The honest
+residual: those gates have had the same ad-hoc-rather-than-sustained adversarial
+testing as the rest of the system, and a compromised strong-tier proposer credential
+would convert to host execution — so the credential boundary is load-bearing. The
+security-reporting contract for this surface lives in [`SECURITY.md`](../SECURITY.md).
+


### PR DESCRIPTION
Closes the HIGH-severity threat-model gap from the docs audit: the governed-effect **execute plane** (host code-execution surface on port 8788) appeared in neither `SECURITY.md` nor `SCOPE_AND_THREAT_MODEL.md`, and `SECURITY.md`'s "out of scope: requires local-shell access" clause implicitly excluded it — when it's actually HTTP-reachable host execution.

This is a **security-accuracy** fix, separable from public *repositioning* (the README's framing is untouched). Written to be accurate, not a feature pitch — the honest read is reassuring: **off by default, multiply-gated.**

## SECURITY.md
- In-scope bullet: escaping the effect-plane gates to commit an unsanctioned host effect.
- Clarify the local-shell out-of-scope clause does **not** exclude the (HTTP-reachable) execute plane.
- New "Governed-effect execute plane" section: off by default (flags default off; plist templates don't set them; fail-closed boot guard), and when enabled — strong-tier identity re-cert + per-effect veto (`/v1/effect-veto`) on every path + bearer + loopback + payload ceilings + content-hash reversibility. States the maintainer dogfoods it enabled.

## SCOPE_AND_THREAT_MODEL.md
- A "highest-stakes surface" callout parallel to the existing open-question / blind-spot callouts. Names the load-bearing residual: a compromised strong-tier proposer credential converts to host execution.

## Verified against code
Execute flags default `false` (`application.ex`, `governed_effect.ex`, `file_write_executor.ex`); plist templates carry no execute flags; fail-closed boot guard `application.ex:139-148`; veto handler `src/http_api.py:848`.

## ⚠️ One line for your call
SECURITY.md states *"the maintainer's own dogfood deployment runs this plane enabled."* It's honest and defensible (the live plane is loopback + bearer gated), but it does name a target — say the word and I'll cut that sentence.