### PR TITLE
Gate observe operator actions on bound identity

### DIFF
--- a/dashboard/redesign/data.js
+++ b/dashboard/redesign/data.js
@@ -87,7 +87,7 @@
         const j = await authFetch("/v1/residents");
         if (!j || !j.residents) return null;
         return j.residents.map((r) => ({
-          name: r.label, status: r.status, coherence: r.coherence, risk: r.risk_score,
+          id: r.agent_id, name: r.label, status: r.status, coherence: r.coherence, risk: r.risk_score,
           verdict: r.verdict, eisv: r.eisv, silence: r.silence_seconds,
           silenceThreshold: r.silence_threshold_seconds, event_driven: r.event_driven === true,
         }));
@@ -329,7 +329,12 @@
         return r && Array.isArray(r.points)
           ? { points: r.points, total: r.total || r.points.length, mode: r.mode || "recent" }
           : null;
-      }, () => ({ points: [], total: 0, mode: "recent" }));
+      }, () => {
+        // Offline: serve a bundled trajectory if the snapshot carries one for
+        // this agent, otherwise an honest empty result.
+        const h = (S().agentHistory || {})[id];
+        return h ? { points: h, total: h.length, mode: "all" } : { points: [], total: 0, mode: "recent" };
+      });
     },
 
     async residentPanels() {

--- a/dashboard/redesign/sections/eisv.js
+++ b/dashboard/redesign/sections/eisv.js
@@ -119,16 +119,98 @@
       return `<div title="${esc(title)}" style="background:color-mix(in srgb, var(--ok) ${pct}%, var(--danger));color:#fff;font-family:var(--font-mono);font-size:var(--text-sm);text-align:center;padding:6px 0;border-radius:var(--radius-1)">${value}</div>`;
     };
     const headLbl = (t) => `<div style="text-align:center;font-size:var(--text-xs);color:var(--muted);text-transform:uppercase;letter-spacing:var(--tracking-label)">${t}</div>`;
