### PR TITLE
feat(wave3a): list_tools + describe_tool BEAM handlers (strangler 4/4, flags off)

### DIFF
--- a/elixir/wave3a_handlers/lib/wave3a_handlers/handlers/describe_tool.ex
+++ b/elixir/wave3a_handlers/lib/wave3a_handlers/handlers/describe_tool.ex
@@ -1,0 +1,136 @@
+defmodule Wave3aHandlers.Handlers.DescribeTool do
+  @moduledoc """
+  Wave 3a `describe_tool` handler — fourth (final) cutover (RFC §5 PR #8),
+  completing the §1.1 wave3a handler set (4/4).
+
+  Same topology as the prior three handlers, gated on
+  `WAVE_3A_DESCRIBE_TOOL_ON_BEAM` in the Python routing table
+  (`src/wave3a_routing.py`). The BEAM side calls the Python probe at
+  `GET /v1/probe/describe_tool?tool_name=<name>`.
+
+  ## First arg-reading handler
+
+  `describe_tool` is the FIRST §1.1 handler that consumes a caller argument.
+  `health_check` reads `lite` defensively, `get_server_info` and `list_tools`
+  ignore their arguments entirely; this handler pulls `"tool_name"` out of the
+  `arguments` map (the inner kwargs the Python proxy posts under
+  `arguments`, unwrapped by the HTTP router) and forwards it to
+  `ProbeClient.describe_tool/1`, which URI-encodes it into the probe query
+  string.
+
+  BEAM serves the **`tool_name`-only case**; any other argument delegates to
+  the Python in-process handler via the proxy fallback — guarantees no silent
+  divergence.
+
+  Argument contract:
+
+    * `arguments` carries any key OTHER than `"tool_name"` (e.g. `lite`,
+      `include_schema`, `include_full_description`) → the BEAM path cannot
+      faithfully forward those, so it short-circuits with a 422
+      `delegated_to_python` envelope BEFORE inspecting `tool_name`. The Python
+      proxy treats any non-2xx as a fallback trigger, so the in-process
+      `handle_describe_tool(<all kwargs>)` runs and honours every argument —
+      byte-parity preserved via the fallback. This guard fires whether or not
+      `tool_name` is also present.
+    * `arguments` is `tool_name`-only and `"tool_name"` is a non-empty binary
+      → forward to the probe. Whitespace-only / unknown names are NOT
+      pre-validated here — the Python `handle_describe_tool` owns the
+      canonical trim + unknown-tool handling and returns the `error_response`
+      payload, which the probe surfaces verbatim (so byte-parity holds on the
+      semantic-error path too).
+    * `arguments` is `tool_name`-only but `"tool_name"` is absent or empty
+      string (or a non-binary) → short-circuit with a 400 `invalid_arguments`
+      envelope. The Python proxy falls back, so the in-process
+      `handle_describe_tool` then runs and returns the canonical
+      `"tool_name is required"` error to the client — byte-parity preserved
+      via the fallback, without a pointless probe call.
+
+  Only `tool_name` is ever forwarded; every other argument is single-sourced
+  from Python via the fallback. That is the documented parity boundary of
+  this slice.
+
+  ## §2.6 parity — single-sourced via the in-process handler
+
+  Like `list_tools`, the payload is built inline inside `handle_describe_tool`
+  and wrapped with `success_response` / `error_response`; there is no
+  separable builder. The probe CALLS the handler and passes its `TextContent`
+  output through verbatim (`src/mcp_handlers/wave3a_probe.py::_describe_tool`),
+  with `server_time` masked for byte-determinism.
+
+  ## Envelope shape and failure modes
+
+  Returns `{:ok, body_map, http_status}`; the HTTP router stamps `ok` and the
+  pinned `protocol_version`. Probe failures map to the shared typed envelopes
+  in `Wave3aHandlers.Handlers.ProbeErrors`.
+  """
+
+  alias Wave3aHandlers.Handlers.ProbeErrors
+  alias Wave3aHandlers.ProbeClient
+
+  @doc """
+  Handle a `describe_tool` dispatch.
+
+  Only `tool_name` is faithfully forwarded by the BEAM path, so:
+
+    * Any argument key other than `"tool_name"` (e.g. `lite`,
+      `include_schema`) → 422 `delegated_to_python`, so the Python proxy falls
+      back to the in-process handler that honours every argument.
+    * `tool_name`-only with a present, non-empty binary → forward to the probe.
+    * `tool_name`-only but missing/empty/non-binary → 400 so the Python proxy
+      falls back to the in-process handler's canonical "tool_name is required".
+  """
+  @spec call(map()) :: {:ok, map(), pos_integer()}
+  def call(arguments) when is_map(arguments) do
+    if has_unforwarded_args?(arguments) do
+      {:ok,
+       %{
+         error: "delegated_to_python",
+         reason: "only tool_name is served on the BEAM path; other arguments delegate to Python",
+         forwarded: false
+       }, 422}
+    else
+      dispatch(arguments)
+    end
+  end
+
+  defp dispatch(arguments) do
+    case fetch_tool_name(arguments) do
+      {:ok, tool_name} ->
+        case ProbeClient.describe_tool(tool_name) do
+          {:ok, envelope} ->
+            {:ok, extract_payload(envelope), 200}
+
+          {:error, reason} ->
+            {body, status} = ProbeErrors.body(reason)
+            {:ok, body, status}
+        end
+
+      :error ->
+        {:ok, %{error: "invalid_arguments", reason: "tool_name is required"}, 400}
+    end
+  end
+
+  # The BEAM path forwards ONLY `tool_name`. If the caller passed any other
+  # key, the BEAM handler cannot faithfully serve the request → delegate to
+  # Python via a non-2xx (422). True iff `arguments` has a key besides
+  # `"tool_name"`.
+  defp has_unforwarded_args?(arguments) do
+    arguments
+    |> Map.keys()
+    |> Enum.any?(&(&1 != "tool_name"))
+  end
+
+  # `tool_name` must be a present, non-empty binary to be worth a probe call.
+  # Empty/absent → :error → 400 → Python fallback emits the canonical
+  # "tool_name is required" error_response.
+  defp fetch_tool_name(%{"tool_name" => name}) when is_binary(name) and name != "",
+    do: {:ok, name}
+
+  defp fetch_tool_name(_), do: :error
+
+  # The probe envelope is `{"ok": true, "protocol_version": "wave3a.v1",
+  # "data": {<payload>}}`. Only `data` is the handler payload — both the
+  # success and the semantic-error (`success: false`) shapes ride inside it.
+  defp extract_payload(%{"data" => data}) when is_map(data), do: data
+  defp extract_payload(envelope), do: envelope
+end

