### PR TITLE
ops(plist): set ProcessType=Interactive on governance-mcp template

### DIFF
--- a/scripts/ops/com.unitares.governance-mcp.plist
+++ b/scripts/ops/com.unitares.governance-mcp.plist
@@ -34,6 +34,14 @@
     <key>KeepAlive</key>
     <true/>
 
+    <!-- Place the server in the Interactive jetsam band so macOS does not
+         pick it first under memory pressure. With ProcessType unset (Standard),
+         a large in-process model/embedding footprint can make this the fattest
+         process and the first jetsam target, killing it without a watchdog
+         signal. Interactive raises its survival priority. -->
+    <key>ProcessType</key>
+    <string>Interactive</string>
+
     <key>StandardOutPath</key>
     <string>/PATH/TO/UNITARES/data/logs/mcp_server.log</string>
 


### PR DESCRIPTION
## What

Add `<key>ProcessType</key><string>Interactive</string>` to the shipped `scripts/ops/com.unitares.governance-mcp.plist` template.

## Why

With `ProcessType` unset, the LaunchAgent runs in the **Standard** jetsam band. A large in-process model/embedding footprint can make the governance server the fattest process on the machine, so macOS jetsam selects it **first** under memory pressure — killing it silently, with no watchdog signal (the failure mode previously seen as unexplained "MCP drops"). `Interactive` raises its survival priority.

The **live deployment already carries this fix**; this PR lands it in the shipped template so anyone else deploying inherits the protection.

## Provenance

Rescued from an **uncommitted edit** that was sitting in the shared working checkout on an already-merged branch — it would have been lost on any `git reset`/branch switch. Master's template did not have it. Comment reworded to be self-contained (dropped an internal cross-reference).

Draft — maintainer merge gate. Ops-config only; no code paths touched.

https://claude.ai/code/session_01JFPiq984CL9Jzc4Ebo7gDG