### PR TITLE
fix(updates): disclose evidence_status when recent_tool_results is inert (#1320)

### DIFF
--- a/src/mcp_handlers/response_formatter.py
+++ b/src/mcp_handlers/response_formatter.py
@@ -342,7 +342,7 @@ def _format_standard(response_data: dict, task_type: str, saved_trust_tier: Any 
     _copy_passthrough_fields(
         response_data,
         result,
-        ("prediction_id", "warnings", "policy_evaluation", "enforcement"),
+        ("prediction_id", "warnings", "policy_evaluation", "enforcement", "evidence_status"),
     )
     return result
 
@@ -585,7 +585,7 @@ def _format_mirror(response_data: dict, saved_trust_tier: Any, meta: Any = None)
     _copy_passthrough_fields(
         response_data,
         result,
-        ("prediction_id", "warnings", "policy_evaluation", "enforcement"),
+        ("prediction_id", "warnings", "policy_evaluation", "enforcement", "evidence_status"),
     )
     return result
 
@@ -632,7 +632,7 @@ def _format_minimal(response_data: dict, using_default_mode: bool, saved_trust_t
     identity_notifications = response_data.get("_identity_notifications")
     if identity_notifications:
         result["identity_notifications"] = identity_notifications
-    _copy_passthrough_fields(response_data, result, ("warnings",))
+    _copy_passthrough_fields(response_data, result, ("warnings", "evidence_status"))
 
     return result
 
@@ -717,7 +717,7 @@ def _format_compact(response_data: dict, using_default_mode: bool, saved_trust_t
     _copy_passthrough_fields(
         response_data,
         result,
-        ("prediction_id", "warnings", "policy_evaluation", "enforcement"),
+        ("prediction_id", "warnings", "policy_evaluation", "enforcement", "evidence_status"),
     )
     return result
 

--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -2049,6 +2049,12 @@ async def execute_post_update_effects(ctx: UpdateContext) -> None:
     evidence_mode = os.environ.get("UNITARES_PHASE5_EVIDENCE_WRITE", "").lower()
     if ctx.recent_tool_results and evidence_mode in ("shadow", "1", "enable"):
         from src.mcp_handlers.observability.outcome_events import _record_outcome_event_inline
+        # #1320: disclose what happens to the evidence. "recorded" rows still
+        # carry verification_source="agent_reported_tool_result" downstream —
+        # recorded means graded-and-stored, not independently verified.
+        ctx.result["evidence_status"] = (
+            "recorded:shadow" if evidence_mode == "shadow" else "recorded"
+        )
         for evidence in ctx.recent_tool_results:
             try:
                 outcome_type, is_bad = _derive_outcome(evidence)
@@ -2083,6 +2089,19 @@ async def execute_post_update_effects(ctx: UpdateContext) -> None:
             "would have processed %d items for agent=%s",
             len(ctx.recent_tool_results), ctx.agent_id,
         )
+        # #1320: the deploy gate (spec §8) is server policy, but silence toward
+        # the caller is not part of it. Without this, the payload validates,
+        # persists into the state row, and reads like evidence downstream while
+        # having had zero effect on scoring — disclose that explicitly.
+        ctx.result["evidence_status"] = "ignored:flag_off"
+        warning = (
+            f"recent_tool_results ({len(ctx.recent_tool_results)} item(s)) was "
+            "accepted but NOT scored or recorded: evidence recording is "
+            "disabled on this server (UNITARES_PHASE5_EVIDENCE_WRITE unset). "
+            "The items did not affect risk, coherence, or calibration."
+        )
+        if warning not in ctx.warnings:
+            ctx.warnings.append(warning)
 
     # R2 PR 5: lineage hooks — chain_obs_count increment + evaluate_lineage_for
     # dispatch. Fail-soft inside the helper. Placed at the end so trajectory

--- a/tests/test_phases_phase5_evidence.py
+++ b/tests/test_phases_phase5_evidence.py
@@ -428,3 +428,76 @@ async def test_kind_to_outcome_type_mapping(monkeypatch):
         assert args.get("verification_source") == "agent_reported_tool_result", (
             f"Expected agent_reported_tool_result; got {args.get('verification_source')}"
         )
+
+
+# ─── evidence_status disclosure (#1320) ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_flag_off_sets_ignored_status_and_warning(monkeypatch):
+    """Flag off + evidence present → evidence_status disclosed and warning appended."""
+    monkeypatch.delenv("UNITARES_PHASE5_EVIDENCE_WRITE", raising=False)
+
+    outcome_event_mock = AsyncMock(return_value=[MagicMock(text='{"outcome_id":"eid"}')])
+    ctx = _make_ctx(
+        recent_tool_results=[
+            {"kind": "test", "tool": "pytest", "summary": "passed", "exit_code": 0}
+        ]
+    )
+
+    with _make_patch_stack(ctx, outcome_event_mock=outcome_event_mock):
+        await execute_post_update_effects(ctx)
+
+    assert ctx.result.get("evidence_status") == "ignored:flag_off"
+    assert any("NOT scored" in w for w in ctx.warnings), (
+        f"Expected flag-off disclosure warning; ctx.warnings={ctx.warnings}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_flag_enabled_sets_recorded_status(monkeypatch):
+    monkeypatch.setenv("UNITARES_PHASE5_EVIDENCE_WRITE", "1")
+
+    outcome_event_mock = AsyncMock(return_value=[MagicMock(text='{"outcome_id":"eid"}')])
+    ctx = _make_ctx(
+        recent_tool_results=[
+            {"kind": "test", "tool": "pytest", "summary": "passed", "exit_code": 0}
+        ]
+    )
+
+    with _make_patch_stack(ctx, outcome_event_mock=outcome_event_mock):
+        await execute_post_update_effects(ctx)
+
+    assert ctx.result.get("evidence_status") == "recorded"
+    assert not any("NOT scored" in w for w in ctx.warnings)
+
+
+@pytest.mark.asyncio
+async def test_flag_shadow_sets_recorded_shadow_status(monkeypatch):
+    monkeypatch.setenv("UNITARES_PHASE5_EVIDENCE_WRITE", "shadow")
+
+    outcome_event_mock = AsyncMock(return_value=[MagicMock(text='{"outcome_id":"eid"}')])
+    ctx = _make_ctx(
+        recent_tool_results=[
+            {"kind": "test", "tool": "pytest", "summary": "passed", "exit_code": 0}
+        ]
+    )
+
+    with _make_patch_stack(ctx, outcome_event_mock=outcome_event_mock):
+        await execute_post_update_effects(ctx)
+
+    assert ctx.result.get("evidence_status") == "recorded:shadow"
+
+
+@pytest.mark.asyncio
+async def test_no_evidence_leaves_status_absent(monkeypatch):
+    """No recent_tool_results → no evidence_status key (absence means nothing offered)."""
+    monkeypatch.delenv("UNITARES_PHASE5_EVIDENCE_WRITE", raising=False)
+
+    outcome_event_mock = AsyncMock(return_value=[MagicMock(text='{"outcome_id":"eid"}')])
+    ctx = _make_ctx(recent_tool_results=[])
+
+    with _make_patch_stack(ctx, outcome_event_mock=outcome_event_mock):
+        await execute_post_update_effects(ctx)
+
+    assert "evidence_status" not in ctx.result


### PR DESCRIPTION
Auto-shipped by ship.sh as a draft PR. Local work is visible; mark ready after validation/review.