### PR TITLE
Skip silence alerts for event-driven residents

### DIFF
--- a/src/background_tasks.py
+++ b/src/background_tasks.py
@@ -1206,16 +1206,26 @@ def _get_expected_interval(meta) -> int | None:
     """Return expected check-in interval for persistent agents, None for ephemeral.
 
     Priority:
-      1. ``cadence.*`` tag (generic, label-independent)
-      2. Hardcoded label fallback (back-compat; retires with tag migration)
-      3. ``embodied`` / ``autonomous`` tag → 300s default
+      1. resident-progress event-driven labels -> no heartbeat interval
+      2. ``cadence.*`` tag (generic, label-independent)
+      3. Hardcoded label fallback (back-compat; retires with tag migration)
+      4. ``embodied`` / ``autonomous`` tag -> 300s default
     """
+    label = getattr(meta, "label", None)
+    if label:
+        try:
+            from src.resident_progress.registry import is_event_driven_label
+
+            if is_event_driven_label(label):
+                return None
+        except Exception:
+            pass
     tags = meta.tags or []
     tagged_cadence = cadence_from_tags(tags)
     if tagged_cadence is not None:
         return tagged_cadence
-    if meta.label and meta.label in _PERSISTENT_AGENT_INTERVALS:
-        return _PERSISTENT_AGENT_INTERVALS[meta.label]
+    if label and label in _PERSISTENT_AGENT_INTERVALS:
+        return _PERSISTENT_AGENT_INTERVALS[label]
     if "embodied" in tags or "autonomous" in tags:
         return 300  # default for embodied/autonomous agents
     return None  # ephemeral — skip

--- a/tests/test_agent_lifecycle.py
+++ b/tests/test_agent_lifecycle.py
@@ -207,7 +207,7 @@ class TestCadenceFromTags:
 
 
 # ============================================================================
-# _get_expected_interval — tag > label fallback > embodied/autonomous default
+# _get_expected_interval — event-driven > tag > label fallback > embodied/autonomous default
 # ============================================================================
 
 class TestExpectedInterval:
@@ -230,10 +230,10 @@ class TestExpectedInterval:
         meta = _protection_meta(label="Lumen", tags=[])
         assert _get_expected_interval(meta) == 300
 
-    def test_watcher_label_falls_back_to_hook_cadence(self):
-        """Watcher is hook-driven; autonomous tag must not force 5-minute daemon cadence."""
+    def test_watcher_event_driven_registry_suppresses_cadence(self):
+        """Watcher is hook-driven; cadence fallback must not page between edits."""
         meta = _protection_meta(label="Watcher", tags=["persistent", "autonomous"])
-        assert _get_expected_interval(meta) == 21600
+        assert _get_expected_interval(meta) is None
 
     def test_falls_back_to_embodied_default(self):
         meta = _protection_meta(label="SomeEmbodied", tags=["embodied"])

--- a/tests/test_background_tasks_silence.py
+++ b/tests/test_background_tasks_silence.py
@@ -196,6 +196,23 @@ async def test_non_persistent_agent_skipped(isolated_silence_state):
 
 
 @pytest.mark.asyncio
+async def test_event_driven_resident_skips_silence_monitor(isolated_silence_state):
+    """Watcher is event-driven; absence of check-ins between edits is not silence."""
+    broadcaster, _ = isolated_silence_state
+
+    stale = datetime.now(timezone.utc) - timedelta(hours=30)
+    meta = _make_meta("watcher-uuid", "Watcher", stale.isoformat())
+    meta.tags = ["persistent", "autonomous"]
+    agent_metadata["watcher-uuid"] = meta
+
+    await background_tasks._silence_check_iteration()
+
+    broadcaster.broadcast_event.assert_not_awaited()
+    assert "watcher-uuid" not in background_tasks._silence_alerted
+    assert "watcher-uuid" not in background_tasks._silence_critical_alerted
+
+
+@pytest.mark.asyncio
 async def test_repeat_iteration_does_not_refire(isolated_silence_state):
     """Once an agent has fired CRITICAL, subsequent iterations stay quiet."""
     broadcaster, _ = isolated_silence_state


### PR DESCRIPTION
## Summary
- make the generic lifecycle silence monitor skip residents registered as event-driven in the resident-progress manifest
- keep Watcher from inheriting a label/autonomous 5-minute heartbeat cadence between edit-triggered runs
- add regression coverage for Watcher silence suppression

## Tests
- python3 -m pytest tests/test_agent_lifecycle.py tests/test_background_tasks_silence.py -q
- ./scripts/dev/test-cache.sh
- ./scripts/dev/test-cache.sh --staged
- pre-push smoke tests: 138 passed