--- a/elixir/wave3a_handlers/lib/wave3a_handlers/handlers/list_tools.ex
+++ b/elixir/wave3a_handlers/lib/wave3a_handlers/handlers/list_tools.ex
@@ -1,0 +1,93 @@
+defmodule Wave3aHandlers.Handlers.ListTools do
+  @moduledoc """
+  Wave 3a `list_tools` handler — third cutover (RFC §5 PR #7).
+
+  Same topology as `Wave3aHandlers.Handlers.GetServerInfo` (PR #6), gated on
+  `WAVE_3A_LIST_TOOLS_ON_BEAM` in the Python routing table
+  (`src/wave3a_routing.py`). The BEAM side calls the Python probe at
+  `GET /v1/probe/list_tools` and passes the payload through verbatim.
+
+  ## §2.6 parity — single-sourced via the in-process handler
+
+  Unlike `get_server_info` (whose payload comes from the standalone
+  `build_server_info_payload`), `list_tools` builds its payload inline inside
+  the Python MCP handler and wraps it with `success_response`. There is no
+  separable builder to share. The probe therefore CALLS `handle_list_tools`
+  directly and surfaces its `TextContent` output verbatim
+  (`src/mcp_handlers/wave3a_probe.py::_list_tools`), so the probe `data`
+  payload is the Python handler's own payload by construction — including the
+  `success_response` envelope fields (`success`, `server_time`,
+  `agent_signature`). `server_time` is masked on the probe side for
+  byte-determinism (§2.6), exactly as `tool_registry` masks its volatile
+  fields.
+
+  ## Handler contract
+
+  BEAM serves the **default-argument case only**; any other argument
+  delegates to the Python in-process handler via the proxy fallback —
+  guarantees no silent divergence.
+
+  No arguments are forwarded. The Python `handle_list_tools` DOES accept
+  filter arguments (`tier`, `essential_only`, `lite`, `progressive`), so this
+  BEAM cutover serves ONLY the default-argument call (empty `arguments` map):
+  the probe invokes `handle_list_tools({})`. If the caller passes ANY argument
+  (the `arguments` map is non-empty), this handler does NOT call the probe —
+  it returns a 422 `delegated_to_python` envelope. The Python proxy treats
+  every non-2xx as a fallback trigger (`wave3a_beam_proxy.py::_call_beam`
+  `raise_for_status` → `HTTPStatusError` → `fallback_reason="non_200"`), so
+  the in-process `handle_list_tools(<filters>)` then runs and serves the
+  correct filtered response. The parity unit (RFC §2.6 "same input") for the
+  BEAM path is the default-argument response; every other input is single-
+  sourced from Python via the fallback, so there is no silent divergence.
+
+  ## Envelope shape and failure modes
+
+  Identical to `GetServerInfo`: returns `{:ok, body_map, http_status}`; the
+  HTTP router stamps `ok` and the pinned `protocol_version`. Probe failures
+  map to the shared typed envelopes in
+  `Wave3aHandlers.Handlers.ProbeErrors`; the Python proxy treats every
+  non-2xx as a fallback trigger, so the worst case is one extra HTTP
+  round-trip plus a Python in-process dispatch.
+  """
+
+  alias Wave3aHandlers.Handlers.ProbeErrors
+  alias Wave3aHandlers.ProbeClient
+
+  @doc """
+  Handle a `list_tools` dispatch.
+
+  The BEAM path forwards NO arguments, so it can only faithfully serve the
+  default-argument call. An empty `arguments` map → serve from the probe. A
+  non-empty `arguments` map (any key present) → return a 422
+  `delegated_to_python` envelope so the Python proxy falls back to the
+  in-process handler, which honours the filters. This is the safe parity
+  guard: the BEAM path never silently serves a default response to a caller
+  who asked for something else.
+  """
+  @spec call(map()) :: {:ok, map(), pos_integer()}
+  def call(arguments) when is_map(arguments) and map_size(arguments) > 0 do
+    {:ok,
+     %{
+       error: "delegated_to_python",
+       reason: "non-default arguments not served on BEAM path",
+       forwarded: false
+     }, 422}
+  end
+
+  def call(arguments) when is_map(arguments) do
+    case ProbeClient.list_tools() do
+      {:ok, envelope} ->
+        {:ok, extract_payload(envelope), 200}
+
+      {:error, reason} ->
+        {body, status} = ProbeErrors.body(reason)
+        {:ok, body, status}
+    end
+  end
+
+  # The probe envelope is `{"ok": true, "protocol_version": "wave3a.v1",
+  # "data": {<payload>}}` per `wave3a_probe.py::_envelope_ok`. Only `data`
+  # is the handler payload; `list_tools` carries no `meta` annotation.
+  defp extract_payload(%{"data" => data}) when is_map(data), do: data
+  defp extract_payload(envelope), do: envelope
+end

--- a/elixir/wave3a_handlers/lib/wave3a_handlers/http_router.ex
+++ b/elixir/wave3a_handlers/lib/wave3a_handlers/http_router.ex
@@ -95,11 +95,14 @@ defmodule Wave3aHandlers.HTTPRouter do
 
   # ---------- /v1/handlers/:tool_name ----------
   # Dispatch table for the wired §1.1 handlers. PR #5 cut over
-  # `health_check`; PR #6 adds `get_server_info`. Every other tool name
-  # returns 501; subsequent PRs (list_tools, describe_tool) add rows here.
+  # `health_check`; PR #6 added `get_server_info`; PR #7/#8 complete the set
+  # with `list_tools` and `describe_tool` (4/4). Every other tool name
+  # returns 501.
   @handler_modules %{
     "health_check" => Wave3aHandlers.Handlers.HealthCheck,
-    "get_server_info" => Wave3aHandlers.Handlers.GetServerInfo
+    "get_server_info" => Wave3aHandlers.Handlers.GetServerInfo,
+    "list_tools" => Wave3aHandlers.Handlers.ListTools,
+    "describe_tool" => Wave3aHandlers.Handlers.DescribeTool
   }
 
   post "/v1/handlers/:tool_name" do

