### PR TITLE
fix(eisv): Stage-0 anchor honesty — require a joinable EISV snapshot to anchor

### DIFF
--- a/scripts/analysis/eisv_skeptic_report.py
+++ b/scripts/analysis/eisv_skeptic_report.py
@@ -37,6 +37,7 @@ from scripts.analysis.outcome_inventory import (
     attach_identity_metadata,
     is_controlled_validation_fixture,
 )
+from src.grounding.outcome_anchors import anchored_outcomes_predicate
 
 
 DEFAULT_DB_URL = os.environ.get(
@@ -1120,6 +1121,7 @@ async def fetch_rows(
     lead_minutes: float,
     outcome_types: Sequence[str],
     dispersion_window_minutes: float = DISPERSION_WINDOW_MINUTES,
+    anchor_predicate: str | None = None,
 ) -> list[OutcomeRow]:
     try:
         import asyncpg
@@ -1240,8 +1242,9 @@ async def fetch_rows(
             ) disp ON TRUE
             WHERE o.ts >= now() - ($1::int * INTERVAL '1 day')
               AND o.outcome_type = ANY($3::text[])
+              AND {anchor_clause}
             ORDER BY o.ts ASC
-            """,
+            """.format(anchor_clause=(anchor_predicate or "TRUE")),
             window_days,
             lead_minutes,
             list(outcome_types),
@@ -1279,6 +1282,18 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
             "The task scope has more data but weaker objectivity."
         ),
     )
+    parser.add_argument(
+        "--anchor-scope",
+        choices=("trusted", "soft", "all"),
+        default="soft",
+        help=(
+            "Which outcomes may anchor the falsifiability test (src.grounding.outcome_anchors). "
+            "trusted = external_signal + a joinable EISV snapshot; soft = also agent-self-attested "
+            "(default — more data); all = no anchor filter (legacy/contaminated: includes "
+            "self-referential and snapshot-less synthetic rows). Use 'all' only to reproduce the "
+            "pre-anchor-honesty numbers."
+        ),
+    )
     parser.add_argument("--output", help="Optional markdown output path")
     return parser.parse_args(argv)
 
@@ -1288,12 +1303,19 @@ async def main_async(args: argparse.Namespace) -> int:
         print("error: --train-fraction must be between 0.1 and 0.9", file=sys.stderr)
         return 2
     outcome_types = STRICT_OUTCOMES if args.scope == "strict" else TASK_OUTCOMES
