### PR TITLE
fix(dogfood): keep BEAM visible in ablation guard

### DIFF
--- a/scripts/diagnostics/dogfood_ablation_guard.py
+++ b/scripts/diagnostics/dogfood_ablation_guard.py
@@ -26,6 +26,7 @@ DEFAULT_TIMEOUT_SECONDS = 120
 IDENTITY_ALERT = "no-session get_governance_metrics is not identity-neutral"
 INVENTORY_ALERT = "outcome inventory no longer exposes BEAM/substrate eprocess lanes"
 MATRIX_ALERT = "ablation matrix default no longer excludes BEAM harness lane"
+GROUPED_MATRIX_ALERT = "ablation matrix grouped mode no longer exposes BEAM harness lane"
 
 
 def identity_neutrality_alert(metrics: dict[str, Any]) -> str | None:
@@ -74,6 +75,22 @@ def matrix_exclusion_alert(text: str) -> str | None:
     """Return an alert if default matrix output no longer excludes BEAM."""
 
     return None if "Excluded harness lanes: `beam`" in text else MATRIX_ALERT
+
+
+def matrix_grouped_lane_alert(text: str) -> str | None:
+    """Return an alert if grouped matrix output stops showing BEAM explicitly.
+
+    Default validation should still keep substrate EISV separated from runtime
+    harness rows, but much of UNITARES now moves through BEAM. The guard must
+    therefore prove BEAM remains visible as its own grouped lane rather than only
+    proving that the default matrix excludes it.
+    """
+
+    if "Harness lane mode: grouped" not in text:
+        return GROUPED_MATRIX_ALERT
+    if not re.search(r"(?im)^\|\s*beam\s*\|", text):
+        return GROUPED_MATRIX_ALERT
+    return None
 
 
 def render_alert_report(alerts: Sequence[str], evidence: Sequence[str]) -> str:
@@ -212,6 +229,30 @@ def collect_alerts(
     except (OSError, RuntimeError, subprocess.TimeoutExpired) as exc:
         alerts.append("ablation matrix lane-exclusion check failed to run")
         evidence.append(f"matrix_error={type(exc).__name__}: {exc}")
+
+    try:
+        grouped_matrix = run_repo_script(
+            repo,
+            python,
+            "scripts/analysis/eisv_ablation_matrix.py",
+            (
+                "--group-by-harness-lane",
+                "--scopes",
+                "task",
+                "--windows",
+                "90",
+                "--leads",
+                "0,30",
+            ),
+            timeout_seconds=timeout_seconds,
+        )
+        grouped_has_beam = matrix_grouped_lane_alert(grouped_matrix) is None
+        evidence.append(f"matrix_grouped_has_beam={grouped_has_beam}")
+        if not grouped_has_beam:
+            alerts.append(GROUPED_MATRIX_ALERT)
+    except (OSError, RuntimeError, subprocess.TimeoutExpired) as exc:
+        alerts.append("ablation matrix grouped BEAM lane check failed to run")
+        evidence.append(f"matrix_grouped_error={type(exc).__name__}: {exc}")
 
     return alerts, evidence
 

--- a/tests/test_dogfood_ablation_guard.py
+++ b/tests/test_dogfood_ablation_guard.py
@@ -1,7 +1,9 @@
 from scripts.diagnostics.dogfood_ablation_guard import (
+    collect_alerts,
     identity_neutrality_alert,
     inventory_lane_alert,
     matrix_exclusion_alert,
+    matrix_grouped_lane_alert,
     parse_inventory_counts,
     render_alert_report,
 )
@@ -55,6 +57,57 @@ def test_matrix_guard_requires_default_beam_exclusion_header():
     assert matrix_exclusion_alert("# EISV Ablation Matrix\n") == (
         "ablation matrix default no longer excludes BEAM harness lane"
     )
+
+
+def test_grouped_matrix_guard_requires_visible_beam_lane():
+    grouped = """# EISV Ablation Matrix
+Harness lane mode: grouped
+
+| Lane | Scope | Window days | Lead min | Trusted | Bad | Prior state | Prior risk | Baseline AUC | Baseline Brier | Best EISV/prior model | AUC delta | AUC delta 95% CI | Brier improvement | Brier improvement 95% CI | Brier perm p | Beats both? | Conclusion |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| beam | task | 90 | 30 | 1200 | 80 | 0 | 0 | - | - | - | - | - | - | - | - | no | INCONCLUSIVE |
+| substrate | task | 90 | 30 | 400 | 5 | 300 | 300 | 0.9 | 0.01 | prior_risk | 0.0 | - | 0.0 | - | - | no | SKEPTICAL |
+"""
+
+    assert matrix_grouped_lane_alert(grouped) is None
+    assert matrix_grouped_lane_alert(grouped.replace("| beam |", "| substrate |", 1)) == (
+        "ablation matrix grouped mode no longer exposes BEAM harness lane"
+    )
+
+
+def test_collect_alerts_runs_grouped_matrix_for_beam_visibility(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_call_tool_no_session(http_url, name, arguments):
+        return {"status": "⚪ unbound", "agent_signature": {"uuid": None}}
+
+    def fake_run_repo_script(repo, python, script, args, *, timeout_seconds):
+        calls.append((script, tuple(args)))
+        if script.endswith("outcome_inventory.py"):
+            return "eprocess_eligible: 2\neprocess_eligible_beam: 1\neprocess_eligible_substrate: 1\nstrict_bad: 0\n"
+        if "--group-by-harness-lane" in args:
+            return "Harness lane mode: grouped\n| Lane | Scope | Beats both? |\n|---|---|---|\n| beam | task | no |\n"
+        return "Excluded harness lanes: `beam`\n"
+
+    monkeypatch.setattr(
+        "scripts.diagnostics.dogfood_ablation_guard.call_tool_no_session",
+        fake_call_tool_no_session,
+    )
+    monkeypatch.setattr(
+        "scripts.diagnostics.dogfood_ablation_guard.run_repo_script",
+        fake_run_repo_script,
+    )
+
+    alerts, evidence = collect_alerts(
+        http_url="http://localhost:8767",
+        repo=tmp_path,
+        python="python3",
+        timeout_seconds=1,
+    )
+
+    assert alerts == []
+    assert any("--group-by-harness-lane" in args for _, args in calls)
+    assert "matrix_grouped_has_beam=True" in evidence
 
 
 def test_render_alert_report_is_silent_when_all_guards_pass():


### PR DESCRIPTION
## Summary
- Adds a BEAM grouped-lane invariant to the UNITARES dogfood/ablation guard.
- Keeps the existing default substrate-only matrix check, but also proves `--group-by-harness-lane` exposes a `beam` row.
- Adds regressions for grouped BEAM visibility and for `collect_alerts` invoking the grouped matrix path.

## Verification
- Focused dogfood guard tests → 8 passed.
- Expanded analysis/guard tests → 28 passed.
- Dogfood/ablation guard live/local smoke against this branch → silent/no alert.
- Local Hermes watchdog forced no-write smoke against this branch → included grouped BEAM/substrate task 90d/30m rows.
- Repo test cache gate → 11188 passed, 23 skipped.
- Pre-push smoke → 138 passed, 10419 deselected; doc-health warnings are advisory/pre-existing.

## Notes
This keeps the separation discipline: default ablation remains substrate-only for EISV validation, while BEAM is explicitly monitored as a first-class runtime-governance lane.