--- a/elixir/wave3a_handlers/lib/wave3a_handlers/probe_client.ex
+++ b/elixir/wave3a_handlers/lib/wave3a_handlers/probe_client.ex
@@ -52,6 +52,21 @@ defmodule Wave3aHandlers.ProbeClient do
   @spec tool_registry() :: {:ok, map()} | {:error, atom() | {atom(), any()}}
   def tool_registry, do: get("/v1/probe/tool_registry")
 
+  @spec list_tools() :: {:ok, map()} | {:error, atom() | {atom(), any()}}
+  def list_tools, do: get("/v1/probe/list_tools")
+
+  @doc """
+  Fetch the single-tool description for `tool_name`.
+
+  `tool_name` is URI-encoded into the query string so names with reserved
+  characters round-trip safely to the Python probe, which reads it from
+  `request.query_params` and forwards it to `handle_describe_tool`.
+  """
+  @spec describe_tool(String.t()) :: {:ok, map()} | {:error, atom() | {atom(), any()}}
+  def describe_tool(tool_name) when is_binary(tool_name) do
+    get("/v1/probe/describe_tool?tool_name=" <> URI.encode_www_form(tool_name))
+  end
+
   defp get(path) do
     case Application.get_env(:wave3a_handlers, :probe_token) do
       token when is_binary(token) and byte_size(token) > 0 ->

--- a/elixir/wave3a_handlers/test/envelope_shape_test.exs
+++ b/elixir/wave3a_handlers/test/envelope_shape_test.exs
@@ -205,13 +205,13 @@ defmodule Wave3aHandlers.EnvelopeShapeTest do
 
   describe "501 envelope (unwired tools)" do
     test "unwired tool name returns 501 with envelope" do
-      # PR #5 cut over `health_check`, PR #6 cut over `get_server_info`;
-      # every OTHER tool name still returns 501 from the dispatch table.
-      # `list_tools` is the next §1.1 handler in line for PR #7 — it's
-      # still unwired, so it serves as a stable canary for the 501 shape.
+      # PR #5-#8 cut over the full §1.1 set (`health_check`,
+      # `get_server_info`, `list_tools`, `describe_tool`); every OTHER tool
+      # name still returns 501 from the dispatch table. A real out-of-scope
+      # governance tool serves as a stable canary for the 501 shape.
       resp =
         :post
-        |> conn("/v1/handlers/list_tools", "{}")
+        |> conn("/v1/handlers/get_governance_metrics", "{}")
         |> put_req_header("content-type", "application/json")
         |> authed()
         |> HTTPRouter.call(@opts)
@@ -223,7 +223,7 @@ defmodule Wave3aHandlers.EnvelopeShapeTest do
       assert body["protocol_version"] == "wave3a.v1"
       assert body["error"] == "not_implemented"
       assert body["reason"] == "handler not wired"
-      assert body["tool_name"] == "list_tools"
+      assert body["tool_name"] == "get_governance_metrics"
     end
 
     test "501 also fires on arbitrary tool names" do

