### PR TITLE
ops: plist templates — render production against a pinned worktree (not the dev checkout)

### DIFF
--- a/scripts/ops/com.unitares.gateway-mcp.plist.template
+++ b/scripts/ops/com.unitares.gateway-mcp.plist.template
@@ -5,6 +5,12 @@
   The gateway exposes a 6-tool subset of the full governance MCP for weak
   external clients (e.g. Cursor). It proxies to the governance server on :8767.
 
+  Production: render __UNITARES_ROOT__ against a MASTER-PINNED worktree
+  (e.g. ~/projects/unitares-deploy), NOT the shared dev checkout — else a
+  concurrent session that switches the dev checkout's branch will deploy the
+  wrong code on this service's next restart. (governance-mcp + agent-orchestrator
+  already run from pinned worktrees; the [DEV] services were pinned 2026-06-29.)
+
   Install (render __VARS__ then load):
     sed -e "s|__UNITARES_ROOT__|$HOME/projects/unitares|g" \
         -e "s|__HOME__|$HOME|g" \

--- a/scripts/ops/com.unitares.sentinel-beam.plist.template
+++ b/scripts/ops/com.unitares.sentinel-beam.plist.template
@@ -2,6 +2,14 @@
 <!--
   launchd manifest for BEAM Sentinel (Wave 1 cutover target).
 
+  Production: render __UNITARES_ROOT__ against a MASTER-PINNED worktree
+  (e.g. ~/projects/unitares-deploy), NOT the shared dev checkout, so a concurrent
+  branch-switch can't deploy the wrong code on restart (provision the Elixir
+  build there once: `mix deps.get && mix compile` in <root>/elixir/sentinel).
+  Point the state files at FIXED $HOME paths via UNITARES_SENTINEL_STATE_FILE /
+  UNITARES_SENTINEL_LEGACY_SESSION_FILE (not __UNITARES_ROOT__-relative) so they
+  survive a re-point; the session anchor is already fixed under $HOME.
+
   Render, but do NOT load while Python Sentinel is still running:
     sed -e "s|__UNITARES_ROOT__|$HOME/projects/unitares|g" \
         -e "s|__HOME__|$HOME|g" \

--- a/scripts/ops/com.unitares.wave3a-handlers.plist.template
+++ b/scripts/ops/com.unitares.wave3a-handlers.plist.template
@@ -14,6 +14,14 @@
   (src/wave3a_beam_proxy.py) is the rollback contract. "Rollback by
   default" is the posture before any handler is wired.
 
+  Production: render __UNITARES_ROOT__ against a MASTER-PINNED worktree
+  (e.g. ~/projects/unitares-deploy), NOT the shared dev checkout — else a
+  concurrent session that switches the dev checkout's branch will deploy the
+  wrong code on this service's next restart. (governance-mcp + agent-orchestrator
+  already run from pinned worktrees; the [DEV] services were pinned 2026-06-29.)
+  Note: the deploy worktree needs the Elixir build provisioned once —
+  `mix deps.get && mix compile` in <root>/elixir/wave3a_handlers.
+
   Install (render __VARS__ then load):
     sed -e "s|__UNITARES_ROOT__|$HOME/projects/unitares|g" \
         -e "s|__HOME__|$HOME|g" \


### PR DESCRIPTION
Closes the install-time half of the deploy-topology footgun. The three service plist templates' install comments rendered `__UNITARES_ROOT__` to the **shared dev checkout** (`$HOME/projects/unitares`) — so a fresh install points production at the workspace that concurrent sessions branch-switch, and a restart can deploy the wrong code.

**Comment-only.** Adds a "Production" note to each of `gateway-mcp`/`wave3a-handlers`/`sentinel-beam` templates steering production renders at a **master-pinned worktree** (like governance-mcp + the orchestrator already use), plus the per-service caveats (Elixir build-provision for wave3a/sentinel; fixed-$HOME sentinel state paths). No `<key>`/`<string>` field changes — fresh installs render identically; the guidance just stops recommending the dev checkout.

Companion to the live fix (the 3 services were pinned to `unitares-deploy` 2026-06-29) so concurrent sessions + free branch-switching never touch a production service.