### PR TITLE
fix: residents/gateway call advertised aliases, not raw twins dropped from the MCP wire (#1292 follow-up)

### DIFF
--- a/agents/sdk/src/unitares_sdk/client.py
+++ b/agents/sdk/src/unitares_sdk/client.py
@@ -453,7 +453,15 @@ class GovernanceClient:
         response_mode: str = "compact",
         **kwargs: Any,
     ) -> CheckinResult:
-        """Check in with governance. Maps to server tool: process_agent_update."""
+        """Check in with governance via the advertised ``sync_state`` tool.
+
+        ``sync_state`` is the promoted agent-facing alias of the raw
+        ``process_agent_update`` handler (same dispatch, same response shape;
+        see ToolAlias in tool_stability.py). We call the alias deliberately:
+        #1292 dropped the raw twin from the lite MCP wire, so calling
+        ``process_agent_update`` by raw name now fails ``Unknown tool`` on the
+        :8767 ``/mcp/`` surface residents use. Do NOT revert to the raw name.
+        """
         args: dict[str, Any] = {
             "response_text": response_text,
             "complexity": complexity,
@@ -462,8 +470,8 @@ class GovernanceClient:
         }
         args.update(kwargs)
 
-        raw = await self.call_tool("process_agent_update", args)
-        self._raise_for_tool_failure("process_agent_update", raw)
+        raw = await self.call_tool("sync_state", args)
+        self._raise_for_tool_failure("sync_state", raw)
 
         # #425: a strict-identity refusal comes back as a structured SUCCESS
         # shape (no isError, no "error" key), so _raise_for_tool_failure passes
@@ -489,8 +497,8 @@ class GovernanceClient:
             if self.continuity_token and not args.get("continuity_token"):
                 retry_args = dict(args)
                 retry_args["continuity_token"] = self.continuity_token
-                raw = await self.call_tool("process_agent_update", retry_args)
-                self._raise_for_tool_failure("process_agent_update", raw)
+                raw = await self.call_tool("sync_state", retry_args)
+                self._raise_for_tool_failure("sync_state", raw)
                 # Capture the rebound session so later calls this run ride it
                 # without re-presenting the token.
                 self._capture_identity(raw)
@@ -631,8 +639,13 @@ class GovernanceClient:
     # --- Metrics ---
 
     async def get_metrics(self, **kwargs: Any) -> MetricsResult:
-        """Get governance metrics. Maps to server tool: get_governance_metrics."""
-        raw = await self.call_tool("get_governance_metrics", kwargs)
+        """Get governance metrics via the advertised ``check_working_state`` alias.
+
+        Same handler as raw ``get_governance_metrics`` (ToolAlias in
+        tool_stability.py); the raw twin was dropped from the lite MCP wire by
+        #1292, so call the alias to avoid ``Unknown tool`` on :8767 ``/mcp/``.
+        """
+        raw = await self.call_tool("check_working_state", kwargs)
         return MetricsResult.model_validate(raw)
 
     # --- Model inference ---

--- a/agents/sdk/src/unitares_sdk/sync_client.py
+++ b/agents/sdk/src/unitares_sdk/sync_client.py
@@ -175,8 +175,11 @@ class SyncGovernanceClient:
             "response_mode": response_mode,
         }
         args.update(kwargs)
-        raw = self.call_tool("process_agent_update", args)
-        self._raise_for_tool_failure("process_agent_update", raw)
+        # sync_state: advertised alias of the raw process_agent_update handler.
+        # #1292 dropped the raw twin from the lite MCP wire; call the alias so
+        # residents don't hit "Unknown tool" on the :8767 /mcp/ surface.
+        raw = self.call_tool("sync_state", args)
+        self._raise_for_tool_failure("sync_state", raw)
 
         decision = raw.get("decision", {})
         verdict = decision.get("action", raw.get("verdict", "proceed"))
@@ -291,7 +294,9 @@ class SyncGovernanceClient:
     # --- Metrics ---
 
     def get_metrics(self, **kwargs: Any) -> MetricsResult:
-        raw = self.call_tool("get_governance_metrics", kwargs)
+        # check_working_state: advertised alias of get_governance_metrics.
+        # #1292 dropped the raw twin from the lite MCP wire (see client.py).
+        raw = self.call_tool("check_working_state", kwargs)
         return MetricsResult.model_validate(raw)
 
     # --- Model inference ---

