### PR TITLE
feat(eisv): label power/MDE + design-tournament synthesis (next-move v0)

### DIFF
--- a/docs/proposals/eisv-grounding-next-move-v0.md
+++ b/docs/proposals/eisv-grounding-next-move-v0.md
@@ -1,0 +1,121 @@
+# EISV grounding/decision — next-move proposal (v0)
+
+**Status:** design-intent / roadmap (not a change). Output of a 15-agent design
+tournament (5 seeded proposals → 3-judge panel → adversarial stress on the top 2
+→ synthesis), grounded in the label-free validation work of PRs #1285/#1289/
+#1293/#1294. Companion to `docs/proposals/eisv-maths-roadmap-v0.md`.
+
+## TL;DR
+
+Run an **"honest-floor" quarter, not a Stage-B quarter.** The maths are not the
+blocker; exogenous **bad-label supply** is — and a power analysis shows the
+outcome-validity gate is unwinnable at the current supply, by arithmetic. Do two
+near-free killer experiments first, build exactly one thin label leg, make the
+AR(1) decontamination null the scientific deliverable, and ship nothing to the
+live verdict path.
+
+## Where the design space landed (tournament ranking, 3-judge mean /30)
+
+| # | proposal | mean | fate |
+|---|---|---|---|
+| 1 | Label-acquisition-first | 26.3 | survived (0/3 fatal) but **not crowned** — headline target arithmetically unreachable |
+| 2 | Validation-as-product | 25.3 | survived (0/3 fatal) but **not crowned** — largely a do-nothing rebrand of in-flight work |
+| 3 | Proprioception-first | 23.3 | — |
+| 4 | Pooled-falsifiability | 22.0 | — |
+| 5 | Radical-simplification | 19.0 | — |
+
+Neither top proposal was crowned as-spec:
+- **Labels** correctly diagnoses the binding constraint but its "≥150 clean /
+  ≥5 balanced agents per quarter" target needs a ~17× sustained rate increase
+  the system cannot *cause* (labels are a property of the world — a solo
+  operator's correction bandwidth + a mostly-non-committing fleet — not of
+  plumbing). Forward-only, so it cannot reclaim the dirty ~96; only 1–3 agents
+  author attributable events, so "5 balanced" may be unreachable in principle.
+- **Validation-as-product** ("the harness IS the undamp") makes no live-path
+  change, its core tests already ran, and its one new test (AR(1)) is already in
+  flight via #1294 — net delta is anticipatory bureaucracy, anti-demand-triggered.
+
+## The power result (this PR: `scripts/analysis/eisv_label_power.py`)
+
+Gate-3 ("an EISV/residual model beats the baseline at predicting bad outcomes")
+is a minority-class problem; power is set by the scarce **bad**-label count.
+Current pooled exogenous budget: **114 bad / 2287 good** (skeptic scored slice
+~21 bad).
+
+- At the realistic scored slice (~21 bad), an EISV model cannot even be shown to
+  beat a **coin** unless its AUC lift over 0.5 exceeds **+0.165**.
+- The comparison target — the previous-outcome (autocorrelation) baseline — is
+  both very high (~0.94 on clean data) and **unpinnable**: it swings 0.61→0.94
+  between contaminated and clean slices, and its own CI is ±0.07 at n=21. There
+  is no stable thing to beat; the headroom (0.06) is narrower than the baseline's
+  own uncertainty.
+- **Caveat against false comfort:** a naive one-sample MDE makes "beat 0.94"
+  look cheap (~13 labels for +0.05). That is an artifact of AUC variance
+  collapsing near the 1.0 ceiling plus ignoring baseline uncertainty; the honest
+  paired (DeLong) requirement is materially larger.
+
+**Conclusion:** Stage-B / `GROUNDING_APPLY` is not validatable on outcomes at
+this label supply, independent of how good the maths are.
+
+## Recommended sequence (falsifiable, reversible, demand-triggered)
+
+1. **Latent-supply count** (read-only, ~days). Instrument operator-correction +
+   resident-resolve + CI paths; count clean, exogenous, attributable bad labels
+   the fleet *would* emit at current activity.
+   - *Gate:* extrapolated ceiling **≥ ~30 clean bad/quarter**. If below, the
+     constraint is structural fleet activity, not engineering — stop building
+     pipeline, go label-free only. (A real decision, not a failure.)
+2. **MDE/power** — *done in this PR.* Result above: underpowered at current
+   supply; records exactly how many bad labels a meaningful lift would need.
+3. **Build ONE label leg only:** operator-correction capture (revert / reject /
+   rejected-PR → `outcome_event` with commit→agent attribution) **plus one
+   exogenous good-label source** (e.g. survived-N-days merged commit).
+   Forward-only, eval-only, never wired to the live verdict. Judge on a
+   **rate-based** criterion with a zero-synthetic contamination audit — not the
+   unreachable 150/5 absolute. Record *why* each item was adjudicated, so
+   EISV/Φ-conditioned selection can be excluded (sampling-circularity guard).
+   - *De-scope:* the resident-adjudication throughput dial (contamination
+     pressure → 497-synthetic redux) and CI-on-critical-path (dead on
+     connectivity).
+4. **AR(1) decontamination null** — the quarter's make-or-break. Once #1294 raw
+   pre-EMA obs accrue, re-run self-predictability with a per-agent
+   persistence/AR(1) null on the raw series.
+   - *Gate:* per-agent hierarchical reference beats **both** fleet-mean **and**
+     per-agent AR(1), out-of-sample, for a majority of agents with ≥50 states.
+     Beating fleet-mean alone is **not** success. If it fails, the "self-model"
+     is dressed-up autocorrelation — the individuality claim dies and must not be
+     shipped or publicly framed.
+5. **Lightweight hygiene only:** anti-laundering guard (synthetic labels — e.g.
+   the 497 BEAM smoke tests — can never count as outcome evidence) +
+   pre-registration of thresholds/nulls, as a checklist that fires *when* an
+   undamp ships, not a standing merge-blocker.
+
+## Do NOT
+
+- Ship Stage B as-spec (no EISV feature beats the baseline; underpowered by
+  arithmetic).
+- Wire **any** new statistic — EISV residual *or* a recent-failure-rate scalar —
+  to the live verdict path. The failure-rate gate is un-deployable (decision-time
+  per-agent label coverage ≈ 0) and hard-codes punish-toward-zero-failures
+  (Axiom-2 / anti-RLHF violation) into the load-bearing path.
+- Pursue the ≥150/≥5-balanced absolute target, build the resident throughput
+  dial, or put CI attribution on the critical path.
+- Stand up a standing merge-blocking validation regime for hypothetical undamps.
+- Frame an "EISV self-model" publicly before the AR(1) null clears.
+- Double-count per-agent autocorrelation as evidence both *for* individuality and
+  *against* EISV.
+
+## Preserved dissent (kept honest)
+
+This plan can become **a permanent retreat dressed as rigor.** Even a clean AR(1)
+win proves only a non-trivial per-agent self-model (detection / individuality) —
+it says nothing about **outcome validity**, which stays blocked behind a label
+supply capped by the world, not the quarter. If the latent-supply count returns
+< ~30 clean bad/quarter, the honest conclusion is not "iterate the pipeline" but
+"**EISV is plausibly permanently unfalsifiable on outcomes**," at which point the
+entire grounding program — not just Stage B — deserves reconsideration. And the
+anti-laundering guard is the only thing preventing a coherence/decontamination
+battery from greenlighting an internally-consistent, perturbation-responsive EISV
+that still bears no relation to real outcomes; if it is ever relaxed under
+ship-pressure, this "honest-floor" posture becomes the most credible-looking way
+to ship an ungrounded undamp.