--- a/elixir/wave3a_handlers/test/handlers/describe_tool_test.exs
+++ b/elixir/wave3a_handlers/test/handlers/describe_tool_test.exs
@@ -1,0 +1,276 @@
+defmodule Wave3aHandlers.Handlers.DescribeToolTest do
+  @moduledoc """
+  ExUnit coverage for the fourth (final) BEAM-side handler (RFC §5 PR #8),
+  completing the §1.1 set (4/4).
+
+  `describe_tool` is the FIRST arg-reading handler, so coverage extends the
+  `get_server_info` template with argument-handling cases:
+
+    * `tool_name` is pulled from `arguments` and forwarded to
+      `ProbeClient.describe_tool/1` (verified via the captured arg).
+    * Probe `data` payload is passed through verbatim (success path), and the
+      semantic-error payload (`success: false`) also rides through `data`.
+    * Missing / empty `tool_name` short-circuits with a 400
+      `invalid_arguments` envelope (no probe call) — the Python proxy falls
+      back to the in-process handler's canonical error.
+    * Probe failure atoms map to the shared typed envelopes
+      (`Wave3aHandlers.Handlers.ProbeErrors`).
+    * HTTP router dispatch — POST /v1/handlers/describe_tool with the
+      proxy-shaped body (`{"arguments": {"tool_name": ...}}`).
+
+  Mocking strategy mirrors `get_server_info_test.exs`: `meck` with
+  `:passthrough` stubs `ProbeClient.describe_tool/1` directly.
+  """
+
+  use ExUnit.Case, async: false
+  import Plug.Test
+  import Plug.Conn
+
+  alias Wave3aHandlers.Handlers.DescribeTool
+  alias Wave3aHandlers.HTTPRouter
+
+  @opts HTTPRouter.init([])
+  @bearer "test-bearer-token-do-not-use-in-prod"
+
+  # Fixture mirroring the Python probe's `/v1/probe/describe_tool` `data`
+  # payload — the masked `handle_describe_tool` lite output.
+  @describe_data %{
+    "success" => true,
+    "server_time" => "<MASKED_TIMESTAMP>",
+    "agent_signature" => %{"uuid" => nil},
+    "tool" => "list_tools",
+    "description" => "List all available governance tools",
+    "tier" => "common",
+    "operation" => "read",
+    "parameters" => ["tier: string", "lite: boolean"],
+    "note" => "Lite mode - use describe_tool(tool_name=..., lite=false) for full schema"
+  }
+
+  @probe_envelope %{
+    "ok" => true,
+    "protocol_version" => "wave3a.v1",
+    "data" => @describe_data
+  }
+
+  setup do
+    Application.put_env(:wave3a_handlers, :beam_token, @bearer)
+    on_exit(fn -> :meck.unload() end)
+    :ok
+  end
+
+  defp authed(conn), do: put_req_header(conn, "authorization", "Bearer #{@bearer}")
+  defp parsed(conn), do: Jason.decode!(conn.resp_body)
+
+  defp stub_probe_ok(envelope \\ @probe_envelope) do
+    :meck.new(Wave3aHandlers.ProbeClient, [:passthrough])
+    :meck.expect(Wave3aHandlers.ProbeClient, :describe_tool, fn _tool_name -> {:ok, envelope} end)
+  end
+
+  # Stub that echoes the forwarded tool_name back into the payload so the
+  # test can assert the argument actually reached ProbeClient.describe_tool/1.
+  defp stub_probe_echo do
+    :meck.new(Wave3aHandlers.ProbeClient, [:passthrough])
+
+    :meck.expect(Wave3aHandlers.ProbeClient, :describe_tool, fn tool_name ->
+      {:ok, %{"ok" => true, "protocol_version" => "wave3a.v1", "data" => %{"tool" => tool_name}}}
+    end)
+  end
+
+  defp stub_probe_error(reason) do
+    :meck.new(Wave3aHandlers.ProbeClient, [:passthrough])
+
+    :meck.expect(Wave3aHandlers.ProbeClient, :describe_tool, fn _tool_name -> {:error, reason} end)
+  end
+
+  describe "DescribeTool.call/1 argument handling" do
+    test "pulls tool_name from arguments and forwards it to the probe" do
+      stub_probe_echo()
+
+      assert {:ok, body, 200} = DescribeTool.call(%{"tool_name" => "health_check"})
+      assert body == %{"tool" => "health_check"}
+    end
+
+    test "missing tool_name short-circuits with a 400 invalid_arguments envelope" do
+      stub_probe_ok()
+
+      assert {:ok, body, 400} = DescribeTool.call(%{})
+      assert body[:error] == "invalid_arguments"
+      assert body[:reason] == "tool_name is required"
+      # No probe call should have been made on the short-circuit path.
+      refute :meck.called(Wave3aHandlers.ProbeClient, :describe_tool, :_)
+    end
+
+    test "empty tool_name short-circuits with a 400 (no probe call)" do
+      stub_probe_ok()
+
+      assert {:ok, body, 400} = DescribeTool.call(%{"tool_name" => ""})
+      assert body[:error] == "invalid_arguments"
+      refute :meck.called(Wave3aHandlers.ProbeClient, :describe_tool, :_)
+    end
+
+    test "non-binary tool_name short-circuits with a 400" do
+      stub_probe_ok()
+
+      assert {:ok, _body, 400} = DescribeTool.call(%{"tool_name" => 123})
+    end
+  end
+
+  describe "DescribeTool.call/1 non-tool_name-argument delegation (parity guard)" do
+    test "an extra key alongside tool_name → 422 delegated_to_python (no probe call)" do
+      stub_probe_ok()
+
+      assert {:ok, body, 422} =
+               DescribeTool.call(%{"tool_name" => "list_tools", "lite" => false})
+
+      assert body[:error] == "delegated_to_python"
+      assert body[:forwarded] == false
+      # The probe must NOT be consulted when an unforwarded arg is present.
+      refute :meck.called(Wave3aHandlers.ProbeClient, :describe_tool, :_)
+    end
+
+    test "include_schema / include_full_description also delegate" do
+      stub_probe_ok()
+
+      for args <- [
+            %{"tool_name" => "list_tools", "include_schema" => true},
+            %{"tool_name" => "list_tools", "include_full_description" => true}
+          ] do
+        assert {:ok, %{error: "delegated_to_python"}, 422} = DescribeTool.call(args)
+      end
+
+      refute :meck.called(Wave3aHandlers.ProbeClient, :describe_tool, :_)
+    end
+
+    test "an extra key WITHOUT tool_name still delegates (422, not 400)" do
+      stub_probe_ok()
+
+      # The unforwarded-arg guard runs before the tool_name check, so the
+      # caller is delegated to Python (which owns both the filter handling and
+      # the canonical missing-tool_name error) rather than served a 400 here.
+      assert {:ok, %{error: "delegated_to_python"}, 422} =
+               DescribeTool.call(%{"lite" => false})
+
+      refute :meck.called(Wave3aHandlers.ProbeClient, :describe_tool, :_)
+    end
+  end
+
+  describe "DescribeTool.call/1 success path" do
+    test "passes the probe data payload through verbatim" do
+      stub_probe_ok()
+
+      assert {:ok, body, 200} = DescribeTool.call(%{"tool_name" => "list_tools"})
+      assert body == @describe_data
+    end
+
+    test "does not forward the probe envelope wrapper" do
+      stub_probe_ok()
+
+      assert {:ok, body, 200} = DescribeTool.call(%{"tool_name" => "list_tools"})
+      refute Map.has_key?(body, "ok")
+      refute Map.has_key?(body, "protocol_version")
+      refute Map.has_key?(body, "data")
+    end
+
+    test "semantic-error payload (success: false) rides through data unchanged" do
+      # An unknown tool returns the Python error_response shape under `data`;
+      # the handler surfaces it as a 200 (the probe call itself succeeded).
+      error_payload = %{
+        "success" => false,
+        "error" => "Unknown tool: nope",
+        "recovery" => %{"action" => "Call list_tools to see available tool names"}
+      }
+
+      stub_probe_ok(%{"ok" => true, "protocol_version" => "wave3a.v1", "data" => error_payload})
+
+      assert {:ok, body, 200} = DescribeTool.call(%{"tool_name" => "nope"})
+      assert body == error_payload
+    end
+  end
+
+  describe "DescribeTool.call/1 error paths (shared ProbeErrors mapping)" do
+    test "ProbeClient.timeout → 504 with stable error tag" do
+      stub_probe_error(:timeout)
+
+      assert {:ok, body, 504} = DescribeTool.call(%{"tool_name" => "list_tools"})
+      assert body[:error] == "probe_timeout"
+    end
+
+    test "ProbeClient.connect_error → 502" do
+      stub_probe_error(:connect_error)
+
+      assert {:ok, body, 502} = DescribeTool.call(%{"tool_name" => "list_tools"})
+      assert body[:error] == "probe_unavailable"
+    end
+
+    test "ProbeClient.{:non_200, status} surfaces the upstream status code" do
+      stub_probe_error({:non_200, 503})
+
+      assert {:ok, body, 502} = DescribeTool.call(%{"tool_name" => "list_tools"})
+      assert body[:error] == "probe_non_200"
+      assert body[:probe_status] == 503
+    end
+  end
+
+  describe "HTTP router dispatch" do
+    test "POST /v1/handlers/describe_tool returns the §2.2 success envelope" do
+      stub_probe_ok()
+
+      resp =
+        :post
+        |> conn(
+          "/v1/handlers/describe_tool",
+          Jason.encode!(%{"arguments" => %{"tool_name" => "list_tools"}})
+        )
+        |> put_req_header("content-type", "application/json")
+        |> authed()
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 200
+      body = parsed(resp)
+
+      assert body["ok"] == true
+      assert body["protocol_version"] == "wave3a.v1"
+      refute Map.has_key?(body, "data")
+      assert body["tool"] == "list_tools"
+    end
+
+    test "missing tool_name surfaces as ok: false / 400 through the router" do
+      stub_probe_ok()
+
+      resp =
+        :post
+        |> conn("/v1/handlers/describe_tool", Jason.encode!(%{"arguments" => %{}}))
+        |> put_req_header("content-type", "application/json")
+        |> authed()
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 400
+      body = parsed(resp)
+      assert body["ok"] == false
+      assert body["protocol_version"] == "wave3a.v1"
+      assert body["error"] == "invalid_arguments"
+    end
+
+    test "an extra argument surfaces as ok: false / 422 (Python-fallback trigger)" do
+      stub_probe_ok()
+
+      resp =
+        :post
+        |> conn(
+          "/v1/handlers/describe_tool",
+          Jason.encode!(%{"arguments" => %{"tool_name" => "list_tools", "lite" => false}})
+        )
+        |> put_req_header("content-type", "application/json")
+        |> authed()
+        |> HTTPRouter.call(@opts)
+
+      # 422 is non-2xx → the Python proxy's raise_for_status fires
+      # (wave3a_beam_proxy.py::_call_beam) → fallback to the in-process handler.
+      assert resp.status == 422
+      body = parsed(resp)
+      assert body["ok"] == false
+      assert body["protocol_version"] == "wave3a.v1"
+      assert body["error"] == "delegated_to_python"
+    end
+  end
+end

