### PR TITLE
docs: regenerate FLAGS.md (fix red master — line-number drift)

### DIFF
--- a/docs/FLAGS.md
+++ b/docs/FLAGS.md
@@ -44,9 +44,9 @@ index; that one is the curated decision record.
 | `UNITARES_DIALECTIC_BEAM_RESOLUTION` | `'0'` | True iff the operator has flipped UNITARES_DIALECTIC_BEAM_RESOLUTION on. | src/mcp_handlers/dialectic/beam_resolve_client.py:28 |
 | `UNITARES_DIALECTIC_ORCHESTRATED_REVIEW` | `'0'` | Opt-in gate for routing reviews through the orchestrator (default OFF) | src/mcp_handlers/dialectic/orchestrator_dispatch.py:38 |
 | `UNITARES_DIALECTIC_REVIEWER_TIMEOUT` | `(required)` | Timeout budget for a structured dialectic reviewer call | src/mcp_handlers/support/llm_delegation.py:68 |
-| `UNITARES_DIALECTIC_REVIEW_BUDGET` | `(required)` | Wall-clock cap for the inline synthetic review (antithesis + synthesis) | src/mcp_handlers/dialectic/handlers.py:1211 |
+| `UNITARES_DIALECTIC_REVIEW_BUDGET` | `(required)` | Wall-clock cap for the inline synthetic review (antithesis + synthesis) | src/mcp_handlers/dialectic/handlers.py:1224 |
 | `UNITARES_DIALECTIC_REVIEW_MAX_TOKENS` | `'1024'` | Run the local heterogeneous model in THIS process (not via the server's call_model tool, whose 30s timeout is shorter than gemma4's 43–70s b | agents/dialectic_reviewer/reviewer.py:181 |
-| `UNITARES_DIALECTIC_SYNTHETIC_REVIEWER` | `'1'` | Whether submit_thesis auto-completes a no-live-reviewer session via the local synthetic reviewer instead of leaving it to hang at awaiting_f | src/mcp_handlers/dialectic/handlers.py:1201 |
+| `UNITARES_DIALECTIC_SYNTHETIC_REVIEWER` | `'1'` | Whether submit_thesis auto-completes a no-live-reviewer session via the local synthetic reviewer instead of leaving it to hang at awaiting_f | src/mcp_handlers/dialectic/handlers.py:1214 |
 | `UNITARES_DIALECTIC_WRITE_JSON_SNAPSHOT` | `'1'` | — | src/mcp_handlers/dialectic/session.py:70 |
 | `UNITARES_DISABLE_PLUGINS` | `(required)` | Load every registered ``governance_mcp.plugins`` entry point | src/plugin_loader.py:40 |
 | `UNITARES_EMBEDDING_MODEL` | `'minilm'` | Derive a config tag matching baseline filename suffix from env vars | src/embeddings.py:48, agents/vigil/agent.py:347 |


### PR DESCRIPTION
Master went red on the `smoke` job's "Check generated docs are fresh" gate (`flag_catalog.py --check`) after #1257 merged.

**Not #1257's content** — that PR touched only bash/docs/CLAUDE.md. The drift is line-number-only: #1253 edited `src/mcp_handlers/dialectic/handlers.py` and shifted two flag definitions (`UNITARES_DIALECTIC_REVIEW_BUDGET` 1211→1224, `UNITARES_DIALECTIC_SYNTHETIC_REVIEWER` 1201→1214) without regenerating the catalog. #1255's new gate caught it.

Pure `python3 scripts/dev/flag_catalog.py` regen; `--check` now clean. Fixes red master.

Note: the catalog pinning source **line numbers** makes this gate brittle — any edit to a flag-defining file drifts it and reddens master. Worth considering tracking by symbol/anchor instead of line, or auto-regenerating in the gate.