--- a/scripts/analysis/eisv_label_power.py
+++ b/scripts/analysis/eisv_label_power.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Label power / MDE analysis — how many exogenous bad labels does gate-3 need?
+
+The EISV design tournament's "pooled killer experiment": convert the
+unvalidatable Stage-B falsifiability gate into a NUMBER. Gate-3 asks whether an
+EISV/residual model's AUC (predicting bad outcomes) beats a baseline. Whether
+that is even *detectable* is a power question set by the count of exogenous
+**bad** labels (the minority class), which is what we are starved of.
+
+This computes, with NO new data:
+  - Hanley-McNeil SE(AUC) as a function of (n_bad, n_good).
+  - MDE: the minimum AUC lift over chance (0.5) detectable at the given power.
+  - Whether the operationally-relevant target — beating the *previous-outcome*
+    (autocorrelation) baseline, whose decontaminated AUC is ~0.94 — is reachable
+    at all (headroom 1-0.94 = 0.06 vs the MDE).
+  - The n_bad required to detect a meaningful lift (default 0.05).
+
+Defaults reflect the live decontaminated pooled set (joinable, trusted+soft):
+n_bad=114, n_good=2287; the skeptic eval's *scored test slice* is ~21 bad.
+
+Method note: Hanley-McNeil gives the SE of a single AUC. For "beat baseline B"
+we treat detectability conservatively as resolving the model's AUC against the
+fixed value B (one-sample), MDE = (z_alpha + z_beta) * SE(AUC=B). A paired
+DeLong test with positive correlation would need somewhat fewer labels, so this
+is a conservative-but-honest floor, not a tight bound — and the conclusion
+(massively underpowered) holds with margin.
+
+Usage:
+    PYTHONPATH=. python3 scripts/analysis/eisv_label_power.py
+    PYTHONPATH=. python3 scripts/analysis/eisv_label_power.py --n-bad 21 --n-good 563
+    PYTHONPATH=. python3 scripts/analysis/eisv_label_power.py --baseline-auc 0.94 --target-lift 0.05
+"""
+from __future__ import annotations
+
+import argparse
+import math
+
+# z(0.95)=1.6449 one-sided alpha=0.05 ; z(0.80)=0.8416 power=80%
+Z_ALPHA_1SIDED = 1.6449
+Z_ALPHA_2SIDED = 1.9600
+Z_POWER_80 = 0.8416
+
+
+def auc_se(auc: float, n_bad: int, n_good: int) -> float:
+    """Hanley-McNeil standard error of an AUC. n_bad = positives (minority)."""
+    if n_bad < 1 or n_good < 1:
+        return float("nan")
+    q1 = auc / (2 - auc)
+    q2 = 2 * auc * auc / (1 + auc)
+    var = (
+        auc * (1 - auc)
+        + (n_bad - 1) * (q1 - auc * auc)
+        + (n_good - 1) * (q2 - auc * auc)
+    ) / (n_bad * n_good)
+    return math.sqrt(max(var, 0.0))
+
+
+def mde_over_chance(n_bad: int, n_good: int, z_alpha: float = Z_ALPHA_1SIDED) -> float:
+    """Smallest true AUC above 0.5 detectable at 80% power. Solve A-0.5=k*SE(A)."""
+    k = z_alpha + Z_POWER_80
+    a = 0.5
+    for _ in range(200):  # fixed-point: A = 0.5 + k*SE(A)
+        a_next = 0.5 + k * auc_se(a, n_bad, n_good)
+        if abs(a_next - a) < 1e-9:
+            break
+        a = a_next
+    return a - 0.5
+
+
+def n_bad_for_lift(lift: float, n_good: int, baseline: float,
+                   z_alpha: float = Z_ALPHA_1SIDED, ratio_cap: int = 25) -> int:
+    """Smallest n_bad so MDE (over the baseline value) <= the target lift.
+
+    Holds the good:bad ratio at min(observed, ratio_cap) so n_good scales with
+    n_bad rather than assuming an unlimited supply of negatives.
+    """
+    k = z_alpha + Z_POWER_80
+    ratio = min(ratio_cap, max(1, n_good))
+    for nb in range(2, 200001):
+        ng = nb * ratio
+        if k * auc_se(baseline + lift, nb, ng) <= lift:
+            return nb
+    return -1
+
+
+def build_report(args) -> str:
+    nb, ng = args.n_bad, args.n_good
+    a: list[str] = []
+    a.append("# EISV label power / MDE — can gate-3 even be tested?\n")
+    a.append(f"Pooled exogenous labels (joinable, trusted+soft): **n_bad={nb}, n_good={ng}** "
+             f"(skeptic scored-test slice ~21 bad).  Power=80%, alpha=0.05 one-sided.\n")
+
+    a.append("## SE(AUC) at the current label budget")
+    a.append("| assumed true AUC | SE (n_bad={}) | SE (n_bad=21) | SE (n_bad=500) |".format(nb))
+    a.append("|---:|---:|---:|---:|")
+    for A in (0.55, 0.70, 0.85, 0.94):
+        a.append(f"| {A:.2f} | {auc_se(A, nb, ng):.3f} | {auc_se(A, 21, 21*20):.3f} | "
+                 f"{auc_se(A, 500, 500*20):.3f} |")
+
+    mde_now = mde_over_chance(nb, ng)
+    mde_21 = mde_over_chance(21, 21 * 20)
+    a.append("\n## Minimum detectable AUC lift over chance (0.5)")
+    a.append(f"- at the full pooled budget (n_bad={nb}): **+{mde_now:.3f}**")
+    a.append(f"- at the skeptic scored slice (n_bad=21): **+{mde_21:.3f}**")
+    a.append("\nMeaning: an EISV model must clear roughly these margins over 0.5 just "
+             "to be distinguishable from a coin — before any comparison to a real baseline.")
+
+    base = args.baseline_auc
+    headroom = 1.0 - base
+    mde_vs_base = (Z_ALPHA_1SIDED + Z_POWER_80) * auc_se(base, nb, ng)
+    base_ci_now = Z_ALPHA_2SIDED * auc_se(base, nb, ng)
+    base_ci_21 = Z_ALPHA_2SIDED * auc_se(base, 21, 21 * 20)
+    a.append("\n## The operationally-relevant bar: beat the autocorrelation baseline")
+    a.append(f"The decontaminated previous-outcome (autocorrelation) baseline AUC is "
+             f"**~{base:.2f}** — entire headroom above it is **{headroom:.2f}**.")
+    a.append(f"- the baseline AUC is itself only known to **+/-{base_ci_now:.3f}** at "
+             f"n_bad={nb} (and +/-{base_ci_21:.3f} at the n_bad=21 scored slice).")
+    a.append(f"- naive one-sample MDE to resolve a model against {base:.2f} (n_bad={nb}): "
+             f"+{mde_vs_base:.3f}")
+    a.append(
+        "\n**Do NOT read the small MDE here as 'reachable'.** It is small for two "
+        "misleading reasons, not because the test is feasible:\n"
+        "  1. AUC variance COLLAPSES toward the 1.0 ceiling (Hanley-McNeil), so any "
+        "comparison pinned near 0.94 looks cheap — an artifact of being near the "
+        "ceiling, not of having signal.\n"
+        f"  2. The baseline is not a fixed target: it is itself estimated on the same "
+        f"~21 bad labels (+/-{base_ci_21:.3f}) AND swings from ~0.61 (contaminated "
+        "slice) to ~0.94 (clean slice). You cannot 'beat by +0.05' a target whose own "
+        "CI is wider than 0.05. The honest paired comparison (DeLong) is dominated by "
+        "this baseline uncertainty, which the one-sample MDE ignores."
+    )
+
+    a.append("\n## How many bad labels would a meaningful lift need? (one-sample, optimistic)")
+    for lift in (0.10, 0.05, 0.03):
+        need = n_bad_for_lift(lift, ng, base)
+        a.append(f"- +{lift:.2f} lift over a {base:.2f} baseline at 80% power: "
+                 f"~{need} bad labels (have {nb}) — optimistic; ignores baseline CI")
+    a.append("These counts are a LOWER bound. They assume a fixed, perfectly-known "
+             "baseline near the ceiling; the real (paired, baseline-uncertain) "
+             "requirement is materially larger.")
+
+    a.append("\n## Reading (decision-relevant)")
+    a.append(
+        "Gate-3 is a minority-class problem; power is set by the scarce BAD-label "
+        "count. Two robust facts survive the caveats:\n"
+        f"  - At the realistic SCORED slice (~21 bad), you cannot even establish that "
+        f"an EISV model beats a COIN unless its lift exceeds **+{mde_21:.3f}** — and "
+        "the skeptic eval already found no feature beats the baseline at all.\n"
+        "  - The comparison target (autocorrelation AUC) is both very high (~0.94) and "
+        "unpinnable (0.61–0.94 across slices, CI wider than any plausible EISV lift). "
+        "There is no stable thing to beat.\n"
+        "Conclusion: Stage-B / GROUNDING_APPLY is NOT validatable on outcomes at this "
+        "label supply — by arithmetic, independent of the maths. The decision now "
+        "hinges on the *other* killer experiment, the latent-supply count: if the "
+        "fleet cannot emit clean bad labels at a rate that reaches the hundreds on a "
+        "reasonable horizon, EISV is plausibly unfalsifiable-on-outcomes and the "
+        "grounding program — not just Stage B — deserves reconsideration."
+    )
+    return "\n".join(a) + "\n"
+
+
+def parse_args(argv=None):
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--n-bad", type=int, default=114, help="exogenous bad labels (minority class)")
+    p.add_argument("--n-good", type=int, default=2287, help="exogenous good labels")
+    p.add_argument("--baseline-auc", type=float, default=0.94,
+                   help="AUC of the previous-outcome/autocorrelation baseline to beat")
+    p.add_argument("--target-lift", type=float, default=0.05)
+    return p.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    print(build_report(parse_args(argv)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_eisv_label_power.py
+++ b/tests/test_eisv_label_power.py
@@ -1,0 +1,20 @@
+"""Sanity checks for the label power / MDE calc (Hanley-McNeil)."""
+from scripts.analysis.eisv_label_power import auc_se, mde_over_chance, n_bad_for_lift
+
+
+def test_se_positive_and_shrinks_with_more_labels():
+    assert auc_se(0.7, 20, 400) > auc_se(0.7, 200, 4000) > auc_se(0.7, 2000, 40000) > 0
+
+
+def test_se_collapses_near_ceiling():
+    # the artifact the report warns about: variance is smaller near AUC=1
+    assert auc_se(0.94, 100, 2000) < auc_se(0.70, 100, 2000)
+
+
+def test_mde_over_chance_shrinks_with_more_labels():
+    assert mde_over_chance(21, 420) > mde_over_chance(114, 2287) > mde_over_chance(1000, 20000) > 0
+
+
+def test_n_bad_for_lift_monotone_in_target():
+    # a smaller lift requires more labels
+    assert n_bad_for_lift(0.03, 2287, 0.94) > n_bad_for_lift(0.10, 2287, 0.94) > 0


### PR DESCRIPTION
## What

Two artifacts from the EISV design tournament:

1. **`scripts/analysis/eisv_label_power.py`** — the "pooled killer experiment": a Hanley-McNeil MDE/power calc (no new data) that turns the unwinnable Stage-B outcome-validity gate into a number.
2. **`docs/proposals/eisv-grounding-next-move-v0.md`** — the 15-agent tournament's recommendation, tracked.

## Power result (live numbers: 114 bad / 2287 good; scored slice ~21 bad)

- At the realistic scored slice (~21 bad), an EISV model **can't be shown to beat a coin** unless its AUC lift over 0.5 exceeds **+0.165**.
- The baseline to beat (autocorrelation, previous-outcome) is both ~**0.94** and **unpinnable** — it swings **0.61→0.94** across contaminated/clean slices and its own CI is **±0.07** at n=21. The headroom (0.06) is narrower than the baseline's uncertainty.
- The script explicitly flags the near-ceiling-variance + baseline-uncertainty artifact, so the deceptively-small one-sample MDE ("~13 labels for +0.05") is **not** misread as feasible.

**Conclusion: gate-3 is not validatable on outcomes at this label supply — by arithmetic, independent of the maths.**

## Tournament synthesis (the proposal doc)

Ranking (3-judge mean /30): labels 26.3 · validation 25.3 · proprioception 23.3 · pooled 22 · simplify 19. Neither top proposal crowned as-spec (labels' target is ~17× the rate the world can supply; validation is a do-nothing rebrand). Recommendation = an **"honest-floor quarter"**: latent-supply count → MDE *(done here)* → one thin operator-correction label leg (forward/eval-only, rate-based) → the **AR(1) decontamination null** as make-or-break (beat per-agent AR(1), not just fleet-mean) → lightweight hygiene. Do-nots and a preserved dissent ("permanent retreat dressed as rigor"; possible unfalsifiability-on-outcomes endgame) included verbatim.

## Scope

Design/analysis only — **no live-path change, no new statistic wired**. 4 tests; full gate green (11,228 passed).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01MhKDiJ5aBnaAiRW84uK69b