--- a/elixir/wave3a_handlers/test/handlers/list_tools_test.exs
+++ b/elixir/wave3a_handlers/test/handlers/list_tools_test.exs
@@ -1,0 +1,238 @@
+defmodule Wave3aHandlers.Handlers.ListToolsTest do
+  @moduledoc """
+  ExUnit coverage for the third BEAM-side handler (RFC §5 PR #7).
+
+  Covers (mirrors `get_server_info_test.exs`):
+
+    * Mocked ProbeClient.list_tools/0 returns a fixture envelope → the
+      handler passes the `data` payload through verbatim (success path).
+    * The probe envelope wrapper (`ok` / `protocol_version`) is NOT
+      forwarded into the body — §2.6 parity requires the flat payload.
+    * Arguments are accepted and ignored (mirrors `get_server_info`).
+    * Probe failure atoms map to the shared typed envelopes
+      (`Wave3aHandlers.Handlers.ProbeErrors`).
+    * HTTP router dispatch — POST /v1/handlers/list_tools with a mocked
+      probe goes end-to-end via Plug.Test and returns the §2.2 envelope.
+
+  Mocking strategy mirrors `get_server_info_test.exs`: `meck` with
+  `:passthrough` stubs `ProbeClient.list_tools/0` directly.
+  """
+
+  use ExUnit.Case, async: false
+  import Plug.Test
+  import Plug.Conn
+
+  alias Wave3aHandlers.Handlers.ListTools
+  alias Wave3aHandlers.HTTPRouter
+
+  @opts HTTPRouter.init([])
+  @bearer "test-bearer-token-do-not-use-in-prod"
+
+  # Fixture mirroring the Python probe's `/v1/probe/list_tools` `data`
+  # payload. The probe CALLS `handle_list_tools({})` and surfaces its
+  # `success_response` output verbatim, with `server_time` masked by the
+  # probe's `mask_timestamps` helper — hence the `<MASKED_TIMESTAMP>` literal
+  # and the deterministic `agent_signature: {"uuid": null}` (no bound caller
+  # in the probe context).
+  @list_tools_data %{
+    "success" => true,
+    "server_time" => "<MASKED_TIMESTAMP>",
+    "agent_signature" => %{"uuid" => nil},
+    "tools" => [
+      %{"name" => "start_session", "hint" => "Create your identity", "tier" => "essential"},
+      %{"name" => "list_tools", "hint" => "List available tools", "tier" => "common"}
+    ],
+    "total_available" => 24,
+    "shown" => 2,
+    "more" => "list_tools(lite=false) for all tools with full category details",
+    "tip" => "describe_tool(tool_name=...) for parameter details and examples"
+  }
+
+  @probe_envelope %{
+    "ok" => true,
+    "protocol_version" => "wave3a.v1",
+    "data" => @list_tools_data
+  }
+
+  setup do
+    Application.put_env(:wave3a_handlers, :beam_token, @bearer)
+    on_exit(fn -> :meck.unload() end)
+    :ok
+  end
+
+  defp authed(conn), do: put_req_header(conn, "authorization", "Bearer #{@bearer}")
+  defp parsed(conn), do: Jason.decode!(conn.resp_body)
+
+  defp stub_probe_ok(envelope \\ @probe_envelope) do
+    :meck.new(Wave3aHandlers.ProbeClient, [:passthrough])
+    :meck.expect(Wave3aHandlers.ProbeClient, :list_tools, fn -> {:ok, envelope} end)
+  end
+
+  defp stub_probe_error(reason) do
+    :meck.new(Wave3aHandlers.ProbeClient, [:passthrough])
+    :meck.expect(Wave3aHandlers.ProbeClient, :list_tools, fn -> {:error, reason} end)
+  end
+
+  describe "ListTools.call/1 success path" do
+    test "passes the probe data payload through verbatim" do
+      stub_probe_ok()
+
+      assert {:ok, body, 200} = ListTools.call(%{})
+      assert body == @list_tools_data
+    end
+
+    test "does not forward the probe envelope wrapper" do
+      stub_probe_ok()
+
+      assert {:ok, body, 200} = ListTools.call(%{})
+      refute Map.has_key?(body, "ok")
+      refute Map.has_key?(body, "protocol_version")
+      refute Map.has_key?(body, "data")
+    end
+
+    test "empty arguments map serves from the probe (default-argument case)" do
+      stub_probe_ok()
+
+      assert {:ok, body, 200} = ListTools.call(%{})
+      assert body == @list_tools_data
+    end
+
+    test "two calls in a row produce identical responses (idempotent)" do
+      stub_probe_ok()
+
+      {:ok, body_a, status_a} = ListTools.call(%{})
+      {:ok, body_b, status_b} = ListTools.call(%{})
+
+      assert status_a == status_b
+      assert body_a == body_b
+    end
+  end
+
+  describe "ListTools.call/1 non-default-argument delegation (parity guard)" do
+    test "non-empty arguments map → 422 delegated_to_python (no probe call)" do
+      stub_probe_ok()
+
+      assert {:ok, body, 422} = ListTools.call(%{"tier" => "essential"})
+      assert body[:error] == "delegated_to_python"
+      assert body[:reason] == "non-default arguments not served on BEAM path"
+      assert body[:forwarded] == false
+      # The probe must NOT be consulted on the delegation path.
+      refute :meck.called(Wave3aHandlers.ProbeClient, :list_tools, [])
+    end
+
+    test "any single non-default filter triggers delegation" do
+      stub_probe_ok()
+
+      for args <- [
+            %{"essential_only" => true},
+            %{"lite" => false},
+            %{"progressive" => true},
+            %{"tier" => "common", "lite" => false}
+          ] do
+        assert {:ok, %{error: "delegated_to_python"}, 422} = ListTools.call(args)
+      end
+
+      refute :meck.called(Wave3aHandlers.ProbeClient, :list_tools, [])
+    end
+  end
+
+  describe "ListTools.call/1 error paths (shared ProbeErrors mapping)" do
+    test "ProbeClient.timeout → 504 with stable error tag" do
+      stub_probe_error(:timeout)
+
+      assert {:ok, body, 504} = ListTools.call(%{})
+      assert body[:error] == "probe_timeout"
+      assert body[:reason] == "Python probe exceeded 500ms budget"
+    end
+
+    test "ProbeClient.probe_token_unset → 503" do
+      stub_probe_error(:probe_token_unset)
+
+      assert {:ok, body, 503} = ListTools.call(%{})
+      assert body[:error] == "service_unavailable"
+    end
+
+    test "ProbeClient.connect_error → 502" do
+      stub_probe_error(:connect_error)
+
+      assert {:ok, body, 502} = ListTools.call(%{})
+      assert body[:error] == "probe_unavailable"
+    end
+
+    test "ProbeClient.{:non_200, status} surfaces the upstream status code" do
+      stub_probe_error({:non_200, 503})
+
+      assert {:ok, body, 502} = ListTools.call(%{})
+      assert body[:error] == "probe_non_200"
+      assert body[:probe_status] == 503
+    end
+
+    test "ProbeClient.envelope_invalid → 502" do
+      stub_probe_error(:envelope_invalid)
+
+      assert {:ok, body, 502} = ListTools.call(%{})
+      assert body[:error] == "probe_envelope_invalid"
+    end
+  end
+
+  describe "HTTP router dispatch" do
+    test "POST /v1/handlers/list_tools returns the §2.2 success envelope" do
+      stub_probe_ok()
+
+      resp =
+        :post
+        |> conn("/v1/handlers/list_tools", "{}")
+        |> put_req_header("content-type", "application/json")
+        |> authed()
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 200
+      body = parsed(resp)
+
+      assert body["ok"] == true
+      assert body["protocol_version"] == "wave3a.v1"
+      refute Map.has_key?(body, "data")
+      assert body["total_available"] == 24
+      assert is_list(body["tools"])
+    end
+
+    test "probe failure surfaces as ok: false at the probe-mapped status" do
+      stub_probe_error(:connect_error)
+
+      resp =
+        :post
+        |> conn("/v1/handlers/list_tools", "{}")
+        |> put_req_header("content-type", "application/json")
+        |> authed()
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 502
+      body = parsed(resp)
+      assert body["ok"] == false
+      assert body["protocol_version"] == "wave3a.v1"
+      assert body["error"] == "probe_unavailable"
+    end
+
+    test "non-default arguments surface as ok: false / 422 (Python-fallback trigger)" do
+      stub_probe_ok()
+
+      resp =
+        :post
+        |> conn(
+          "/v1/handlers/list_tools",
+          Jason.encode!(%{"arguments" => %{"tier" => "essential"}})
+        )
+        |> put_req_header("content-type", "application/json")
+        |> authed()
+        |> HTTPRouter.call(@opts)
+
+      # 422 is non-2xx → the Python proxy's raise_for_status fires
+      # (wave3a_beam_proxy.py::_call_beam) → fallback to the in-process handler.
+      assert resp.status == 422
+      body = parsed(resp)
+      assert body["ok"] == false
+      assert body["protocol_version"] == "wave3a.v1"
+      assert body["error"] == "delegated_to_python"
+    end
+  end
+end

