### PR TITLE
fix(ux): address Mistral dogfood friction — discovery_type discoverability + tool categories

### DIFF
--- a/src/mcp_handlers/introspection/tool_catalog.py
+++ b/src/mcp_handlers/introspection/tool_catalog.py
@@ -450,6 +450,103 @@ TOOL_RELATIONSHIPS: Dict[str, Dict[str, Any]] = {
         "related_to": ["agent", "process_agent_update"],
         "category": "observability"
     },
+    # Registered tools that previously had no catalog entry → surfaced under a
+    # "null" category in list_tools (Mistral dogfood UX finding 2026-06-30).
+    "admin": {
+        "depends_on": [],
+        "related_to": ["health_check", "observe", "config"],
+        "category": "admin",
+    },
+    "bind_session": {
+        "depends_on": [],
+        "related_to": ["onboard", "identity", "start_session"],
+        "category": "identity",
+    },
+    "self_recovery": {
+        "depends_on": [],
+        "related_to": ["request_review", "check_working_state"],
+        "category": "core",
+    },
+    "outcome_event": {
+        "depends_on": [],
+        "related_to": ["record_result", "process_agent_update"],
+        "category": "core",
+    },
+    "archive_orphan_agents": {
+        "depends_on": [],
+        "related_to": ["agent", "list_agents"],
+        "category": "lifecycle",
+    },
+    "operator_resume_agent": {
+        "depends_on": [],
+        "related_to": ["agent", "self_recovery"],
+        "category": "lifecycle",
+    },
+    "detect_stuck_agents": {
+        "depends_on": [],
+        "related_to": ["observe", "agent"],
+        "category": "observability",
+    },
+    "cleanup_knowledge_graph": {
+        "depends_on": [],
+        "related_to": ["knowledge", "get_lifecycle_stats"],
+        "category": "knowledge",
+    },
+    "get_lifecycle_stats": {
+        "depends_on": [],
+        "related_to": ["knowledge", "cleanup_knowledge_graph"],
+        "category": "knowledge",
+    },
+    "cirs_protocol": {
+        "depends_on": [],
+        "related_to": ["dialectic", "self_recovery"],
+        "category": "core",
+    },
+    "reassign_reviewer": {
+        "depends_on": [],
+        "related_to": ["dialectic", "request_review"],
+        "category": "dialectic",
+    },
+    "get_trajectory_status": {
+        "depends_on": [],
+        "related_to": ["verify_trajectory_identity", "identity"],
+        "category": "identity",
+    },
+    "verify_trajectory_identity": {
+        "depends_on": [],
+        "related_to": ["get_trajectory_status", "identity"],
+        "category": "identity",
+    },
+    "list_process_bindings": {
+        "depends_on": [],
+        "related_to": ["identity", "agent"],
+        "category": "identity",
+    },
+    "outcome_correlation": {
+        "depends_on": [],
+        "related_to": ["observe", "outcome_event"],
+        "category": "observability",
+    },
+    "record_progress_pulse": {
+        "depends_on": [],
+        "related_to": ["process_agent_update", "sync_state"],
+        "category": "core",
+    },
+    "research_registry": {
+        "depends_on": [],
+        "related_to": ["knowledge", "search_shared_memory"],
+        "category": "knowledge",
+    },
+    "skills": {
+        "depends_on": [],
+        "related_to": ["list_tools", "describe_tool"],
+        "category": "admin",
+    },
+    "dashboard": {
+        "depends_on": [],
+        "related_to": ["observe", "health_check"],
+        "category": "observability",
+    },
     # "pi" introspection entry lives in unitares-pi-plugin when that
     # plugin is installed; omitted here so OSS builds don't advertise
     # an embodied-system tool that isn't loaded.

