### PR TITLE
fix(dialectic): restore awaiting_facilitation on reconstruction (fixes #1259)

### DIFF
--- a/docs/FLAGS.md
+++ b/docs/FLAGS.md
@@ -44,9 +44,9 @@ index; that one is the curated decision record.
 | `UNITARES_DIALECTIC_BEAM_RESOLUTION` | `'0'` | True iff the operator has flipped UNITARES_DIALECTIC_BEAM_RESOLUTION on. | src/mcp_handlers/dialectic/beam_resolve_client.py:28 |
 | `UNITARES_DIALECTIC_ORCHESTRATED_REVIEW` | `'0'` | Opt-in gate for routing reviews through the orchestrator (default OFF) | src/mcp_handlers/dialectic/orchestrator_dispatch.py:38 |
 | `UNITARES_DIALECTIC_REVIEWER_TIMEOUT` | `(required)` | Timeout budget for a structured dialectic reviewer call | src/mcp_handlers/support/llm_delegation.py:68 |
-| `UNITARES_DIALECTIC_REVIEW_BUDGET` | `(required)` | Wall-clock cap for the inline synthetic review (antithesis + synthesis) | src/mcp_handlers/dialectic/handlers.py:1211 |
+| `UNITARES_DIALECTIC_REVIEW_BUDGET` | `(required)` | Wall-clock cap for the inline synthetic review (antithesis + synthesis) | src/mcp_handlers/dialectic/handlers.py:1224 |
 | `UNITARES_DIALECTIC_REVIEW_MAX_TOKENS` | `'1024'` | Run the local heterogeneous model in THIS process (not via the server's call_model tool, whose 30s timeout is shorter than gemma4's 43–70s b | agents/dialectic_reviewer/reviewer.py:181 |
-| `UNITARES_DIALECTIC_SYNTHETIC_REVIEWER` | `'1'` | Whether submit_thesis auto-completes a no-live-reviewer session via the local synthetic reviewer instead of leaving it to hang at awaiting_f | src/mcp_handlers/dialectic/handlers.py:1201 |
+| `UNITARES_DIALECTIC_SYNTHETIC_REVIEWER` | `'1'` | Whether submit_thesis auto-completes a no-live-reviewer session via the local synthetic reviewer instead of leaving it to hang at awaiting_f | src/mcp_handlers/dialectic/handlers.py:1214 |
 | `UNITARES_DIALECTIC_WRITE_JSON_SNAPSHOT` | `'1'` | — | src/mcp_handlers/dialectic/session.py:70 |
 | `UNITARES_DISABLE_PLUGINS` | `(required)` | Load every registered ``governance_mcp.plugins`` entry point | src/plugin_loader.py:40 |
 | `UNITARES_EMBEDDING_MODEL` | `'minilm'` | Derive a config tag matching baseline filename suffix from env vars | src/embeddings.py:48, agents/vigil/agent.py:347 |

--- a/src/mcp_handlers/dialectic/handlers.py
+++ b/src/mcp_handlers/dialectic/handlers.py
@@ -2008,11 +2008,11 @@ async def handle_submit_synthesis(arguments: Dict[str, Any]) -> Sequence[TextCon
                     if aid and aid in _SESSION_METADATA_CACHE:
                         del _SESSION_METADATA_CACHE[aid]
 
-                # A terminal session no longer needs human facilitation. The
-                # synthetic-success (~submit_synthetic) and reviewer-reassignment
-                # paths already clear this flag, but the main multi-agent resolve
-                # did not — leaving a stale awaiting_facilitation=true on a resolved
-                # session, which the live surface wrongly badges / floats to top.
+                # A terminal session no longer needs human facilitation. The guard
+                # reads the in-memory flag, which is now accurate on the resolve path
+                # because _reconstruct_session_from_dict restores it (#1259) — before
+                # that fix the loaded session always looked not-awaiting here, so this
+                # silently no-op'd and a resolved session kept a stale flag.
                 if getattr(session, "awaiting_facilitation", False):
                     session.awaiting_facilitation = False
                     try:

--- a/src/mcp_handlers/dialectic/session.py
+++ b/src/mcp_handlers/dialectic/session.py
@@ -138,6 +138,12 @@ def _reconstruct_session_from_dict(session_id: str, session_data: Dict) -> Optio
         session.transcript = transcript
         session.resolution = resolution
         session.synthesis_round = int(session_data.get("synthesis_round", 0) or 0)
+        # Restore awaiting_facilitation (#1259). The DialecticSession ctor defaults
+        # it to False, so without this a loaded session always looks not-awaiting in
+        # memory — which silently defeated the #1253 resolve-clear guard (a resolved
+        # session kept a stale awaiting_facilitation=true) and re-armed the
+        # reviewer-stuck set/emit path. get_session is SELECT *, so the column is present.
+        session.awaiting_facilitation = bool(session_data.get("awaiting_facilitation", False))
         created_at_str = session_data.get("created_at")
         if created_at_str:
             # Handle both string and datetime objects from different backends

--- a/tests/test_dialectic_session_handlers.py
+++ b/tests/test_dialectic_session_handlers.py
@@ -179,6 +179,24 @@ class TestReconstructSessionFromDict:
         assert session.phase == DialecticPhase.SYNTHESIS
         assert session.synthesis_round == 1
 
+    def test_reconstruction_restores_awaiting_facilitation(self):
+        """#1259: the flag must round-trip through reconstruction. The ctor
+        defaults it False, so if reconstruct drops it a loaded session looks
+        not-awaiting in memory — which silently no-op'd the #1253 resolve-clear
+        guard (resolved sessions kept a stale awaiting_facilitation=true)."""
+        from src.mcp_handlers.dialectic.session import _reconstruct_session_from_dict
+
+        data = _make_session_dict()
+        data["awaiting_facilitation"] = True
+        session = _reconstruct_session_from_dict("sess_aw", data)
+        assert session.awaiting_facilitation is True
+
+        # Absent key -> safe default False (no regression for older snapshots).
+        data2 = _make_session_dict()
+        data2.pop("awaiting_facilitation", None)
+        session2 = _reconstruct_session_from_dict("sess_aw2", data2)
+        assert session2.awaiting_facilitation is False
+
     def test_reconstruction_with_resolution(self):
         from src.mcp_handlers.dialectic.session import _reconstruct_session_from_dict
 


### PR DESCRIPTION
Fixes #1259.

## Root cause (corrected)

The #1259 issue first theorized the BEAM resolution saga clobbered the flag — **wrong**. lease-plane never writes `awaiting_facilitation` (`dialectic_saga.ex:289` sets only `status/phase/resolution_json`; the string appears nowhere in `elixir/lease_plane/`).

The real cause: **`_reconstruct_session_from_dict` never restored `awaiting_facilitation`.** It rebuilds phase/transcript/resolution/synthesis_round/etc., but not this flag — so a `load_session` round-trip leaves the `DialecticSession` ctor default (`False`) in memory. The #1253 resolve-clear is guarded `if session.awaiting_facilitation` → reads stale `False` → **silently no-ops**, and the DB `true` (persisted at create by #1220) survives. `get_session` is `SELECT *`, so the column was always in the dict — just never read.

## Fix

Restore the flag in `_reconstruct_session_from_dict` from `session_data` (absent key → `False`, no regression for older snapshots). This makes the #1253 guard accurate on the resolve path, and also un-breaks the reviewer-stuck re-set guard (`if not getattr(session,'awaiting_facilitation',False)`) which read the same stale flag and could re-emit `dialectic_facilitation_needed`. Updated the resolve-site comment to match.

## Verification context

Found live: a forced session that went awaiting→resolved kept `awaiting_facilitation=true` in prod despite #1253 being deployed. The mechanism is confirmed by reading the reconstruct path, not theorized.

## Test
`test_reconstruction_restores_awaiting_facilitation` (round-trip true + absent→false). 609 dialectic tests green; ruff clean; no hang (local dialectic run 17.6s).

Refs: #1253, #1220, #1167, #1250.

https://claude.ai/code/session_01WQqbU1hSg1BiG8UJxp3tHt