### PR TITLE
fix(dashboard): durable EISV fallback so daily residents (Chronicler) show state

### DIFF
--- a/src/http_api.py
+++ b/src/http_api.py
@@ -2873,6 +2873,72 @@ def _latest_eisv_for_agent(agent_id: str) -> Optional[dict]:
     return None
 
 
+async def _durable_latest_eisv_for_agent(
+    agent_id: str, label: Optional[str] = None,
+) -> Optional[dict]:
+    """Most recent durable EISV check-in for an agent from core.agent_state.
+
+    The residents panel reads live EISV from the broadcaster's in-memory ring
+    (~6h, fleet-wide). A *daily* resident like Chronicler checks in once per
+    24h, so its eisv_update has almost always rotated out of the ring by the
+    time the panel loads — leaving its EISV blank even though it checked in
+    fine. core.agent_state persists every check-in (the same source
+    /v1/agents/{id}/history reads), so fall back to it.
+
+    Returns a broadcaster-event-shaped dict so ``_extract_eisv_fields`` consumes
+    it unchanged (E in state_json; I/S/V/coherence/risk_score in columns;
+    verdict/action in state_json). Read-only; returns None on miss or error so
+    the panel degrades to "no EISV" rather than erroring.
+    """
+    try:
+        from src.db import get_db
+        db = get_db()
+        async with db.acquire() as conn:
+            # Identity resolution mirrors http_agent_history: history is keyed by
+            # the agent's UUID identity, but the resident row may carry the
+            # structured id (mcp_DATE_<8hex>) whose suffix is that UUID's prefix.
+            row = await conn.fetchrow(
+                """
+                WITH ids AS (
+                    SELECT identity_id FROM core.identities WHERE agent_id = $1
+                    UNION
+                    SELECT identity_id FROM core.identities
+                     WHERE substring($1 from '([0-9a-f]{8})$') IS NOT NULL
+                       AND agent_id ~ '^[0-9a-f]{8}-'
+                       AND agent_id LIKE substring($1 from '([0-9a-f]{8})$') || '%'
+                )
+                SELECT s.recorded_at,
+                       (s.state_json->>'E')::real AS e,
+                       s.integrity AS i, s.entropy AS s_entropy, s.volatility AS v,
+                       s.coherence, s.risk_score,
+                       s.state_json->>'verdict' AS verdict,
+                       s.state_json->>'action'  AS action
+                FROM core.agent_state s
+                WHERE s.identity_id IN (SELECT identity_id FROM ids)
+                  AND s.synthetic = false
+                ORDER BY s.recorded_at DESC
+                LIMIT 1
+                """,
+                agent_id,
+            )
+        if not row:
+            return None
+        recorded_at = row["recorded_at"]
+        return {
+            "type": "eisv_update",
+            "agent_id": agent_id,
+            "agent_name": label,
+            "timestamp": recorded_at.isoformat() if recorded_at else None,
+            "eisv": {"E": row["e"], "I": row["i"], "S": row["s_entropy"], "V": row["v"]},
+            "coherence": row["coherence"],
+            "metrics": {"risk_score": row["risk_score"], "verdict": row["verdict"]},
+            "decision": {"action": row["action"]},
+        }
+    except Exception as exc:  # noqa: BLE001 — read-only panel fallback, degrade gracefully
+        logger.debug("durable EISV fallback failed for %s: %s", agent_id, exc)
+        return None
+
+
 def _extract_eisv_fields(event: dict) -> dict:
     """Pull the data-shape we expose to the dashboard from a raw broadcaster event.
 
@@ -3098,6 +3164,19 @@ async def http_residents(request):
                         agent_id = event_agent_id
                         meta = getattr(mcp_server_obj, "agent_metadata", {}).get(event_agent_id)
 
+            # Durable EISV fallback. A daily resident (Chronicler) checks in once
+            # per 24h, so its eisv_update has usually rotated out of the
+            # broadcaster's ~6h in-memory ring by the time the panel loads — the
+            # ring lookups above return None and its EISV shows blank. Read the
+            # latest persisted check-in from core.agent_state instead. Labeled
+            # distinctly ("agent_state") so the provenance stays honest.
+            eisv_source = "broadcaster_eisv"
+            if latest is None and agent_id:
+                durable_latest = await _durable_latest_eisv_for_agent(agent_id, label)
+                if durable_latest:
+                    latest = durable_latest
+                    eisv_source = "agent_state"
+
             history = _coherence_history_for_agent(agent_id) if agent_id else []
             recent_writes = await _recent_writes_for_agent(agent_id) if agent_id else []
 
@@ -3118,13 +3197,13 @@ async def http_residents(request):
                     last_checkin_source = "agent_metadata"
                 else:
                     last_checkin_str = latest_eisv_at
-                    last_checkin_source = "broadcaster_eisv"
+                    last_checkin_source = eisv_source
             elif metadata_dt:
                 last_checkin_str = metadata_last_update
                 last_checkin_source = "agent_metadata"
             elif latest_dt:
                 last_checkin_str = latest_eisv_at
-                last_checkin_source = "broadcaster_eisv"
+                last_checkin_source = eisv_source
 
             silence_seconds: Optional[float] = None
             last_dt = _parse_resident_timestamp(last_checkin_str)

--- a/tests/test_http_residents_resolve.py
+++ b/tests/test_http_residents_resolve.py
@@ -340,3 +340,100 @@ async def test_residents_event_driven_flag_authoritative_for_watcher():
     by_label = {r["label"]: r for r in data["residents"]}
     assert by_label["Watcher"]["event_driven"] is True
     assert by_label["Vigil"]["event_driven"] is False
+
+
+@pytest.mark.asyncio
+async def test_residents_durable_eisv_fallback_populates_daily_resident():
+    """A daily resident's EISV must survive the broadcaster ring rotating out.
+
+    Chronicler checks in once per 24h; its eisv_update has almost always
+    rotated out of the broadcaster's ~6h in-memory ring by the time the panel
+    loads, so the in-memory lookups return None and its EISV would render
+    blank. The durable core.agent_state fallback fills it. Here the ring is
+    empty (post-rotation), and the durable read supplies the latest check-in.
+    """
+    from src import http_api
+
+    request = SimpleNamespace(
+        headers={},
+        query_params={},
+        url=SimpleNamespace(path="/v1/residents"),
+        client=SimpleNamespace(host="127.0.0.1"),
+    )
+    server = SimpleNamespace(agent_metadata={
+        "uuid-chron": _resident_meta(
+            label="Chronicler",
+            last_update="2026-06-29T00:19:38+00:00",
+            tags=[],
+        ),
+    })
+
+    http_api.broadcaster_instance.event_history.clear()  # ring rotated out
+
+    durable = {
+        "type": "eisv_update",
+        "agent_id": "uuid-chron",
+        "agent_name": "Chronicler",
+        "timestamp": "2026-06-29T00:19:38+00:00",
+        "eisv": {"E": 0.767, "I": 0.727, "S": 0.269, "V": 0.028},
+        "coherence": 0.517,
+        "metrics": {"risk_score": 0.0, "verdict": "approve"},
+        "decision": {"action": "approve"},
+    }
+
+    with patch("src.mcp_handlers.shared.lazy_mcp_server", server), \
+            patch("src.http_api._recent_writes_for_agent", AsyncMock(return_value=[])), \
+            patch("src.http_api._durable_latest_eisv_for_agent",
+                  AsyncMock(return_value=durable)) as durable_mock:
+        resp = await http_api.http_residents(request)
+
+    data = json.loads(resp.body.decode())
+    chron = next(r for r in data["residents"] if r["label"] == "Chronicler")
+    # The core fix: EISV is populated from the durable store, not blank.
+    assert chron["eisv"] == {"E": 0.767, "I": 0.727, "S": 0.269, "V": 0.028}
+    assert chron["coherence"] == 0.517
+    assert chron["verdict"] == "approve"
+    # Fallback only fires once, and only because the ring had nothing.
+    durable_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_residents_durable_eisv_not_consulted_when_ring_has_event():
+    """The durable fallback is a backstop, not the primary path. When the
+    broadcaster ring already has a live event for the agent, the DB read must
+    be skipped — live signal wins and we don't pay a query per resident."""
+    from src import http_api
+
+    request = SimpleNamespace(
+        headers={},
+        query_params={},
+        url=SimpleNamespace(path="/v1/residents"),
+        client=SimpleNamespace(host="127.0.0.1"),
+    )
+    server = SimpleNamespace(agent_metadata={
+        "uuid-vigil": _resident_meta(
+            label="Vigil",
+            last_update="2026-04-28T10:01:56+00:00",
+            tags=[],
+        ),
+    })
+
+    http_api.broadcaster_instance.event_history.clear()
+    http_api.broadcaster_instance.event_history.append({
+        "type": "eisv_update",
+        "agent_id": "uuid-vigil",
+        "timestamp": "2026-04-28T10:06:04+00:00",
+        "eisv": {"E": 0.8, "I": 0.8, "S": 0.1, "V": 0.0},
+        "metrics": {"coherence": 0.49, "risk_score": 0.0, "verdict": "proceed"},
+    })
+
+    with patch("src.mcp_handlers.shared.lazy_mcp_server", server), \
+            patch("src.http_api._recent_writes_for_agent", AsyncMock(return_value=[])), \
+            patch("src.http_api._durable_latest_eisv_for_agent",
+                  AsyncMock(return_value=None)) as durable_mock:
+        resp = await http_api.http_residents(request)
+
+    data = json.loads(resp.body.decode())
+    vigil = next(r for r in data["residents"] if r["label"] == "Vigil")
+    assert vigil["last_checkin_source"] == "broadcaster_eisv"
+    durable_mock.assert_not_awaited()


