### PR TITLE
feat(mcp): consolidated admin/diagnostics action-router

### DIFF
--- a/src/mcp_handlers/consolidated.py
+++ b/src/mcp_handlers/consolidated.py
@@ -48,6 +48,14 @@ from .admin.calibration import (
 )
 from .admin.handlers import (
     handle_get_telemetry_metrics,
+    handle_get_server_info,
+    handle_get_connection_status,
+    handle_get_workspace_health,
+    handle_get_tool_usage_stats,
+    handle_reset_monitor,
+    handle_cleanup_stale_locks,
+    handle_debug_request_context,
+    handle_validate_file_path,
 )
 from .admin.config import (
     handle_get_thresholds,
@@ -253,6 +261,40 @@ handle_observe = action_router(
 )
 
 # ``pi`` consolidated tool moved to unitares-pi-plugin (see register() there).
+
+# ============================================================
+# Consolidated Admin / Diagnostics Tool
+# ============================================================
+
+handle_admin = action_router(
+    "admin",
+    actions={
+        "server_info": handle_get_server_info,
+        "connections": handle_get_connection_status,
+        "workspace_health": handle_get_workspace_health,
+        "tool_usage": handle_get_tool_usage_stats,
+        "telemetry": handle_get_telemetry_metrics,
+        "debug_context": handle_debug_request_context,
+        "validate_path": handle_validate_file_path,
+        "reset_monitor": handle_reset_monitor,
+        "cleanup_locks": handle_cleanup_stale_locks,
+    },
+    timeout=20.0,
+    description="Unified admin/diagnostics operations: server_info, connections, workspace_health, tool_usage, telemetry, debug_context, validate_path, reset_monitor, cleanup_locks",
+    # #425 action-level identity: only the cheap protocol-inspection read
+    # (server_info — the standalone get_server_info is pre_onboard) serves
+    # unbound. Every other diagnostic/maintenance action stays identity-gated,
+    # preserving each standalone tool's current requirement.
+    pre_onboard_actions={"server_info"},
+    examples=[
+        "admin(action='server_info')",
+        "admin(action='workspace_health')",
+        "admin(action='tool_usage', window_hours=168)",
+        "admin(action='telemetry', include_calibration=false)",
+        "admin(action='validate_path', file_path='docs/notes.md')",
+        "admin(action='cleanup_locks', dry_run=true)",
+    ],
+)
 
 # ============================================================
 # Consolidated Dialectic Tool

--- a/src/mcp_handlers/schemas/admin.py
+++ b/src/mcp_handlers/schemas/admin.py
@@ -141,3 +141,67 @@ class ConfigParams(AgentIdentityMixin):
     """Parameters for config"""
 
 
+class AdminParams(AgentIdentityMixin):
+    """Unified admin / diagnostics operations.
+
+    Consolidates the low-traffic operator/diagnostic single-purpose tools
+    (server_info, connections, workspace_health, tool_usage, telemetry,
+    debug_context, validate_path, reset_monitor, cleanup_locks) behind one
+    action router. The original single-purpose tools remain registered for
+    backwards compatibility; this router is the discoverable surface.
+    """
+    action: Literal[
+        "server_info",
+        "connections",
+        "workspace_health",
+        "tool_usage",
+        "telemetry",
+        "debug_context",
+        "validate_path",
+        "reset_monitor",
+        "cleanup_locks",
+    ] = Field(..., description="Diagnostic/maintenance operation to perform")
+    # server_info
+    detail: Literal["basic", "full"] = Field(
+        "basic", description="Detail level (for action=server_info)."
+    )
+    # telemetry / tool_usage — window_hours default diverges by action and is
+    # resolved in the validator below (telemetry=24, tool_usage=168) so the
+    # underlying handlers keep their original defaults without edits.
+    window_hours: Optional[float] = Field(
+        None,
+        description="Time window in hours (for action=telemetry default 24, action=tool_usage default 168).",
+    )
+    include_calibration: bool = Field(
+        False,
+        description="Include full calibration metrics (for action=telemetry). Default false to reduce response size.",
+    )
+    tool_name: Optional[str] = Field(
+        None, description="Filter by a specific tool name (for action=tool_usage)."
+    )
+    # cleanup_locks
+    max_age_seconds: float = Field(
+        300.0,
+        description="Max age in seconds before a lock is stale (for action=cleanup_locks). Default 300.",
+    )
+    dry_run: bool = Field(
+        False,
+        description="If true, report what would be cleaned without acting (for action=cleanup_locks).",
+    )
+    # validate_path
+    file_path: Optional[str] = Field(
+        None, description="Path to validate against project policy (required for action=validate_path)."
+    )
+
+    @model_validator(mode="after")
+    def _apply_action_window_defaults(self):
+        # Mirror the per-handler window_hours defaults so omitting the param
+        # routes the same value the standalone tool would have used.
+        if self.window_hours is None:
+            if self.action == "tool_usage":
+                self.window_hours = 168.0
+            elif self.action == "telemetry":
+                self.window_hours = 24.0
+        return self
+
+

--- a/src/mcp_handlers/stakes_table.py
+++ b/src/mcp_handlers/stakes_table.py
@@ -83,6 +83,10 @@ _HIGH: frozenset[tuple[str, Optional[str]]] = frozenset({
     # dialectic — resolve / reassign a governance review
     ("dialectic", "synthesis"),
     ("dialectic", "reassign"),
+    # admin — destructive / state-resetting maintenance (mirrors the
+    # standalone reset_monitor / cleanup_stale_locks classification)
+    ("admin", "reset_monitor"),
+    ("admin", "cleanup_locks"),
     # single-purpose admin / destructive / pause-state tools
     ("archive_old_test_agents", None),
     ("archive_orphan_agents", None),
@@ -134,6 +138,15 @@ _BASELINE: frozenset[tuple[str, Optional[str]]] = frozenset({
     ("observe", "telemetry"),
     ("observe", "audit_events"),
     ("observe", "outcome_evidence"),
+    # admin — diagnostic reads (destructive actions are in _HIGH); mirrors the
+    # standalone get_server_info / get_workspace_health / ... classification
+    ("admin", "server_info"),
+    ("admin", "connections"),
+    ("admin", "workspace_health"),
+    ("admin", "tool_usage"),
+    ("admin", "telemetry"),
+    ("admin", "debug_context"),
+    ("admin", "validate_path"),
     # dialectic — participation + reads (resolution is in _HIGH)
     ("dialectic", "get"),
     ("dialectic", "list"),

--- a/src/mcp_handlers/tool_stability.py
+++ b/src/mcp_handlers/tool_stability.py
@@ -268,6 +268,26 @@ _TOOL_ALIASES: Dict[str, ToolAlias] = {
     "aggregate_metrics": ToolAlias(old_name="aggregate_metrics", new_name="observe", reason="consolidated",
         migration_note="Use observe(action='aggregate')", inject_action="aggregate"),
 
+    # Admin / diagnostics tools → admin(action='...')
+    "get_server_info": ToolAlias(old_name="get_server_info", new_name="admin", reason="consolidated",
+        migration_note="Use admin(action='server_info')", inject_action="server_info"),
+    "get_connection_status": ToolAlias(old_name="get_connection_status", new_name="admin", reason="consolidated",
+        migration_note="Use admin(action='connections')", inject_action="connections"),
+    "get_workspace_health": ToolAlias(old_name="get_workspace_health", new_name="admin", reason="consolidated",
+        migration_note="Use admin(action='workspace_health')", inject_action="workspace_health"),
+    "get_tool_usage_stats": ToolAlias(old_name="get_tool_usage_stats", new_name="admin", reason="consolidated",
+        migration_note="Use admin(action='tool_usage')", inject_action="tool_usage"),
+    "get_telemetry_metrics": ToolAlias(old_name="get_telemetry_metrics", new_name="admin", reason="consolidated",
+        migration_note="Use admin(action='telemetry') or observe(action='telemetry')", inject_action="telemetry"),
+    "debug_request_context": ToolAlias(old_name="debug_request_context", new_name="admin", reason="consolidated",
+        migration_note="Use admin(action='debug_context')", inject_action="debug_context"),
+    "validate_file_path": ToolAlias(old_name="validate_file_path", new_name="admin", reason="consolidated",
+        migration_note="Use admin(action='validate_path', file_path='...')", inject_action="validate_path"),
+    "reset_monitor": ToolAlias(old_name="reset_monitor", new_name="admin", reason="consolidated",
+        migration_note="Use admin(action='reset_monitor')", inject_action="reset_monitor"),
+    "cleanup_stale_locks": ToolAlias(old_name="cleanup_stale_locks", new_name="admin", reason="consolidated",
+        migration_note="Use admin(action='cleanup_locks')", inject_action="cleanup_locks"),
+
     # Dialectic tools → dialectic(action='...')
     "get_dialectic_session": ToolAlias(old_name="get_dialectic_session", new_name="dialectic", reason="consolidated",
         migration_note="Use dialectic(action='get', session_id='...')", inject_action="get"),

--- a/src/tool_modes.py
+++ b/src/tool_modes.py
@@ -194,6 +194,7 @@ TOOL_TIERS: dict[str, Set[str]] = {
         "compare_me_to_similar",
         "get_knowledge_graph",
         "cleanup_knowledge_graph",       # KG lifecycle cleanup (Dec 2025)
+        "admin",                         # Consolidated diagnostics/maintenance (Jun 2026)
     }
 }
 
@@ -236,6 +237,9 @@ TOOL_OPERATIONS: dict[str, str] = {
     # Configuration
     "get_thresholds": "read",             # Get current thresholds
     "set_thresholds": "write",            # Set threshold overrides
+
+    # Consolidated diagnostics/maintenance
+    "admin": "admin",                     # Mixed read/maintenance (action-routed)
 
     # Knowledge Graph
     "store_knowledge_graph": "write",     # Store discovery

--- a/src/tool_schemas.py
+++ b/src/tool_schemas.py
@@ -149,6 +149,7 @@ TOOL_ORDER = [
     "observe",
     "dialectic",
     "dashboard",
+    "admin",
 ]
 
 

--- a/tests/test_consolidated_handlers.py
+++ b/tests/test_consolidated_handlers.py
@@ -578,6 +578,63 @@ class TestObserveHandler:
         assert valid == expected
 
 
+class TestAdminHandler:
+    """Tests for the admin/diagnostics consolidated handler."""
+
+    @pytest.mark.asyncio
+    async def test_missing_action_returns_error(self):
+        from src.mcp_handlers.consolidated import handle_admin
+        result = await handle_admin({})
+        data = _parse_response(result)
+        assert data["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_invalid_action_returns_error(self):
+        from src.mcp_handlers.consolidated import handle_admin
+        result = await handle_admin({"action": "rm_rf"})
+        data = _parse_response(result)
+        assert data["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_valid_actions_list_complete(self):
+        from src.mcp_handlers.consolidated import handle_admin
+        result = await handle_admin({"action": "bad"})
+        data = _parse_response(result)
+        valid = sorted(data["recovery"]["valid_actions"])
+        expected = sorted(["server_info", "connections", "workspace_health",
+                           "tool_usage", "telemetry", "debug_context",
+                           "validate_path", "reset_monitor", "cleanup_locks"])
+        assert valid == expected
+
+    @pytest.mark.asyncio
+    async def test_routes_to_underlying_handler(self):
+        from src.mcp_handlers.consolidated import handle_admin
+        mock = _make_mock_handler({"server": "ok"})
+        with _patch_router_action(handle_admin, "server_info", mock):
+            result = await handle_admin({"action": "server_info"})
+        mock.assert_awaited_once()
+        assert _parse_response(result) == {"server": "ok"}
+
+
+class TestAdminParamsSchema:
+    """The action-routed schema must declare every routable field and resolve
+    the divergent window_hours default (telemetry=24, tool_usage=168)."""
+
+    def test_window_default_diverges_by_action(self):
+        from src.mcp_handlers.schemas.admin import AdminParams
+        assert AdminParams(action="telemetry").window_hours == 24.0
+        assert AdminParams(action="tool_usage").window_hours == 168.0
+        # Explicit value is never overridden.
+        assert AdminParams(action="telemetry", window_hours=72).window_hours == 72
+        # Non-window actions leave it unset.
+        assert AdminParams(action="server_info").window_hours is None
+
+    def test_schema_auto_maps_to_admin_tool(self):
+        from src.tool_schemas import get_pydantic_schemas
+        from src.mcp_handlers.schemas.admin import AdminParams
+        assert get_pydantic_schemas().get("admin") is AdminParams
+
+
 @pytest.fixture
 def _pi_handler():
     """``pi`` action router lives in unitares-pi-plugin as of Phase B1.

--- a/tests/test_stakes_table.py
+++ b/tests/test_stakes_table.py
@@ -48,6 +48,9 @@ ROUTER_ACTIONS = {
     "dialectic": ["get", "list", "quick", "request", "thesis", "antithesis",
                   "synthesis", "reassign"],
     "research_registry": ["list", "query", "get", "stats", "export", "record"],
+    "admin": ["server_info", "connections", "workspace_health", "tool_usage",
+              "telemetry", "debug_context", "validate_path", "reset_monitor",
+              "cleanup_locks"],
 }
 
 # External-plugin surfaces this server does not own. They register only when an


### PR DESCRIPTION
## What

Adds a consolidated **`admin`** action-router MCP tool that folds nine standalone operator/diagnostics tools behind one `action` param, following the established `observe`/`config`/`export` router pattern in `consolidated.py`.

| `admin(action=…)` | folds | stakes | identity |
|---|---|---|---|
| `server_info` | `get_server_info` | baseline | pre_onboard |
| `connections` | `get_connection_status` | baseline | required |
| `workspace_health` | `get_workspace_health` | baseline | required |
| `tool_usage` | `get_tool_usage_stats` | baseline | required |
| `telemetry` | `get_telemetry_metrics` | baseline | required |
| `debug_context` | `debug_request_context` | baseline | required |
| `validate_path` | `validate_file_path` | baseline | required |
| `reset_monitor` | `reset_monitor` | **high** | required |
| `cleanup_locks` | `cleanup_stale_locks` | **high** | required |

## Scope / safety

- **Additive, back-compat preserved.** The nine standalone tools stay `register=True`; their old names alias to `admin(action=…)` for gate canonicalization + migration notes. This mirrors how `observe` left `detect_anomalies` etc. registered.
- **Surface reduction is a deliberate follow-up.** Flipping the nine to alias-only (`register=False`) requires migrating direct callers (dashboard/operator), same hazard as the resident migration — out of scope here.
- **Gating/stakes faithfully preserved** per standalone tool (verified live, not assumed): `server_info` pre_onboard; `reset_monitor`/`cleanup_locks` high; rest required/baseline.
- **`window_hours` default divergence** (telemetry=24, tool_usage=168) resolved in the `AdminParams` validator — zero handler edits.
- Placed in the **advanced tier** (operator/full mode), not LITE — the admin tools were never in the lean agent surface.

## Verification

- Full gate green: **11,195 passed, 22 skipped, 81.94% coverage**.
- New unit tests for the router + `AdminParams` window-default logic.
- Live-verified: registration, full param schema exposure, stakes/identity preservation through alias canonicalization, and FastMCP typed-wrapper registration in full mode with legacy tools intact.
- Independent code-review pass: clean, no issues ≥80 confidence.

https://claude.ai/code/session_01RhZajJZ6UpgG5g2nGk6uTU