--- a/agents/sdk/tests/test_client.py
+++ b/agents/sdk/tests/test_client.py
@@ -236,7 +236,9 @@ class TestOnboardFailureSurfaces:
 
 class TestToolMapping:
     @pytest.mark.asyncio
-    async def test_checkin_maps_to_process_agent_update(self):
+    async def test_checkin_maps_to_sync_state(self):
+        # #1292 dropped the raw process_agent_update twin from the lite MCP
+        # wire; checkin() must call the advertised sync_state alias instead.
         session = AsyncMock()
         session.call_tool = AsyncMock(return_value=make_mcp_result({
             "success": True,
@@ -249,11 +251,12 @@ class TestToolMapping:
         result = await client.checkin("did work", complexity=0.5)
         session.call_tool.assert_called_once()
         tool_name = session.call_tool.call_args[0][0]
-        assert tool_name == "process_agent_update"
+        assert tool_name == "sync_state"
         assert isinstance(result, CheckinResult)
 
     @pytest.mark.asyncio
-    async def test_get_metrics_maps_to_get_governance_metrics(self):
+    async def test_get_metrics_maps_to_check_working_state(self):
+        # #1292: raw get_governance_metrics off the lite wire; use the alias.
         session = AsyncMock()
         session.call_tool = AsyncMock(return_value=make_mcp_result({
             "success": True,
@@ -263,7 +266,7 @@ class TestToolMapping:
 
         await client.get_metrics()
         tool_name = session.call_tool.call_args[0][0]
-        assert tool_name == "get_governance_metrics"
+        assert tool_name == "check_working_state"
 
     @pytest.mark.asyncio
     async def test_search_knowledge_maps_to_knowledge_action_search(self):

--- a/agents/sdk/tests/test_sync_client.py
+++ b/agents/sdk/tests/test_sync_client.py
@@ -167,7 +167,9 @@ class TestSyncIdentityCapture:
 
 
 class TestSyncToolMapping:
-    def test_checkin_maps_to_process_agent_update(self):
+    def test_checkin_maps_to_sync_state(self):
+        # #1292 dropped the raw twin from the lite MCP wire; the alias resolves
+        # over both REST and MCP, so checkin() calls sync_state on all transports.
         client = SyncGovernanceClient(transport="rest")
         calls = []
 
@@ -181,10 +183,10 @@ class TestSyncToolMapping:
 
         client.call_tool = fake_call
         result = client.checkin("test")
-        assert calls[-1] == "process_agent_update"
+        assert calls[-1] == "sync_state"
         assert isinstance(result, CheckinResult)
 
-    def test_get_metrics_maps_to_get_governance_metrics(self):
+    def test_get_metrics_maps_to_check_working_state(self):
         client = SyncGovernanceClient(transport="rest")
         calls = []
 
@@ -194,7 +196,7 @@ class TestSyncToolMapping:
 
         client.call_tool = fake_call
         client.get_metrics()
-        assert calls[-1] == "get_governance_metrics"
+        assert calls[-1] == "check_working_state"
 
     def test_call_model_omits_none_provider(self):
         client = SyncGovernanceClient(transport="rest")

--- a/agents/sentinel/agent.py
+++ b/agents/sentinel/agent.py
@@ -893,7 +893,9 @@ async def adjudicate_finding(
     args = build_resolution_outcome_args(
         "sentinel_finding", status, fingerprint, agent.agent_uuid, reason
     )
-    await client.call_tool("outcome_event", args)
+    # record_result: advertised alias of outcome_event (raw twin dropped from
+    # the lite MCP wire by #1292).
+    await client.call_tool("record_result", args)
     log(f"recorded external-truth outcome ({status}) for sentinel finding {fingerprint}")
     return args
 

--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -396,7 +396,9 @@ def _emit_resolution_outcome(
             log("resolution outcome skipped: no resolved Watcher identity", "warning")
             return
         args = build_resolution_outcome_args(status, fingerprint, uuid, reason)
-        client.call_tool("outcome_event", args, timeout=15)
+        # record_result: advertised alias of outcome_event (raw twin dropped
+        # from the lite MCP wire by #1292).
+        client.call_tool("record_result", args, timeout=15)
         log(f"recorded external-truth outcome ({status}) for finding {fingerprint}")
     except Exception as e:  # noqa: BLE001 — best-effort, never break resolution
         log(f"resolution outcome emit skipped: {e}", "warning")

--- a/src/gateway/tools.py
+++ b/src/gateway/tools.py
@@ -44,7 +44,9 @@ async def handle_status(client: GovernanceMCPClient, agent_id: Optional[str] = N
         args: dict = {}
         if agent_id:
             args["agent_id"] = agent_id
-        raw = await client.call_tool("get_governance_metrics", args)
+        # check_working_state: advertised alias of get_governance_metrics
+        # (raw twin dropped from the lite MCP wire by #1292).
+        raw = await client.call_tool("check_working_state", args)
         return json.dumps(simplifiers.simplify_status(raw))
     except Exception as exc:
         logger.warning("status failed: %s", exc)
@@ -67,7 +69,9 @@ async def handle_checkin(
         }
         if agent_id:
             args["agent_id"] = agent_id
-        raw = await client.call_tool("process_agent_update", args)
+        # sync_state: advertised alias of process_agent_update
+        # (raw twin dropped from the lite MCP wire by #1292).
+        raw = await client.call_tool("sync_state", args)
         return json.dumps(simplifiers.simplify_checkin(raw))
     except Exception as exc:
         logger.warning("checkin failed: %s", exc)

--- a/tests/test_gateway_tools.py
+++ b/tests/test_gateway_tools.py
@@ -31,13 +31,13 @@ class TestHandleStatus:
         result = json.loads(await handle_status(mock_client))
         assert result["ok"] is True
         assert result["data"]["verdict"] == "proceed"
-        mock_client.call_tool.assert_called_with("get_governance_metrics", {})
+        mock_client.call_tool.assert_called_with("check_working_state", {})
 
     @pytest.mark.asyncio
     async def test_with_agent_id(self, mock_client):
         mock_client.call_tool.return_value = {"action": "proceed"}
         await handle_status(mock_client, agent_id="my-agent")
-        mock_client.call_tool.assert_called_with("get_governance_metrics", {"agent_id": "my-agent"})
+        mock_client.call_tool.assert_called_with("check_working_state", {"agent_id": "my-agent"})
 
     @pytest.mark.asyncio
     async def test_error(self, mock_client):
@@ -56,7 +56,7 @@ class TestHandleCheckin:
         result = json.loads(await handle_checkin(mock_client, summary="Fixed bug"))
         assert result["ok"] is True
         assert result["data"]["verdict"] == "proceed"
-        mock_client.call_tool.assert_called_with("process_agent_update", {
+        mock_client.call_tool.assert_called_with("sync_state", {
             "summary": "Fixed bug",
             "complexity": 0.5,
             "confidence": 0.7,
@@ -66,7 +66,7 @@ class TestHandleCheckin:
     async def test_custom_params(self, mock_client):
         mock_client.call_tool.return_value = {"action": "guide"}
         await handle_checkin(mock_client, summary="Work", complexity=0.9, confidence=0.3)
-        mock_client.call_tool.assert_called_with("process_agent_update", {
+        mock_client.call_tool.assert_called_with("sync_state", {
             "summary": "Work",
             "complexity": 0.9,
             "confidence": 0.3,
@@ -76,7 +76,7 @@ class TestHandleCheckin:
     async def test_agent_id_forwarded(self, mock_client):
         mock_client.call_tool.return_value = {"action": "proceed"}
         await handle_checkin(mock_client, summary="Work", agent_id="perplexity-bot")
-        mock_client.call_tool.assert_called_with("process_agent_update", {
+        mock_client.call_tool.assert_called_with("sync_state", {
             "summary": "Work",
             "complexity": 0.5,
             "confidence": 0.7,

--- a/tests/test_mcp_extra_passthrough.py
+++ b/tests/test_mcp_extra_passthrough.py
@@ -31,9 +31,36 @@ def test_checkin_tool_preserves_s22_extra_argument_passthrough():
 
 
 def test_process_agent_update_handler_still_dispatchable():
-    """Hidden from the lite wire, but still a register=True handler — so the
-    gateway, hooks, and compat wrappers can call it by raw name (the server
-    dispatches any registered handler whether or not it is advertised)."""
+    """Still a register=True handler, so REST ``/v1/tools/call`` and in-process
+    callers can invoke it by raw name.
+
+    CAVEAT (learned the hard way, 2026-06-30): "registered handler" does NOT
+    mean "callable over the MCP ``/mcp/`` wire". FastMCP only dispatches tools
+    present in ``mcp._tool_manager`` (the advertised set). #1292 dropped the raw
+    twin from that set, so every resident/SDK/gateway caller that reached it by
+    raw name over ``/mcp/`` broke with ``Unknown tool``. Raw-name access is a
+    REST/in-process affordance only — MCP-wire callers MUST use the advertised
+    alias. See test_resident_workflow_aliases_advertised_on_mcp_wire below.
+    """
     from src.mcp_handlers import TOOL_HANDLERS
 
     assert "process_agent_update" in TOOL_HANDLERS
+
+
+def test_resident_workflow_aliases_advertised_on_mcp_wire():
+    """The workflow aliases residents/SDK/gateway call over ``/mcp/`` MUST be
+    present in the FastMCP tool manager (the advertised wire) — not merely in
+    TOOL_HANDLERS.
+
+    This guards the 2026-06-30 outage: #1292 pruned the raw twins
+    (process_agent_update / get_governance_metrics / outcome_event) from the
+    lite wire, and the check-in/metrics/outcome paths call these aliases. A
+    future prune that drops an alias from the wire would silently dark every
+    resident again; assert on the wire, not on internal dispatch.
+    """
+    from src import mcp_server
+
+    for alias in ("sync_state", "check_working_state", "record_result"):
+        assert mcp_server.mcp._tool_manager.get_tool(alias) is not None, (
+            f"{alias!r} missing from the MCP wire — residents call it over /mcp/"
+        )

--- a/tests/test_resolution_outcome.py
+++ b/tests/test_resolution_outcome.py
@@ -60,7 +60,9 @@ async def test_adjudicate_finding_posts_outcome_attributed_to_sentinel():
     agent._ensure_identity.assert_awaited_once_with(client)
     client.call_tool.assert_awaited_once()
     tool, payload = client.call_tool.await_args.args
-    assert tool == "outcome_event"
+    # #1292 dropped raw outcome_event from the lite MCP wire; sentinel posts
+    # via the advertised record_result alias (same handler).
+    assert tool == "record_result"
     assert payload["agent_id"] == "sentinel-uuid"
     assert payload["outcome_type"] == "sentinel_finding_dismissed"
     assert payload["is_bad"] is True


### PR DESCRIPTION
## What broke
Dashboard showed **lumen + vigil down** (2026-06-30). Lumen's hardware was healthy; the residents' governance check-ins were crash-looping:

```
GovernanceConnectionError: Unknown tool: process_agent_update
```

## Root cause
**#1292** dropped three raw twins (`process_agent_update`, `get_governance_metrics`, `outcome_event`) from the lite MCP `/mcp/` advertised surface to de-duplicate the agent-facing tool list. Correct intent — but it updated **none** of the in-house callers that hard-code those raw names over the same wire, and its regression test asserted only REST/internal dispatch (`TOOL_HANDLERS`), never the FastMCP wire residents actually use. FastMCP can't register-but-hide a tool from `tools/list`, so raw-name dispatch only ever worked over REST/in-process — the wire fix must be client-side.

Every Python-SDK resident check-in (Vigil, Chronicler, Lumen's central check-in) failed each cycle → dashboard "down".

## Fix
Repoint every MCP-wire caller at the advertised alias (same handler via ToolAlias in `tool_stability.py`, identical response shape):

| Caller | was | now |
|---|---|---|
| SDK `checkin()` | `process_agent_update` | `sync_state` |
| SDK `get_metrics()` | `get_governance_metrics` | `check_working_state` |
| Gateway `status` | `get_governance_metrics` | `check_working_state` |
| Gateway `checkin` | `process_agent_update` | `sync_state` |
| watcher + sentinel | `outcome_event` | `record_result` |

Plus `test_resident_workflow_aliases_advertised_on_mcp_wire`: asserts the aliases residents depend on are present in `mcp._tool_manager` (**the wire**, not just `TOOL_HANDLERS`) — the exact gap that let #1292 through — and corrects the misleading "dispatches any registered handler" docstring.

## Verification
- Residents kickstarted: exit 0, check-in returns `200 POST /mcp/` (was the exact call throwing `Unknown tool`).
- All three aliases resolve on the live server.
- SDK suite **235 passed**; gateway + passthrough + param-alias tests **31 passed**. Updated 4 SDK + 5 gateway tests that hard-coded the old outgoing names.

## Deploy note
Residents run from the dev checkout and are **already fixed live**. The **gateway** runs from `unitares-deploy` (tracks `master`), so its fix goes live on merge + deploy pull + `gateway-mcp` restart.