### PR TITLE
fix(orientation): drop duplicate raw-twin tools from the lite advertised surface (26→23)

### DIFF
--- a/src/tool_modes.py
+++ b/src/tool_modes.py
@@ -65,13 +65,16 @@ LITE_MODE_TOOLS: Set[str] = {
     # Session hook (required by automation)
     "bind_session",               # Session-start hook for MCP identity sync
 
-    # Raw implementation tools kept callable for compatibility wrappers/hooks.
-    # They are intentionally common-tier, not essential-tier: primary workflow
-    # names remain the promoted agent-facing surface.
-    "onboard",                    # Raw implementation for start_session
-    "process_agent_update",       # Raw implementation for sync_state
-    "get_governance_metrics",     # Raw implementation for check_working_state
-    "outcome_event",              # Raw implementation for record_result
+    # Raw implementation tools stay register=True (so the gateway, hooks, and
+    # compat wrappers can still call them by name — the server dispatches any
+    # registered handler whether or not it is advertised), but are NOT advertised
+    # in the lite orientation surface: agents saw both the friendly alias AND its
+    # raw twin (start_session+onboard, sync_state+process_agent_update, ...), which
+    # is duplicate noise when orienting. The promoted friendly names carry the wire.
+    # onboard is kept advertised for now — it sits in the identity/onboarding
+    # coupled surface (CLAUDE.md) and the gov-plugin nudges still name it; hiding it
+    # is a deliberate cross-repo follow-up, not this change.
+    "onboard",                    # Raw implementation for start_session (identity surface — kept)
 
     # Recovery
     "self_recovery",              # Primary recovery path for stuck agents

--- a/tests/test_mcp_extra_passthrough.py
+++ b/tests/test_mcp_extra_passthrough.py
@@ -3,11 +3,19 @@
 from __future__ import annotations
 
 
-def test_process_agent_update_registered_for_extra_argument_passthrough():
-    """The registered FastMCP tool must preserve internal S22 envelope fields."""
+def test_checkin_tool_preserves_s22_extra_argument_passthrough():
+    """The advertised check-in tool (``sync_state``) must preserve internal S22
+    envelope fields.
+
+    ``process_agent_update`` is the raw implementation underneath. It is no longer
+    advertised in the lite orientation surface (it was a duplicate of the promoted
+    ``sync_state`` name), so the passthrough contract is asserted on the wire-facing
+    alias — which inherits passthrough because its target is in
+    ``EXTRA_ARGUMENT_PASSTHROUGH_TOOLS``.
+    """
     from src import mcp_server
 
-    tool = mcp_server.mcp._tool_manager.get_tool("process_agent_update")
+    tool = mcp_server.mcp._tool_manager.get_tool("sync_state")
     assert tool is not None
 
     arg_model = tool.fn_metadata.arg_model
@@ -20,3 +28,12 @@ def test_process_agent_update_registered_for_extra_argument_passthrough():
     assert "comparison_key" in properties
     assert "harness_type" not in properties
     assert "verification_source" not in properties
+
+
+def test_process_agent_update_handler_still_dispatchable():
+    """Hidden from the lite wire, but still a register=True handler — so the
+    gateway, hooks, and compat wrappers can call it by raw name (the server
+    dispatches any registered handler whether or not it is advertised)."""
+    from src.mcp_handlers import TOOL_HANDLERS
+
+    assert "process_agent_update" in TOOL_HANDLERS

--- a/tests/test_unitares_cli_script.py
+++ b/tests/test_unitares_cli_script.py
@@ -237,10 +237,13 @@ def test_health_reports_status_and_version(cli_env):
 def test_tools_lists_core_governance_tools(cli_env):
     result = _run(cli_env, "tools")
     assert "Tools:" in result.stdout
-    # A few tools are always exposed in lite mode.
+    # The /v1/tools REST surface lists canonical handler names (not the workflow
+    # aliases). Assert core tools that are stably present; the duplicate raw twins
+    # (process_agent_update / get_governance_metrics) were dropped from the lite
+    # orientation surface, so don't assert on them here.
     assert "onboard" in result.stdout
-    assert "process_agent_update" in result.stdout
-    assert "get_governance_metrics" in result.stdout
+    assert "health_check" in result.stdout
+    assert "list_tools" in result.stdout
 
 
 def test_onboard_persists_session_and_continuity_token(cli_env, tmp_path):


### PR DESCRIPTION
## Why

Agents reported feeling **overwhelmed by the number of tools** when orienting. Investigation showed the real cause isn't the rarely-used admin/diagnostic tools (those aren't even in the orientation surface) — it's that the lite `tools/list` the harness injects advertised **both** each promoted friendly name **and** its raw implementation twin:

| Friendly (promoted) | Raw twin, also advertised |
|---|---|
| `sync_state` | `process_agent_update` |
| `check_working_state` | `get_governance_metrics` |
| `record_result` | `outcome_event` |

An agent literally saw `sync_state` *and* `process_agent_update` — same operation, twice.

## What

Remove `process_agent_update`, `get_governance_metrics`, `outcome_event` from `LITE_MODE_TOOLS`. They **stay `register=True`** — the server dispatches any registered handler whether or not it's advertised, so the gateway, hooks, and compat wrappers keep calling them by raw name with zero change.

**Net: the agent orientation surface drops 26 → 23, no duplicate pairs.**

## Why it's safe (verified, not assumed)

- **Unadvertised ≠ uncallable.** `get_workspace_health` (registered, never in LITE) is callable via the gateway client against the live lite server → removing from LITE only hides from `tools/list`, doesn't break dispatch.
- **S22 passthrough preserved.** `sync_state` inherits `extra="allow"` + passthrough because its target is in `EXTRA_ARGUMENT_PASSTHROUGH_TOOLS` (verified: `comparison_key` present, no `harness_type` leak). Test repointed accordingly + a guard that `process_agent_update` stays dispatchable.
- **Gateway/CLI unaffected** — 53 gateway tests pass; the `/v1/tools` CLI surface lists canonical names and its test was repointed to stable ones.

## Deliberately kept

- **`onboard`** stays advertised — it's in the identity/onboarding coupled surface (CLAUDE.md) and the gov-plugin nudges still name it. Hiding it is a conscious cross-repo follow-up, not this PR.
- **`knowledge` / `dialectic`** stay — multi-action routers, not pure duplicates of `search_shared_memory` / `request_review`.

## Verification

- Full gate: **11,205 passed, 22 skipped, 81.93% coverage**.
- Empirically confirmed the advertised lite surface is 23 (was 26), the 3 twins still registered/callable, and the wire-surface drift guard tracks the change.

https://claude.ai/code/session_01RhZajJZ6UpgG5g2nGk6uTU