### PR TITLE
fix(migrations): add missing schema_migrations footer to 053/054

### DIFF
--- a/db/postgres/migrations/053_dialectic_awaiting_facilitation.sql
+++ b/db/postgres/migrations/053_dialectic_awaiting_facilitation.sql
@@ -25,3 +25,8 @@ COMMENT ON COLUMN core.dialectic_sessions.awaiting_facilitation IS
     'TRUE when the reviewer is stuck and no auto-replacement was found, routing '
     'the session to human facilitation (#1015). Highest-priority surface signal. '
     'Mirrors the in-memory DialecticSession.awaiting_facilitation flag (#1167).';
+
+-- Register migration
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (53, 'dialectic_awaiting_facilitation', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/db/postgres/migrations/054_effects_consumed_nonces.sql
+++ b/db/postgres/migrations/054_effects_consumed_nonces.sql
@@ -31,3 +31,8 @@ COMMENT ON TABLE effects.consumed_nonces IS
     'Single-use ledger for effect-binding grant nonces (#1075). One row per '
     'consumed gnt.v1 grant; INSERT ... ON CONFLICT DO NOTHING enforces single '
     'use at /v1/effect-veto. Purge on grant_exp < now().';
+
+-- Register migration
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (54, 'effects_consumed_nonces', NOW())
+ON CONFLICT (version) DO NOTHING;


### PR DESCRIPTION
## Problem

Migrations **053** (`dialectic_awaiting_facilitation`, #1220) and **054** (`effects_consumed_nonces`, #1249) merged to `master` **without the `INSERT INTO core.schema_migrations … ON CONFLICT DO NOTHING` footer** that every other migration carries.

This left the system in a quietly inconsistent state, found while auditing for unfinished work:

- The live `governance` DB **already had** the 053/054 schema objects (`core.dialectic_sessions.awaiting_facilitation` column, `effects.consumed_nonces` table) — applied by hand during the #1220/#1249 deploys.
- But `core.schema_migrations` was stuck at **52**, because `unitares_doctor`'s source-manifest parser (and `apply_migrations.py`, which shares it) key off the registration INSERT, not the filename. The doctor reported `max 52, no pending` — schema and registry silently diverged.
- A future hand-apply via `psql -f` would have re-run the DDL but never recorded the version, perpetuating the drift.

## Fix

Add the standard footer to both files (identical pattern to 052). The DDL is `ADD COLUMN IF NOT EXISTS` / `CREATE TABLE IF NOT EXISTS`, so re-running through `apply_migrations.py` is a no-op against the existing objects and just records versions 53/54.

## Verification

Ran `apply_migrations.py --apply` against the live DB:
- `053 … ok: version 53 recorded`
- `054 … ok: version 54 recorded`
- `Applied 2 migration(s); DB now at version 54.`

`unitares_doctor.py` now green: `✓ schema_migrations: schema at version 54; registry matches source manifest`. Live registry reconciled — this PR only brings the source files into the convention so the drift can't recur.

https://claude.ai/code/session_01VdKuDaD3BMoGRwidFSJBUe