### PR TITLE
fix(identity): redact full session_key in onboard-pin debug logs

### DIFF
--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -2333,7 +2333,9 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     # that boundary is documented on the constant and in
     # docs/ontology/identity.md.
     try:
-        logger.debug(f"[ONBOARD_PIN] base_session_key={base_session_key!r}")
+        # Redact the full session_key (write-proof string) — prefix + length only.
+        _bsk = f"{base_session_key[:8]}...(len={len(base_session_key)})" if base_session_key else repr(base_session_key)
+        logger.debug(f"[ONBOARD_PIN] base_session_key={_bsk}")
         base_fp = _extract_base_fingerprint(base_session_key)
         from .session import SUBAGENT_PIN_NX_SPAWN_REASONS
         await set_onboard_pin(

--- a/src/mcp_handlers/identity/session.py
+++ b/src/mcp_handlers/identity/session.py
@@ -824,10 +824,12 @@ def _extract_base_fingerprint(session_key: str) -> Optional[str]:
     parts = session_key.split(":")
     if len(parts) >= 2:
         ua_hash = parts[1]
-        logger.debug(f"[ONBOARD_PIN] extract_fp: raw={session_key!r} ({len(parts)} parts) -> ua_hash={ua_hash!r}")
+        # Redact the full session_key (it is a write-proof string); a prefix +
+        # length keeps the fingerprint shape debuggable without logging the proof.
+        logger.debug(f"[ONBOARD_PIN] extract_fp: raw={session_key[:8]}...(len={len(session_key)}) ({len(parts)} parts) -> ua_hash={ua_hash!r}")
         return f"ua:{ua_hash}"
     # Single-part key (unusual) — return as-is
-    logger.debug(f"[ONBOARD_PIN] extract_fp: raw={session_key!r} (single part) -> as-is")
+    logger.debug(f"[ONBOARD_PIN] extract_fp: raw={session_key[:8]}...(len={len(session_key)}) (single part) -> as-is")
     return session_key
 
 


### PR DESCRIPTION
## Triage of the 92 master `clear-text-logging` CodeQL alerts

| bucket | count | verdict |
|---|---|---|
| truncated UUIDs (`agent_uuid[:8]`), cosmetic labels/names, `structured_id` | ~85 | **false positive** — identifiers, not credentials |
| already-truncated `session_key[:20/30]` prefixes | ~4 | defensible (a prefix can't be replayed) |
| **full `session_key!r` / `base_session_key!r` at DEBUG** | **3** | **real** — the per-process write-proof string in clear text |
| `continuity_token` (the signed proof) | 0 | never logged ✓ |

## This PR

Fixes only the 3 real ones — redacts the full `session_key` to **prefix + length** (`session_key[:8]...(len=N)`), matching the `[:N]` truncation convention already used in these files. Fingerprint shape stays debuggable; the proof string no longer hits the logs. None-safe at the handlers site.

- `identity/session.py:827,830` — `extract_fp` raw key
- `identity/handlers.py:2336` — `base_session_key`

**No behavior change** — `_extract_base_fingerprint` return values verified unchanged (multi → `ua:…`, single → as-is, None → None). Full gate green (11,236 passed).

## Honest scope note

This **reduces real exposure but will not clear the CodeQL alerts** — the rule flags *any* identity-variable logging, truncated included (it already flags `session_key[:30]` at L820). The ~85 false-positive alerts are a **separate triage decision** (bulk-dismiss as FP, or tune the CodeQL config to stop flagging truncated identifiers/labels) — deliberately *not* bundled here.

## Surface
Identity = single-writer/load-bearing surface (scanned: no in-flight identity PRs). **Draft, gated for your review — not auto-merged.**

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01MhKDiJ5aBnaAiRW84uK69b