### PR TITLE
fix(ollama-bridge): map checkin/get_metrics to live tool names

### DIFF
--- a/scripts/client/ollama_bridge.py
+++ b/scripts/client/ollama_bridge.py
@@ -215,7 +215,7 @@ def make_wrappers(mcp_tools: dict, identity: "IdentityConfig", session: "Session
             complexity: How complex the task was, from 0.0 (trivial) to 1.0 (very hard)
             confidence: How confident you are in your work, from 0.0 to 1.0 (default 0.7)
         """
-        return mcp_tools["process_agent_update"](**session.bind(
+        return mcp_tools["sync_state"](**session.bind(
             response_text=description,
             complexity=complexity,
             confidence=confidence,
@@ -224,7 +224,7 @@ def make_wrappers(mcp_tools: dict, identity: "IdentityConfig", session: "Session
     @tool
     def get_metrics() -> str:
         """Get your current EISV state vector, coherence, risk score, and verdict."""
-        return mcp_tools["get_governance_metrics"](**session.bind())
+        return mcp_tools["check_working_state"](**session.bind(include_state="true", lite="true"))
 
     @tool
     def search_knowledge(query: str) -> str:

--- a/tests/test_ollama_bridge_script.py
+++ b/tests/test_ollama_bridge_script.py
@@ -121,8 +121,8 @@ def test_wrappers_echo_session_id_on_writes():
         return _f
 
     mcp_tools = {n: rec(n) for n in (
-        "health_check", "onboard", "identity", "process_agent_update",
-        "get_governance_metrics", "knowledge", "leave_note", "agent",
+        "health_check", "onboard", "identity", "sync_state",
+        "check_working_state", "knowledge", "leave_note", "agent",
         "describe_tool",
     )}
     identity = bridge.IdentityConfig()  # fresh new_session
@@ -133,7 +133,7 @@ def test_wrappers_echo_session_id_on_writes():
     assert session.client_session_id == "csid-9"
 
     tools["checkin"]("verified", 0.3, 0.8)
-    assert calls["process_agent_update"]["client_session_id"] == "csid-9"
+    assert calls["sync_state"]["client_session_id"] == "csid-9"
 
     tools["list_agents"]()
     assert calls["agent"]["client_session_id"] == "csid-9"


### PR DESCRIPTION
## Problem

`scripts/client/ollama_bridge.py` (the smolagents bridge that lets a local Ollama model act as a governed agent) had two wrappers calling **removed legacy tool names**:

| wrapper | called | should call |
|---|---|---|
| `checkin` | `process_agent_update` ❌ | `sync_state` |
| `get_metrics` | `get_governance_metrics` ❌ | `check_working_state` |

These are the legacy halves of the friendly-alias map in `CLAUDE.md` (`sync_state -> process_agent_update`, `check_working_state -> get_governance_metrics`). The MCP surface exposes the friendly names; the legacy names aren't in the tool collection, so both wrappers raised `KeyError` at call time.

`onboard` worked, so the bridge *looked* functional — but the two core governance loops (check-in and state read) were dead. Any local model using the bridge would fail the moment it tried to check in or read its EISV state.

## Fix

Point both wrappers at the live names; `get_metrics` passes `include_state`/`lite` for a useful summary. 2-line change + test update.

## Verification

- **Live**: `gemma4` via the bridge runs `register_agent → get_metrics → checkin` with zero tool errors; `get_metrics` returns real EISV (coherence 0.4985, risk 0.2412, verdict present).
- **Unit**: updated the test's fake tool surface to the live names; `tests/test_ollama_bridge_script.py` 10/10, plus `test_param_aliases.py` + `test_describe_tool_drift.py` green (35 passed).

https://claude.ai/code/session_01U688kgvVK2W24doyV592Hd