### PR TITLE
fix(inference): stop the blocking Ollama probe from stalling the event loop

### DIFF
--- a/src/mcp_handlers/support/inference_registry.py
+++ b/src/mcp_handlers/support/inference_registry.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass, replace
 import os
 import socket
+import time
 from typing import Any
 
 from .host_adapter import host_adapter_available, host_adapter_enabled
@@ -37,7 +38,12 @@ class InferenceHost:
         return asdict(self)
 
 
-def _ollama_available() -> bool:
+_OLLAMA_PROBE_TTL_S = 5.0
+# {"ts": monotonic seconds of last probe, "available": last result, "primed": bool}
+_ollama_probe_cache: dict[str, Any] = {"ts": 0.0, "available": False, "primed": False}
+
+
+def _probe_ollama_socket() -> bool:
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.settimeout(0.5)
@@ -46,6 +52,29 @@ def _ollama_available() -> bool:
         return result == 0
     except Exception:
         return False
+
+
+def _ollama_available() -> bool:
+    """Reachability of the local Ollama endpoint, cached for a short TTL.
+
+    The probe is a BLOCKING socket connect (up to 500ms when Ollama is down). It
+    is reached from every host-registry read — including the unauthenticated
+    ``pre_onboard`` tools ``list_inference_hosts`` / ``describe_inference_host``.
+    Caching bounds how often we re-probe so the blocking call cannot be amplified
+    into event-loop pressure by repeated calls, and so a single host lookup or a
+    success-path routing check does not re-run the socket connect. Async callers
+    should still offload the first (cache-priming) probe off the loop — see the
+    ``asyncio.to_thread`` use in the handlers.
+    """
+    now = time.monotonic()
+    cache = _ollama_probe_cache
+    if cache["primed"] and (now - cache["ts"]) < _OLLAMA_PROBE_TTL_S:
+        return bool(cache["available"])
+    available = _probe_ollama_socket()
+    cache["ts"] = now
+    cache["available"] = available
+    cache["primed"] = True
+    return available
 
 
 def _hf_token_present() -> bool:

--- a/src/mcp_handlers/support/model_inference.py
+++ b/src/mcp_handlers/support/model_inference.py
@@ -12,6 +12,7 @@ Usage tracked in EISV (Energy consumption) for self-regulation.
 
 from typing import Dict, Any, Sequence
 from mcp.types import TextContent
+import asyncio
 import hashlib
 import os
 import time