-    const header = `<div></div>` + cols.map((c) => headLbl(c.label)).join("");
+    // Each resident is its own grid row (shared column template) so the whole
+    // row is a click target for the per-agent trajectory below. Rows without an
+    // agent id (e.g. snapshot-only) stay inert.
+    const gridCols = `minmax(72px,1.4fr) repeat(${cols.length}, 1fr)`;
+    const rowGrid = `display:grid;grid-template-columns:${gridCols};gap:4px;align-items:stretch`;
+    const header = `<div style="${rowGrid};padding:0 1px"><div></div>${cols.map((c) => headLbl(c.label)).join("")}</div>`;
     const body = rows.map((r) => {
       const name = `<div style="font-size:var(--text-sm);color:var(--ink-2);display:flex;align-items:center;min-width:0;overflow:hidden;text-overflow:ellipsis">${esc(r.name)}</div>`;
-      return name + cols.map((c) => cell(c.frac(r), fmt(c.val(r)), `${r.name} ${c.label} = ${fmt(c.val(r))}`)).join("");
+      const cells = cols.map((c) => cell(c.frac(r), fmt(c.val(r)), `${r.name} ${c.label} = ${fmt(c.val(r))}`)).join("");
+      const clickable = !!r.id;
+      const attrs = clickable
+        ? ` data-traj-id="${esc(r.id)}" data-traj-name="${esc(r.name)}" title="Click for ${esc(r.name)}'s EISV trajectory"` : "";
+      return `<div${attrs} style="${rowGrid};border-radius:var(--radius-1);padding:1px${clickable ? ";cursor:pointer" : ""}">${name}${cells}</div>`;
     }).join("");
     return `<div class="panel" style="margin-bottom:var(--space-5)">
         <div class="panel-head" style="margin-bottom:var(--space-3)"><h2>Fleet heatmap</h2>
-          <span class="spring"></span><span class="fresh">green = healthy · red = strained</span></div>
-        <div style="display:grid;grid-template-columns:minmax(72px,1.4fr) repeat(${cols.length}, 1fr);gap:4px;align-items:stretch">
-          ${header}${body}</div></div>`;
+          <span class="spring"></span><span class="fresh">green = healthy · red = strained · click a row</span></div>
+        <div style="display:flex;flex-direction:column;gap:4px">${header}${body}</div></div>`;
+  }
+
+  // ---- Per-agent EISV trajectory (drill-down from the heatmap) -------------
+  let trajChart = null, selectedId = null, selectedName = null, trajPoints = [], trajLoading = false, clickBound = false;
+
+  function fmtT(t) {
+    const d = new Date(t);
+    return isNaN(d) ? "" : (d.getMonth() + 1) + "/" + d.getDate();
+  }
+
+  function buildTrajectory() {
+    if (trajChart) { trajChart.destroy(); trajChart = null; }
+    const cv = $("#eisv-traj-canvas");
+    if (!cv || !window.Chart || !trajPoints.length) return;
+    const E = cssVar("--eisv-e"), I = cssVar("--eisv-i"), C = cssVar("--eisv-c"), muted = cssVar("--muted");
+    const labels = trajPoints.map((p) => fmtT(p.t));
+    trajChart = new Chart(cv, {
+      type: "line",
+      data: { labels, datasets: [
+        ds("Energy", trajPoints.map((p) => p.E), E),
+        ds("Integrity", trajPoints.map((p) => p.I), I),
+        ds("Coherence", trajPoints.map((p) => p.coherence), C, { fill: false, borderDash: [5, 4], borderWidth: 1.5 }),
+      ] },
+      options: baseOptions({ min: 0, max: 1 }),
+      plugins: [refLine(MODEL.coherenceEq, muted)],
+    });
+  }
+
+  function renderTrajectory() {
+    const mount = $("#eisv-trajectory");
+    if (!mount) return;
+    const headHTML = (sub) => `<div class="panel-head" style="margin-bottom:var(--space-3)">
+        <h2>${selectedName ? esc(selectedName) + " · trajectory" : "Agent trajectory"}</h2>
+        <span class="spring"></span><span class="fresh">${sub}</span></div>`;
+    const note = (txt) => `<p style="color:var(--muted);font-size:var(--text-sm);margin:0">${txt}</p>`;
+    let inner;
+    if (!selectedId) inner = headHTML("click a resident above") + note("Select a resident in the heatmap to see its own EISV check-in history.");
+    else if (trajLoading) inner = headHTML("loading…") + note("Loading trajectory…");
+    else if (!trajPoints.length) inner = headHTML("no history") + note("No check-in history available" + (MODEL.source === "snapshot" ? " offline." : "."));
+    else inner = headHTML(trajPoints.length + " check-ins") + `<div style="height:220px"><canvas id="eisv-traj-canvas"></canvas></div>`;
+    mount.innerHTML = `<div class="panel" style="margin-bottom:var(--space-5)">${inner}</div>`;
+    if (selectedId && !trajLoading && trajPoints.length) buildTrajectory();
+  }
+
+  function applySelectionHighlight() {
+    document.querySelectorAll("#eisv-heatmap [data-traj-id]").forEach((el) => {
+      el.style.outline = el.getAttribute("data-traj-id") === selectedId ? "1.5px solid var(--accent)" : "none";
+      el.style.outlineOffset = "-1px";
+    });
+  }
+
+  async function selectAgent(id, name) {
+    selectedId = id; selectedName = name; trajLoading = true; trajPoints = [];
+    renderTrajectory(); applySelectionHighlight();
+    const r = await DATA.agentHistory(id, { mode: "all", limit: 120 });
+    if (selectedId !== id) return; // a newer selection won — drop this result
+    trajLoading = false;
+    trajPoints = (r && r.points) || [];
+    renderTrajectory();
+  }
+
+  // Delegated click on the stable mount, bound once. Closest [data-traj-id]
+  // survives the heatmap's periodic in-place re-render.
+  function bindHeatmapClicks() {
+    if (clickBound) return;
+    const mount = document.getElementById("eisv-mount");
+    if (!mount) return;
+    mount.addEventListener("click", (e) => {
+      const row = e.target.closest("[data-traj-id]");
+      if (!row || !mount.contains(row)) return;
+      const id = row.getAttribute("data-traj-id");
+      if (id) selectAgent(id, row.getAttribute("data-traj-name") || id);
+    });
+    clickBound = true;
   }
 
   function render() {
@@ -137,6 +219,7 @@
          <span class="eyebrow" style="margin:0">Fleet trajectory · last ${MODEL.series.length} min</span>
          <span class="spring"></span><span class="src-badge ${MODEL.source}">${MODEL.source}</span></div>
        <div id="eisv-heatmap">${heatmapHTML(MODEL.residents)}</div>
+       <div id="eisv-trajectory"></div>
        <div class="panel" style="margin-bottom:var(--space-5)">
          <div class="panel-head" style="margin-bottom:var(--space-3)"><h2>Energy · Integrity · Coherence</h2></div>
          <div style="height:240px"><canvas id="eisv-upper"></canvas></div>
@@ -145,6 +228,9 @@
          <div class="panel-head" style="margin-bottom:var(--space-3)"><h2>Entropy · Valence</h2></div>
          <div style="height:200px"><canvas id="eisv-lower"></canvas></div>
        </div>`;
