### PR TITLE
feat(ux): surface provisional-verdict caveat + reflection in experience envelope

### DIFF
--- a/src/mcp_handlers/middleware/envelope_step.py
+++ b/src/mcp_handlers/middleware/envelope_step.py
@@ -171,6 +171,58 @@ def _recovery_hint(
     )
 
 
+def _verdict_caveat(source_payload: Dict[str, Any]) -> Optional[str]:
+    """Plain-language warning that the verdict is provisional, lifted from
+    risk_attribution to the envelope surface.
+
+    The self-disclosure already exists in the canonical payload, but it sits
+    three levels deep (risk_attribution.discriminability / .primary_driver).
+    A reader skimming the friendly state_summary alone would see a clean
+    'safe'/'proceed' and miss that the system is explicitly telling itself not
+    to trust that verdict yet (dogfood: a maxed self-reported ethical_drift
+    returned status=healthy with the only caveat buried in risk_attribution).
+    This re-exposes it where the skimmer actually looks; it computes no new
+    signal. Returns None when the verdict is NOT provisional (baseline warm).
+    """
+    attribution = source_payload.get("risk_attribution")
+    if not isinstance(attribution, dict):
+        return None
+    primary_driver = attribution.get("primary_driver")
+    discriminability = attribution.get("discriminability")
+    discriminability = discriminability if isinstance(discriminability, dict) else {}
+    cold_start = primary_driver == "phi_cold_start"
+    non_discriminative = discriminability.get("non_discriminative") is True
+    if not (cold_start or non_discriminative):
+        return None
+    until = discriminability.get("updates_until_baseline")
+    tail = ""
+    if isinstance(until, int) and until > 0:
+        tail = f" ~{until} more check-in(s) until the behavioral signal is weighted."
+    return (
+        "Verdict is provisional: the behavioral baseline isn't warm yet, so it "
+        "runs on the cold-start prior and risk_score is non-discriminative "
+        "during bootstrap. A 'safe'/'proceed' here means 'no evidence of trouble "
+        "yet', not a validated all-clear — don't read it as vindication of a high "
+        "self-reported drift. See raw_governance.risk_attribution for the full "
+        "provenance." + tail
+    )
+
+
+def _reflection(source_payload: Dict[str, Any]) -> Optional[str]:
+    """Lift the single mirror reflection to the envelope surface.
+
+    The reflection ("You're near a basin boundary. Proceed carefully.") is a
+    real actionable signal, but in the raw payload it lives only under
+    _mirror_reflection (full mode) or reflection (mirror mode) — invisible to a
+    reader of the friendly fields. Surface it as a top-level string when present.
+    """
+    for key in ("reflection", "_mirror_reflection", "_mirror_question"):
+        value = source_payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
 def _memory_suggestions(payload: Dict[str, Any]) -> Optional[List[Dict[str, Any]]]:
     """Surface prior discoveries the canonical payload already carries."""
     payload = _harvest_payload(payload)
