### PR TITLE
feat(eisv): persist raw pre-EMA obs (raw_obs) — unlock the honest individuality test

### DIFF
--- a/src/behavioral_state.py
+++ b/src/behavioral_state.py
@@ -396,6 +396,17 @@ class BehavioralEISV:
             "S": self._baseline_S.to_dict(),
             "V": self._baseline_V.to_dict(),
         }
+        # This check-in's RAW (pre-EMA) observation [E_obs, I_obs, S_obs]. Just
+        # the latest triple — NOT the full obs_history — so the append-only DB
+        # row carries the un-smoothed input at ~3 floats/row (negligible, unlike
+        # the ~5KB full history). Across successive rows this reconstructs the raw
+        # per-agent series, which the smoothed E/I/S/V cannot: it is the input the
+        # honest persistence/AR(1) self-predictability test needs (the
+        # individuality axiom cannot be earned against a pre-smoothed signal — see
+        # scripts/analysis/eisv_self_predictability.py scope limit). Absent before
+        # the first update() (no observation recorded yet).
+        if self.obs_history:
+            d["raw_obs"] = [round(v, 4) for v in self.obs_history[-1]]
         return d
 
     def to_dict_with_history(self) -> Dict:

--- a/tests/test_behavioral_state.py
+++ b/tests/test_behavioral_state.py
@@ -266,3 +266,27 @@ def test_to_dict_for_persistence_round_trips_baseline_without_histories():
     assert restored.is_baselined is True
     # Welford baseline survived → z-scoring works post-restore
     assert restored._baseline_E.count == src._baseline_E.count
+
+
+class TestRawObsPersistence:
+    """to_dict_for_persistence carries this check-in's raw (pre-EMA) observation
+    so a forward raw series is reconstructable from append-only DB rows."""
+
+    def test_raw_obs_absent_before_any_update(self):
+        state = BehavioralEISV()
+        assert "raw_obs" not in state.to_dict_for_persistence()
+
+    def test_raw_obs_is_latest_observation(self):
+        state = BehavioralEISV()
+        state.update(0.8, 0.7, 0.2)
+        state.update(0.3, 0.4, 0.85)  # the latest raw input
+        d = state.to_dict_for_persistence()
+        assert d["raw_obs"] == [0.3, 0.4, 0.85]
+
+    def test_raw_obs_reflects_clamping_not_smoothing(self):
+        state = BehavioralEISV()
+        state.update(1.5, -0.2, 0.5)  # clamped to [0,1] in update()
+        d = state.to_dict_for_persistence()
+        # raw obs is the clamped input, NOT the EMA-smoothed E/I/S
+        assert d["raw_obs"] == [1.0, 0.0, 0.5]
+        assert d["raw_obs"] != [round(state.E, 4), round(state.I, 4), round(state.S, 4)]


### PR DESCRIPTION
## What

One additive key. `core.agent_state.state_json` only stores the **EMA-smoothed** E/I/S/V (the append-only path uses the lean `to_dict_for_persistence()`, which drops `obs_history`). This change adds `raw_obs = [E_obs, I_obs, S_obs]` — this check-in's latest **raw, clamped, pre-EMA** observation — to that serializer.

## Why

The self-predictability eval (#1289) showed the individuality claim cannot be earned on the stored signal: beating a per-agent **persistence/AR(1)** null is the honest test, and it's **confounded on a pre-smoothed series** (persistence trivially wins on an EMA). The raw obs is the input that test needs — and it was being thrown away on persist.

## Cost / safety

- **~3 floats/row**, not the ~5KB full `obs_history` (`to_dict_with_history` already exists but is used only for the single-overwritten JSON file, not the per-check-in DB rows).
- **Purely additive & forward-only**: `from_dict` ignores unknown keys; jsonb consumers unaffected; smoothed fields unchanged; no migration, no backfill.
- Write-path touched but behavior-neutral — full gate green (11,228 passed).

## Unlocks (follow-up, once data accrues)

Re-run `eisv_self_predictability.py` with a per-agent persistence/AR(1) null on the reconstructed raw series — the label-free test that actually earns or refutes the individuality axiom (the council's open item).

## Sequence
- #1285 anchor honesty + de-contaminated outcome eval
- #1289 estimator self-predictability (label-free)
- #1293 policy coherence stress-test (label-free)
- **this** — raw-obs persistence (enabler for the honest individuality test)

3 tests; full gate green.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01MhKDiJ5aBnaAiRW84uK69b