+    bindHeatmapClicks();
+    renderTrajectory();
+    applySelectionHighlight();
     if (window.Chart) build();
     else $("#eisv-mount").insertAdjacentHTML("beforeend", `<p class="empty">Chart.js not loaded.</p>`);
   }
@@ -163,7 +249,7 @@
     // Swap the heatmap in place too — its own container, so the canvases above
     // are untouched.
     const hm = document.getElementById("eisv-heatmap");
-    if (hm) hm.innerHTML = heatmapHTML(MODEL.residents);
+    if (hm) { hm.innerHTML = heatmapHTML(MODEL.residents); applySelectionHighlight(); }
     const badge = document.querySelector("#eisv-mount .src-badge");
     if (badge) { badge.className = "src-badge " + MODEL.source; badge.textContent = MODEL.source; }
   }
@@ -196,7 +282,10 @@
     return true;
   }
   // re-theme without refetch (called on theme toggle) — full rebuild reads new tokens
-  function retheme() { if (MODEL.series.length && window.Chart) build(); }
+  function retheme() {
+    if (MODEL.series.length && window.Chart) build();
+    if (selectedId && trajPoints.length && window.Chart) buildTrajectory();
+  }
 
   window.EISV = { load, retheme, applyEvent };
 })();

--- a/dashboard/redesign/sections/eisv.js
+++ b/dashboard/redesign/sections/eisv.js
@@ -194,7 +194,8 @@
     const r = await DATA.agentHistory(id, { mode: "all", limit: 120 });
     if (selectedId !== id) return; // a newer selection won — drop this result
     trajLoading = false;
-    trajPoints = (r && r.points) || [];
+    // withFallback wraps the result as { source, data: { points, ... } }.
+    trajPoints = (r && r.data && r.data.points) || [];
     renderTrajectory();
   }
 