@@ -329,6 +381,21 @@ def build_experience_envelope(
     risk_text = _risk_summary(coherence, risk)
     if risk_text:
         envelope["risk_summary"] = risk_text
+
+    # Provisional-verdict caveat: pull the cold-start / non-discriminative
+    # self-disclosure out of risk_attribution so a reader of state_summary
+    # alone is not misled by a clean 'safe'/'proceed'. Also flag it inside
+    # state_summary itself, where the skimmer actually looks.
+    caveat = _verdict_caveat(source_payload)
+    if caveat:
+        envelope["verdict_caveat"] = caveat
+        summary = envelope.get("state_summary")
+        if isinstance(summary, dict):
+            summary["verdict_provisional"] = True
+
+    reflection = _reflection(source_payload)
+    if reflection:
+        envelope["reflection"] = reflection
 
     suggestions = _memory_suggestions(payload)
     if suggestions:

--- a/tests/test_agent_experience_envelope.py
+++ b/tests/test_agent_experience_envelope.py
@@ -214,6 +214,73 @@ def test_sync_state_envelope_near_edge_proceed_hint_does_not_say_pause():
     assert "only if work stalls" in env["recovery_hint"]
 
 
+def test_sync_state_envelope_surfaces_provisional_verdict_caveat():
+    """A clean verdict riding on the cold-start prior must carry its caveat at
+    the envelope surface, not three levels deep in risk_attribution."""
+    payload = {
+        "success": True,
+        "decision": {"action": "proceed"},
+        "metrics": {"coherence": 0.7, "risk_score": 0.05, "verdict": "safe"},
+        "health_status": "healthy",
+        "risk_attribution": {
+            "primary_driver": "phi_cold_start",
+            "verdict": "safe",
+            "discriminability": {
+                "baselined": False,
+                "non_discriminative": True,
+                "updates_until_baseline": 4,
+            },
+        },
+    }
+    env = build_experience_envelope("sync_state", "process_agent_update", payload)
+    assert "verdict_caveat" in env
+    assert "provisional" in env["verdict_caveat"].lower()
+    assert "4 more check-in" in env["verdict_caveat"]
+    assert env["state_summary"]["verdict_provisional"] is True
+
+
+def test_sync_state_envelope_no_caveat_when_baseline_warm():
+    """Once the behavioral baseline is warm and discriminative, the verdict is
+    authoritative — no provisional caveat, no state_summary flag."""
+    payload = {
+        "success": True,
+        "decision": {"action": "proceed"},
+        "metrics": {"coherence": 0.8, "risk_score": 0.1, "verdict": "safe"},
+        "health_status": "healthy",
+        "risk_attribution": {
+            "primary_driver": "behavioral_assessment",
+            "verdict": "safe",
+            "discriminability": {
+                "baselined": True,
+                "non_discriminative": False,
+                "updates_until_baseline": 0,
+            },
+        },
+    }
+    env = build_experience_envelope("sync_state", "process_agent_update", payload)
+    assert "verdict_caveat" not in env
+    assert "verdict_provisional" not in env["state_summary"]
+
+
+def test_sync_state_envelope_surfaces_reflection():
+    """The mirror reflection is a real actionable signal but lives only under
+    _mirror_reflection/reflection in the raw payload — lift it to the surface."""
+    full_mode = {
+        "success": True,
+        "decision": {"action": "proceed"},
+        "metrics": {"coherence": 0.6, "risk_score": 0.2},
+        "_mirror_reflection": "You're near a basin boundary. Proceed carefully.",
+    }
+    env = build_experience_envelope("sync_state", "process_agent_update", full_mode)
+    assert env["reflection"] == "You're near a basin boundary. Proceed carefully."
+
+    mirror_mode = dict(full_mode)
+    del mirror_mode["_mirror_reflection"]
+    mirror_mode["reflection"] = "You're close to a governance edge."
+    env = build_experience_envelope("sync_state", "process_agent_update", mirror_mode)
+    assert env["reflection"] == "You're close to a governance edge."
+
+
 def test_sync_state_envelope_surfaces_discoveries():
     payload = {
         "success": True,


### PR DESCRIPTION
## Summary

A dogfood pass on the verdict UX (sonnet) reproduced two known gaps in the agent-experience envelope:

1. **Buried cold-start caveat.** A maxed self-reported `ethical_drift` ([0.9, 0.9, 0.9]) returned `status: healthy` / `verdict: safe` / `action: proceed`. The only "don't trust this verdict yet" disclosure lived three levels deep in `risk_attribution.discriminability` / `.primary_driver`. A reader skimming the friendly `state_summary` alone sees a clean verdict and misses that the system is explicitly telling itself the verdict is provisional (running on the Φ cold-start prior, behavioral baseline not warm).
2. **Buried reflection.** The mirror reflection (e.g. "You're near a basin boundary. Proceed carefully.") is a real actionable signal but appears only under `_mirror_reflection` (full mode) / `reflection` (mirror mode) in the raw payload — invisible to a reader of the friendly fields.

The experience envelope (`middleware/envelope_step.py`) is the friendly read surface, so both signals are lifted there.

## Changes

- **`verdict_caveat`** (top-level) — a plain-language provisional-verdict warning, emitted only when the verdict rides on `phi_cold_start` or a non-discriminative (bootstrap) baseline. Also sets `verdict_provisional: true` inside `state_summary`, where a skimmer actually looks. Stays silent once the baseline is warm and discriminative, so a real all-clear is not diluted.
- **`reflection`** (top-level) — lifts the mirror reflection when present (`reflection` / `_mirror_reflection` / `_mirror_question`).

Both harvest from values the canonical payload already carries — no new governance signal is computed, consistent with the envelope's translate-only contract. Fields are omitted when there is nothing to say.

## Scope notes

- Out of scope here: the `sync_state` vs `check_working_state` verdict disagreement (two governance-core computation paths) — that is a writer-locked core surface, not an envelope translation, and is left for a dedicated change.

## Tests

Added envelope tests for the provisional caveat surfacing (with `updates_until_baseline` countdown), the warm-baseline no-caveat case, and reflection lift in both full and mirror payload shapes. `test_agent_experience_envelope.py` (24), `test_response_formatter.py`, `test_risk_discriminability.py`, and `test_enrichments_mirror.py` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YcTkp1R5sj2bXMbVNdWkUW

---
_Generated by [Claude Code](https://claude.ai/code/session_01YcTkp1R5sj2bXMbVNdWkUW)_