### PR TITLE
chore(dogfood): quiet CI and doc-health polish

### DIFF
--- a/.github/workflows/repo-scope.yml
+++ b/.github/workflows/repo-scope.yml
@@ -35,9 +35,9 @@ jobs:
         run: bash scripts/dev/check-repo-scope.sh --base "${{ steps.base.outputs.ref }}"
 
       # The file guard checks committed content; a PR description is not a file,
-      # so lint it separately for the same chat-session register. Body passed via
-      # env (never inlined) to avoid script injection.
-      - name: Lint PR body for chat-session register
+      # so lint it separately for operator-local paths and chat-session register.
+      # Body passed via env (never inlined) to avoid script injection.
+      - name: Lint PR body for local paths and chat register
         if: github.event_name == 'pull_request'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
@@ -49,10 +49,22 @@ jobs:
             echo "PR body register: allow-register marker present — skipping."
             exit 0
           fi
-          bad=$(printf '%s' "$PR_BODY" | grep -niE '/Users/cirwel|per your guidance|your overlay|you flagged|questions for [Kk]enny|live-verifier|council pass|council fold' || true)
-          if [ -n "$bad" ]; then
-            echo "::error::PR body reads like a personal chat session or leaks an operator-local path. Rewrite third-person/imperative; move working notes out of the public record."
-            printf '%s\n' "$bad"
+          failures=0
+          bad_paths=$(printf '%s' "$PR_BODY" | grep -niE '/Users/cirwel' || true)
+          if [ -n "$bad_paths" ]; then
+            echo "::error::PR body leaks an operator-local path (/Users/cirwel). Use repo-relative paths, environment variables, or neutral checkout wording."
+            printf '%s\n' "$bad_paths"
+            failures=1
+          fi
+
+          bad_register=$(printf '%s' "$PR_BODY" | grep -niE 'per your guidance|your overlay|you flagged|questions for [Kk]enny|live-verifier|council pass|council fold' || true)
+          if [ -n "$bad_register" ]; then
+            echo "::error::PR body reads like a personal chat session. Rewrite third-person/imperative; move working notes out of the public record."
+            printf '%s\n' "$bad_register"
+            failures=1
+          fi
+
+          if [ "$failures" -ne 0 ]; then
             exit 1
           fi
           echo "PR body register: clean"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,8 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: '3.12'
+        cache: 'pip'
+        cache-dependency-path: requirements-full.txt
 
     - name: Install dependencies
       run: |
@@ -126,6 +128,8 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+        cache-dependency-path: requirements-full.txt
 
     - name: Install dependencies
       run: |
@@ -174,6 +178,8 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version: '22'
+        cache: 'npm'
+        cache-dependency-path: dashboard/package-lock.json
 
     - name: Install dashboard deps
       working-directory: dashboard

--- a/docs/dev/CANONICAL_SOURCES.md
+++ b/docs/dev/CANONICAL_SOURCES.md
@@ -63,6 +63,8 @@ These are live but intentionally specialized. They should not be treated as gene
 |-----|--------|--------------|
 | `docs/guides/CIRS_PROTOCOL.md` | specialized protocol reference | CIRS-specific coordination flows |
 | `docs/dev/CIRCUIT_BREAKER_DIALECTIC.md` | specialized recovery reference | Circuit-breaker and dialectic recovery flow |
+| `docs/dev/KNOWLEDGE_GRAPH_SEMANTICS.md` | specialized developer reference | Shared-memory write/read, link, and audit semantics |
+| `docs/dev/SESSION_KEY_DERIVATION.md` | specialized developer reference | Session-key resolution priority and proof-origin trust model |
 | `docs/dev/TOOL_REGISTRATION.md` | specialized developer reference | MCP/tool registration work |
 
 ## Supporting Non-Canonical Artifacts

--- a/docs/dev/KNOWLEDGE_GRAPH_SEMANTICS.md
+++ b/docs/dev/KNOWLEDGE_GRAPH_SEMANTICS.md
@@ -20,8 +20,8 @@ builds on it. All actions route through the consolidated `knowledge(...)` tool
    `knowledge_read` event.
 3. **B responds** — `knowledge(action="answer_question",
    response_to={discovery_id, response_type}, summary=...)` → a new discovery
-   linked back via `response_to_id`, forming a chain queryable through
-   `get_response_chain()`.
+   linked back via `response_to_id`, forming a chain queryable through the
+   internal `get_response_chain` helper.
 
 > Write discipline (see CLAUDE.md "Strict Identity"): **search before writing.**
 > If a related entry exists, prefer a linked correction or `supersede` over a