--- a/dashboard/redesign/snapshot.js
+++ b/dashboard/redesign/snapshot.js
@@ -9,13 +9,35 @@ window.SNAPSHOT = {
   capturedAt: "2026-06-19T19:30:00Z",
   health: { version: "2.13.0", uptime: "21h 15m", db: "connected" },
   residents: [
-    { name:"Watcher",    status:"healthy", coherence:0.50, risk:0.00, verdict:"proceed", eisv:{E:0.77,I:0.66,S:0.24,V:+0.10}, silence:25,    silenceThreshold:3600,   event_driven:true },
-    { name:"Vigil",      status:"healthy", coherence:0.49, risk:0.00, verdict:"proceed", eisv:{E:0.75,I:0.77,S:0.16,V:-0.02}, silence:101,   silenceThreshold:3600 },
-    { name:"Lumen",      status:"careful", coherence:0.50, risk:0.00, verdict:"proceed", eisv:{E:0.31,I:0.83,S:0.15,V:-0.52}, silence:56,    silenceThreshold:3600 },
-    { name:"Sentinel",   status:"healthy", coherence:0.50, risk:0.00, verdict:"proceed", eisv:{E:0.77,I:0.68,S:0.26,V:+0.09}, silence:273,   silenceThreshold:3600 },
-    { name:"Steward",    status:"dark",    coherence:null, risk:null, verdict:null,      eisv:null,                          silence:32,    silenceThreshold:3600 },
-    { name:"Chronicler", status:"healthy", coherence:0.50, risk:0.00, verdict:"proceed", eisv:{E:0.81,I:0.68,S:0.22,V:+0.11}, silence:67156, silenceThreshold:172800 },
+    { id:"mcp_20260416_907e3195", name:"Watcher",    status:"healthy", coherence:0.50, risk:0.00, verdict:"proceed", eisv:{E:0.77,I:0.66,S:0.24,V:+0.10}, silence:25,    silenceThreshold:3600,   event_driven:true },
+    { id:"mcp_20260406_e55caaf1", name:"Vigil",      status:"healthy", coherence:0.49, risk:0.00, verdict:"proceed", eisv:{E:0.75,I:0.77,S:0.16,V:-0.02}, silence:101,   silenceThreshold:3600 },
+    { id:"mcp_20260428_69a1a4f7", name:"Lumen",      status:"careful", coherence:0.50, risk:0.00, verdict:"proceed", eisv:{E:0.31,I:0.83,S:0.15,V:-0.52}, silence:56,    silenceThreshold:3600 },
+    { id:"mcp_20260407_f92dcea8", name:"Sentinel",   status:"healthy", coherence:0.50, risk:0.00, verdict:"proceed", eisv:{E:0.77,I:0.68,S:0.26,V:+0.09}, silence:273,   silenceThreshold:3600 },
+    { id:"mcp_20260417_9a6681ec", name:"Steward",    status:"dark",    coherence:null, risk:null, verdict:null,      eisv:null,                          silence:32,    silenceThreshold:3600 },
+    { id:"mcp_20260419_chron001", name:"Chronicler", status:"healthy", coherence:0.50, risk:0.00, verdict:"proceed", eisv:{E:0.81,I:0.68,S:0.22,V:+0.11}, silence:67156, silenceThreshold:172800 },
   ],
+  // Bundled per-agent trajectory for the offline drill-down demo — Lumen's
+  // energy declining into the strained cell the heatmap flags. Live uses
+  // /v1/agents/{id}/history (thousands of real points); this is just the
+  // offline stand-in for one agent.
+  agentHistory: {
+    "mcp_20260428_69a1a4f7": [
+      { t:"2026-06-06", E:0.55, I:0.84, S:0.11, V:-0.30, coherence:0.51, risk:0.10 },
+      { t:"2026-06-07", E:0.53, I:0.84, S:0.12, V:-0.33, coherence:0.51, risk:0.11 },
+      { t:"2026-06-08", E:0.50, I:0.83, S:0.12, V:-0.36, coherence:0.50, risk:0.12 },
+      { t:"2026-06-09", E:0.48, I:0.84, S:0.13, V:-0.39, coherence:0.50, risk:0.13 },
+      { t:"2026-06-10", E:0.46, I:0.83, S:0.13, V:-0.41, coherence:0.50, risk:0.14 },
+      { t:"2026-06-11", E:0.44, I:0.83, S:0.14, V:-0.43, coherence:0.50, risk:0.15 },
+      { t:"2026-06-12", E:0.42, I:0.83, S:0.14, V:-0.45, coherence:0.50, risk:0.16 },
+      { t:"2026-06-13", E:0.40, I:0.83, S:0.14, V:-0.47, coherence:0.50, risk:0.17 },
+      { t:"2026-06-14", E:0.38, I:0.83, S:0.15, V:-0.48, coherence:0.50, risk:0.18 },
+      { t:"2026-06-15", E:0.36, I:0.83, S:0.15, V:-0.49, coherence:0.50, risk:0.18 },
+      { t:"2026-06-16", E:0.35, I:0.83, S:0.15, V:-0.50, coherence:0.50, risk:0.19 },
+      { t:"2026-06-17", E:0.33, I:0.83, S:0.15, V:-0.51, coherence:0.50, risk:0.19 },
+      { t:"2026-06-18", E:0.32, I:0.83, S:0.15, V:-0.51, coherence:0.50, risk:0.19 },
+      { t:"2026-06-19", E:0.31, I:0.83, S:0.15, V:-0.52, coherence:0.50, risk:0.19 },
+    ],
+  },
   // representative until wired to live tool calls (agent/detect_stuck/knowledge/calibration)
   stats: {
     agentsActive: 6, agentsTotal: 658, stuck: 0, discoveries: 1204, discoveriesToday: 12,

--- a/src/mcp_handlers/consolidated.py
+++ b/src/mcp_handlers/consolidated.py
@@ -15,7 +15,13 @@ Each consolidated tool uses an 'action' parameter to select the operation.
 Original tools remain available for backwards compatibility.
 """
 
+from functools import wraps
+from typing import Any, Awaitable, Callable, Dict, Sequence
+
+from mcp.types import TextContent
+
 from .decorators import action_router
+from .utils import success_response
 
 # Import original handlers to delegate to
 from .knowledge.handlers import (
@@ -88,6 +94,77 @@ from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 # Pi orchestration (``pi`` action router + handlers) moved to the
 # ``unitares-pi-plugin`` package — registered via the
 # ``governance_mcp.plugins`` entry point at server startup.
+
+
+def _has_bound_observe_operator_identity() -> bool:
+    try:
+        from .context import get_context_agent_id, get_session_proof_origin
+
+        if not get_context_agent_id():
+            return False
+        return get_session_proof_origin() != "server_inferred"
+    except Exception:
+        return False
+
+
+def _observe_operator_refusal(
+    action: str, arguments: Dict[str, Any]
+) -> Sequence[TextContent]:
+    from .identity_bootstrap import strict_identity_refusal_payload
+
+    return success_response(
+        strict_identity_refusal_payload(
+            "observe",
+            hint=(
+                f"observe(action='{action}') is an operator observability "
+                "surface and requires a bound governance identity before "
+                "returning telemetry or audit evidence."
+            ),
+            next_step=(
+                "Call onboard(force_new=true), then retry observe(...) with "
+                "the returned client_session_id."
+            ),
+            safe_options=[
+                {
+                    "action": "start_fresh",
+                    "call": "onboard(force_new=true)",
+                    "when": "This is a new process-instance with no causal predecessor.",
+                },
+                {
+                    "action": "declare_lineage",
+                    "call": (
+                        "onboard(force_new=true, parent_agent_id=<prior UUID>, "
+                        "spawn_reason='new_session')"
+                    ),
+                    "when": "A finished predecessor explicitly handed this work to you.",
+                },
+                {
+                    "action": "stay_read_only",
+                    "call": "observe(action='aggregate') or observe(action='anomalies')",
+                    "when": "You need pre-onboard fleet-level read data only.",
+                },
+            ],
+            surface_context={
+                "tool": "observe",
+                "action": action,
+                "requirement": "operator_observability_identity",
+            },
+        ),
+        arguments=arguments,
+    )
+
+
+def _observe_operator_action(
+    action: str,
+    handler: Callable[[Dict[str, Any]], Awaitable[Sequence[TextContent]]],
+) -> Callable[[Dict[str, Any]], Awaitable[Sequence[TextContent]]]:
+    @wraps(handler)
+    async def guarded(arguments: Dict[str, Any]) -> Sequence[TextContent]:
+        if _has_bound_observe_operator_identity():
+            return await handler(arguments)
+        return _observe_operator_refusal(action, arguments)
+
+    return guarded
 
 # ============================================================
 # Consolidated Knowledge Graph Tool
@@ -237,9 +314,13 @@ handle_observe = action_router(
         "similar": handle_compare_me_to_similar,
         "anomalies": handle_detect_anomalies,
         "aggregate": handle_aggregate_metrics,
-        "telemetry": handle_get_telemetry_metrics,
-        "audit_events": handle_audit_events,
-        "outcome_evidence": handle_outcome_evidence,
+        "telemetry": _observe_operator_action(
+            "telemetry", handle_get_telemetry_metrics
+        ),
+        "audit_events": _observe_operator_action("audit_events", handle_audit_events),
+        "outcome_evidence": _observe_operator_action(
+            "outcome_evidence", handle_outcome_evidence
+        ),
     },
     timeout=15.0,
     description="Unified observability operations: agent, compare, similar, anomalies, aggregate, telemetry, audit_events, outcome_evidence",

--- a/src/mcp_handlers/observability/handlers.py
+++ b/src/mcp_handlers/observability/handlers.py
@@ -1335,6 +1335,41 @@ async def handle_audit_events(arguments: Dict[str, Any]) -> Sequence[TextContent
         return error_response(
             "event_type or event_types is required",
             error_code="missing_argument",
+            details={
+                "next_step": (
+                    "Retry observe(action='audit_events') with event_type=<name> "
+                    "or event_types=[<name>, ...]."
+                ),
+                "safe_options": [
+                    {
+                        "action": "query_one_type",
+                        "call": (
+                            "observe(action='audit_events', "
+                            "event_type='continuity_token_deprecated_accept', since='14d')"
+                        ),
+                    },
+                    {
+                        "action": "query_multiple_types",
+                        "call": (
+                            "observe(action='audit_events', "
+                            "event_types=['governance_decision', "
+                            "'coordination_failure.mcp_handler_timeout.tool_decorator'], "
+                            "since='24h')"
+                        ),
+                    },
+                    {
+                        "action": "inspect_tool_schema",
+                        "call": "describe_tool(tool_name='observe')",
+                    },
+                ],
+            },
+            recovery={
+                "required_one_of": ["event_type", "event_types"],
+                "examples": [
+                    "observe(action='audit_events', event_type='continuity_token_deprecated_accept', since='14d')",
+                    "observe(action='audit_events', event_types=['governance_decision'], since='24h')",
+                ],
+            },
         )
 
     # Default 7d (168h). The primary use case is multi-week grace-window

--- a/tests/test_consolidated_handlers.py
+++ b/tests/test_consolidated_handlers.py
@@ -10,7 +10,7 @@ import pytest
 import sys
 from contextlib import contextmanager
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
@@ -576,6 +576,25 @@ class TestObserveHandler:
                            "aggregate", "telemetry", "audit_events",
                            "outcome_evidence"])
         assert valid == expected
+
+    @pytest.mark.asyncio
+    async def test_operator_action_refuses_unbound_caller_even_with_agent_arg(self):
+        from src.mcp_handlers.consolidated import handle_observe
+
+        with patch("src.mcp_handlers.context.get_context_agent_id", return_value=None):
+            result = await handle_observe({
+                "action": "telemetry",
+                "agent_id": "deb879b6-4ff8-4dee-81ce-0683f4563dc5",
+            })
+
+        data = _parse_response(result)
+        assert data["success"] is True
+        assert data["status"] == "identity_required"
+        assert data["surface_context"]["action"] == "telemetry"
+        assert data["agent_signature"]["uuid"] is None
+        assert "next_step" in data
+        assert "safe_options" in data
+        assert "skip_rate_metrics" not in data
 
 
 class TestAdminHandler:

--- a/tests/test_observability_handlers.py
+++ b/tests/test_observability_handlers.py
@@ -1786,6 +1786,9 @@ class TestHandleAuditEvents:
         data = parse_result(result)
         assert data["success"] is False
         assert "event_type" in data.get("error", "").lower()
+        assert data["next_step"].startswith("Retry observe(action='audit_events')")
+        assert data["safe_options"]
+        assert data["recovery"]["required_one_of"] == ["event_type", "event_types"]
 
     @pytest.mark.asyncio
     async def test_shorthand_window_resolves_correctly(self):
@@ -1989,11 +1992,18 @@ class TestHandleAuditEvents:
 
         with patch("src.audit_db.query_audit_events_async", new=fake_query):
             from src.mcp_handlers.consolidated import handle_observe
-            result = await handle_observe({
-                "action": "audit_events",
-                "event_type": "continuity_token_deprecated_accept",
-                "since": "14d",
-            })
+            with patch(
+                "src.mcp_handlers.context.get_context_agent_id",
+                return_value="operator-agent",
+            ), patch(
+                "src.mcp_handlers.context.get_session_proof_origin",
+                return_value="caller_asserted",
+            ):
+                result = await handle_observe({
+                    "action": "audit_events",
+                    "event_type": "continuity_token_deprecated_accept",
+                    "since": "14d",
+                })
 
         data = parse_result(result)
         assert data["success"] is True
@@ -2215,11 +2225,18 @@ class TestHandleOutcomeEvidence:
 
         with patch("src.db.get_db", return_value=db):
             from src.mcp_handlers.consolidated import handle_observe
-            result = await handle_observe({
-                "action": "outcome_evidence",
-                "diagnostic": "claim_only_task_completed",
-                "since": "7d",
-            })
+            with patch(
+                "src.mcp_handlers.context.get_context_agent_id",
+                return_value="operator-agent",
+            ), patch(
+                "src.mcp_handlers.context.get_session_proof_origin",
+                return_value="caller_asserted",
+            ):
+                result = await handle_observe({
+                    "action": "outcome_evidence",
+                    "diagnostic": "claim_only_task_completed",
+                    "since": "7d",
+                })
 
         data = parse_result(result)
         assert data["success"] is True


### PR DESCRIPTION
Fixes dogfood finding 84975588cbbd322f. Summary: require a bound caller context before observe(action='telemetry'), observe(action='audit_events'), or observe(action='outcome_evidence') returns operator telemetry/audit evidence; enrich audit_events missing-filter errors with next_step and safe_options; add focused regression coverage. Tests: python3 -m pytest targeted observe/audit tests; ./scripts/dev/test-cache.sh (11204 passed, 22 skipped, 4 warnings, coverage 81.85%). Note: staged test-cache refused while an unrelated plist change was dirty; that plist change was parked in a stash before PR creation.