### PR TITLE
identity: low-risk simplification-council wins (dedup verify, doc honesty)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,10 @@ Operational rules:
 1. Start each driver with `start_session(force_new=true)` (`onboard` is the
    canonical tool underneath). Save the returned `uuid` and `client_session_id`.
 2. For later check-ins and writes in the same running process, pass
-   `client_session_id`. Adapters should do this automatically.
+   `client_session_id`. Adapters should do this automatically. If your adapter
+   does not thread it, you fall back to the weak transport-fingerprint pin and
+   can fragment under co-residency — check `session_source`/`tier` in the
+   onboard response to confirm you bound as expected.
 3. To continue prior work in a fresh process, mint fresh and declare the cause:
    `start_session(force_new=true, parent_agent_id=<prior_uuid>, spawn_reason="new_session")`.
    Use this only for a real handoff from a finished predecessor.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,10 @@ Operational rules:
 1. Start each driver with `start_session(force_new=true)` (`onboard` is the
    canonical tool underneath). Save the returned `uuid` and `client_session_id`.
 2. For later check-ins and writes in the same running process, pass
-   `client_session_id`. Adapters should do this automatically.
+   `client_session_id`. Adapters should do this automatically. If your adapter
+   does not thread it, you fall back to the weak transport-fingerprint pin and
+   can fragment under co-residency — check `session_source`/`tier` in the
+   onboard response to confirm you bound as expected.
 3. To continue prior work in a fresh process, mint fresh and declare the cause:
    `start_session(force_new=true, parent_agent_id=<prior_uuid>, spawn_reason="new_session")`.
    Use this only for a real handoff from a finished predecessor.

--- a/src/mcp_handlers/decorators.py
+++ b/src/mcp_handlers/decorators.py
@@ -349,8 +349,8 @@ def get_call_identity_requirement(tool_name: str, arguments) -> str:
 def _resolve_canonical_and_action(tool_name: str, arguments):
     """Canonical tool name + resolved action for a CALL — the shared seam.
 
-    Both the #425 identity resolver and the #775 stakes resolver agree on which
-    canonical (tool, action) a call maps to, or their decisions diverge on
+    Both the #425 identity resolver and the #775 stakes resolver MUST agree on
+    which canonical (tool, action) a call maps to, or their decisions diverge on
     aliased calls. This helper is the single canonicalization point used by both
     resolvers; `test_action_level_identity.py` and `test_stakes_table.py` pin
     the important alias/default-action behavior from each gate's perspective.

--- a/src/mcp_handlers/identity/session.py
+++ b/src/mcp_handlers/identity/session.py
@@ -289,26 +289,19 @@ def extract_token_agent_uuid(token: str) -> Optional[str]:
     `verify_token_fresh(token)` rather than tightening this function. Callers
     that rely on resume-after-long-idle will regress silently if `exp` starts
     being enforced here.
+
+    Routes through `_decode_token_payload` (like `extract_token_iat`/`_exp`) so
+    the HMAC/version/decode verify lives in exactly one place — and, per that
+    helper's contract, expiry is NOT checked here (the resume-after-idle
+    invariant above is preserved).
     """
-    if not token or not isinstance(token, str):
+    payload = _decode_token_payload(token)
+    if payload is None:
         return None
-    secret = _get_continuity_secret()
-    if not secret:
+    aid = payload.get("aid")
+    if not aid or not isinstance(aid, str):
         return None
-    try:
-        version, payload_b64, sig_b64 = token.split(".", 2)
-        if version != "v1":
-            return None
-        expected_sig = _b64url_encode(hmac.new(secret, payload_b64.encode(), hashlib.sha256).digest())
-        if not hmac.compare_digest(expected_sig, sig_b64):
-            return None
-        payload = json.loads(_b64url_decode(payload_b64).decode())
-        aid = payload.get("aid")
-        if not aid or not isinstance(aid, str):
-            return None
-        return aid
-    except Exception:
-        return None
+    return aid
 
 
 def extract_token_agent_uuid_safe(token: object) -> Optional[str]:

--- a/src/mcp_handlers/schemas/identity.py
+++ b/src/mcp_handlers/schemas/identity.py
@@ -43,8 +43,23 @@ class IdentityParams(AgentIdentityMixin):
 
 
 class OnboardParams(AgentIdentityMixin):
-    """
-    Single entry point for new agents
+    """Single entry point for new agents.
+
+    The schema exposes many fields, but the "Strict Identity, Simple Contract"
+    normal path uses only a few — the rest are adapter/advanced-only. So the
+    surface a reader sees matches the contract the docs describe:
+
+    - Normal path: `force_new` (mint fresh — the default posture for a new
+      process), and on later calls `client_session_id` (the write binding,
+      threaded by adapters). For a real handoff from a finished predecessor:
+      `parent_agent_id` + `spawn_reason`.
+    - Advanced / adapter-only: `name` (cosmetic), `model_type`, `client_hint`,
+      `resume`, `orchestrated`, `thread_id`, `trajectory_signature`,
+      `process_fingerprint`, `initial_state`, `response_mode`. Ordinary
+      interactive callers should not need these.
+
+    See docs/ontology/identity.md ("Strict Identity, Simple Contract" + the
+    identifier reference table) for which identifier to pass when.
     """
     name: Optional[str] = Field(
         default=None,


### PR DESCRIPTION
## Summary

Implements the small, genuine, low-risk wins from the identity-layer **simplification council** (verdict: *already simplified where it counts; the complexity is incident-earned, not gratuitous*). These are the only local changes the council backed — it explicitly **rejected** the `bind_session` merge and the three-resolver merge, and left the real architectural lever (UUID-keyed storage migration) to deliberate, Wave-3-gated advancement.

### Changes

- **`session.py` — token-verify dedup (the one with teeth).** `extract_token_agent_uuid` hand-rolled its own HMAC/version/decode, despite the module claiming (L209-211) its extractors single-source verify through `_decode_token_payload`. Routed it through that helper so security-critical verify lives in **one** place. **Behavior-preserving** across every branch (valid / expired / tampered-sig / wrong-version / non-dict payload / missing-aid / non-str): `_decode_token_payload` does **not** check expiry (preserving the PR #42 Part-C resume-after-idle invariant the docstring guards), and its `isinstance(dict)` check subsumes the old `.get`-on-non-dict→except→None path.
- **`schemas/identity.py` — `OnboardParams` docstring.** Annotated the normal-path fields (`force_new`, `client_session_id`, `parent_agent_id`, `spawn_reason`) vs the advanced/adapter-only ones, so the surface a reader sees matches the "Strict Identity, Simple Contract." Pure doc; no resolution logic changed.
- **`CLAUDE.md` + `AGENTS.md` (shared contract, parity-checked).** Note that an adapter not threading `client_session_id` falls back to the weak transport pin and can fragment under co-residency — check `session_source`/`tier` in the onboard response. Turns a silent deferred failure into a checkable property.
- **`decorators.py` — restore dropped "MUST"** in `_resolve_canonical_and_action`'s docstring (the #1307 review nit), so the shared-seam rationale reads correctly rather than as a tautology.

## Testing

`pytest` is unavailable in this container (fresh clone, deps not installed), so CI is the full gate. Locally verified: `py_compile` clean on all touched modules; `scripts/dev/check-shared-contract.sh` → "in sync (152 lines)"; and the token dedup checked **branch-by-branch** for equivalence against the prior inline logic.

## Not in scope (council guidance)

- `continuity_token`-as-resume retirement is **already in flight** (S1-a/S1-c shipped); only the operator sunset-flag flip remains — and the anti-hijack Role-3 path must be kept. Not touched here.
- UUID-keyed storage migration (the genuine altitude move) — already proposed; deliberate Wave-3-gated, not rushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019yEvz5tQNVwQdisKeWLrC2)_