### PR TITLE
feat(metrics): historize governance health (EISV / verdicts / findings)

### DIFF
--- a/agents/chronicler/scrapers.py
+++ b/agents/chronicler/scrapers.py
@@ -129,6 +129,74 @@ def checkins_7d(_repo_root: Path) -> float:
 
 
 # ---------------------------------------------------------------------------
+# Governance-health series. The metrics above answer "how big / how busy";
+# these answer "how healthy" — the core EISV / verdict / finding signal, which
+# was live-only (no time-series) until now. Each reads core.agent_state (every
+# non-synthetic check-in) or audit.events over a trailing 7-day window, so they
+# share the `.7d` convention and group under "governance" on the dashboard.
+# ---------------------------------------------------------------------------
+
+
+def governance_coherence_mean_7d(_repo_root: Path) -> float:
+    """Fleet-mean coherence over the last 7 days — headline governance health.
+
+    avg() across every non-synthetic check-in. A sustained drop is the earliest
+    broad signal that the fleet is drifting."""
+    return _fetchval(
+        "SELECT avg(coherence) FROM core.agent_state "
+        "WHERE recorded_at > now() - interval '7 days' AND synthetic = false"
+    )
+
+
+def governance_risk_mean_7d(_repo_root: Path) -> float:
+    """Fleet-mean risk_score over the last 7 days — counterpart to coherence."""
+    return _fetchval(
+        "SELECT avg(risk_score) FROM core.agent_state "
+        "WHERE recorded_at > now() - interval '7 days' AND synthetic = false"
+    )
+
+
+def governance_guide_7d(_repo_root: Path) -> float:
+    """`guide` sub-actions in the last 7 days — soft governance corrections.
+
+    The verdict sub-action is persisted in state_json->>'action'. `guide` is a
+    proceed-with-nudge; its count shows how often governance is steering rather
+    than just approving."""
+    return _fetchval(
+        "SELECT count(*) FROM core.agent_state "
+        "WHERE recorded_at > now() - interval '7 days' AND synthetic = false "
+        "AND state_json->>'action' = 'guide'"
+    )
+
+
+def governance_pause_7d(_repo_root: Path) -> float:
+    """Hard governance interventions in the last 7 days — pauses/blocks/rejects.
+
+    Anything that is neither approve nor guide (e.g. cirs_block, pause, reject).
+    Kept open-ended via NOT IN so a new hard-stop action folds in automatically
+    instead of being silently dropped."""
+    return _fetchval(
+        "SELECT count(*) FROM core.agent_state "
+        "WHERE recorded_at > now() - interval '7 days' AND synthetic = false "
+        "AND state_json->>'action' IS NOT NULL "
+        "AND state_json->>'action' NOT IN ('approve', 'guide')"
+    )
+
+
+def governance_sentinel_findings_7d(_repo_root: Path) -> float:
+    """Sentinel findings (incl. forced-release alarms) in the last 7 days.
+
+    Reads the durable audit.events store — the same source /v1/sentinel/backlog
+    queries — so the count tracks what the analytical resident is flagging over
+    time, not just what's currently in the in-memory ring."""
+    return _fetchval(
+        "SELECT count(*) FROM audit.events "
+        "WHERE event_type IN ('sentinel_finding', 'sentinel_alarm_finding') "
+        "AND ts > now() - interval '7 days'"
+    )
+
+
+# ---------------------------------------------------------------------------
 # GitHub traffic (CIRWEL org, non-archived repos, rolling 14-day window)
 # ---------------------------------------------------------------------------
 #