--- a/src/mcp_handlers/wave3a_probe.py
+++ b/src/mcp_handlers/wave3a_probe.py
@@ -585,6 +585,100 @@ async def _tool_registry(request: Request) -> JSONResponse:
     )
 
 
+def _extract_handler_payload(result: Any) -> Dict[str, Any]:
+    """Parse the JSON payload out of an MCP handler's ``TextContent`` return.
+
+    The in-process introspection handlers (``handle_list_tools`` /
+    ``handle_describe_tool``) build their payload inline and wrap it with
+    ``success_response`` / ``error_response`` — there is no separable builder
+    like ``build_server_info_payload``. The faithful way to single-source the
+    payload (§2.6 byte-parity: "call the same function, do not reconstruct")
+    is therefore to invoke the handler and surface its own output verbatim.
+
+    Each handler returns a ``Sequence[TextContent]`` whose first element
+    carries the JSON response in ``.text`` — exactly the bytes the MCP
+    transport wrapper (``src/tool_registration.py``) ``json.loads`` before
+    returning to the client. We decode the same bytes here so the probe
+    payload is the handler's payload by construction (both the success and
+    the semantic-error shapes pass through unchanged).
+    """
+    if isinstance(result, (list, tuple)) and result:
+        first = result[0]
+        text = getattr(first, "text", None)
+        if isinstance(text, str):
+            try:
+                decoded = json.loads(text)
+            except (TypeError, ValueError):
+                return {"text": text}
+            if isinstance(decoded, dict):
+                return decoded
+            return {"data": decoded}
+    return {"error": "handler_returned_unexpected_shape"}
+
+
+async def _list_tools(request: Request) -> JSONResponse:
+    start = time.monotonic()
+    endpoint = f"{PROBE_PREFIX}/list_tools"
+    auth_err = _auth_or_response(request)
+    if auth_err is not None:
+        return _record_and_return(
+            request, auth_err, endpoint=endpoint, start_monotonic=start
+        )
+
+    # §2.6 parity: single-source the payload by CALLING the same handler the
+    # in-process MCP dispatch uses. ``handle_list_tools`` builds its payload
+    # inline (no separable builder), so the probe invokes it and passes its
+    # output through verbatim — never reconstructs it. Arguments are the
+    # handler defaults (lite=true, progressive=false): the BEAM-side handler
+    # ignores caller args (mirrors ``get_server_info``), so the parity unit
+    # is the default-argument response. Lazy import so test patches at module
+    # scope work.
+    from src.mcp_handlers.introspection.tool_introspection import handle_list_tools
+
+    result = await handle_list_tools({})
+    payload = _extract_handler_payload(result)
+    # The ``success_response`` envelope adds a volatile ``server_time``; mask
+    # it (and any other timestamp/UUID/PID) so the response is byte-
+    # deterministic across calls — same determinism contract as
+    # ``tool_registry`` (§2.6).
+    masked = mask_timestamps(payload)
+    response = JSONResponse(_envelope_ok(masked), status_code=200)
+    return _record_and_return(
+        request, response, endpoint=endpoint, start_monotonic=start
+    )
+
+
+async def _describe_tool(request: Request) -> JSONResponse:
+    start = time.monotonic()
+    endpoint = f"{PROBE_PREFIX}/describe_tool"
+    auth_err = _auth_or_response(request)
+    if auth_err is not None:
+        return _record_and_return(
+            request, auth_err, endpoint=endpoint, start_monotonic=start
+        )
+
+    # ``tool_name`` is the only caller-supplied argument forwarded by the
+    # BEAM ``describe_tool`` handler. Read it from the query string and pass
+    # it to the SAME handler the MCP dispatch uses. Missing / unknown
+    # ``tool_name`` is handled INSIDE ``handle_describe_tool`` (it returns the
+    # canonical ``error_response``), so the probe surfaces that error verbatim
+    # rather than reconstructing it — byte-parity holds on both the success
+    # and the semantic-error paths. Lazy import so test patches at module
+    # scope work.
+    from src.mcp_handlers.introspection.tool_introspection import (
+        handle_describe_tool,
+    )
+
+    tool_name = request.query_params.get("tool_name")
+    result = await handle_describe_tool({"tool_name": tool_name})
+    payload = _extract_handler_payload(result)
+    masked = mask_timestamps(payload)
+    response = JSONResponse(_envelope_ok(masked), status_code=200)
+    return _record_and_return(
+        request, response, endpoint=endpoint, start_monotonic=start
+    )
+
+
 # ---------------------------------------------------------------------------
 # Route registration
 # ---------------------------------------------------------------------------
