### PR TITLE
fix(telemetry): read tool-usage stats from audit.tool_usage (live sink), not stale JSONL

### DIFF
--- a/src/audit_db.py
+++ b/src/audit_db.py
@@ -102,6 +102,89 @@ async def append_tool_usage_async(
         return False
 
 
+async def get_tool_usage_stats_async(
+    window_hours: float = 24 * 7,
+    tool_name: Optional[str] = None,
+    agent_id: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Read tool-usage stats from the live ``audit.tool_usage`` DB sink.
+
+    Returns the same shape as ``ToolUsageTracker.get_usage_stats`` (a drop-in for
+    the legacy JSONL reader), or ``None`` when the DB is unavailable so callers can
+    fall back to the JSONL tracker. Never raises.
+
+    ``audit.tool_usage`` is the authoritative sink — written on every dispatched
+    call by ``append_tool_usage_async``. The JSONL sink is best-effort and has
+    drifted stale, so the readers prefer this path.
+    """
+    try:
+        from src.db import get_db
+        db = get_db()
+        if not hasattr(db, "_pool") or db._pool is None:
+            await db.init()
+
+        where = ["ts > now() - ($1 * interval '1 hour')"]
+        params: List[Any] = [float(window_hours)]
+        if tool_name:
+            params.append(tool_name)
+            where.append(f"tool_name = ${len(params)}")
+        if agent_id:
+            params.append(agent_id)
+            where.append(f"agent_id = ${len(params)}")
+        sql = (
+            "SELECT tool_name, "
+            "count(*)::bigint AS total_calls, "
+            "count(*) FILTER (WHERE success)::bigint AS success_count "
+            "FROM audit.tool_usage "
+            "WHERE " + " AND ".join(where) + " "
+            "GROUP BY tool_name"
+        )
+        async with db.acquire() as conn:
+            rows = await conn.fetch(sql, *params)
+    except Exception:
+        return None
+
+    from src.tool_usage_tracker import ToolUsageTracker
+    removed = ToolUsageTracker.REMOVED_TOOLS
+
+    counts = []
+    for r in rows:
+        t = r["tool_name"]
+        if not t or t in removed:
+            continue
+        total = int(r["total_calls"])
+        ok = int(r["success_count"])
+        counts.append((t, total, ok))
+
+    counts.sort(key=lambda x: x[1], reverse=True)
+    total_calls = sum(c[1] for c in counts)
+
+    tool_stats: Dict[str, Any] = {}
+    for t, total, ok in counts:
+        tool_stats[t] = {
+            "total_calls": total,
+            "success_count": ok,
+            "error_count": total - ok,
+            "success_rate": (ok / total) if total else 0.0,
+            "percentage_of_total": (total / total_calls * 100) if total_calls else 0.0,
+        }
+
+    sorted_tools = [(t, total) for (t, total, _ok) in counts]
+    return {
+        "total_calls": total_calls,
+        "unique_tools": len(tool_stats),
+        "window_hours": window_hours,
+        "tools": tool_stats,
+        "most_used": [{"tool": t, "calls": c} for t, c in sorted_tools[:10]],
+        "least_used": [{"tool": t, "calls": c} for t, c in sorted_tools[-10:]],
+        "agent_usage": (
+            {agent_id: {t: s["total_calls"] for t, s in tool_stats.items()}}
+            if agent_id else None
+        ),
+        "source": "db",
+    }
+
+
 async def audit_health_check_async() -> Dict[str, Any]:
     """Health check for audit storage backend."""
     from src.db import get_db

--- a/src/mcp_handlers/admin/handlers.py
+++ b/src/mcp_handlers/admin/handlers.py
@@ -260,19 +260,29 @@ async def handle_check_continuity_health(arguments: Dict[str, Any]) -> Sequence[
 @mcp_tool("get_tool_usage_stats", timeout=15.0)
 async def handle_get_tool_usage_stats(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """Get tool usage statistics to identify which tools are actually used vs unused"""
-    from src.tool_usage_tracker import get_tool_usage_tracker
-    
     window_hours = arguments.get("window_hours", 24 * 7)  # Default: 7 days
     tool_name = arguments.get("tool_name")
     agent_id = arguments.get("agent_id")
-    
-    tracker = get_tool_usage_tracker()
-    stats = tracker.get_usage_stats(
+
+    # Prefer the authoritative DB sink (audit.tool_usage); the legacy JSONL sink
+    # is best-effort and has drifted stale. Fall back to JSONL only when the DB
+    # is unavailable (degraded/local mode).
+    from src.audit_db import get_tool_usage_stats_async
+    stats = await get_tool_usage_stats_async(
         window_hours=window_hours,
         tool_name=tool_name,
-        agent_id=agent_id
+        agent_id=agent_id,
     )
-    
+    if stats is None:
+        from src.tool_usage_tracker import get_tool_usage_tracker
+        stats = get_tool_usage_tracker().get_usage_stats(
+            window_hours=window_hours,
+            tool_name=tool_name,
+            agent_id=agent_id,
+        )
+        if isinstance(stats, dict):
+            stats["source"] = "jsonl_fallback"
+
     return success_response(stats)
 
 def get_workspace_last_agent_file(mcp_server) -> Path:

--- a/src/mcp_handlers/introspection/tool_introspection.py
+++ b/src/mcp_handlers/introspection/tool_introspection.py
@@ -14,6 +14,37 @@ from src.logging_utils import get_logger
 from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 logger = get_logger(__name__)
 
+import time as _time
+
+# Progressive-ordering usage cache. list_tools(progressive=True) reads tool-call
+# counts to order the tool list; reading audit.tool_usage per call would put a
+# ~100ms windowed aggregate on the discovery path, so the {tool: stats} map is
+# cached briefly. Keyed by window_hours -> (monotonic_expiry, tools_dict).
+_USAGE_ORDER_CACHE: Dict[float, Any] = {}
+_USAGE_ORDER_TTL_S = 120.0
+
+
+async def _usage_tools_for_ordering(window_hours: float = 168) -> Dict[str, Dict[str, Any]]:
+    """Tool-call stats for progressive ordering — DB-first (audit.tool_usage),
+    TTL-cached, JSONL fallback. Returns ``{tool: {total_calls, ...}}`` (empty on
+    any failure so ordering degrades to tier-based)."""
+    now = _time.monotonic()
+    cached = _USAGE_ORDER_CACHE.get(window_hours)
+    if cached and cached[0] > now:
+        return cached[1]
+    tools: Dict[str, Any] = {}
+    try:
+        from src.audit_db import get_tool_usage_stats_async
+        stats = await get_tool_usage_stats_async(window_hours=window_hours)
+        if stats is None:
+            from src.tool_usage_tracker import get_tool_usage_tracker
+            stats = get_tool_usage_tracker().get_usage_stats(window_hours=window_hours)
+        tools = stats.get("tools", {}) if isinstance(stats, dict) else {}
+    except Exception:
+        tools = {}
+    _USAGE_ORDER_CACHE[window_hours] = (now + _USAGE_ORDER_TTL_S, tools)
+    return tools
+
 
 def _describe_tool_deprecation_block(tool_name: str) -> Dict[str, Any] | None:
     return tool_catalog.describe_tool_deprecation_block(tool_name)
@@ -194,34 +225,29 @@ async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
         tools_list.append(tool_info)
     
     # PROGRESSIVE DISCLOSURE: Order tools by usage frequency (if enabled)
-    def get_usage_data(window_hours: int = 168) -> Dict[str, Dict[str, Any]]:
-        """Get tool usage statistics for ordering."""
-        try:
-            from src.tool_usage_tracker import get_tool_usage_tracker
-            tracker = get_tool_usage_tracker()
-            stats = tracker.get_usage_stats(window_hours=window_hours)
-            return stats.get("tools", {})
-        except Exception:
-            return {}
-    
+    async def get_usage_data(window_hours: int = 168) -> Dict[str, Dict[str, Any]]:
+        """Get tool usage statistics for ordering (DB-first, cached, JSONL fallback)."""
+        return await _usage_tools_for_ordering(window_hours)
+
     def order_tools_by_usage(tools: List[Dict[str, Any]], usage_data: Dict[str, Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Order tools by usage frequency, fallback to tier-based ordering."""
         # Tier priority for fallback (essential > common > advanced)
         tier_priority = {"essential": 3, "common": 2, "advanced": 1}
-        
+
         def sort_key(tool: Dict[str, Any]) -> tuple:
             tool_name = tool["name"]
-            call_count = usage_data.get(tool_name, {}).get("call_count", 0)
+            # get_usage_stats reports per-tool counts under "total_calls".
+            call_count = usage_data.get(tool_name, {}).get("total_calls", 0)
             tier_prio = tier_priority.get(tool.get("tier", "common"), 0)
             # Primary: usage count (descending), Secondary: tier priority (descending)
             return (-call_count, -tier_prio)
-        
+
         return sorted(tools, key=sort_key)
-    
+
     # Apply progressive ordering if enabled
     usage_data = {}
     if progressive:
-        usage_data = get_usage_data()
+        usage_data = await get_usage_data()
         tools_list = order_tools_by_usage(tools_list, usage_data)
     
     # Count tools by tier
@@ -381,8 +407,9 @@ async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
             
             for tool in tools:
                 tool_name = tool["name"]
-                call_count = usage_data.get(tool_name, {}).get("call_count", 0)
-                
+                # get_usage_stats reports per-tool counts under "total_calls".
+                call_count = usage_data.get(tool_name, {}).get("total_calls", 0)
+
                 if call_count > 10:
                     most_used.append(tool["name"])
                 elif call_count > 0:
@@ -410,7 +437,7 @@ async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
         
         try:
             if not usage_data:  # Get if not already fetched
-                usage_data = get_usage_data()
+                usage_data = await get_usage_data()
             progressive_sections = group_tools_progressively(tools_list, usage_data)
         except Exception:
             pass  # Graceful degradation - skip grouping if stats unavailable

--- a/tests/test_admin_handlers.py
+++ b/tests/test_admin_handlers.py
@@ -368,13 +368,10 @@ class TestGetToolUsageStats:
 
     @pytest.mark.asyncio
     async def test_usage_stats_default(self, patch_context_agent_id):
-        mock_tracker = MagicMock()
-        mock_tracker.get_usage_stats.return_value = {
-            "total_calls": 100,
-            "unique_tools": 15,
-        }
-        with patch("src.tool_usage_tracker.get_tool_usage_tracker",
-                    return_value=mock_tracker):
+        # DB sink (audit.tool_usage) is now the primary source.
+        db_stats = {"total_calls": 100, "unique_tools": 15, "source": "db"}
+        with patch("src.audit_db.get_tool_usage_stats_async",
+                    new=AsyncMock(return_value=db_stats)):
             from src.mcp_handlers.admin.handlers import handle_get_tool_usage_stats
             result = await handle_get_tool_usage_stats({})
 
@@ -384,11 +381,8 @@ class TestGetToolUsageStats:
 
     @pytest.mark.asyncio
     async def test_usage_stats_with_filters(self, patch_context_agent_id):
-        mock_tracker = MagicMock()
-        mock_tracker.get_usage_stats.return_value = {"total_calls": 5}
-
-        with patch("src.tool_usage_tracker.get_tool_usage_tracker",
-                    return_value=mock_tracker):
+        db_reader = AsyncMock(return_value={"total_calls": 5, "source": "db"})
+        with patch("src.audit_db.get_tool_usage_stats_async", new=db_reader):
             from src.mcp_handlers.admin.handlers import handle_get_tool_usage_stats
             result = await handle_get_tool_usage_stats({
                 "tool_name": "health_check",
@@ -396,10 +390,11 @@ class TestGetToolUsageStats:
                 "window_hours": 48,
             })
 
-            # Verify filters were passed through
-            call_kwargs = mock_tracker.get_usage_stats.call_args
-            assert call_kwargs.kwargs.get("tool_name") == "health_check" or \
-                   call_kwargs[1].get("tool_name") == "health_check"
+            # Filters flow through to the DB reader.
+            call_kwargs = db_reader.call_args.kwargs
+            assert call_kwargs.get("tool_name") == "health_check"
+            assert call_kwargs.get("agent_id") == "agent-1"
+            assert call_kwargs.get("window_hours") == 48
 
 
 # ============================================================================
@@ -1860,16 +1855,20 @@ class TestListTools:
         mock_mcp_server.SERVER_VERSION = "test-1.0.0"
 
         mock_tracker = MagicMock()
+        # Per-tool counts live under "total_calls" (DB reader and JSONL reader
+        # agree on this key). The DB path returns None in tests (no DB), so the
+        # JSONL fallback — this mocked tracker — supplies the counts.
         mock_tracker.get_usage_stats.return_value = {
             "tools": {
-                "onboard": {"call_count": 15},
-                "health_check": {"call_count": 3},
-                "list_tools": {"call_count": 0},
-                "process_agent_update": {"call_count": 50},
+                "onboard": {"total_calls": 15},
+                "health_check": {"total_calls": 3},
+                "list_tools": {"total_calls": 0},
+                "process_agent_update": {"total_calls": 50},
             }
         }
 
-        with patch("src.mcp_handlers.admin.handlers.mcp_server", mock_mcp_server), \
+        with patch("src.audit_db.get_tool_usage_stats_async", new=AsyncMock(return_value=None)), \
+             patch("src.mcp_handlers.admin.handlers.mcp_server", mock_mcp_server), \
              patch("src.mcp_handlers.TOOL_HANDLERS", {
                  "onboard": None,
                  "process_agent_update": None,
@@ -1905,6 +1904,14 @@ class TestListTools:
             assert "progressive" in data
             assert data["progressive"]["enabled"] is True
             assert "sections" in data
+            # Grouping must reflect the real counts (regression for the
+            # call_count→total_calls key bug: with the bug every tool reads 0,
+            # so most_used/commonly_used would be empty and these would fail).
+            sections = data["sections"]
+            assert "onboard" in sections["most_used"]["tools"]            # 15 > 10
+            assert "process_agent_update" in sections["most_used"]["tools"]  # 50 > 10
+            assert "health_check" in sections["commonly_used"]["tools"]   # 3 in 1..10
+            assert "list_tools" in sections["available"]["tools"]         # 0
 
     @pytest.mark.asyncio
     async def test_list_tools_lite_progressive(self, mock_mcp_server, patch_context_agent_id):
@@ -1914,12 +1921,13 @@ class TestListTools:
         mock_tracker = MagicMock()
         mock_tracker.get_usage_stats.return_value = {
             "tools": {
-                "onboard": {"call_count": 20},
-                "health_check": {"call_count": 5},
+                "onboard": {"total_calls": 20},
+                "health_check": {"total_calls": 5},
             }
         }
 
-        with patch("src.mcp_handlers.admin.handlers.mcp_server", mock_mcp_server), \
+        with patch("src.audit_db.get_tool_usage_stats_async", new=AsyncMock(return_value=None)), \
+             patch("src.mcp_handlers.admin.handlers.mcp_server", mock_mcp_server), \
              patch("src.mcp_handlers.TOOL_HANDLERS", {
                  "onboard": None,
                  "process_agent_update": None,

--- a/tests/test_handlers_admin.py
+++ b/tests/test_handlers_admin.py
@@ -186,17 +186,9 @@ class TestGetToolUsageStats:
 
     @pytest.mark.asyncio
     async def test_usage_stats_default(self):
-        mock_tracker = MagicMock()
-        mock_tracker.get_usage_stats.return_value = {
-            "total_calls": 100,
-            "unique_tools": 15,
-            "tools": [
-                {"name": "process_agent_update", "calls": 50},
-                {"name": "get_governance_metrics", "calls": 30},
-            ],
-        }
-
-        with patch("src.tool_usage_tracker.get_tool_usage_tracker", return_value=mock_tracker):
+        # DB sink (audit.tool_usage) is now the primary source.
+        db_stats = {"total_calls": 100, "unique_tools": 15, "source": "db"}
+        with patch("src.audit_db.get_tool_usage_stats_async", new=AsyncMock(return_value=db_stats)):
             from src.mcp_handlers.admin.handlers import handle_get_tool_usage_stats
             result = await handle_get_tool_usage_stats({})
 
@@ -205,13 +197,8 @@ class TestGetToolUsageStats:
 
     @pytest.mark.asyncio
     async def test_usage_stats_with_filters(self):
-        mock_tracker = MagicMock()
-        mock_tracker.get_usage_stats.return_value = {
-            "total_calls": 10,
-            "tools": [{"name": "ping_agent", "calls": 10}],
-        }
-
-        with patch("src.tool_usage_tracker.get_tool_usage_tracker", return_value=mock_tracker):
+        db_reader = AsyncMock(return_value={"total_calls": 10, "source": "db"})
+        with patch("src.audit_db.get_tool_usage_stats_async", new=db_reader):
             from src.mcp_handlers.admin.handlers import handle_get_tool_usage_stats
             result = await handle_get_tool_usage_stats({
                 "tool_name": "ping_agent",
@@ -221,9 +208,11 @@ class TestGetToolUsageStats:
 
             data = json.loads(result[0].text)
             assert data["total_calls"] == 10
-            # Verify filters were passed through
-            call_kwargs = mock_tracker.get_usage_stats.call_args
-            assert call_kwargs.kwargs.get("tool_name") == "ping_agent" or call_kwargs[1].get("tool_name") == "ping_agent"
+            # Filters flow through to the DB reader.
+            call_kwargs = db_reader.call_args.kwargs
+            assert call_kwargs.get("tool_name") == "ping_agent"
+            assert call_kwargs.get("agent_id") == "agent-1"
+            assert call_kwargs.get("window_hours") == 48
 
 
 # ============================================================================

--- a/tests/test_tool_usage_db_reader.py
+++ b/tests/test_tool_usage_db_reader.py
@@ -1,0 +1,116 @@
+"""Tests for the DB-backed tool-usage reader (audit.tool_usage).
+
+The legacy JSONL sink is best-effort and drifted stale; the live sink is the
+audit.tool_usage table. These tests cover the reader's shape parity with the
+JSONL reader, REMOVED_TOOLS filtering, the DB-unavailable fallback path, and the
+progressive-ordering key fix (call_count -> total_calls).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import ExitStack
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import src.mcp_handlers.core  # noqa: F401  (settle handler registration)
+import src.mcp_handlers.consolidated  # noqa: F401
+
+from src.audit_db import get_tool_usage_stats_async
+from src.mcp_handlers.introspection.tool_introspection import handle_list_tools
+
+
+def _mock_db(rows):
+    """A get_db() stand-in whose acquire() yields a conn returning ``rows``."""
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=rows)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=conn)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    db = MagicMock()
+    db._pool = object()  # truthy so the reader skips db.init()
+    db.acquire = MagicMock(return_value=cm)
+    return db, conn
+
+
+def test_db_reader_shape_filtering_and_sorting():
+    rows = [
+        {"tool_name": "get_governance_metrics", "total_calls": 100, "success_count": 98},
+        {"tool_name": "knowledge", "total_calls": 10, "success_count": 9},
+        # REMOVED_TOOLS entry must be dropped:
+        {"tool_name": "store_knowledge", "total_calls": 999, "success_count": 999},
+    ]
+    db, _conn = _mock_db(rows)
+    with patch("src.db.get_db", return_value=db):
+        stats = asyncio.run(get_tool_usage_stats_async(window_hours=24))
+
+    assert stats is not None
+    assert stats["source"] == "db"
+    assert "store_knowledge" not in stats["tools"], "REMOVED_TOOLS not filtered"
+    assert stats["unique_tools"] == 2
+    assert stats["total_calls"] == 110  # removed tool excluded from total
+    # most_used sorted by calls desc
+    assert stats["most_used"][0] == {"tool": "get_governance_metrics", "calls": 100}
+    # per-tool shape parity with the JSONL reader
+    t = stats["tools"]["knowledge"]
+    assert t["total_calls"] == 10
+    assert t["success_count"] == 9
+    assert t["error_count"] == 1
+    assert t["success_rate"] == pytest.approx(0.9)
+    assert t["percentage_of_total"] == pytest.approx(10 / 110 * 100)
+
+
+def test_db_reader_agent_usage_only_with_agent_filter():
+    rows = [{"tool_name": "identity", "total_calls": 4, "success_count": 4}]
+    db, _conn = _mock_db(rows)
+    with patch("src.db.get_db", return_value=db):
+        no_filter = asyncio.run(get_tool_usage_stats_async(window_hours=24))
+        with_filter = asyncio.run(
+            get_tool_usage_stats_async(window_hours=24, agent_id="agent-x")
+        )
+    assert no_filter["agent_usage"] is None
+    assert with_filter["agent_usage"] == {"agent-x": {"identity": 4}}
+
+
+def test_db_reader_returns_none_when_db_unavailable():
+    # get_db raising must yield None so callers fall back to JSONL — never raise.
+    with patch("src.db.get_db", side_effect=RuntimeError("no pool")):
+        stats = asyncio.run(get_tool_usage_stats_async(window_hours=24))
+    assert stats is None
+
+
+def test_get_tool_usage_stats_handler_falls_back_to_jsonl():
+    from src.mcp_handlers.admin.handlers import handle_get_tool_usage_stats
+
+    tracker = MagicMock()
+    tracker.get_usage_stats = MagicMock(return_value={"total_calls": 7, "tools": {}})
+    with ExitStack() as stack:
+        # DB path unavailable -> None
+        stack.enter_context(
+            patch("src.audit_db.get_tool_usage_stats_async", new=AsyncMock(return_value=None))
+        )
+        stack.enter_context(
+            patch("src.tool_usage_tracker.get_tool_usage_tracker", return_value=tracker)
+        )
+        result = asyncio.run(handle_get_tool_usage_stats({}))
+    payload = json.loads(result[0].text)
+    body = payload.get("data", payload)
+    assert body.get("source") == "jsonl_fallback"
+    assert body.get("total_calls") == 7
+
+
+def test_progressive_ordering_uses_total_calls(monkeypatch):
+    """Regression: order/grouping read per-tool 'total_calls' (not the nonexistent
+    'call_count', which made progressive ordering a silent no-op)."""
+    import src.mcp_handlers.introspection.tool_introspection as ti
+
+    async def fake_usage(window_hours: int = 168):
+        return {"health_check": {"total_calls": 50}, "describe_tool": {"total_calls": 5}}
+
+    monkeypatch.setattr(ti, "_usage_tools_for_ordering", fake_usage)
+    resp = json.loads(asyncio.run(handle_list_tools({"progressive": True}))[0].text)
+    names = [t["name"] for t in resp["tools"]]
+    # 50-call tool must sort ahead of the 5-call tool; both ahead of any 0-call tool.
+    assert names.index("health_check") < names.index("describe_tool")


### PR DESCRIPTION
## Problem

Every tool call is recorded to **two** sinks: the authoritative DB table `audit.tool_usage` (`audit_db.append_tool_usage_async`) and a legacy best-effort JSONL file (`data/tool_usage.jsonl`). The JSONL writer **silently froze on 2026-06-11** (its write is best-effort and swallows failures) while the DB sink stayed healthy (9.47M rows, current to the minute).

But both **readers** read the frozen JSONL:
- `get_tool_usage_stats` (the "which tools are actually used" tool)
- `list_tools(progressive=True)` usage ordering

So the in-product usage analytics served Jun-11 data while the live sink sat unread — and any data-driven tool-pruning decision was flying blind.

## Fix

- **New DB reader** `audit_db.get_tool_usage_stats_async` — windowed aggregate over `audit.tool_usage`, returns the **same shape** as the JSONL reader, or `None` on DB-unavailable for clean fallback. Never raises.
- **Repoint both readers DB-first, JSONL fallback.** The explicit query tool tags `source: "db" | "jsonl_fallback"` so operators can see which sink answered.
- **Pre-existing latent bug fixed:** `order_tools_by_usage` and `group_tools_progressively` read `usage_data[tool]["call_count"]`, but the stats dict keys per-tool counts under `"total_calls"` — so usage-based ordering/grouping was a **silent no-op** (always tier-fallback), independent of the JSONL freeze.

## Safety / perf

- DB read uses the post-#218 ExecutorPool pattern (`async with db.acquire()`), so the anyio task group never sees a raw asyncpg await.
- The hot `progressive` path is behind a **120s monotonic TTL cache** (the ~128ms aggregate runs at most once per window per 2 min; non-progressive `list_tools` is untouched).
- SQL is fully parameterized (`$1..$3`); window via `$1 * interval '1 hour'`.
- All failure paths are non-raising and fall back to the JSONL tracker.

## Verification

- Full gate green: **11,202 passed, 22 skipped, 81.95% coverage**.
- **Live**: the DB reader returns 164,523 calls/24h with correct top-tools — vs JSONL frozen at Jun 11.
- New test file (`test_tool_usage_db_reader.py`): shape parity, REMOVED_TOOLS filtering, agent-filter, DB-unavailable→None, handler JSONL fallback, and an end-to-end regression for the `call_count`→`total_calls` fix.
- Independent code review: clean after one fix (two progressive tests now actually exercise the ordering fix rather than passing vacuously).

## Note

This is the prerequisite for the data-driven removal/deprecation pass from the MCP tool-surface review — `get_tool_usage_stats` now tells the truth. The legacy JSONL sink is left in place (vestigial, best-effort); retiring it is a separate follow-up.

https://claude.ai/code/session_01RhZajJZ6UpgG5g2nGk6uTU