@@ -213,6 +281,11 @@ SCRAPERS: dict[str, Callable[[Path], float]] = {
     "agents.active.7d": agents_active_7d,
     "kg.entries.count": kg_entries_count,
     "checkins.7d": checkins_7d,
+    "governance.coherence.mean.7d": governance_coherence_mean_7d,
+    "governance.risk.mean.7d": governance_risk_mean_7d,
+    "governance.guide.7d": governance_guide_7d,
+    "governance.pause.7d": governance_pause_7d,
+    "governance.sentinel.findings.7d": governance_sentinel_findings_7d,
     "github.cirwel.traffic.views.14d": github_cirwel_traffic_views_14d,
     "github.cirwel.traffic.views.uniques.14d": github_cirwel_traffic_views_uniques_14d,
     "github.cirwel.traffic.clones.14d": github_cirwel_traffic_clones_14d,

--- a/src/fleet_metrics/catalog.py
+++ b/src/fleet_metrics/catalog.py
@@ -109,6 +109,37 @@ register(Metric(
     unit="calls",
 ))
 
+# Governance-health series — the core EISV / verdict / finding signal over
+# time. Live state has always exposed these, but they were never historized,
+# so "is the fleet trending healthier or worse this month?" had no chart. Each
+# is a trailing-7-day aggregate over core.agent_state or audit.events, scraped
+# daily by Chronicler.
+register(Metric(
+    name="governance.coherence.mean.7d",
+    description="Fleet-mean coherence over the last 7 days (non-synthetic check-ins). Headline governance-health signal; a sustained drop = broad drift.",
+    unit="coherence",
+))
+register(Metric(
+    name="governance.risk.mean.7d",
+    description="Fleet-mean risk_score over the last 7 days (non-synthetic check-ins). Counterpart to coherence.",
+    unit="risk",
+))
+register(Metric(
+    name="governance.guide.7d",
+    description="`guide` sub-actions in the last 7 days — soft governance corrections (proceed-with-nudge). From core.agent_state.state_json->>'action'.",
+    unit="verdicts",
+))
+register(Metric(
+    name="governance.pause.7d",
+    description="Hard governance interventions in the last 7 days — actions other than approve/guide (cirs_block, pause, reject). Open-ended so new hard-stop actions fold in.",
+    unit="verdicts",
+))
+register(Metric(
+    name="governance.sentinel.findings.7d",
+    description="Sentinel findings (incl. forced-release alarms) in the last 7 days, from durable audit.events. Tracks how much the analytical resident is flagging over time.",
+    unit="findings",
+))
+
 # GitHub traffic for the CIRWEL org. The GitHub traffic API only exposes a
 # rolling 14-day window, so daily snapshots overlap heavily by design — the
 # longitudinal value is the trend curve, not point-in-time deltas. Aggregated

--- a/tests/test_chronicler.py
+++ b/tests/test_chronicler.py
@@ -86,6 +86,73 @@ class TestDbScrapers:
             assert name in SCRAPERS, f"{name} missing from SCRAPERS registry"
 
 
+class TestGovernanceHealthScrapers:
+    """The governance-health series — EISV/verdict/finding aggregates that were
+    live-only until now. Each reads core.agent_state or audit.events over a
+    trailing 7-day window. Tests pin the SQL shape (table, window, filter) so a
+    refactor can't silently change what the chart means."""
+
+    def test_coherence_mean_averages_nonsynthetic_checkins(self, tmp_path: Path):
+        from agents.chronicler import scrapers
+
+        with patch.object(scrapers, "_fetchval", return_value=0.49) as m:
+            value = scrapers.governance_coherence_mean_7d(tmp_path)
+
+        assert value == 0.49
+        sql = m.call_args.args[0]
+        assert "avg(coherence)" in sql
+        assert "core.agent_state" in sql
+        assert "synthetic = false" in sql
+        assert "7 days" in sql
+
+    def test_risk_mean_averages_risk_score(self, tmp_path: Path):
+        from agents.chronicler import scrapers
+
+        with patch.object(scrapers, "_fetchval", return_value=0.07) as m:
+            value = scrapers.governance_risk_mean_7d(tmp_path)
+
+        assert value == 0.07
+        sql = m.call_args.args[0]
+        assert "avg(risk_score)" in sql
+        assert "synthetic = false" in sql
+
+    def test_guide_counts_guide_action(self, tmp_path: Path):
+        from agents.chronicler import scrapers
+
+        with patch.object(scrapers, "_fetchval", return_value=310.0) as m:
+            value = scrapers.governance_guide_7d(tmp_path)
+
+        assert value == 310.0
+        sql = m.call_args.args[0]
+        assert "state_json->>'action' = 'guide'" in sql
+        assert "7 days" in sql
+
+    def test_pause_counts_nonapprove_nonguide_actions(self, tmp_path: Path):
+        """Hard interventions = anything that isn't approve/guide, kept
+        open-ended so a new hard-stop action folds in without a code change."""
+        from agents.chronicler import scrapers
+
+        with patch.object(scrapers, "_fetchval", return_value=3.0) as m:
+            value = scrapers.governance_pause_7d(tmp_path)
+
+        assert value == 3.0
+        sql = m.call_args.args[0]
+        assert "NOT IN ('approve', 'guide')" in sql
+        assert "IS NOT NULL" in sql  # NULL action must not count as a pause
+
+    def test_sentinel_findings_count_durable_audit_events(self, tmp_path: Path):
+        from agents.chronicler import scrapers
+
+        with patch.object(scrapers, "_fetchval", return_value=135.0) as m:
+            value = scrapers.governance_sentinel_findings_7d(tmp_path)
+
+        assert value == 135.0
+        sql = m.call_args.args[0]
+        assert "audit.events" in sql
+        assert "sentinel_finding" in sql
+        assert "sentinel_alarm_finding" in sql
+
+
 class TestTestsCountScraper:
     def test_counts_only_test_prefixed_py_files(self, tmp_path: Path):
         from agents.chronicler.scrapers import tests_unitares_count

--- a/tests/test_fleet_metrics.py
+++ b/tests/test_fleet_metrics.py
@@ -30,6 +30,30 @@ class TestCatalog:
         for name in ("agents.active.7d", "kg.entries.count", "checkins.7d"):
             assert name in _catalog, f"{name} missing from catalog"
 
+    def test_governance_metrics_registered(self):
+        """The governance-health series must be in the catalog or their daily
+        POSTs 404 silently and the charts never populate."""
+        for name in (
+            "governance.coherence.mean.7d",
+            "governance.risk.mean.7d",
+            "governance.guide.7d",
+            "governance.pause.7d",
+            "governance.sentinel.findings.7d",
+        ):
+            assert name in _catalog, f"{name} missing from catalog"
+
+    def test_every_scraper_has_a_catalog_entry(self):
+        """Invariant: every name Chronicler scrapes must be catalog-registered.
+
+        The POST endpoint validates against the catalog, so any SCRAPERS name
+        without an entry is a silent 404 each daily run. This subset check
+        guards all current and future scrapers at once, rather than relying on
+        per-name lists drifting in step."""
+        from agents.chronicler.scrapers import SCRAPERS
+
+        missing = sorted(name for name in SCRAPERS if name not in _catalog)
+        assert not missing, f"scrapers missing catalog entries (will 404): {missing}"
+
     def test_require_known_name_returns_entry(self):
         entry = require("tokei.unitares.src.code")
         assert isinstance(entry, Metric)


### PR DESCRIPTION
## What

The metrics oracle charted infra (LOC, test count, GitHub traffic, lease/ODE latency) but **none of the core governance signal** — coherence, risk, verdict mix, and Sentinel findings were all live-only, so "is the fleet trending healthier or worse this month?" had no chart. This is gap #2 from the dashboard residents/metrics review.

## Change

Five trailing-7d Chronicler scrapers, registered in **both** `SCRAPERS` and the server-side catalog (an unregistered name 404s at POST):

| Metric | Source | Value now |
|---|---|---|
| `governance.coherence.mean.7d` | `avg(coherence)` non-synthetic | 0.496 |
| `governance.risk.mean.7d` | `avg(risk_score)` | 0.065 |
| `governance.guide.7d` | `action='guide'` (soft corrections) | 310 |
| `governance.pause.7d` | `action NOT IN (approve,guide)` (hard stops) | 3 |
| `governance.sentinel.findings.7d` | durable `audit.events` finding types | 135 |

All read `core.agent_state` (non-synthetic) or `audit.events`. They **auto-group under "governance"** in the dashboard metric picker (it reads the catalog) — no front-end change.

## Verified

Ran all five against the live governance DB — values above. Tests: SQL-shape pin per scraper (table/window/filter), catalog registration, and a **new invariant** — every `SCRAPERS` name must have a catalog entry, so future scrapers can't silently 404. 55 pass.

> Note: a new series has no history until Chronicler's first post-deploy run; charts start empty and accrue one point/day. No meaningful backfill for trailing-window aggregates — a one-off `python3 agents/chronicler/agent.py` after deploy seeds the first point.

This completes the metrics half of the residents/metrics review (the residents-panel half shipped via #1254, #1261, #1266).

https://claude.ai/code/session_0124JwLQNcBihZq683GT7ueR