### PR TITLE
feat(dev): kg_report.py — KG backlog + hygiene report (conservative cooling)

### DIFF
--- a/scripts/dev/kg_report.py
+++ b/scripts/dev/kg_report.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Knowledge-graph backlog + hygiene report (with conservative dry-run cleanup).
+
+The KG (`knowledge.discoveries`) accumulates an issue-tracker-like backlog that
+no surface reports cleanly: `open` is used as a default, so it mixes a small
+actionable todo list with a large tail of aging notes and entries whose cited
+GitHub issue has long since closed. `knowledge action=stats` gives raw counts
+and `run_kg_lifecycle_cleanup` archives *already-resolved* / ephemeral items by
+age — but nothing transitions stale `open` rows or surfaces the real backlog.
+This fills that gap.
+
+Three report sections (all read-only):
+
+  1. ACTIONABLE BACKLOG — open bug_found / improvement / question /
+     architectural_decision, by severity. The untracked todo list.
+  2. STALE-CITATION SWEEP — open discoveries citing a GitHub issue # that is no
+     longer open. Strong "this entry is probably done" signal. Report-only:
+     a closed issue does not *prove* the discovery is resolved, so a human (or
+     a later targeted pass) makes that call.
+  3. HYGIENE —
+       a. COLD candidates: open note/insight rows older than --cold-age-days
+          (default 30), excluding permanent types/tags. These are what --apply
+          can cool.
+       b. PROMOTE candidates: open high/critical actionable rows not linked to
+          an open issue — candidates to file as real GitHub issues.
+
+Cleanup (`--apply`, dry-run by default): cools ONLY the section-3a cold
+candidates (open note/insight → `cold`, still queryable, reversible) via the
+sanctioned `KnowledgeGraphLifecycle._batch_update_status` primitive, which keeps
+the active backend and canonical PG table aligned. Never deletes (matches the
+lifecycle's "archive forever" philosophy); never touches actionable rows.
+
+Usage:
+    python3 scripts/dev/kg_report.py                 # report only
+    python3 scripts/dev/kg_report.py --json
+    python3 scripts/dev/kg_report.py --apply          # cool aged notes (writes)
+    python3 scripts/dev/kg_report.py --cold-age-days 60
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+DEFAULT_DSN = "postgresql://postgres:postgres@localhost:5432/governance"
+ACTIONABLE_TYPES = (
+    "bug_found", "improvement", "question", "architectural_decision",
+    "optimization",
+)
+NOTE_TYPES = ("note", "insight")
+COLD_AGE_DAYS_DEFAULT = 30
+ISSUE_RE = r"#([0-9]{2,4})"
+
+
+def _lifecycle_consts():
+    """Permanent type/tag sets from the live lifecycle module (so cooling never
+    cools a row the sanctioned cleanup would treat as permanent). Pinned fallback.
+    """
+    try:
+        from src.knowledge_graph_lifecycle import PERMANENT_TYPES, PERMANENT_TAGS  # type: ignore
+        return set(PERMANENT_TYPES), set(PERMANENT_TAGS)
+    except Exception:
+        return (
+            {"architecture_decision", "architectural_decision", "learning", "pattern"},
+            {"permanent", "pinned", "protected", "invariant"},
+        )
+
+
+def _clean(s: str) -> str:
+    """Collapse whitespace/newlines so multi-line summaries fit one table row."""
+    return " ".join((s or "").split())
+
+
+def connect():
+    import psycopg2  # type: ignore
+    return psycopg2.connect(os.environ.get("GOVERNANCE_DATABASE_URL", DEFAULT_DSN))
+
+
+def open_issue_numbers():
+    """Set of currently-open GitHub issue numbers, or None if gh is unavailable."""
+    try:
+        out = subprocess.run(
+            ["gh", "issue", "list", "--state", "open", "--limit", "300",
+             "--json", "number"],
+            capture_output=True, text=True, timeout=30, check=True,
+        ).stdout
+        return {i["number"] for i in json.loads(out)}
+    except Exception:
+        return None
+
+
+def gather(cold_age_days: int) -> dict:
+    perm_types, perm_tags = _lifecycle_consts()
+    open_issues = open_issue_numbers()
+    conn = connect()
+    try:
+        cur = conn.cursor()
+
+        # 1. Actionable backlog: type x severity (open, actionable types).
+        cur.execute(
+            """
+            SELECT type, coalesce(severity,'(none)'), count(*)
+            FROM knowledge.discoveries
+            WHERE status='open' AND type = ANY(%s)
+            GROUP BY 1,2 ORDER BY 1, 3 DESC
+            """,
+            (list(ACTIONABLE_TYPES),),
+        )
+        backlog = [{"type": t, "severity": s, "n": n} for t, s, n in cur.fetchall()]
+
+        # 2/3b. Open rows with their cited issue numbers + flags for triage.
+        cur.execute(
+            f"""
+            SELECT id, type, coalesce(severity,'(none)') AS severity,
+                   left(coalesce(summary,''), 90) AS summary,
+                   ARRAY(
+                     SELECT DISTINCT (m)[1]::int
+                     FROM regexp_matches(
+                       coalesce(summary,'')||' '||coalesce(details,''),
+                       '{ISSUE_RE}', 'g') AS m
+                   ) AS cited_issues
+            FROM knowledge.discoveries
+            WHERE status='open'
+            """
+        )
+        open_rows = [
+            {"id": i, "type": t, "severity": s, "summary": _clean(sm), "cited": list(c)}
+            for i, t, s, sm, c in cur.fetchall()
+        ]
+
+        # 3a. Cold candidates: aged open note/insight, not permanent type/tag,
+        #     and not self-marked canonical/design-principle in the summary
+        #     (those read as load-bearing knowledge — keep them warm, report them
+        #     under a separate "kept" count so the skip is visible, not silent).
+        cur.execute(
+            """
+            SELECT id, type, coalesce(severity,'(none)'),
+                   coalesce(summary,''),
+                   extract(day FROM now()-created_at)::int AS age_days
+            FROM knowledge.discoveries
+            WHERE status='open'
+              AND type = ANY(%s)
+              AND created_at < now() - (%s || ' days')::interval
+              AND NOT (type = ANY(%s))
+              AND NOT (coalesce(tags,'{}') && %s)
+            ORDER BY created_at
+            """,
+            (list(NOTE_TYPES), str(cold_age_days),
+             list(perm_types), list(perm_tags)),
+        )
+        cold_candidates, cold_kept_canonical = [], []
+        for i, t, s, sm, a in cur.fetchall():
+            row = {"id": i, "type": t, "severity": s,
+                   "summary": _clean(sm), "age_days": a}
+            up = sm.upper()
+            if "CANONICAL" in up or "DESIGN PRINCIPLE" in up or "INVARIANT" in up:
+                cold_kept_canonical.append(row)
+            else:
+                cold_candidates.append(row)
+    finally:
+        conn.close()
+
+    # Derive stale-citation + promote sets in python (needs the open-issue set).
+    stale_citation = []
+    for r in open_rows:
+        if not r["cited"]:
+            continue
+        if open_issues is None:
+            r["_cited_state"] = "unknown(gh unavailable)"
+        else:
+            still_open = [n for n in r["cited"] if n in open_issues]
+            if still_open:
+                continue  # cites a live issue — not stale
+            r["_cited_state"] = "all-closed"
+        stale_citation.append(r)
+
+    promote = [
+        r for r in open_rows
+        if r["severity"] in ("high", "critical")
+        and r["type"] in ACTIONABLE_TYPES
+        and (open_issues is None or not any(n in open_issues for n in r["cited"]))
+    ]
+
+    return {
+        "open_issue_set_known": open_issues is not None,
+        "cold_age_days": cold_age_days,
+        "actionable_backlog": backlog,
+        "stale_citation": stale_citation,
+        "cold_candidates": cold_candidates,
+        "cold_kept_canonical": cold_kept_canonical,
+        "promote_candidates": promote,
+    }
+
+
+def apply_cooling(cold_candidates: list, dry_run: bool) -> dict:
+    """Transition the cold candidates open -> cold via the sanctioned dual-store
+    primitive. Candidate selection already happened (pure SQL); this only mutates.
+    """
+    ids = [c["id"] for c in cold_candidates]
+    if dry_run or not ids:
+        return {"cooled": 0, "dry_run": dry_run, "ids": ids}
+
+    # Real mutation needs the app context (active KG backend + PG). Imported here
+    # so report/dry-run never depend on it.
+    sys.path.insert(0, os.getcwd())
+    import asyncio
+    from datetime import datetime, timezone
+    from src.knowledge_graph_lifecycle import KnowledgeGraphLifecycle  # type: ignore
+
+    async def _run():
+        lc = KnowledgeGraphLifecycle()
+        graph = await lc._get_graph()
+        await lc._batch_update_status(graph, ids, "cold", datetime.now(timezone.utc))
+
+    asyncio.run(_run())
+    return {"cooled": len(ids), "dry_run": False, "ids": ids}
+
+
+def _print(r: dict, applied: dict) -> None:
+    print("KG backlog + hygiene report\n" + "=" * 32)
+    if not r["open_issue_set_known"]:
+        print("  ⚠ gh unavailable — stale-citation/promote use cited-issue text only\n")
+
+    print("\n[1] ACTIONABLE BACKLOG (open, actionable types)")
+    if not r["actionable_backlog"]:
+        print("    (none)")
+    for b in r["actionable_backlog"]:
+        print(f"    {b['type']:<24} {b['severity']:<8} {b['n']}")
+
+    sc = r["stale_citation"]
+    print(f"\n[2] STALE-CITATION SWEEP — {len(sc)} open rows whose cited #refs are all non-open (closed issues/PRs)")
+    for x in sc[:20]:
+        print(f"    {x['id'][:24]:<24} {x['type']:<14} cites {x['cited']}  {x['summary'][:48]}")
+    if len(sc) > 20:
+        print(f"    … +{len(sc)-20} more")
+
+    cc = r["cold_candidates"]
+    verb = "COOLED" if applied.get("cooled") else "WOULD COOL"
+    print(f"\n[3a] HYGIENE — {len(cc)} aged open note/insight (> {r['cold_age_days']}d) → {verb} to cold")
+    for x in cc[:15]:
+        print(f"    {x['id'][:24]:<24} {x['type']:<8} {x['age_days']:>4}d  {x['summary'][:52]}")
+    if len(cc) > 15:
+        print(f"    … +{len(cc)-15} more")
+    kept = r.get("cold_kept_canonical", [])
+    if kept:
+        print(f"    ↳ kept warm ({len(kept)} self-marked CANONICAL/DESIGN-PRINCIPLE/INVARIANT, not cooled):")
+        for x in kept[:6]:
+            print(f"      · {x['id'][:24]:<24} {x['age_days']:>4}d  {x['summary'][:50]}")
+
+    pc = r["promote_candidates"]
+    print(f"\n[3b] PROMOTE — {len(pc)} open high/critical actionable, no open-issue link")
+    for x in pc:
+        print(f"    {x['id'][:24]:<24} {x['type']:<14} {x['severity']:<8} {x['summary'][:50]}")
+
+    if applied.get("cooled"):
+        print(f"\n✓ Applied: cooled {applied['cooled']} discoveries to cold (reversible).")
+    elif cc:
+        print(f"\n(dry-run) re-run with --apply to cool the {len(cc)} aged notes above.")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--cold-age-days", type=int, default=COLD_AGE_DAYS_DEFAULT)
+    ap.add_argument("--apply", action="store_true",
+                    help="cool aged note/insight rows to cold (default: dry-run)")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    r = gather(args.cold_age_days)
+    applied = apply_cooling(r["cold_candidates"], dry_run=not args.apply)
+    if args.json:
+        print(json.dumps({"report": r, "applied": applied}, indent=2, default=str))
+    else:
+        _print(r, applied)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

`scripts/dev/kg_report.py` — a deterministic report that surfaces the issue-tracker-like backlog living in the KG (`knowledge.discoveries`), which no current surface shows cleanly. **Draft — leave the merge to you; it has an `--apply` mutator.**

## Why

GitHub shows 6 open issues; the KG holds **204 `open` discoveries** — but `open` is used as a default, so it mixes a small actionable todo list with a large stale tail. `knowledge action=stats` gives raw counts and `run_kg_lifecycle_cleanup` archives *already-resolved*/ephemeral items by age, but nothing surfaces the real backlog or transitions stale `open` rows. This is that view.

## Three read-only sections (live output today)

```
[1] ACTIONABLE BACKLOG   15 open actionable rows (1 high bug, rest med/low)
[2] STALE-CITATION       67 open rows whose cited #refs are all closed
[3a] HYGIENE             74 aged open note/insight (>30d) → cold candidates
                         (7 self-marked CANONICAL/DESIGN-PRINCIPLE kept warm)
[3b] PROMOTE             1 open high/critical actionable, no open-issue link
                         → the recurring deploy-procedure-gap bug (≥3rd time)
```

## `--apply` (dry-run by default)

Cools **only** the 3a candidates `open → cold` (reversible, still queryable) via the sanctioned `KnowledgeGraphLifecycle._batch_update_status` (keeps active backend + canonical PG aligned). Safety:
- Never deletes (matches the lifecycle's "archive forever" philosophy).
- Never touches actionable rows (bug/improvement/decision) — those are reported for human triage only.
- Skips self-marked `CANONICAL`/`DESIGN-PRINCIPLE`/`INVARIANT` rows — kept warm, reported under a visible "kept warm" count, not silently cooled.
- Candidate selection is pure SQL, so report/dry-run never need the app context; only real mutation imports the lifecycle primitive.

Stale-citation (section 2) is **report-only** — a closed issue doesn't prove the discovery is resolved; that call stays human/targeted.

## Notes

- Deterministic, no metered API (per repo policy). `--json` for automation; `--cold-age-days N`.
- Wireable into a weekly Vigil/Chronicler sweep or the `dashboard/redesign/sections/discoveries.js` panel.
- Genre-matches `scripts/dev/adoption_kpi.py` / `oc807_burnin.py`.

Related theme: #1001 (a structured KG↔issue link in `related_to`/`provenance` would make the stale-citation sweep regex-free and bidirectional).

https://claude.ai/code/session_01SPNdECYnwv6ApR1Pb3CkMR