### PR DESCRIPTION
## What

The Chronicler panel showed only `daily · ran Xh ago` with **no EISV** — the third gap Kenny flagged ("chronicler not emitting events"). But Chronicler *does* check in fine once per day.

**Root cause:** `/v1/residents` reads EISV only from the broadcaster's **in-memory ring** (~6h, fleet-wide). A *daily* resident's `eisv_update` has almost always rotated out of the ring by the time the panel loads, so the lookup returns `None`, EISV renders blank, and the source falls back to `agent_metadata`. (Same volatility class as the Sentinel panel bug — the live ring is too short-lived for an infrequent reporter.)

The check-ins are durable: `core.agent_state` persists every one — the same source `/v1/agents/{id}/history` reads. **Chronicler has 69 durable rows.**

## Change

`_durable_latest_eisv_for_agent()` reads the latest `core.agent_state` row (identity-resolved like `http_agent_history`) and shapes it like a broadcaster event so `_extract_eisv_fields` consumes it unchanged. `http_residents` calls it **only when the in-memory ring lookup is None**.

- Live residents (Vigil/Sentinel/Watcher/Lumen) always have a fresh ring event → **never pay a DB read**; at most the daily ones (Chronicler, Steward) do.
- EISV sourced this way is labeled `agent_state` (not `broadcaster_eisv`) so provenance stays honest.
- Read-only, fail-open: a DB error degrades to "no EISV", never 500s.
- **Pure backend** — `data.js` already passes `c.eisv` through and the Chronicler renderer shows E/I/S/V when present; no JS change.

## Verified

Ran the durable reader against the live governance DB:
```
timestamp: 2026-06-29T00:19:38Z   (latest of 69 durable check-ins)
eisv: E=0.767 I=0.727 S=0.269 V=0.028   coherence=0.517   verdict=approve
```
Flows correctly through `_extract_eisv_fields`. Tests: durable fallback populates a daily resident's EISV when the ring is empty; fallback is **not** consulted when the ring has a live event (backstop, not primary path). 15 pass.

> This is the third of the three Residents-panel gaps. The other two: #1254 (System Health per-check detail, merged) and #1261 (Sentinel summary durable, green/draft).

https://claude.ai/code/session_0124JwLQNcBihZq683GT7ueR