@@ -603,6 +697,8 @@ def register_wave3a_probe_routes(app) -> None:
         Route(f"{PROBE_PREFIX}/health_snapshot", _health_snapshot, methods=["GET"]),
         Route(f"{PROBE_PREFIX}/server_info", _server_info, methods=["GET"]),
         Route(f"{PROBE_PREFIX}/tool_registry", _tool_registry, methods=["GET"]),
+        Route(f"{PROBE_PREFIX}/list_tools", _list_tools, methods=["GET"]),
+        Route(f"{PROBE_PREFIX}/describe_tool", _describe_tool, methods=["GET"]),
     ]
     for route in routes:
         if route.path in existing_paths:

--- a/src/wave3a_routing.py
+++ b/src/wave3a_routing.py
@@ -71,8 +71,18 @@ _ENV_FLAG_ROUTES: Dict[str, Dict[str, str]] = {
         "tool_name": "get_server_info",
         "beam_url": "http://127.0.0.1:8770/v1/handlers/get_server_info",
     },
-    # PR #7/#8 add their rows here. Each row independent so the operator
-    # can cut over handlers one at a time and roll them back independently.
+    # RFC §5 PR #7 — third cutover.
+    "WAVE_3A_LIST_TOOLS_ON_BEAM": {
+        "tool_name": "list_tools",
+        "beam_url": "http://127.0.0.1:8770/v1/handlers/list_tools",
+    },
+    # RFC §5 PR #8 — fourth (final) cutover, completes the §1.1 wave3a set.
+    "WAVE_3A_DESCRIBE_TOOL_ON_BEAM": {
+        "tool_name": "describe_tool",
+        "beam_url": "http://127.0.0.1:8770/v1/handlers/describe_tool",
+    },
+    # Each row independent so the operator can cut over handlers one at a
+    # time and roll them back independently.
 }
 
 

--- a/tests/integration/test_wave_3a_probe.py
+++ b/tests/integration/test_wave_3a_probe.py
@@ -90,6 +90,8 @@ AUTHED_ENDPOINTS = [
     f"{PROBE_PREFIX}/health_snapshot",
     f"{PROBE_PREFIX}/server_info",
     f"{PROBE_PREFIX}/tool_registry",
+    f"{PROBE_PREFIX}/list_tools",
+    f"{PROBE_PREFIX}/describe_tool",
 ]
 
 LIVENESS_ENDPOINT = f"{PROBE_PREFIX}/health"
@@ -328,6 +330,137 @@ class TestServerInfoProbeProcessFlag:
         body = response.json()
         assert "meta" in body
         assert body["meta"].get("probe_process") is True