+    if args.anchor_scope == "all":
+        anchor_predicate = None
+    else:
+        anchor_predicate = anchored_outcomes_predicate(
+            include_soft=(args.anchor_scope == "soft"), table_alias="o"
+        )
     rows = await fetch_rows(
         args.db_url,
         window_days=args.window_days,
         lead_minutes=args.lead_minutes,
         outcome_types=outcome_types,
         dispersion_window_minutes=args.dispersion_window_minutes,
+        anchor_predicate=anchor_predicate,
     )
     report = build_report(
         rows,

--- a/scripts/analysis/outcome_anchor_inventory.py
+++ b/scripts/analysis/outcome_anchor_inventory.py
@@ -30,7 +30,12 @@ except ImportError:
     print("ERROR: psycopg2 not installed. Run: pip install psycopg2-binary", file=sys.stderr)
     sys.exit(1)
 
-from src.grounding.outcome_anchors import AnchorTier, tier_for_source  # noqa: E402
+from src.grounding.outcome_anchors import (  # noqa: E402
+    AnchorTier,
+    tier_for_source,
+    ANCHORED_OUTCOMES_SQL,
+    ANCHORED_OUTCOMES_WITH_SOFT_SQL,
+)
 
 
 def main() -> int:
@@ -76,6 +81,59 @@ def main() -> int:
     if total:
         print(f"Self-referential / unknown EXCLUDED: {excl_c}/{total} "
               f"({100*excl_c/total:.0f}%) — Invariant 4 in effect")
+
+    # Joinability gap: provenance-trusted is necessary but not sufficient. A row
+    # can only anchor the residual test if it carries an EISV snapshot at outcome
+    # time (roadmap §6.3); the canonical ANCHORED_OUTCOMES_SQL ANDs that in. The
+    # delta vs the raw TRUSTED count above is snapshot-less / synthetic traffic
+    # (e.g. BEAM wiring smoke tests) that must NOT train the gate.
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            SELECT count(*),
+                   sum(CASE WHEN is_bad THEN 1 ELSE 0 END),
+                   count(DISTINCT agent_id)
+            FROM audit.outcome_events
+            WHERE {ANCHORED_OUTCOMES_SQL}
+            """
+        )
+        anchorable_c, anchorable_bad, anchorable_agents = cur.fetchone()
+        anchorable_bad = int(anchorable_bad or 0)
+        cur.execute(
+            f"""
+            SELECT count(*), sum(CASE WHEN is_bad THEN 1 ELSE 0 END)
+            FROM audit.outcome_events
+            WHERE {ANCHORED_OUTCOMES_WITH_SOFT_SQL}
+            """
+        )
+        soft_anchorable_c, soft_anchorable_bad = cur.fetchone()
+        soft_anchorable_bad = int(soft_anchorable_bad or 0)
+
+    print(f"\nJoinable anchor budget (TRUSTED + EISV snapshot): {anchorable_c} events, "
+          f"{anchorable_bad} bad, across {anchorable_agents} agents")
+    print(f"  (+soft self-attested if opted in: {soft_anchorable_c} events, {soft_anchorable_bad} bad)")
+    contamination = trusted_c - anchorable_c
+    if contamination > 0:
+        print(f"  ⚠ {contamination} TRUSTED rows are snapshot-less/synthetic "
+              f"({100*contamination/trusted_c:.0f}% of TRUSTED) — excluded from anchoring, "
+              f"correctly not training the gate")
+    # Per-agent coverage bounds B's per-agent falsifiability gate (§6.3).
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            WITH a AS (
+                SELECT agent_id,
+                       sum(CASE WHEN NOT is_bad THEN 1 ELSE 0 END) good,
+                       sum(CASE WHEN is_bad THEN 1 ELSE 0 END) bad
+                FROM audit.outcome_events WHERE {ANCHORED_OUTCOMES_SQL}
+                GROUP BY agent_id)
+            SELECT count(*) FILTER (WHERE good >= 5 AND bad >= 5)
+            FROM a
+            """
+        )
+        rich_agents = cur.fetchone()[0]
+    flag = "  ⚠ no agent has a balanced label set — B's per-agent gate un-runnable" if rich_agents == 0 else ""
+    print(f"agents with good>=5 AND bad>=5 (B-gate-ready): {rich_agents}{flag}")
 
     # Gap check: is the most objective bad anchor (a failing test) flowing?
     with conn.cursor() as cur:

--- a/src/grounding/outcome_anchors.py
+++ b/src/grounding/outcome_anchors.py
@@ -85,21 +85,74 @@ def is_exogenous_anchor(
     return False
 
 
+def is_anchorable(
+    verification_source: Optional[str],
+    *,
+    eisv_present: bool,
+    snapshot_missing: bool = False,
+    include_soft: bool = False,
+) -> bool:
+    """True if an outcome row may anchor the residual/falsifiability test.
+
+    Full anchorability = exogenous provenance (``is_exogenous_anchor``) AND a
+    joinable EISV snapshot at outcome time. The row-level twin of
+    ``ANCHORED_OUTCOMES_SQL``: a trusted-provenance row with no state has nothing
+    to compute a residual against (roadmap §6.3), and snapshot-less synthetic
+    harness traffic must never train the gate. ``eisv_present`` is whether the row
+    carries an EISV vector (e.g. ``eisv_e is not None``); ``snapshot_missing``
+    mirrors the ``detail.snapshot_missing`` flag.
+    """
+    if not is_exogenous_anchor(verification_source, include_soft=include_soft):
+        return False
+    return bool(eisv_present) and not snapshot_missing
+
+
 # --- Canonical SQL predicates -------------------------------------------------
 # The single source of truth for "which outcome_events rows may anchor". Use
 # these in any query that feeds a baseline update or a falsifiability gate, so
-# the Invariant-4 exclusion is applied uniformly and is greppable.
+# both the Invariant-4 exclusion AND the joinability requirement are applied
+# uniformly and greppably.
+#
+# Anchorability has two parts, both required:
+#   1. exogenous provenance  (tier, below) — Invariant 4;
+#   2. a joinable EISV snapshot at outcome time — roadmap §6.3.
+# A trusted-provenance row with no state at outcome time cannot anchor the
+# residual test: there is nothing to compute `measurement − reference` against.
+# This is not a cosmetic filter — it is the §6.3 precondition. It also removes
+# synthetic harness traffic (BEAM wiring smoke tests emit external_signal with
+# snapshot_missing=true and no eisv_*), which must never train the gate. The
+# snapshot bridge (db/mixins/tool_usage.py) attaches state for genuinely
+# instrumented agents, so real outcomes pass; non-instrumented/synthetic ones
+# correctly do not.
 
-#: Externally-anchored outcomes only (default — the honest anchor set).
-ANCHORED_OUTCOMES_SQL = "verification_source = 'external_signal'"
+#: A row carries the EISV state needed to compute a residual at outcome time.
+#: Required for any anchor — see module note above (roadmap §6.3).
+JOINABLE_SNAPSHOT_SQL = (
+    "(eisv_e IS NOT NULL "
+    "AND coalesce((detail->>'snapshot_missing')::boolean, false) = false)"
+)
 
-#: Externally-anchored + soft self-attested (opt-in; tolerate gameable signal).
-ANCHORED_OUTCOMES_WITH_SOFT_SQL = (
+_TRUSTED_SOURCE_SQL = "verification_source = 'external_signal'"
+_TRUSTED_OR_SOFT_SOURCE_SQL = (
     "verification_source IN ('external_signal', 'agent_reported_tool_result')"
 )
 
-#: Rows that must NEVER anchor — self-referential or unknown provenance. Useful
-#: for an assertion / audit that nothing leaked the loop's self-validation in.
+#: Externally-anchored outcomes only (default — the honest anchor set):
+#: exogenous provenance AND a joinable snapshot.
+ANCHORED_OUTCOMES_SQL = f"({_TRUSTED_SOURCE_SQL}) AND {JOINABLE_SNAPSHOT_SQL}"
+
+#: Externally-anchored + soft self-attested (opt-in; tolerate gameable signal).
+#: Still requires a joinable snapshot.
+ANCHORED_OUTCOMES_WITH_SOFT_SQL = (
+    f"({_TRUSTED_OR_SOFT_SOURCE_SQL}) AND {JOINABLE_SNAPSHOT_SQL}"
+)
+
+#: Rows that must NEVER anchor on *provenance* grounds — self-referential or
+#: unknown source. Useful for an assertion / audit that nothing leaked the loop's
+#: self-validation in. NB: this is provenance-only and is deliberately NOT the
+#: complement of ANCHORED_OUTCOMES_SQL — a trusted-provenance row that simply
+#: lacks a snapshot is neither an anchor nor a provenance leak (it is unjoinable,
+#: a coverage gap, not an Invariant-4 violation).
 EXCLUDED_OUTCOMES_SQL = (
     "(verification_source IS NULL "
     "OR verification_source NOT IN ('external_signal', 'agent_reported_tool_result'))"
@@ -107,5 +160,9 @@ EXCLUDED_OUTCOMES_SQL = (
 
 
 def anchored_outcomes_predicate(*, include_soft: bool = False) -> str:
-    """Return the SQL predicate selecting anchorable outcome rows."""
+    """Return the SQL predicate selecting anchorable outcome rows.
+
+    Selects rows with exogenous provenance AND a joinable EISV snapshot — both
+    are required (see module note; roadmap §6.3).
+    """
     return ANCHORED_OUTCOMES_WITH_SOFT_SQL if include_soft else ANCHORED_OUTCOMES_SQL

--- a/src/grounding/outcome_anchors.py
+++ b/src/grounding/outcome_anchors.py
@@ -159,10 +159,28 @@ EXCLUDED_OUTCOMES_SQL = (
 )
 
 
-def anchored_outcomes_predicate(*, include_soft: bool = False) -> str:
+def anchored_outcomes_predicate(
+    *, include_soft: bool = False, table_alias: Optional[str] = None
+) -> str:
     """Return the SQL predicate selecting anchorable outcome rows.
 
     Selects rows with exogenous provenance AND a joinable EISV snapshot — both
     are required (see module note; roadmap §6.3).
+
+    ``table_alias`` qualifies the column references (``verification_source``,
+    ``eisv_e``, ``detail``) with ``<alias>.`` so the predicate can be AND-ed into
+    a query that aliases ``audit.outcome_events`` (e.g. ``... o`` in the skeptic
+    report). With no alias the bare-column constants are returned unchanged.
     """
-    return ANCHORED_OUTCOMES_WITH_SOFT_SQL if include_soft else ANCHORED_OUTCOMES_SQL
+    base = ANCHORED_OUTCOMES_WITH_SOFT_SQL if include_soft else ANCHORED_OUTCOMES_SQL
+    if not table_alias:
+        return base
+    a = f"{table_alias}."
+    # The three column tokens are distinct and do not appear as substrings of one
+    # another in the predicate, so targeted replacement is safe here.
+    return (
+        base
+        .replace("verification_source", f"{a}verification_source")
+        .replace("eisv_e", f"{a}eisv_e")
+        .replace("detail->>", f"{a}detail->>")
+    )

--- a/tests/test_outcome_anchors.py
+++ b/tests/test_outcome_anchors.py
@@ -71,6 +71,21 @@ def test_sql_predicates_exclude_self_referential():
     assert "agent_reported_tool_result" in ANCHORED_OUTCOMES_WITH_SOFT_SQL
 
 
+def test_table_alias_qualifies_columns():
+    """With table_alias, every column ref is prefixed so the predicate can be
+    AND-ed into an aliased query (e.g. the skeptic report's `... o`)."""
+    p = anchored_outcomes_predicate(table_alias="o")
+    assert "o.verification_source" in p
+    assert "o.eisv_e" in p
+    assert "o.detail->>" in p
+    # no bare (unqualified) column tokens leak through
+    assert "(verification_source" not in p and " verification_source" not in p
+    assert "(eisv_e" not in p
+    # no alias requested -> unchanged constant
+    assert anchored_outcomes_predicate() == ANCHORED_OUTCOMES_SQL
+    assert anchored_outcomes_predicate(include_soft=True, table_alias="o").count("o.eisv_e") == 1
+
+
 def test_anchor_predicates_require_joinable_snapshot():
     """Both anchor predicates must AND-in the joinable-snapshot requirement, so a
     snapshot-less row (synthetic harness traffic / non-instrumented agent) cannot

--- a/tests/test_outcome_anchors.py
+++ b/tests/test_outcome_anchors.py
@@ -11,9 +11,11 @@ from src.grounding.outcome_anchors import (
     AnchorTier,
     tier_for_source,
     is_exogenous_anchor,
+    is_anchorable,
     anchored_outcomes_predicate,
     ANCHORED_OUTCOMES_SQL,
     ANCHORED_OUTCOMES_WITH_SOFT_SQL,
+    JOINABLE_SNAPSHOT_SQL,
 )
 
 
@@ -62,8 +64,34 @@ def test_soft_requires_explicit_optin():
 def test_sql_predicates_exclude_self_referential():
     assert "server_observation" not in ANCHORED_OUTCOMES_SQL
     assert "server_observation" not in ANCHORED_OUTCOMES_WITH_SOFT_SQL
-    assert ANCHORED_OUTCOMES_SQL == "verification_source = 'external_signal'"
+    assert "verification_source = 'external_signal'" in ANCHORED_OUTCOMES_SQL
     assert anchored_outcomes_predicate() == ANCHORED_OUTCOMES_SQL
     assert anchored_outcomes_predicate(include_soft=True) == ANCHORED_OUTCOMES_WITH_SOFT_SQL
     # the soft predicate admits exactly the two non-excluded sources
     assert "agent_reported_tool_result" in ANCHORED_OUTCOMES_WITH_SOFT_SQL
+
+
+def test_anchor_predicates_require_joinable_snapshot():
+    """Both anchor predicates must AND-in the joinable-snapshot requirement, so a
+    snapshot-less row (synthetic harness traffic / non-instrumented agent) cannot
+    anchor the residual test (roadmap §6.3)."""
+    assert JOINABLE_SNAPSHOT_SQL in ANCHORED_OUTCOMES_SQL
+    assert JOINABLE_SNAPSHOT_SQL in ANCHORED_OUTCOMES_WITH_SOFT_SQL
+    assert "eisv_e IS NOT NULL" in JOINABLE_SNAPSHOT_SQL
+    assert "snapshot_missing" in JOINABLE_SNAPSHOT_SQL
+
+
+def test_is_anchorable_requires_provenance_and_snapshot():
+    # trusted provenance + a real snapshot anchors
+    assert is_anchorable("external_signal", eisv_present=True) is True
+    # trusted provenance but no snapshot does NOT anchor (the synthetic-smoke case)
+    assert is_anchorable("external_signal", eisv_present=False) is False
+    # snapshot present but flagged missing does NOT anchor
+    assert is_anchorable("external_signal", eisv_present=True, snapshot_missing=True) is False
+    # excluded provenance never anchors, snapshot or not
+    assert is_anchorable("server_observation", eisv_present=True) is False
+    assert is_anchorable(None, eisv_present=True) is False
+    # soft self-attested only with explicit opt-in, and still needs a snapshot
+    assert is_anchorable("agent_reported_tool_result", eisv_present=True) is False
+    assert is_anchorable("agent_reported_tool_result", eisv_present=True, include_soft=True) is True
+    assert is_anchorable("agent_reported_tool_result", eisv_present=False, include_soft=True) is False


### PR DESCRIPTION
## What

The Stage-0 anchor predicate (`src/grounding/outcome_anchors.py`) keyed only on `verification_source = 'external_signal'`. That made **provenance-trusted** sufficient to anchor B's falsifiability gate (roadmap §6.3) — but anchorability also requires a **joinable EISV snapshot** at outcome time. Without one there is nothing to compute a residual (`measurement − reference`) against.

## Why it matters (live audit, `governance.audit.outcome_events`)

| metric | value |
|---|---|
| raw `external_signal` (old "anchor budget") | 1,695 / 498 bad |
| **joinable** (TRUSTED + EISV snapshot) | **22 / 1 bad / 3 agents** |
| snapshot-less / synthetic TRUSTED rows | 1,673 (**99%**) |
| agents with good≥5 AND bad≥5 (B-gate-ready) | **0** |

99% of the "anchor set" is synthetic BEAM wiring smoke traffic (`kind=wiring_smoke_test`, `harness=beam`, `snapshot_missing=true`) carrying no EISV vector. Left unfixed, Stage B's per-agent gate would train on synthetic traffic.

## Change

- `JOINABLE_SNAPSHOT_SQL` added and AND-ed into both `ANCHORED_OUTCOMES_SQL` and `ANCHORED_OUTCOMES_WITH_SOFT_SQL`; row-level `is_anchorable()` twin.
- `EXCLUDED_OUTCOMES_SQL` deliberately left provenance-only — a trusted row that merely lacks a snapshot is a *coverage gap*, not an Invariant-4 leak, so it's neither anchor nor "excluded".
- `outcome_anchor_inventory.py` now reports the joinable budget, contamination delta, and per-agent B-gate-readiness.
- Tests extended (13 pass).

## Risk

**Not live-affecting.** Only the analysis script consumes the predicate today; no verdict/grounding path reads it (`GROUNDING_APPLY` off, Stage B unshipped). This corrects the anchor set *before* anything depends on it.

## Notable

The `+soft` joinable budget is **2,414 events / 114 bad** — the real (if gameable) exogenous-ish signal lives in the `agent_reported_tool_result` SOFT tier, not TRUSTED. Relevant to whether Stage B opts into soft self-attestation.

## Follow-ups (not in this PR)

- Steady TRUSTED flow: the genuine channel (Watcher/Sentinel resolve→`external_signal`) is wired but idle (≈20 rows ever); CI pass/fail has attribution + connectivity gaps that need design, not a quick webhook.
- The BEAM harness emitting `external_signal` for smoke tests is itself questionable — defensible to fix at the emitter too, but the predicate is the correct backstop layer.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01MhKDiJ5aBnaAiRW84uK69b