--- a/docs/dev/SESSION_KEY_DERIVATION.md
+++ b/docs/dev/SESSION_KEY_DERIVATION.md
@@ -1,8 +1,8 @@
 # Session-key derivation — schemes, stability, and privacy/security model
 
 How the server decides "which caller is this?" on each request, and what each
-signal is and isn't trusted for. The mechanics live in one function —
-`derive_session_key()` / `_derive_session_key_impl()` in
+signal is and isn't trusted for. The mechanics live in one function path:
+`derive_session_key` / `_derive_session_key_impl` in
 `src/mcp_handlers/identity/session.py` — fed by a frozen `SessionSignals`
 snapshot captured once at the transport layer (`src/mcp_handlers/context.py`).
 This doc is the privacy/security companion to that code and to the identity
@@ -75,6 +75,6 @@ identity — hence injected ⇒ `server_inferred`.
 
 ## One-line summary
 
-`derive_session_key()` picks the strongest *present* signal; `proof_origin`
+`derive_session_key` picks the strongest *present* signal; `proof_origin`
 then decides whether that signal is strong enough to **write**. Reads are
 lenient; writes require a proof the caller actually transmitted.

--- a/docs/manual/04-integrating-agents.md
+++ b/docs/manual/04-integrating-agents.md
@@ -135,7 +135,7 @@ For daemons and cron-style agents, the **`unitares-sdk`** ([`../../agents/sdk/RE
 
 - Subclass **`GovernanceAgent`** and override `run_cycle(client)` (required). Optional hooks: `on_after_checkin(...)`, `on_verdict_pause(...)` (return `True` to retry the check-in after self-recovery).
 - **Daemon:** `agent.run_forever(interval=60)` loops with idle heartbeats. **Scheduled:** `agent.run_once()` for one cycle under launchd/systemd/cron.
-- Identity anchors persist at `~/.unitares/anchors/<name>.json`; agent state via `save_state(dict)` / `load_state()`.
+- Identity anchors persist at `~/.unitares/anchors/<name>.json`; agent state via `save_state(dict)` / `load_state`.
 - Constructor knobs: `name`, `mcp_url` (default `http://127.0.0.1:8767/mcp/`), `persistent`, `refuse_fresh_onboard`, `cycle_timeout_seconds`, `parent_agent_id`, `spawn_reason`.
 
 The resident agents (Vigil, Sentinel, Chronicler) in [`../../agents/`](../../agents/) are reference implementations of these patterns.

--- a/elixir/dialectic_live/README.md
+++ b/elixir/dialectic_live/README.md
@@ -40,8 +40,9 @@ mix deps.get
 mix phx.server          # http://127.0.0.1:8790
 ```
 
-Config (`config/runtime.exs`, all overridable by env): `PORT` (8790),
-`GOVERNANCE_WS_URL`, `GOVERNANCE_TOOLS_URL`, `UNITARES_HTTP_API_TOKEN`,
-`GOVERNANCE_START_FIREHOSE`. As a standing service it runs via
-`scripts/start.sh` under `scripts/ops/com.unitares.dialectic-live.plist.template`
-(operator-promoted; no `RunAtLoad`).
+Config ([`./config/runtime.exs`](./config/runtime.exs), all overridable by env):
+`PORT` (8790), `GOVERNANCE_WS_URL`, `GOVERNANCE_TOOLS_URL`,
+`UNITARES_HTTP_API_TOKEN`, `GOVERNANCE_START_FIREHOSE`. As a standing service it
+runs via [`./scripts/start.sh`](./scripts/start.sh) under
+`scripts/ops/com.unitares.dialectic-live.plist.template` (operator-promoted; no
+`RunAtLoad`).

--- a/scripts/diagnostics/check_doc_health.py
+++ b/scripts/diagnostics/check_doc_health.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python3
 """Check documentation health: dead refs, ghost tools, hardcoded IPs/counts.
 
-Also prints an advisory **demotion-candidate** list: planning/RFC docs whose own
-status says the work shipped but which still live in an active location
+Can also print an advisory **demotion-candidate** list: planning/RFC docs whose
+own status says the work shipped but which still live in an active location
 (proposals/ outside resolved/, or the ontology/ identity tree). That list is
-triage, not a defect — it never affects the exit code; clear it by moving
-fully-shipped docs to proposals/resolved/ (or stubbing them out) on a real
-signal, rather than letting a subsystem's doc set sprawl.
+triage, not a defect, so it is opt-in via ``--demotion-candidates`` and never
+affects the exit code; clear it by moving fully-shipped docs to
+proposals/resolved/ (or stubbing them out) on a real signal, rather than letting
+a subsystem's doc set sprawl.
 
 Usage:
-    python3 scripts/diagnostics/check_doc_health.py [--strict]
+    python3 scripts/diagnostics/check_doc_health.py [--strict] [--demotion-candidates]
 
 Exit codes:
-    0 — no warnings (or warnings only in non-strict mode; the demotion advisory
-        never sets a non-zero code)
+    0 — no warnings (or warnings only in non-strict mode)
     1 — warnings found (strict mode only) — demotion candidates excluded
 """
 
@@ -310,6 +310,7 @@ _TOOL_ALLOWLIST = {
     "acquire", "release",  # asyncio.Lock / Semaphore methods
     "accept",  # socket.accept(), TLS accept
     "getAuthToken",  # JS dashboard helper
+    "load", "retheme", "applyEvent", "notifyNew", "refreshActive",  # dashboard hooks
 }
 
 # Files/dirs where ghost tool warnings are noise (plans, specs, internal
@@ -526,6 +527,7 @@ def collect_md_files() -> list[Path]:
 
 def main():
     strict = "--strict" in sys.argv
+    show_demotion = "--demotion-candidates" in sys.argv
     md_files = collect_md_files()
     tool_names = _load_tool_names()
 
@@ -555,9 +557,10 @@ def main():
     if counts:
         all_warnings.append(("Hardcoded counts (will go stale)", counts))
 
-    # Advisory: surfaced for triage, never gates the exit code (demotion is a
-    # judgment call, not a defect). Printed separately from the warning total.
-    demotion = check_demotion_candidates(md_files)
+    # Advisory: surfaced only when requested, never gates the exit code
+    # (demotion is a judgment call, not a defect). Printed separately from the
+    # warning total so pre-push stays quiet unless an operator is auditing docs.
+    demotion = check_demotion_candidates(md_files) if show_demotion else []
 
     if not all_warnings and not demotion:
         print("📄 Doc health: all clear")

--- a/tests/test_doc_health_dead_refs.py
+++ b/tests/test_doc_health_dead_refs.py
@@ -480,8 +480,29 @@ def test_demotion_does_not_gate_strict_exit(tmp_path, monkeypatch, doc_health, c
     # WOULD gate strict). We want a clean case: demotion candidate and nothing else.
     (p.parent / "README.md").write_text("- [x](shipped-v0.md)\n")
     monkeypatch.setattr(doc_health, "REPO_ROOT", tmp_path)
-    monkeypatch.setattr(doc_health.sys, "argv", ["check_doc_health.py", "--strict"])
+    monkeypatch.setattr(
+        doc_health.sys,
+        "argv",
+        ["check_doc_health.py", "--strict", "--demotion-candidates"],
+    )
     assert doc_health.main() == 0
+    assert "Demotion candidates" in capsys.readouterr().out
+
+
+def test_demotion_advisory_is_opt_in(tmp_path, monkeypatch, doc_health, capsys):
+    """Default doc-health output stays quiet for advisory-only demotion candidates."""
+    p = tmp_path / "docs" / "proposals" / "shipped-v0.md"
+    p.parent.mkdir(parents=True)
+    p.write_text("# X\n\n**Status:** shipped, deployed, complete.\n")
+    (p.parent / "README.md").write_text("- [x](shipped-v0.md)\n")
+
+    monkeypatch.setattr(doc_health, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(doc_health.sys, "argv", ["check_doc_health.py"])
+
+    assert doc_health.main() == 0
+    out = capsys.readouterr().out
+    assert "Doc health: all clear" in out
+    assert "Demotion candidates" not in out
 
 
 def test_collect_md_files_skips_elixir_deps_and_build_dirs(tmp_path, monkeypatch, doc_health):


### PR DESCRIPTION
## Summary
- Split PR-body scope-guard diagnostics so operator-local path leaks and chat-register wording produce distinct errors.
- Clear doc-health noise in default/pre-push output: direct warnings are fixed, while demotion-candidate audits remain available behind an explicit flag.
- Add dependency caching to GitHub Actions setup steps for Python and dashboard Node installs.

## Validation
- `python3 scripts/diagnostics/check_doc_health.py`
- `python3 scripts/diagnostics/check_doc_health.py --strict`
- `python3 scripts/diagnostics/check_doc_health.py --demotion-candidates`
- `python3 -m pytest tests/test_doc_health_dead_refs.py -q`
- `bash -n scripts/dev/check-repo-scope.sh`
- `bash scripts/dev/check-repo-scope.sh --files ...touched files...`
- workflow YAML parsed locally
- `ruff check .`
- doc drift / skills manifest / skill freshness / flags / ports checks
- `./scripts/dev/test-cache.sh`
- pre-push smoke gate