+
+
+# ---------------------------------------------------------------------------
+# Case 9 — list_tools / describe_tool envelope + parity-source (PR #7/#8)
+# ---------------------------------------------------------------------------
+
+
+class TestListToolsEnvelope:
+    """list_tools probe single-sources its payload by CALLING the in-process
+    ``handle_list_tools`` and surfacing its output verbatim (§2.6 parity)."""
+
+    def test_list_tools_envelope(self, client: TestClient, token_set: str) -> None:
+        response = client.get(
+            f"{PROBE_PREFIX}/list_tools", headers=_bearer(VALID_TOKEN)
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["ok"] is True
+        assert body["protocol_version"] == PROTOCOL_VERSION
+        assert "data" in body
+        data = body["data"]
+        assert isinstance(data, dict)
+        # Forbid a nested envelope.
+        assert "ok" not in data
+        assert "protocol_version" not in data
+        # The handler's own payload rode through: lite list_tools carries
+        # `tools` and the `success_response` envelope `success` flag.
+        assert "tools" in data
+        assert data.get("success") is True
+        # `server_time` is masked for byte-determinism (§2.6).
+        assert data.get("server_time") == "<MASKED_TIMESTAMP>"
+
+
+class TestDescribeToolEnvelope:
+    """describe_tool probe forwards ``tool_name`` to the in-process
+    ``handle_describe_tool`` and surfaces both success and semantic-error
+    shapes verbatim."""
+
+    def test_describe_tool_known_tool(
+        self, client: TestClient, token_set: str
+    ) -> None:
+        response = client.get(
+            f"{PROBE_PREFIX}/describe_tool",
+            params={"tool_name": "list_tools"},
+            headers=_bearer(VALID_TOKEN),
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["ok"] is True
+        assert body["protocol_version"] == PROTOCOL_VERSION
+        data = body["data"]
+        assert data.get("success") is True
+        assert data.get("tool") == "list_tools"
+        assert "parameters" in data
+
+    def test_describe_tool_missing_name_returns_canonical_error(
+        self, client: TestClient, token_set: str
+    ) -> None:
+        # No tool_name query param → the handler's own `error_response`
+        # ("tool_name is required") rides through `data`. The probe envelope
+        # is still ok=True (the probe call itself succeeded); the semantic
+        # failure is inside `data.success`.
+        response = client.get(
+            f"{PROBE_PREFIX}/describe_tool", headers=_bearer(VALID_TOKEN)
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["ok"] is True
+        data = body["data"]
+        assert data.get("success") is False
+        assert "tool_name is required" in data.get("error", "")
+
+    def test_describe_tool_unknown_tool_returns_canonical_error(
+        self, client: TestClient, token_set: str
+    ) -> None:
+        response = client.get(
+            f"{PROBE_PREFIX}/describe_tool",
+            params={"tool_name": "no_such_tool_xyz"},
+            headers=_bearer(VALID_TOKEN),
+        )
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert data.get("success") is False
+        assert "Unknown tool" in data.get("error", "")
+
+
+class TestListToolsDescribeToolDeterminism:
+    """§2.6 + determinism: list_tools / describe_tool must be byte-equal
+    across two calls (the masked `server_time` is the only volatile field;
+    `agent_signature` is the deterministic unbound `{"uuid": null}`). Same
+    contract as the tool_registry determinism guard."""
+
+    def test_list_tools_two_calls_byte_equal(
+        self, client: TestClient, token_set: str
+    ) -> None:
+        import json
+
+        first = client.get(
+            f"{PROBE_PREFIX}/list_tools", headers=_bearer(VALID_TOKEN)
+        )
+        second = client.get(
+            f"{PROBE_PREFIX}/list_tools", headers=_bearer(VALID_TOKEN)
+        )
+        assert first.status_code == 200 and second.status_code == 200
+        assert json.dumps(first.json(), sort_keys=True) == json.dumps(
+            second.json(), sort_keys=True
+        ), (
+            "list_tools response differed across calls — a non-deterministic "
+            "field escaped masking; extend _VOLATILE_FIELD_NAMES or "
+            "_VOLATILE_SUFFIXES in src/mcp_handlers/wave3a_probe.py"
+        )
+
+    def test_describe_tool_two_calls_byte_equal(
+        self, client: TestClient, token_set: str
+    ) -> None:
+        import json
+
+        first = client.get(
+            f"{PROBE_PREFIX}/describe_tool",
+            params={"tool_name": "list_tools"},
+            headers=_bearer(VALID_TOKEN),
+        )
+        second = client.get(
+            f"{PROBE_PREFIX}/describe_tool",
+            params={"tool_name": "list_tools"},
+            headers=_bearer(VALID_TOKEN),
+        )
+        assert first.status_code == 200 and second.status_code == 200
+        assert json.dumps(first.json(), sort_keys=True) == json.dumps(
+            second.json(), sort_keys=True
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Finishes the Wave-3a MCP-handler strangler — `list_tools` and `describe_tool` join `health_check` + `get_server_info` on the BEAM listener (`elixir/wave3a_handlers`). **Flags default OFF** (routing rows added only); the live cutover (`WAVE_3A_LIST_TOOLS_ON_BEAM` / `WAVE_3A_DESCRIBE_TOOL_ON_BEAM`) is a separate operator step, like the prior cutovers. Part of the 2026-06-29 "standing track" cadence on the BEAM migration.

## §2.6 byte-parity

`handle_list_tools` / `handle_describe_tool` build their payload inline (no separable builder like `build_server_info_payload`), so the new probe endpoints (`/v1/probe/list_tools`, `/v1/probe/describe_tool`) **invoke the same handler** and surface its `TextContent` JSON verbatim — never reconstruct it. Timestamps are masked probe-side per the existing `tool_registry` precedent.

## First arg-taking handlers — the parity guard

`health_check`/`get_server_info` ignore arguments; these two don't (`list_tools`: tier/essential_only/lite/progressive; `describe_tool`: tool_name + lite/include_schema). To avoid silently serving a **default** response to a caller who passed filters, the BEAM handlers **delegate to Python on any non-default argument**:
- `list_tools` with a non-empty args map → `422 delegated_to_python`
- `describe_tool` with any key besides `tool_name` → `422 delegated_to_python`

`wave3a_beam_proxy.py::_call_beam` `raise_for_status` treats any non-2xx as a fallback trigger (→ `fallback_reason="non_200"`), so the in-process Python handler then runs and honours every argument. **BEAM serves the common default/`tool_name`-only case; Python serves arg-passing calls — no silent divergence either way.** This is the safe completion for arg-taking tools (vs brittle typed-arg-forwarding across the GET query boundary).

## Tests

`mix test` → **83 / 0**. Python wave3a suite → **57 passed, 1 skipped**. Added: handler tests (happy path + delegation cases), probe envelope/known-tool/missing-tool/unknown-tool + two-call determinism, router-level 422 assertions.

## Not in scope

- Cutover (flag flips) — operator step.
- Full typed-arg-forwarding — deliberately replaced by the delegate-on-args guard; these are the strangler's lowest-value handlers and arg-passing calls are correctly served by Python.

https://claude.ai/code/session_01VdKuDaD3BMoGRwidFSJBUe