@@ -19,6 +20,7 @@ import time
 from ..utils import success_response, error_response, require_argument
 from ..decorators import mcp_tool
 from .inference_registry import (
+    _ollama_available,
     get_inference_host,
     host_for_routed_provider,
     list_inference_hosts,
@@ -49,7 +51,11 @@ async def handle_list_inference_hosts(arguments: Dict[str, Any]) -> Sequence[Tex
             "0", "false", "no",
         )
     provider_kind = arguments.get("provider_kind")
-    hosts = list_inference_hosts(
+    # list_inference_hosts() runs a blocking Ollama socket probe; offload it off
+    # the event loop so this unauthenticated pre_onboard read can't stall the
+    # anyio task group (see CLAUDE.md "Substrate Tax" + the cached probe).
+    hosts = await asyncio.to_thread(
+        list_inference_hosts,
         include_unconfigured=bool(include_unconfigured),
         provider_kind=provider_kind,
     )
@@ -68,7 +74,9 @@ async def handle_describe_inference_host(arguments: Dict[str, Any]) -> Sequence[
     if error:
         return [error]
 
-    host = get_inference_host(str(host_id))
+    # get_inference_host() runs a blocking Ollama socket probe; offload it (same
+    # reasoning as list_inference_hosts above — unauthenticated pre_onboard read).
+    host = await asyncio.to_thread(get_inference_host, str(host_id))
     if host is None:
         return [error_response(
             f"Inference host '{host_id}' is not registered",
@@ -232,18 +240,10 @@ async def handle_call_model(arguments: Dict[str, Any]) -> Sequence[TextContent]:
             model = f"{model}:fastest"  # Auto-select fastest provider
         logger.info(f"Using Hugging Face Inference Providers: {model}")
     elif provider == "auto":
-        # Auto-select: Try Ollama first (local, free), then Gemini, then HF
-        # Check if Ollama is available
-        ollama_available = False
-        try:
-            import socket
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.settimeout(0.5)
-            result = sock.connect_ex(('localhost', 11434))
-            sock.close()
-            ollama_available = (result == 0)
-        except Exception:
-            pass
+        # Auto-select: Try Ollama first (local, free), then Gemini, then HF.
+        # Reuse the registry's cached probe instead of a second inline socket
+        # connect — same source of truth, and it benefits from the TTL cache.
+        ollama_available = _ollama_available()
 
         if ollama_available:
             # Prefer Ollama (local, free, no token needed)

--- a/tests/test_model_inference.py
+++ b/tests/test_model_inference.py
@@ -70,6 +70,19 @@ def _make_mock_response(content="Test response", tokens=42, model="gemini-flash"
     return mock_response
 
 
+@pytest.fixture(autouse=True)
+def _reset_ollama_probe_cache():
+    """The registry caches its blocking Ollama probe for a short TTL. Reset it
+    before each test so socket-mocked availability is re-evaluated per test
+    rather than served stale from a prior test within the TTL window."""
+    from src.mcp_handlers.support import inference_registry
+
+    inference_registry._ollama_probe_cache.update(
+        {"ts": 0.0, "available": False, "primed": False}
+    )
+    yield
+
+
 # =============================================================================
 # Tests: OpenAI SDK unavailable
 # =============================================================================
@@ -167,6 +180,37 @@ class TestInferenceHostRegistry:
         parsed = _parse_text_content(result)
         assert parsed["success"] is False
         assert parsed["error_code"] == "INFERENCE_HOST_NOT_FOUND"
+
+    @pytest.mark.asyncio
+    async def test_describe_inference_host_known_returns_host(self):
+        """Positive path: a registered host_id resolves and reflects availability."""
+        with patch(
+            "src.mcp_handlers.support.inference_registry._ollama_available",
+            return_value=True,
+        ):
+            from src.mcp_handlers.support.model_inference import handle_describe_inference_host
+
+            result = await handle_describe_inference_host({"host_id": "ollama:local"})
+
+        parsed = _parse_text_content(result)
+        assert parsed["success"] is True
+        assert parsed["host"]["host_id"] == "ollama:local"
+        assert parsed["host"]["provider_kind"] == "ollama"
+        assert parsed["host"]["available"] is True
+
+    def test_ollama_available_caches_probe_within_ttl(self):
+        """The blocking socket probe runs once within the TTL, not per call —
+        the bound on event-loop pressure from repeated host-registry reads."""
+        from src.mcp_handlers.support import inference_registry
+
+        with patch.object(
+            inference_registry, "_probe_ollama_socket", return_value=True
+        ) as probe:
+            assert inference_registry._ollama_available() is True
+            assert inference_registry._ollama_available() is True
+            assert inference_registry._ollama_available() is True
+
+        assert probe.call_count == 1
 
 
 # =============================================================================


### PR DESCRIPTION
Follow-up to the review of the inference host registry (merged as #1304; it was also bundled in the now-closed #1308).

## Problem
`inference_registry._ollama_available()` does a **synchronous `socket.connect_ex`** (500ms timeout when Ollama is down), reached via `_base_hosts()` on every host-registry read — including the **unauthenticated `pre_onboard`** tools `list_inference_hosts` / `describe_inference_host`. So an unidentified caller can repeatedly stall the anyio task group, and a single `describe_inference_host` lookup (or the success-path `host_for_routed_provider` check) re-runs the probe needlessly. This is exactly the blocking-I/O-on-the-loop pattern `CLAUDE.md`'s "Substrate Tax" warns about.

## Fix
1. **TTL-cache the probe** (5s) in `inference_registry` — repeated reads don't re-probe, so the blocking call can't be amplified, and host lookups / success-path checks reuse the result. `_ollama_available()` serves the cache; `_probe_ollama_socket()` is the raw connect.
2. **Offload off the loop** in the two `pre_onboard` handlers via `asyncio.to_thread`, so the unauthenticated read path never blocks the event loop (the `run_in_executor` pattern from the Substrate Tax doc).
3. **Dedupe** the second inline socket probe in `call_model`'s `auto` branch to reuse the cached `_ollama_available()`.

## Tests
- Autouse fixture resets the probe cache per test (so existing socket-mocked auto-selection tests stay per-test).
- New: positive `describe_inference_host(host_id="ollama:local")` path, and a cache-bound regression (probe runs **once** within the TTL).
- Focused green: `test_model_inference` 57, `test_action_level_identity` 21; ruff clean. Full gate via CI.

Draft per the repo contract — maintainer is the merge gate.

https://claude.ai/code/session_016hEfHU8KZFZV2DXMmsBM8W