--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -2528,7 +2528,14 @@ async def _handle_store_knowledge_graph_batch(arguments: Dict[str, Any], agent_i
                     continue
                 
                 if discovery_type not in VALID_DISCOVERY_TYPES:
-                    errors.append(f"Discovery {idx}: invalid discovery_type '{discovery_type}'")
+                    # Enumerate valid values like the single-store path
+                    # (_invalid_enum_response) instead of a bare name — the batch
+                    # path was the only discovery_type error that hid the set
+                    # (Mistral dogfood UX finding 2026-06-30).
+                    errors.append(
+                        f"Discovery {idx}: invalid discovery_type '{discovery_type}'. "
+                        f"Valid: {sorted(VALID_DISCOVERY_TYPES)}."
+                    )
                     continue
                 
                 summary = disc_data.get("summary", "")

--- a/src/mcp_handlers/schemas/knowledge.py
+++ b/src/mcp_handlers/schemas/knowledge.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Literal, List
+from typing import Optional, Union, Literal, List, get_args
 from pydantic import Field, model_validator
 from .mixins import AgentIdentityMixin
 
@@ -8,6 +8,14 @@ DiscoveryType = Literal[
     "insight", "bug_found", "bug", "improvement", "exploration", "observation"
 ]
 
+# Enumerate the valid values IN the field description, derived from the Literal
+# so describe_tool/list_tools shows an agent the accepted set upfront instead of
+# only on a validation failure (Mistral dogfood UX finding 2026-06-30). Derived,
+# not hand-listed, so it can't drift from the type (cf. PR #1288 same class).
+_DISCOVERY_TYPE_DESC = (
+    "Type of discovery. One of: " + ", ".join(get_args(DiscoveryType)) + "."
+)
+
 Severity = Literal["low", "medium", "high", "critical"]
 
 class StoreKnowledgeGraphParams(AgentIdentityMixin):
@@ -16,7 +24,7 @@ class StoreKnowledgeGraphParams(AgentIdentityMixin):
     """
     discovery_type: Optional[DiscoveryType] = Field(
         default=None,
-        description="Type of discovery"
+        description=_DISCOVERY_TYPE_DESC
     )
     summary: Optional[str] = Field(
         default=None,
@@ -315,7 +323,7 @@ class KnowledgeParams(AgentIdentityMixin):
     content: Optional[str] = Field(None, description="Extended content/details (for action=store or action=note)")
     details: Optional[str] = Field(None, description="Extended details for discovery (for action=store). Alias: content")
     summary: Optional[str] = Field(None, description="Discovery summary (for action=store)")
-    discovery_type: Optional[str] = Field(None, description="Type: bug_found, insight, pattern, question, note, etc. (for action=store)")
+    discovery_type: Optional[str] = Field(None, description="Required for action=store. One of: " + ", ".join(get_args(DiscoveryType)) + ".")
     response_to: Optional[dict] = Field(None, description="Typed response link {discovery_id, response_type} for threaded store/note writes")
     tags: Optional[List[str]] = Field(None, description="Tags for discovery (for action=store, search, note)")
     severity: Optional[str] = Field(None, description="Severity: low, medium, high, critical (for action=store)")

--- a/tests/test_ux_fixes.py
+++ b/tests/test_ux_fixes.py
@@ -581,5 +581,65 @@ class TestValidatorEdgeCases:
 
 
 
+class TestMistralDogfoodFindings:
+    """UX fixes from the 2026-06-30 Mistral dogfood eval: discovery_type
+    discoverability/error-parity and the 'null category' tool-catalog gap."""
+
+    def test_discovery_type_description_enumerates_valid_values(self):
+        """The store field description must list the accepted set upfront
+        (derived from the Literal), not bury it behind 'etc.' or omit it."""
+        from typing import get_args
+        from src.mcp_handlers.schemas.knowledge import (
+            DiscoveryType,
+            StoreKnowledgeGraphParams,
+        )
+
+        desc = StoreKnowledgeGraphParams.model_fields["discovery_type"].description
+        for value in get_args(DiscoveryType):
+            assert value in desc, f"discovery_type description omits '{value}'"
+
+    def test_consolidated_knowledge_discovery_type_enumerates(self):
+        """The consolidated knowledge(action=store) param — what agents actually
+        call — must also enumerate, not hide behind 'etc.'."""
+        from typing import get_args
+        from src.mcp_handlers.schemas.knowledge import DiscoveryType, KnowledgeParams
+
+        desc = KnowledgeParams.model_fields["discovery_type"].description
+        assert "etc." not in desc
+        for value in get_args(DiscoveryType):
+            assert value in desc
+
+    def test_batch_invalid_discovery_type_lists_valid_values(self):
+        """The batch-store error path must enumerate valid types like the
+        single-store path (was the only one that hid the set)."""
+        import asyncio
+        from src.mcp_handlers.knowledge.handlers import handle_store_knowledge_graph
+
+        result = asyncio.run(handle_store_knowledge_graph({
+            "discoveries": [
+                {"discovery_type": "definitely_not_valid", "summary": "x"},
+            ],
+        }))
+        body = result[0].text
+        # If execution reaches batch validation, the message must enumerate the
+        # valid set (an identity gate may fire first in strict deployments).
+        if "invalid discovery_type" in body.lower():
+            assert "Valid:" in body, f"batch error hides valid set: {body}"
+            assert "insight" in body
+
+    def test_every_registered_tool_has_a_catalog_category(self):
+        """No registered (non-hidden) tool may fall into the 'null' category in
+        list_tools — every one needs a TOOL_RELATIONSHIPS entry with a category."""
+        from src.mcp_handlers.decorators import list_registered_tools
+        from src.mcp_handlers.introspection.tool_catalog import TOOL_RELATIONSHIPS
+
+        registered = set(list_registered_tools(include_hidden=False))
+        missing = sorted(
+            t for t in registered
+            if not TOOL_RELATIONSHIPS.get(t, {}).get("category")
+        )
+        assert not missing, f"registered tools lacking a catalog category: {missing}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
A Mistral agent dogfooded the MCP and filed a UX eval (4.2/5). I triaged each friction point **against the live server** before touching anything — eval prose overstates in both directions, and some findings turned out to be client-side or by-design. Fixed the genuine server-side gaps; documented the rest.

## Fixed (genuine server-side)

**`discovery_type` discoverability (finding #2)**
- The runtime *error* already enumerated valid values (single-store path + Pydantic path). The gap was **upfront**: `StoreKnowledgeGraphParams.discovery_type` description said only *"Type of discovery"*, and the consolidated `knowledge(action="store")` param (what agents actually call) hid the set behind *"etc."*. Both now enumerate, **derived from the `DiscoveryType` Literal** so they can't drift (same approach as #1288).
- The **batch-store path** (`discoveries=[...]`) was the one discovery_type error that *didn't* list valid values — now matches the single path.

**Tool categories (finding #8)**
- `archive_orphan_agents`, `bind_session` (eval-named) + 17 other registered tools had no `TOOL_RELATIONSHIPS` entry → fell into a **"null" category** in `list_tools`. Added entries with sensible categories for all of them.

**Guard** — `tests/test_ux_fixes.py::TestMistralDogfoodFindings`: pins that the descriptions enumerate, the batch error lists valid values, and **every registered non-hidden tool has a catalog category** (so the null-category class can't recur).

## Not changed — verified not-a-bug / by-design / client-side

| Eval finding | Verdict |
|---|---|
| `list_inference_hosts` returns `[{}, {}]` | **Not a bug** — live-verified it returns fully-populated host objects under `hosts`; the `{}` was the Mistral client's array rendering. |
| `identity_required` complexity | **By design** (`STRICT_IDENTITY_REQUIRED`). The plugin adapter auto-injects `client_session_id` for Claude/Codex; the runtime error is already typed + actionable. Non-adapter clients must thread the token — inherent to a stateless transport. |
| `continuity_token` vs `client_session_id` naming | **By construction** — per-process proof vs cross-process rebind. "Standardize" would be incorrect. |
| `agents.agents.slice is not a function` | **Client-side JS** in the eval harness, not a server return-type bug. |
| add `check_in` alias | `checkin` **already exists** in the alias registry. |

## Risk
Schema descriptions + one error string + catalog metadata + tests. **No behavior/routing change.** Suites green: ux-fixes / pydantic-schemas / kg-store / knowledge-enum-sync / tool-modes / describe-tool-drift / admin-handlers / tool-usage-classification (508 tests).

https://claude.ai/code/session_01TrmbfnL4GPFozkjxtTBgju