### PR TITLE
fix(ablation): exclude controlled demo profiler rows

### DIFF
--- a/scripts/analysis/eisv_ablation_matrix.py
+++ b/scripts/analysis/eisv_ablation_matrix.py
@@ -43,7 +43,10 @@ from scripts.analysis.eisv_skeptic_report import (
     score_deltas_vs_baseline,
     summarize_conclusion,
 )
-from scripts.analysis.outcome_inventory import harness_lane_from_detail
+from scripts.analysis.outcome_inventory import (
+    harness_lane_from_detail,
+    is_controlled_validation_fixture,
+)
 
 DEFAULT_EXCLUDED_HARNESS_LANES = ("beam",)
 
@@ -258,9 +261,14 @@ def filter_rows_for_validation(
     coverage collapse when it is really instrumentation.
     """
     excluded = {str(lane) for lane in exclude_harness_lanes if str(lane)}
+    eligible_rows = [
+        row for row in rows if not is_controlled_validation_fixture(row.detail)
+    ]
     if not excluded:
-        return list(rows)
-    return [row for row in rows if harness_lane_from_detail(row.detail) not in excluded]
+        return eligible_rows
+    return [
+        row for row in eligible_rows if harness_lane_from_detail(row.detail) not in excluded
+    ]
 
 
 def split_rows_by_harness_lane(

--- a/scripts/analysis/eisv_skeptic_report.py
+++ b/scripts/analysis/eisv_skeptic_report.py
@@ -33,7 +33,10 @@ from typing import Any, Sequence
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(PROJECT_ROOT))
 
-from scripts.analysis.outcome_inventory import is_controlled_validation_fixture
+from scripts.analysis.outcome_inventory import (
+    attach_identity_metadata,
+    is_controlled_validation_fixture,
+)
 
 
 DEFAULT_DB_URL = os.environ.get(
@@ -1059,7 +1062,12 @@ def _parse_detail(raw: Any) -> dict[str, Any]:
 
 
 def _row_from_record(record: Any) -> OutcomeRow:
-    detail = _parse_detail(record.get("detail"))
+    detail = dict(
+        attach_identity_metadata(
+            record.get("detail"),
+            record.get("identity_metadata"),
+        )
+    )
     n_prior = record.get("n_prior_snapshots")
     n_prior = int(n_prior) if n_prior is not None else None
     # Gate dispersion on a minimum snapshot count: a stddev over 1-2 points is
@@ -1138,6 +1146,7 @@ async def fetch_rows(
                 o.eisv_verdict,
                 o.eisv_coherence,
                 o.detail,
+                identity_meta.metadata AS identity_metadata,
                 o.verification_source,
                 EXTRACT(EPOCH FROM (o.ts - ps.recorded_at))::float AS prior_state_age_seconds,
                 ps.risk_score AS prior_risk,
@@ -1171,6 +1180,13 @@ async def fetch_rows(
                 disp.prior_v_disp,
                 disp.prior_risk_disp
             FROM audit.outcome_events o
+            LEFT JOIN LATERAL (
+                SELECT ident_meta.metadata
+                FROM core.identities ident_meta
+                WHERE ident_meta.agent_id = o.agent_id
+                ORDER BY ident_meta.updated_at DESC NULLS LAST
+                LIMIT 1
+            ) identity_meta ON TRUE
             LEFT JOIN LATERAL (
                 SELECT
                     s.recorded_at,

--- a/scripts/analysis/outcome_inventory.py
+++ b/scripts/analysis/outcome_inventory.py
@@ -137,6 +137,35 @@ _CONTROLLED_FIXTURE_FLAGS = frozenset(
 )
 _CONTROLLED_FIXTURE_BINDINGS = frozenset({"synthetic_negative_control"})
 _CONTROLLED_FIXTURE_TEST_NAMES = frozenset({"clean_control", "overconfidence_probe"})
+_IDENTITY_METADATA_DETAIL_KEY = "_identity_metadata"
+_CONTROLLED_IDENTITY_LABEL_PREFIXES = (
+    "quick-demo-agent",
+    "perf-profile-checkin",
+)
+_CONTROLLED_IDENTITY_PURPOSES = frozenset({"testing", "demo", "profiling", "benchmark"})
+
+
+def attach_identity_metadata(
+    detail: Mapping[str, Any] | str | None,
+    identity_metadata: Mapping[str, Any] | str | None,
+) -> Mapping[str, Any]:
+    """Return detail with identity metadata attached under a private key.
+
+    Historical demo/perf check-in harnesses wrote ordinary auto-checkin outcome
+    details while the controlled-harness signal lived on ``core.identities``.
+    Attach it to the analysis detail map so fixture filters can keep those rows
+    out of live validation without changing the public outcome schema.
+    """
+    normalized = dict(_normalized_detail(detail))
+    metadata = _normalized_detail(identity_metadata)
+    if metadata and _IDENTITY_METADATA_DETAIL_KEY not in normalized:
+        normalized[_IDENTITY_METADATA_DETAIL_KEY] = dict(metadata)
+    return normalized
+
+
+def _identity_metadata_from_detail(detail: Mapping[str, Any]) -> Mapping[str, Any]:
+    metadata = detail.get(_IDENTITY_METADATA_DETAIL_KEY) or detail.get("identity_metadata")
+    return _normalized_detail(metadata)
 
 
 def is_controlled_validation_fixture(detail: Mapping[str, Any] | str | None) -> bool:
@@ -144,8 +173,9 @@ def is_controlled_validation_fixture(detail: Mapping[str, Any] | str | None) -> 
 
     These rows are useful for harness plumbing and local red-team checks, but they
     must not be counted as live fleet validation evidence. Keep this deliberately
-    conservative: explicit fixture flags win, and the legacy one-shot calibration
-    probe names cover rows written before the flags existed.
+    conservative: explicit fixture flags win, legacy one-shot calibration probe
+    names cover rows written before the flags existed, and known demo/perf
+    identity labels catch auto-checkin outcomes whose detail was otherwise plain.
     """
     normalized = _normalized_detail(detail)
     if any(_truthy(normalized.get(flag)) for flag in _CONTROLLED_FIXTURE_FLAGS):
@@ -154,7 +184,32 @@ def is_controlled_validation_fixture(detail: Mapping[str, Any] | str | None) -> 
     if binding in _CONTROLLED_FIXTURE_BINDINGS:
         return True
     test_name = normalized.get("test_name")
-    return bool(test_name in _CONTROLLED_FIXTURE_TEST_NAMES)
+    if test_name in _CONTROLLED_FIXTURE_TEST_NAMES:
+        return True
+
+    identity_metadata = _identity_metadata_from_detail(normalized)
+    if identity_metadata:
+        if any(_truthy(identity_metadata.get(flag)) for flag in _CONTROLLED_FIXTURE_FLAGS):
+            return True
+        labels = (
+            identity_metadata.get("label"),
+            identity_metadata.get("display_name"),
+            identity_metadata.get("name"),
+            identity_metadata.get("agent_id"),
+            identity_metadata.get("public_agent_id"),
+        )
+        normalized_labels = [str(label).strip().lower() for label in labels if label]
+        if any(
+            label.startswith(prefix)
+            for label in normalized_labels
+            for prefix in _CONTROLLED_IDENTITY_LABEL_PREFIXES
+        ):
+            return True
+        purpose = str(identity_metadata.get("purpose") or "").strip().lower()
+        if purpose in _CONTROLLED_IDENTITY_PURPOSES:
+            return True
+
+    return False
 
 
 def _verification_source(row: OutcomeInventoryRow) -> str:
@@ -542,8 +597,16 @@ def _build_fetch_query(lead_minutes: Sequence[float]) -> str:
             o.is_bad,
             COALESCE(o.verification_source, o.detail->>'verification_source') AS verification_source,
             o.detail,
+            identity_meta.metadata AS identity_metadata,
             {", ".join(lead_selects)}
         FROM audit.outcome_events o
+        LEFT JOIN LATERAL (
+            SELECT ident_meta.metadata
+            FROM core.identities ident_meta
+            WHERE ident_meta.agent_id = o.agent_id
+            ORDER BY ident_meta.updated_at DESC NULLS LAST
+            LIMIT 1
+        ) identity_meta ON TRUE
         WHERE o.ts >= now() - ($1::int * INTERVAL '1 day')
         ORDER BY o.ts ASC
     """
@@ -562,7 +625,10 @@ def _row_from_record(
         outcome_type=str(data["outcome_type"]),
         is_bad=bool(data["is_bad"]),
         verification_source=data.get("verification_source"),
-        detail=_normalized_detail(data.get("detail")),
+        detail=attach_identity_metadata(
+            data.get("detail"),
+            data.get("identity_metadata"),
+        ),
         prior_state_by_lead=prior_state_by_lead,
     )
 

--- a/scripts/demo/quick_demo.py
+++ b/scripts/demo/quick_demo.py
@@ -28,7 +28,10 @@ What you'll see:
   code still handles that AGENT_PAUSED reply, you just won't trip it in 7 steps.
 
 No Postgres reads, no dashboard required — everything you see comes back
-in the check-in response shape that any client would receive.
+in the check-in response shape that any client would receive. The run still
+persists controlled demo identities/state/outcome rows on the target server;
+analysis scripts classify ``quick-demo-agent*`` identities as controlled harness
+rows and exclude them from live validation cohorts.
 """
 from __future__ import annotations
 

--- a/scripts/diagnostics/mcp_call.py
+++ b/scripts/diagnostics/mcp_call.py
@@ -4,16 +4,16 @@ MCP Tool Caller - Clean CLI for calling MCP tools without shell quoting issues.
 
 Usage:
     # List all tools
-    python scripts/mcp_call.py --list
+    python scripts/diagnostics/mcp_call.py --list
 
     # Call a tool
-    python scripts/mcp_call.py process_agent_update agent_id=my_agent update_type=reflection content="Hello world"
+    python scripts/diagnostics/mcp_call.py process_agent_update agent_id=my_agent update_type=reflection content="Hello world"
 
     # With session binding
-    python scripts/mcp_call.py --session my_session bind_identity agent_id=my_agent
+    python scripts/diagnostics/mcp_call.py --session my_session bind_identity agent_id=my_agent
 
     # Show tool schema
-    python scripts/mcp_call.py --describe update_agent_metadata
+    python scripts/diagnostics/mcp_call.py --describe update_agent_metadata
 """
 
 import argparse

--- a/scripts/perf/profile_checkin.py
+++ b/scripts/perf/profile_checkin.py
@@ -21,11 +21,11 @@ realistic payload through the live in-handler path and reports two things:
      stage (in practice ``enrichment`` and ``locked_update`` dominate), not just a
      lump total.
 
-This is READ-ONLY: it adds no production instrumentation and changes no server
-code. It only *drives* real check-ins and *reads* the log the server already
-writes. It extends ``scripts/dev/parse_update_phase_logs.py`` (which parses only
-``total`` + ``enrichment`` from an arbitrary log slice) by generating a controlled
-run and decomposing every phase.
+This is CODE-READ-ONLY: it adds no production instrumentation and changes no
+server code. It does drive real ``onboard``/``process_agent_update`` calls, so a
+live server will persist controlled profiling identities, state, and auto-checkin
+outcome rows. The analysis scripts classify ``perf-profile-checkin*`` identities
+as controlled harness rows and exclude them from live validation cohorts.
 
 Usage::
 

--- a/tests/test_diagnostics_mcp_call.py
+++ b/tests/test_diagnostics_mcp_call.py
@@ -65,7 +65,7 @@ def test_resolve_session_binding_uses_newest_cache_entry(mcp_call_module, tmp_pa
     assert arguments["client_session_id"] == "agent-new"
 
 
-def test_retry_with_lineage_mints_and_persists_fresh_session(
+def test_maybe_retry_with_lineage_mints_and_persists_fresh_session(
     mcp_call_module, tmp_path, monkeypatch
 ):
     calls: list[tuple[str, dict, str | None]] = []
@@ -114,3 +114,8 @@ def test_retry_with_lineage_mints_and_persists_fresh_session(
     cache_payload = (tmp_path / ".unitares" / "session-agent-child.json").read_text()
     assert '"uuid": "child-uuid"' in cache_payload
     assert '"continuity_token"' not in cache_payload
+
+
+def test_module_docstring_uses_actual_diagnostics_path(mcp_call_module):
+    assert "scripts/diagnostics/mcp_call.py --list" in mcp_call_module.__doc__
+    assert "python scripts/mcp_call.py" not in mcp_call_module.__doc__

--- a/tests/test_eisv_ablation_matrix.py
+++ b/tests/test_eisv_ablation_matrix.py
@@ -65,6 +65,30 @@ def test_filter_rows_for_validation_excludes_beam_harness_by_default():
     ]
 
 
+def test_filter_rows_for_validation_always_excludes_controlled_demo_perf_rows():
+    substrate = _row(0, bad=False, risk=0.1)
+    demo = _row(1, bad=True, risk=None)
+    demo = OutcomeRow(
+        **{
+            **demo.__dict__,
+            "detail": {"_identity_metadata": {"label": "quick-demo-agent_6d051ff8"}},
+        }
+    )
+    perf = _row(2, bad=False, risk=0.2)
+    perf = OutcomeRow(
+        **{
+            **perf.__dict__,
+            "detail": {"_identity_metadata": {"label": "perf-profile-checkin"}},
+        }
+    )
+
+    assert filter_rows_for_validation([substrate, demo, perf]) == [substrate]
+    assert filter_rows_for_validation(
+        [substrate, demo, perf],
+        exclude_harness_lanes=(),
+    ) == [substrate]
+
+
 def test_split_rows_by_harness_lane_keeps_beam_visible():
     substrate = _row(0, bad=False, risk=0.1)
     beam = _row(1, bad=True, risk=None)

--- a/tests/test_eisv_skeptic_report.py
+++ b/tests/test_eisv_skeptic_report.py
@@ -1,6 +1,7 @@
 import dataclasses
 from datetime import datetime, timedelta, timezone
 
+from scripts.analysis import eisv_skeptic_report as skeptic_module
 from scripts.analysis.eisv_skeptic_report import (
     MIN_DISPERSION_SNAPSHOTS,
     ModelScore,
@@ -210,3 +211,43 @@ def test_build_report_includes_ablation_delta_section():
     assert "| `prior_risk_binned` |" in report
     assert "AUC delta" in report
     assert "Brier improvement" in report
+
+
+def test_skeptic_record_conversion_preserves_identity_metadata_for_fixture_filtering():
+    row = skeptic_module._row_from_record(
+        {
+            "ts": datetime(2026, 1, 1, tzinfo=timezone.utc),
+            "outcome_id": "outcome-1",
+            "agent_id": "agent-demo",
+            "outcome_type": "task_failed",
+            "outcome_score": 0.0,
+            "is_bad": True,
+            "detail": {"source": "auto_checkin"},
+            "identity_metadata": {"label": "perf-profile-checkin_be34425f"},
+            "verification_source": "agent_reported_tool_result",
+            "prior_state_age_seconds": None,
+            "prior_risk": None,
+            "prior_phi": None,
+            "prior_verdict": None,
+            "prior_coherence": None,
+            "prior_e": None,
+            "prior_i": None,
+            "prior_s": None,
+            "prior_v": None,
+            "eisv_verdict": None,
+            "eisv_e": None,
+            "eisv_i": None,
+            "eisv_s": None,
+            "eisv_v": None,
+            "eisv_phi": None,
+            "eisv_coherence": None,
+            "n_prior_snapshots": None,
+            "prior_s_disp": None,
+            "prior_e_disp": None,
+            "prior_i_disp": None,
+            "prior_v_disp": None,
+            "prior_risk_disp": None,
+        }
+    )
+
+    assert row.detail["_identity_metadata"] == {"label": "perf-profile-checkin_be34425f"}

--- a/tests/test_outcome_inventory.py
+++ b/tests/test_outcome_inventory.py
@@ -1,3 +1,4 @@
+from scripts.analysis import outcome_inventory as inventory_module
 from scripts.analysis.outcome_inventory import (
     OutcomeInventoryRow,
     build_inventory,
@@ -301,3 +302,35 @@ def test_controlled_validation_fixture_detection_covers_legacy_and_new_markers()
     )
     assert is_controlled_validation_fixture({"calibration_excluded": True})
     assert not is_controlled_validation_fixture({"test_name": "real_pytest_suite"})
+
+
+def test_controlled_validation_fixture_detection_covers_demo_perf_identity_metadata():
+    assert is_controlled_validation_fixture(
+        {"_identity_metadata": {"label": "quick-demo-agent_6d051ff8"}}
+    )
+    assert is_controlled_validation_fixture(
+        {"_identity_metadata": {"label": "perf-profile-checkin_be34425f"}}
+    )
+    assert is_controlled_validation_fixture(
+        {"_identity_metadata": {"purpose": "testing", "label": "demo-harness"}}
+    )
+    assert not is_controlled_validation_fixture(
+        {"_identity_metadata": {"purpose": "implementation", "label": "real-agent"}}
+    )
+
+
+def test_inventory_record_conversion_preserves_identity_metadata_for_fixture_filtering():
+    row = inventory_module._row_from_record(
+        {
+            "outcome_type": "task_failed",
+            "is_bad": True,
+            "verification_source": "agent_reported_tool_result",
+            "detail": {"source": "auto_checkin"},
+            "identity_metadata": {"label": "quick-demo-agent_abc123"},
+            "prior_state_lead_0": False,
+        },
+        (0.0,),
+    )
+
+    assert row.detail["_identity_metadata"] == {"label": "quick-demo-agent_abc123"}
+    assert is_controlled_validation_fixture(row.detail)


### PR DESCRIPTION
## Summary
- Excludes controlled demo/profiling check-in cohorts from live ablation validation by attaching `core.identities.metadata` to analysis details and extending controlled-fixture detection.
- Keeps BEAM harness partitioning intact while filtering `quick-demo-agent*`, `perf-profile-checkin*`, and explicit testing/demo/profiling identity metadata from predictive slices.
- Clarifies that `quick_demo.py` and `profile_checkin.py` persist controlled rows on live servers, and fixes the stale `scripts/mcp_call.py` usage path in the diagnostics helper docstring.

## Verification
- `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 -m pytest tests/test_outcome_inventory.py tests/test_eisv_skeptic_report.py tests/test_eisv_ablation_matrix.py tests/test_diagnostics_mcp_call.py -q -o 'addopts='` → 38 passed
- `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 -m pytest tests/test_outcome_inventory.py tests/test_eisv_skeptic_report.py tests/test_eisv_ablation_matrix.py tests/test_diagnostics_mcp_call.py tests/test_analysis_tools.py -q -o 'addopts='` → 74 passed
- `git diff --check` → passed
- `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 -m py_compile scripts/analysis/outcome_inventory.py scripts/analysis/eisv_skeptic_report.py scripts/analysis/eisv_ablation_matrix.py scripts/demo/quick_demo.py scripts/perf/profile_checkin.py scripts/diagnostics/mcp_call.py` → passed
- `scripts/analysis/outcome_inventory.py --window-days 30 --leads 0,5,30` → substrate task-scope bad dropped to 18 after controlled cohort filtering; BEAM remains visible as its own lane.
- `scripts/analysis/eisv_ablation_matrix.py --scopes task --windows 30 --leads 5,30` → no beats-both slice; task 30d substrate is skeptical/inconclusive rather than polluted by demo/perf failures.
- Pre-push hook → 138 passed, 10411 deselected, 1 warning; doc-health advisory warnings are pre-existing/unrelated.

## Notes
This is plumbing hygiene, not EISV validation. It prevents controlled demo/profiler rows from being interpreted as live validation evidence while preserving their operational usefulness.