### PR TITLE
docs(proposals): redis-retirement Phase 1 plan + Phase 0 no-free-deletion correction (re-land)

### DIFF
--- a/docs/proposals/redis-retirement-phase-1-plan.md
+++ b/docs/proposals/redis-retirement-phase-1-plan.md
@@ -1,0 +1,139 @@
+# Redis Retirement — Phase 1 Implementation Plan (durable PG mirror)
+
+**Status:** Draft / implementation plan
+**Parent:** `redis-retirement-v0.md` (v0.1). This details Phase 1 only.
+**Goal:** make PostgreSQL a complete durable mirror of the session/identity state that today lives only in Redis, running dual-write with Redis authoritative until parity ≥99%. No Redis is removed in Phase 1 (that's Phase 2).
+
+## The central decision: FK forces a new table, not `core.sessions`
+
+`core.sessions` cannot hold the ephemeral 94%:
+
+```sql
+-- db/postgres/schema.sql:123-142
+CREATE TABLE core.sessions (
+    session_id   TEXT PRIMARY KEY,
+    identity_id  BIGINT NOT NULL REFERENCES core.identities(identity_id) ON DELETE CASCADE,
+    ...
+);
+```
+
+`identity_id` is **NOT NULL FK → core.identities → core.agents**. The Redis `session:` payload stores an `agent_uuid` *string* with no identity/agent row (that's the whole point of `persist=False`). Writing ephemeral sessions into `core.sessions` would require eagerly minting `core.agents` + `core.identities` rows for every transient resolve — polluting the agent population with probes that never do real work, and contradicting both the lazy-creation design (`resolution.py:1274-1299`) and the strict-identity contract ("reads don't need a bound caller; writes do").
+
+**Decision: a new FK-less mirror table `core.session_bindings`**, modeled on the existing shadow-table FK reasoning (migrations 043/044: *"we deliberately leave FKs OFF — it is a write-only replica, not a referential target"*). It mirrors the Redis `session:` payload 1:1, keyed by `session_key`, holding `agent_uuid` as a plain string. This gives durable cross-restart session→uuid continuity **without** forcing identity persistence.
+
+`core.sessions` keeps its current role: the record that an identity actually onboarded/worked. `core.session_bindings` is the resolution-layer mirror. When an ephemeral session later does real work, the existing `ensure_agent_persisted` path (`persistence.py:583`) still creates the agent/identity/`core.sessions` rows — unchanged.
+
+> Note: `core.agent_sessions` (schema.sql:111-118) looks like an abandoned precursor to this — but its PK is `agent_id` (one row per agent, answers "what session is this agent on"), the inverse of the `session_key → agent_uuid` lookup the resolver needs, and it is empty (0 rows live). Don't repurpose it; the keying is wrong. Leave it or drop it in Phase 2 cleanup.
+
+## Schema (one new migration)
+
+```sql
+-- core.session_bindings — FK-less durable mirror of the Redis session: payload
+CREATE TABLE IF NOT EXISTS core.session_bindings (
+    session_key         TEXT PRIMARY KEY,
+    agent_uuid          TEXT NOT NULL,                 -- plain string, NO FK (mirrors Redis)
+    display_agent_id    TEXT NULL,
+    label               TEXT NULL,
+    spawn_reason        TEXT NULL,
+    bind_ip_ua          TEXT NULL,                     -- for the PATH 1 hijack check
+    trajectory_required BOOLEAN NOT NULL DEFAULT FALSE,
+    bind_count          INTEGER NOT NULL DEFAULT 1,
+    bound_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at          TIMESTAMPTZ NOT NULL           -- TTL parity with SESSION_TTL_SECONDS / -1≈far-future
+);
+CREATE INDEX IF NOT EXISTS idx_session_bindings_expires ON core.session_bindings(expires_at);
+CREATE INDEX IF NOT EXISTS idx_session_bindings_uuid    ON core.session_bindings(agent_uuid);
+
+-- core.onboard_pins — durable mirror of recent_onboard:* (IP:UA-fallback routing)
+CREATE TABLE IF NOT EXISTS core.onboard_pins (
+    fingerprint         TEXT PRIMARY KEY,              -- e.g. "ua:<md5prefix>" or scoped variant
+    agent_uuid          TEXT NOT NULL,
+    client_session_id   TEXT NOT NULL,
+    expires_at          TIMESTAMPTZ NOT NULL           -- 30-min TTL (PIN_TTL=1800)
+);
+CREATE INDEX IF NOT EXISTS idx_onboard_pins_expires ON core.onboard_pins(expires_at);
+```
+
+Extend `core.cleanup_expired_sessions()` (schema.sql:441-455) — or add a sibling reaper — to `DELETE FROM core.session_bindings WHERE expires_at < now()` and the same for `core.onboard_pins`. The session-cleanup background task already runs (`background_tasks.py`).
+
+Migration is **MANUAL** per repo convention (diff vs `core.schema_migrations` on deploy) — next free slot, CI-gated by `unitares_doctor.py`.
+
+## DB mixin methods (new, in `src/db/mixins/session.py`)
+
+```python
+async def upsert_session_binding(session_key, agent_uuid, *, display_agent_id, label,
+                                 spawn_reason, bind_ip_ua, trajectory_required,
+                                 expires_at, mint_guard=False) -> bool
+# INSERT ... ON CONFLICT (session_key) DO UPDATE ... ; when mint_guard, the
+# UPDATE branch is WHERE session_bindings.agent_uuid = EXCLUDED.agent_uuid
+# (refuse to clobber a different live uuid — the S21-a guard, now ATOMIC in one
+# statement, strictly stronger than the old non-atomic Redis get+setex).
+
+async def get_session_binding(session_key) -> Optional[SessionBindingRecord]
+async def lookup_onboard_pin_pg(fingerprint, *, refresh_ttl) -> Optional[str]
+async def set_onboard_pin_pg(fingerprint, agent_uuid, client_session_id, *, if_absent) -> bool
+# if_absent → INSERT ... ON CONFLICT DO NOTHING (the NX-claim semantics for subagents)
+```
+
+This **fixes the S21-a race properly**: the council found the Redis guard was never atomic (`get` then `setex`). A single `INSERT ... ON CONFLICT (session_key) DO UPDATE ... WHERE agent_uuid = EXCLUDED.agent_uuid` is atomic at the row level — a net improvement, not a regression.
+
+## The two blocker ports
+
+### C3 — fingerprint hijack check into PATH 2
+
+Extract the hijack logic from PATH 1 (`resolution.py:651-753`) into a shared helper:
+
+```python
+async def _fingerprint_hijack_check(session_key, agent_uuid, bound_bind_ip_ua) -> bool:
+    # returns True if strict-mode says fall through to fresh session.
+    # reads current_fp from get_session_signals().ip_ua_fingerprint,
+    # honors session_fingerprint_check_mode() + prefix_bind_fingerprint_mode(),
+    # emits identity_hijack_suspected on violation. Pure logic — no Redis.
+```
+
+Call it from **both** PATH 1 (passing `cached.get("bind_ip_ua")`) and PATH 2 (passing `binding.bind_ip_ua` from `core.session_bindings`). The `bind_ip_ua` is already captured at bind time (`persistence.py:153-172`) and will now be written to `core.session_bindings`. This closes the gap where retiring PATH 1 would silently disable hijack detection — the check survives in PATH 2 *before* PATH 1 is touched.
+
+### C2 — onboard pin into Postgres
+
+Dual-write `set_onboard_pin` (`session.py:977-1030`) to both Redis and `core.onboard_pins` (under the shadow flag). On the read side (`_derive_session_key_impl` step 7, `session.py:746-783`), add a PG fallback after the Redis lookup. Preserve the `if_absent`/NX subagent semantics via `ON CONFLICT DO NOTHING`. Keep an in-process L1 dict to avoid a PG hit on every IP:UA-fallback request.
+
+## Dual-write harness (reuse the proven Wave 3 / grounding pattern)
+
+Two independent flags, both default off (mirrors `grounding_shadow`/`grounding_apply`, `governance_config.py:1060-1084`):
+
+- `UNITARES_SESSION_MIRROR_SHADOW=1` — on every `_cache_session` Redis write and every `set_onboard_pin`, **also** write to `core.session_bindings` / `core.onboard_pins`. Redis stays authoritative for reads. Behavior-neutral.
+- `UNITARES_SESSION_MIRROR_APPLY=1` — resolver PATH 2 reads `core.session_bindings` (and pin lookup reads `core.onboard_pins`) as the source of truth. Only flip after parity is proven.
+
+**Parity check script** `scripts/ops/session_mirror_divergence_check.py`, modeled on `scripts/ops/wave3_shadow_divergence_check.py` (1-148): for each live Redis `session:` key, compare against `core.session_bindings` (present? agent_uuid match? rich fields match?), emit `coordination_failure.*.shadow_divergence` to `audit.events`, and report the **mirror ratio** (target: ≥99%, inverse of today's ~6%). Gate the APPLY flip on that ratio.
+
+## Build order (within Phase 1)
+
+1. **Prep:** fix `persistence.py:583` to check `create_session`'s return value and reconcile cache on conflict (small, independently shippable).
+2. **Migration:** `core.session_bindings` + `core.onboard_pins` + cleanup extension.
+3. **DB methods:** the 4 mixin methods above + `SessionBindingRecord`.
+4. **Hijack helper:** extract C3 into a shared function, wire into PATH 1 (no behavior change yet — proves parity of the extraction).
+5. **Shadow dual-write:** wire `UNITARES_SESSION_MIRROR_SHADOW` into `_cache_session` and `set_onboard_pin`.
+6. **Parity script** + run in production (Redis authoritative) until ratio ≥99%.
+7. **Apply flip:** `UNITARES_SESSION_MIRROR_APPLY` — PATH 2 reads `core.session_bindings`, runs the hijack helper; pin lookup reads PG. Run with Redis still up as L1.
+
+Phase 2 (separate plan/PR) deletes PATH 1, the Redis branches, `redis_client.py`, the dependency, and the ~229 Redis tests (single-writer-surface — its own draft PR).
+
+## Effort
+
+| Step | Effort |
+|---|---|
+| 1 prep (return-value fix) | XS |
+| 2 migration | S |
+| 3 DB methods | S |
+| 4 hijack helper extraction | M (identity hot path — careful + tests) |
+| 5 shadow dual-write | M |
+| 6 parity script + soak | S code, then **wall-clock soak** (days, operator-gated) |
+| 7 apply flip | M + verification |
+
+Phase 1 is **M–L total**, dominated by step 4 (identity resolution is a single-writer surface per CLAUDE.md — coordinate, ship with tests) and the step-6 soak window. It is entirely behind two default-off flags until the apply flip, so it ships incrementally without risk to the live path.
+
+## Open questions for the operator
+
+1. **Pin durability:** PG-backed `core.onboard_pins` (survives restart, recommended) vs. in-process TTL dict (simpler, loses pins on restart — same as a Redis pin expiry). Plan above assumes PG-backed.
+2. **Ephemeral binding TTL:** Redis has 347 permanent (TTL=-1) session keys. Mirror them as far-future `expires_at`, or impose the 24h `SESSION_TTL` uniformly on the PG mirror? (Recommend: impose 24h — permanent ephemeral bindings are almost certainly unintended accumulation.)
+3. **Verify before build:** this plan should get a council pass (architect + code-reviewer + live-verifier) the same way v0 did — the FK/new-table decision and the hijack-helper extraction are the two highest-risk calls.

--- a/docs/proposals/redis-retirement-phase-1-plan.md
+++ b/docs/proposals/redis-retirement-phase-1-plan.md
@@ -4,11 +4,11 @@
 **Parent:** `redis-retirement-v0.md` (v0.1). This details Phase 1 only.
 **Goal:** make PostgreSQL durably carry the session/identity state that today lives only in Redis, so Redis can later be retired — while *measuring*, not assuming, how much of that state actually needs mirroring.
 
-> **v1 → v1.1 council changes.** A three-member council (architect + code-reviewer + live-verifier) reviewed v1 against the running system. Outcome: the FK reasoning and new-table-vs-alternatives analysis hold, but v1 was **over-scoped, under-specified, and its schema was provably incomplete.** Key revisions: (1) the durable artifact that actually matters is the **onboard pin (C2)** — restructure Phase 1 so pins + persist-time rich fields + the hijack helper (all unconditionally needed) ship first, and the full `core.session_bindings` ephemeral mirror is **gated on a shadow-phase measurement** (architect: it may be solving a problem the pin already solves). (2) Add the two missing columns the live-verifier found (`public_agent_id`, `api_key_hash`). (3) Fix the two-table drift hazard with an explicit authority contract. (4) Replace the point-in-time parity gate. (5) Fix two extraction blockers (B1 `resume` mutation, B2 PATH 2 data shape).
+> **v1 → v1.1 council changes.** A three-member council (architect + code-reviewer + live verification) reviewed v1 against the running system. Outcome: the FK reasoning and new-table-vs-alternatives analysis hold, but v1 was **over-scoped, under-specified, and its schema was provably incomplete.** Key revisions: (1) the durable artifact that actually matters is the **onboard pin (C2)** — restructure Phase 1 so pins + persist-time rich fields + the hijack helper (all unconditionally needed) ship first, and the full `core.session_bindings` ephemeral mirror is **gated on a shadow-phase measurement** (architect: it may be solving a problem the pin already solves). (2) Add the two missing columns live verification found (`public_agent_id`, `api_key_hash`). (3) Fix the two-table drift hazard with an explicit authority contract. (4) Replace the point-in-time parity gate. (5) Fix two extraction blockers (B1 `resume` mutation, B2 PATH 2 data shape).
 
 ## The central decision: FK forces a separate store, not `core.sessions`
 
-`core.sessions` cannot hold the ephemeral 94% (live-verifier confirmed `\d core.sessions`):
+`core.sessions` cannot hold the ephemeral 94% (live verification confirmed `\d core.sessions`):
 
 ```sql
 session_id   TEXT PRIMARY KEY,
@@ -43,7 +43,7 @@ Build `core.session_bindings` as an **instrumented shadow only**. During the soa
 
 This defers the heaviest, most-uncertain piece behind data instead of assuming it.
 
-## Schema (corrected per live-verifier)
+## Schema (corrected per live verification)
 
 ```sql
 -- core.onboard_pins — Phase 1A. Durable mirror of recent_onboard:* keys.
@@ -133,4 +133,4 @@ Phase 2 (separate PR): delete PATH 1, Redis branches, `redis_client.py`, the dep
 
 ## Provenance
 
-v1 from the Phase 1 facts dossier. v1.1 from a council on 2026-06-27: architect (FK alternatives, drift hazard, the pins-vs-mirror challenge, parity-metric critique), code-reviewer (B1/B2/M1/M2/M3, write-site enumeration), live-verifier (the two missing columns + key-format + TTL ground-truth against 865 live payloads). Live-verifier refutations are why the schema gained `public_agent_id`/`api_key_hash` and lost `label`.
+v1 from the Phase 1 facts dossier. v1.1 from a council on 2026-06-27: architect (FK alternatives, drift hazard, the pins-vs-mirror challenge, parity-metric critique), code-reviewer (B1/B2/M1/M2/M3, write-site enumeration), live verification (the two missing columns + key-format + TTL ground-truth against 865 live payloads). Live-verification refutations are why the schema gained `public_agent_id`/`api_key_hash` and lost `label`.

--- a/docs/proposals/redis-retirement-phase-1-plan.md
+++ b/docs/proposals/redis-retirement-phase-1-plan.md
@@ -1,139 +1,136 @@
 # Redis Retirement — Phase 1 Implementation Plan (durable PG mirror)
 
-**Status:** Draft / implementation plan
+**Status:** Draft / implementation plan — **v1.1, revised after council review (2026-06-27).**
 **Parent:** `redis-retirement-v0.md` (v0.1). This details Phase 1 only.
-**Goal:** make PostgreSQL a complete durable mirror of the session/identity state that today lives only in Redis, running dual-write with Redis authoritative until parity ≥99%. No Redis is removed in Phase 1 (that's Phase 2).
+**Goal:** make PostgreSQL durably carry the session/identity state that today lives only in Redis, so Redis can later be retired — while *measuring*, not assuming, how much of that state actually needs mirroring.
 
-## The central decision: FK forces a new table, not `core.sessions`
+> **v1 → v1.1 council changes.** A three-member council (architect + code-reviewer + live-verifier) reviewed v1 against the running system. Outcome: the FK reasoning and new-table-vs-alternatives analysis hold, but v1 was **over-scoped, under-specified, and its schema was provably incomplete.** Key revisions: (1) the durable artifact that actually matters is the **onboard pin (C2)** — restructure Phase 1 so pins + persist-time rich fields + the hijack helper (all unconditionally needed) ship first, and the full `core.session_bindings` ephemeral mirror is **gated on a shadow-phase measurement** (architect: it may be solving a problem the pin already solves). (2) Add the two missing columns the live-verifier found (`public_agent_id`, `api_key_hash`). (3) Fix the two-table drift hazard with an explicit authority contract. (4) Replace the point-in-time parity gate. (5) Fix two extraction blockers (B1 `resume` mutation, B2 PATH 2 data shape).
 
-`core.sessions` cannot hold the ephemeral 94%:
+## The central decision: FK forces a separate store, not `core.sessions`
+
+`core.sessions` cannot hold the ephemeral 94% (live-verifier confirmed `\d core.sessions`):
 
 ```sql
--- db/postgres/schema.sql:123-142
-CREATE TABLE core.sessions (
-    session_id   TEXT PRIMARY KEY,
-    identity_id  BIGINT NOT NULL REFERENCES core.identities(identity_id) ON DELETE CASCADE,
-    ...
-);
+session_id   TEXT PRIMARY KEY,
+identity_id  BIGINT NOT NULL REFERENCES core.identities(identity_id) ON DELETE CASCADE
 ```
 
-`identity_id` is **NOT NULL FK → core.identities → core.agents**. The Redis `session:` payload stores an `agent_uuid` *string* with no identity/agent row (that's the whole point of `persist=False`). Writing ephemeral sessions into `core.sessions` would require eagerly minting `core.agents` + `core.identities` rows for every transient resolve — polluting the agent population with probes that never do real work, and contradicting both the lazy-creation design (`resolution.py:1274-1299`) and the strict-identity contract ("reads don't need a bound caller; writes do").
+`identity_id` is NOT NULL FK → `core.identities` → `core.agents`. The Redis `session:` payload stores an `agent_id` *string* (the UUID) with no identity/agent row — that's the point of `persist=False` (`resolution.py:1274-1299`).
 
-**Decision: a new FK-less mirror table `core.session_bindings`**, modeled on the existing shadow-table FK reasoning (migrations 043/044: *"we deliberately leave FKs OFF — it is a write-only replica, not a referential target"*). It mirrors the Redis `session:` payload 1:1, keyed by `session_key`, holding `agent_uuid` as a plain string. This gives durable cross-restart session→uuid continuity **without** forcing identity persistence.
+**Alternatives considered and rejected (architect steelmanned each):**
+- **α eager identity persistence** — would mint `core.agents`/`core.identities` rows for ~900 transient probes, polluting the agent population and every agent-derived metric, inverting "reads don't need a bound caller." Cleanest schema, worst ontology. Reject.
+- **β nullable `identity_id` on `core.sessions`** — genuinely the cleanest *end-state* (one table; ephemeral→worked is one `UPDATE`). Loses only on *migration safety*: dropping NOT NULL on a load-bearing FK with live joins/CASCADE is a hot-table mutation, vs. the new table being additive and flag-isolated (zero blast radius until APPLY). **Decision: new table for migration safety, but β goes on a Phase-3 docket** so the two-table split isn't permanent by inertia.
+- **γ repurpose `core.agent_sessions`** — wrong cardinality (PK `agent_id`, the inverse mapping) and carries the very FK we're escaping. Reject. **Drop `core.agent_sessions` in Phase 2** (it's empty, 0 rows confirmed) rather than leave a misleading empty table.
 
-`core.sessions` keeps its current role: the record that an identity actually onboarded/worked. `core.session_bindings` is the resolution-layer mirror. When an ephemeral session later does real work, the existing `ensure_agent_persisted` path (`persistence.py:583`) still creates the agent/identity/`core.sessions` rows — unchanged.
+## Restructured Phase 1: 1A unconditional, 1B measured
 
-> Note: `core.agent_sessions` (schema.sql:111-118) looks like an abandoned precursor to this — but its PK is `agent_id` (one row per agent, answers "what session is this agent on"), the inverse of the `session_key → agent_uuid` lookup the resolver needs, and it is empty (0 rows live). Don't repurpose it; the keying is wrong. Leave it or drop it in Phase 2 cleanup.
+The council's central insight: the only population that *needs* cross-restart continuity is IP:UA-fallback clients (Claude Desktop, REST without `client_session_id`), and that is exactly what the **onboard pin** serves. Client-key-bearing clients re-anchor themselves by re-presenting their key on restart. So the full ephemeral `session_bindings` mirror may be redundant with the pin. We **build the things needed regardless first, then let the shadow phase decide** whether the ephemeral mirror earns its place.
 
-## Schema (one new migration)
+### Phase 1A — needed regardless of the 1B decision
+
+1. **Prep fix:** `persistence.py:583` must check `create_session`'s return value and reconcile the cache on conflict (small, independently shippable).
+2. **Onboard pins → durable** (`core.onboard_pins`). This is the load-bearing continuity anchor. Dual-write `set_onboard_pin` (`session.py:977-1030`) to PG; add a PG fallback to the lookup at `_derive_session_key_impl` step 7 (`session.py:746-783`); preserve `if_absent`/NX subagent semantics via `ON CONFLICT DO NOTHING`; keep an in-process L1 to avoid a PG hit per request.
+3. **Rich fields onto `core.sessions` at persist time.** When `ensure_agent_persisted` writes `core.sessions`, also persist `spawn_reason`, `bind_ip_ua`, `public_agent_id`, `trajectory_required` into `client_info`/`metadata` JSONB (no schema change — both are JSONB). This makes the *persisted* population complete on its own.
+4. **Hijack-check helper (C3)** extracted from `resolution.py:651-753` — see blocker fixes below — and wired into **both** PATH 1 and PATH 2, reading `bind_ip_ua` from whichever store. This must land before PATH 1 is ever removed so detection survives.
+5. **Shadow harness scaffolding** (flags + audit events), reusing the grounding/Wave-3 pattern.
+
+### Phase 1B — `core.session_bindings`, gated on measurement
+
+Build `core.session_bindings` as an **instrumented shadow only**. During the soak, the parity script's primary output is not "does PG mirror Redis" but: **how often would dropping the ephemeral mirror entirely cause a cold-mint that neither PATH 2 (`core.sessions`) nor a live onboard pin would have covered?**
+
+- If that number is **~zero** → drop `core.session_bindings` entirely. Ship the strictly simpler design: pins + persist-time rich fields. The drift hazard and the parity-gate problem vanish with it.
+- If **material** (e.g. long-lived keyless Claude Desktop sessions outliving the 30-min pin TTL, hit by a routine plist restart) → keep it, with the consistency contract below.
+
+This defers the heaviest, most-uncertain piece behind data instead of assuming it.
+
+## Schema (corrected per live-verifier)
 
 ```sql
--- core.session_bindings — FK-less durable mirror of the Redis session: payload
+-- core.onboard_pins — Phase 1A. Durable mirror of recent_onboard:* keys.
+CREATE TABLE IF NOT EXISTS core.onboard_pins (
+    fingerprint        TEXT PRIMARY KEY,   -- full suffix after "recent_onboard:", e.g. "ua:<hash>|<transport>|<model>" (1-3 pipe segments)
+    agent_uuid         TEXT NOT NULL CHECK (agent_uuid ~ '^[0-9a-fA-F-]{36}$'),
+    client_session_id  TEXT NOT NULL,
+    expires_at         TIMESTAMPTZ NOT NULL    -- 30-min TTL (PIN_TTL=1800)
+);
+CREATE INDEX IF NOT EXISTS idx_onboard_pins_expires ON core.onboard_pins(expires_at);
+
+-- core.session_bindings — Phase 1B (instrumented shadow; keep only if measured material).
+-- FK-less mirror of the Redis session: payload. Column set verified against 865 live payloads.
 CREATE TABLE IF NOT EXISTS core.session_bindings (
     session_key         TEXT PRIMARY KEY,
-    agent_uuid          TEXT NOT NULL,                 -- plain string, NO FK (mirrors Redis)
+    agent_uuid          TEXT NOT NULL CHECK (agent_uuid ~ '^[0-9a-fA-F-]{36}$'),  -- maps from Redis JSON "agent_id"; CHECK enforces "proof not label"
+    public_agent_id     TEXT NULL,   -- ADDED (live in 59.8% of payloads)
     display_agent_id    TEXT NULL,
-    label               TEXT NULL,
+    api_key_hash        TEXT NULL,   -- ADDED (live in 40.2%, legacy sessions) — without it the parity check flags 40% as divergent
     spawn_reason        TEXT NULL,
-    bind_ip_ua          TEXT NULL,                     -- for the PATH 1 hijack check
+    bind_ip_ua          TEXT NULL,   -- consumed by the C3 hijack check on PATH 2
     trajectory_required BOOLEAN NOT NULL DEFAULT FALSE,
     bind_count          INTEGER NOT NULL DEFAULT 1,
     bound_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
-    expires_at          TIMESTAMPTZ NOT NULL           -- TTL parity with SESSION_TTL_SECONDS / -1≈far-future
+    expires_at          TIMESTAMPTZ NULL   -- NULL = permanent (Redis TTL=-1); see TTL policy
 );
 CREATE INDEX IF NOT EXISTS idx_session_bindings_expires ON core.session_bindings(expires_at);
 CREATE INDEX IF NOT EXISTS idx_session_bindings_uuid    ON core.session_bindings(agent_uuid);
-
--- core.onboard_pins — durable mirror of recent_onboard:* (IP:UA-fallback routing)
-CREATE TABLE IF NOT EXISTS core.onboard_pins (
-    fingerprint         TEXT PRIMARY KEY,              -- e.g. "ua:<md5prefix>" or scoped variant
-    agent_uuid          TEXT NOT NULL,
-    client_session_id   TEXT NOT NULL,
-    expires_at          TIMESTAMPTZ NOT NULL           -- 30-min TTL (PIN_TTL=1800)
-);
-CREATE INDEX IF NOT EXISTS idx_onboard_pins_expires ON core.onboard_pins(expires_at);
 ```
 
-Extend `core.cleanup_expired_sessions()` (schema.sql:441-455) — or add a sibling reaper — to `DELETE FROM core.session_bindings WHERE expires_at < now()` and the same for `core.onboard_pins`. The session-cleanup background task already runs (`background_tasks.py`).
+Notes: `label` dropped (zero live backing). `agent_id`→`agent_uuid` rename is explicit and the extraction code must map it. The `CHECK` on `agent_uuid` makes "this column holds the UUID-proof, never a display label" a schema invariant (architect: otherwise the no-lookup-by-label identity invariant is enforced only by discipline). **Naming disambiguation:** migration 049 already added `coordination.session_resolution_sagas` — unrelated; `core.session_bindings` is the resolution mirror, not a saga.
 
-Migration is **MANUAL** per repo convention (diff vs `core.schema_migrations` on deploy) — next free slot, CI-gated by `unitares_doctor.py`.
+**TTL policy (open Q2, data-backed):** all currently-expiring keys are ≤24h, so a 24h cap truncates nothing live — it only bounds the ~363 permanent (TTL=-1) keys, which read as accumulation cruft. Recommendation: store expiring keys with their `expires_at`, store permanent keys as 24h-from-now (not NULL-forever). Reaper extends `core.cleanup_expired_sessions()` (schema.sql:441-455) to both new tables.
 
-## DB mixin methods (new, in `src/db/mixins/session.py`)
+## Blocker fixes (code-reviewer)
 
+**B1 — `resume` mutation can't be extracted.** The PATH 1 block mutates the outer local `resume = False` (resolution.py:753); a plain helper can't do that. The helper must **return** `should_block: bool`; both call sites apply it:
 ```python
-async def upsert_session_binding(session_key, agent_uuid, *, display_agent_id, label,
-                                 spawn_reason, bind_ip_ua, trajectory_required,
-                                 expires_at, mint_guard=False) -> bool
-# INSERT ... ON CONFLICT (session_key) DO UPDATE ... ; when mint_guard, the
-# UPDATE branch is WHERE session_bindings.agent_uuid = EXCLUDED.agent_uuid
-# (refuse to clobber a different live uuid — the S21-a guard, now ATOMIC in one
-# statement, strictly stronger than the old non-atomic Redis get+setex).
-
-async def get_session_binding(session_key) -> Optional[SessionBindingRecord]
-async def lookup_onboard_pin_pg(fingerprint, *, refresh_ttl) -> Optional[str]
-async def set_onboard_pin_pg(fingerprint, agent_uuid, client_session_id, *, if_absent) -> bool
-# if_absent → INSERT ... ON CONFLICT DO NOTHING (the NX-claim semantics for subagents)
+should_block = await _fingerprint_hijack_check(session_key, bound_bind_ip_ua, agent_uuid)
+if should_block:
+    resume = False   # PATH 1; PATH 2 falls through to mint analogously
 ```
+Helper closes over (thread as params): `session_key`, `agent_uuid`, the bind-time `bind_ip_ua`, and re-derives the fp-mode config internally. It reads `get_session_signals().ip_ua_fingerprint` and emits `identity_hijack_suspected` via `_broadcaster()` — pure logic, no Redis.
 
-This **fixes the S21-a race properly**: the council found the Redis guard was never atomic (`get` then `setex`). A single `INSERT ... ON CONFLICT (session_key) DO UPDATE ... WHERE agent_uuid = EXCLUDED.agent_uuid` is atomic at the row level — a net improvement, not a regression.
+**B2 — PATH 2 data shape.** `db.get_session` returns a `SessionRecord` with no `.get()` and no `bind_ip_ua`. So `get_session_binding` must (a) return a **plain dict**, and (b) the dict must carry `bind_ip_ua` (hence the column). Otherwise the helper raises `AttributeError`, or — if it silently sees `None` — the check is dead code on PATH 2.
 
-## The two blocker ports
+**M1 — atomic guard must surface the block.** `INSERT ... ON CONFLICT (session_key) DO UPDATE SET ... WHERE session_bindings.agent_uuid = EXCLUDED.agent_uuid` is atomic, but the blocked case returns `INSERT 0 0` with **no error**. Use `RETURNING agent_uuid` to distinguish inserted/updated/blocked, and emit `S21A_OVERWRITE_BLOCKED` on the blocked case (preserving the log/audit sentinel the Redis guard had). This is still strictly stronger than the old non-atomic Redis `get`+`setex`.
 
-### C3 — fingerprint hijack check into PATH 2
+**M2 — uncovered write site.** The sliding-TTL refresh `raw_redis.expire("session:"+key, SESSION_TTL)` at **resolution.py:788** is outside `_cache_session`. The dual-write must also call `update_session_activity` (already in `SessionMixin`) at that PATH 1 hit site, or PG bindings stale while Redis stays fresh.
 
-Extract the hijack logic from PATH 1 (`resolution.py:651-753`) into a shared helper:
+**M3 — read must filter expiry.** Existing `get_session` does NOT filter `expires_at` (pre-existing bug — don't repeat). `get_session_binding` must filter `expires_at IS NULL OR expires_at > now()`.
 
-```python
-async def _fingerprint_hijack_check(session_key, agent_uuid, bound_bind_ip_ua) -> bool:
-    # returns True if strict-mode says fall through to fresh session.
-    # reads current_fp from get_session_signals().ip_ua_fingerprint,
-    # honors session_fingerprint_check_mode() + prefix_bind_fingerprint_mode(),
-    # emits identity_hijack_suspected on violation. Pure logic — no Redis.
-```
+**Write sites that must dual-write (enumerate before coding):** `_cache_session` rich path (`persistence.py:240-301`), `_cache_session` bare path, the resolution.py:788 TTL refresh, and `set_onboard_pin`. Wiring only `_cache_session` misses the TTL refresh and the raw-redis rich path.
 
-Call it from **both** PATH 1 (passing `cached.get("bind_ip_ua")`) and PATH 2 (passing `binding.bind_ip_ua` from `core.session_bindings`). The `bind_ip_ua` is already captured at bind time (`persistence.py:153-172`) and will now be written to `core.session_bindings`. This closes the gap where retiring PATH 1 would silently disable hijack detection — the check survives in PATH 2 *before* PATH 1 is touched.
+## Two-table consistency contract (architect blocker — only if 1B keeps the table)
 
-### C2 — onboard pin into Postgres
+If `core.session_bindings` survives 1B, the same `session_key` will exist in both it and `core.sessions` after a session works → two TTLs, two reapers that can disagree → a *manufactured* ghost-fork (PATH 2 reads `session_bindings`, misses a reaped row, cold-mints). Mandatory:
+1. **`core.session_bindings` is the resolution authority** for any key present in both.
+2. `ensure_agent_persisted` updates **both** rows in one transaction.
+3. The two `expires_at` clocks are kept in lockstep (derive the binding TTL from the session TTL for persisted keys), so the reapers can't disagree.
 
-Dual-write `set_onboard_pin` (`session.py:977-1030`) to both Redis and `core.onboard_pins` (under the shadow flag). On the read side (`_derive_session_key_impl` step 7, `session.py:746-783`), add a PG fallback after the Redis lookup. Preserve the `if_absent`/NX subagent semantics via `ON CONFLICT DO NOTHING`. Keep an in-process L1 dict to avoid a PG hit on every IP:UA-fallback request.
+## Parity gate (architect — replaces the point-in-time ratio)
 
-## Dual-write harness (reuse the proven Wave 3 / grounding pattern)
+A point-in-time full-scan ratio conflates writer-correctness with expiry-race noise under churn (920 keys turning over, independent Redis/PG expiry clocks) — it may never read 99% even with a perfect writer. Instead:
+- **Write-path parity:** instrument the dual-writer — for each Redis write, did the paired PG write succeed in the same operation? Target ~100%.
+- **Birth-cohort parity:** sample keys bound 5–60 min ago (committed, not yet expired); these should match exactly.
+- **The 1B decision metric:** cold-mints-not-covered-by-pin (above).
+- Snapshot ratio = smoke test only. Reconcile the expiry clocks *before* measuring.
+- Watch `audit.events` volume (920 keys × scan freq) — don't flood the partition.
 
-Two independent flags, both default off (mirrors `grounding_shadow`/`grounding_apply`, `governance_config.py:1060-1084`):
+## Build order
 
-- `UNITARES_SESSION_MIRROR_SHADOW=1` — on every `_cache_session` Redis write and every `set_onboard_pin`, **also** write to `core.session_bindings` / `core.onboard_pins`. Redis stays authoritative for reads. Behavior-neutral.
-- `UNITARES_SESSION_MIRROR_APPLY=1` — resolver PATH 2 reads `core.session_bindings` (and pin lookup reads `core.onboard_pins`) as the source of truth. Only flip after parity is proven.
+1A: prep fix → `core.onboard_pins` + dual-write/lookup → rich fields on `core.sessions` → hijack helper (B1/B2) wired into PATH 1+2 → shadow scaffolding.
+1B: `core.session_bindings` instrumented shadow → soak → **decide keep/drop on the cold-mint-not-covered metric** → if keep, apply the consistency contract + APPLY flip.
 
-**Parity check script** `scripts/ops/session_mirror_divergence_check.py`, modeled on `scripts/ops/wave3_shadow_divergence_check.py` (1-148): for each live Redis `session:` key, compare against `core.session_bindings` (present? agent_uuid match? rich fields match?), emit `coordination_failure.*.shadow_divergence` to `audit.events`, and report the **mirror ratio** (target: ≥99%, inverse of today's ~6%). Gate the APPLY flip on that ratio.
-
-## Build order (within Phase 1)
-
-1. **Prep:** fix `persistence.py:583` to check `create_session`'s return value and reconcile cache on conflict (small, independently shippable).
-2. **Migration:** `core.session_bindings` + `core.onboard_pins` + cleanup extension.
-3. **DB methods:** the 4 mixin methods above + `SessionBindingRecord`.
-4. **Hijack helper:** extract C3 into a shared function, wire into PATH 1 (no behavior change yet — proves parity of the extraction).
-5. **Shadow dual-write:** wire `UNITARES_SESSION_MIRROR_SHADOW` into `_cache_session` and `set_onboard_pin`.
-6. **Parity script** + run in production (Redis authoritative) until ratio ≥99%.
-7. **Apply flip:** `UNITARES_SESSION_MIRROR_APPLY` — PATH 2 reads `core.session_bindings`, runs the hijack helper; pin lookup reads PG. Run with Redis still up as L1.
-
-Phase 2 (separate plan/PR) deletes PATH 1, the Redis branches, `redis_client.py`, the dependency, and the ~229 Redis tests (single-writer-surface — its own draft PR).
+Phase 2 (separate PR): delete PATH 1, Redis branches, `redis_client.py`, the dependency, drop `core.agent_sessions`, ~229 Redis tests (single-writer surface — its own draft PR).
 
 ## Effort
 
-| Step | Effort |
-|---|---|
-| 1 prep (return-value fix) | XS |
-| 2 migration | S |
-| 3 DB methods | S |
-| 4 hijack helper extraction | M (identity hot path — careful + tests) |
-| 5 shadow dual-write | M |
-| 6 parity script + soak | S code, then **wall-clock soak** (days, operator-gated) |
-| 7 apply flip | M + verification |
-
-Phase 1 is **M–L total**, dominated by step 4 (identity resolution is a single-writer surface per CLAUDE.md — coordinate, ship with tests) and the step-6 soak window. It is entirely behind two default-off flags until the apply flip, so it ships incrementally without risk to the live path.
+1A is **M** (pins + helper extraction + persist-path rich fields, all with tests; identity = single-writer surface). 1B is **S code + a soak window**, and may *reduce* to near-zero if the measurement says drop the table. Net Phase 1: **M**, less than v1 estimated, because the heaviest piece is now conditional.
 
 ## Open questions for the operator
 
-1. **Pin durability:** PG-backed `core.onboard_pins` (survives restart, recommended) vs. in-process TTL dict (simpler, loses pins on restart — same as a Redis pin expiry). Plan above assumes PG-backed.
-2. **Ephemeral binding TTL:** Redis has 347 permanent (TTL=-1) session keys. Mirror them as far-future `expires_at`, or impose the 24h `SESSION_TTL` uniformly on the PG mirror? (Recommend: impose 24h — permanent ephemeral bindings are almost certainly unintended accumulation.)
-3. **Verify before build:** this plan should get a council pass (architect + code-reviewer + live-verifier) the same way v0 did — the FK/new-table decision and the hijack-helper extraction are the two highest-risk calls.
+1. **Pin store:** PG-backed `core.onboard_pins` (survives restart, recommended — pins are the real continuity anchor) vs. in-process TTL dict.
+2. **Permanent-key TTL:** impose 24h on the ~363 TTL=-1 keys (recommended — data shows no live key exceeds 24h) vs. mirror as permanent.
+3. **1B disposition:** accept the measure-then-decide gate on `core.session_bindings`, or commit up-front to either keeping it (belt-and-suspenders) or dropping it (pins-only). Recommendation: **measure** — the shadow phase is the cheapest possible place to settle it.
+
+## Provenance
+
+v1 from the Phase 1 facts dossier. v1.1 from a council on 2026-06-27: architect (FK alternatives, drift hazard, the pins-vs-mirror challenge, parity-metric critique), code-reviewer (B1/B2/M1/M2/M3, write-site enumeration), live-verifier (the two missing columns + key-format + TTL ground-truth against 865 live payloads). Live-verifier refutations are why the schema gained `public_agent_id`/`api_key_hash` and lost `label`.

--- a/docs/proposals/redis-retirement-v0.md
+++ b/docs/proposals/redis-retirement-v0.md
@@ -47,9 +47,16 @@ Resident agents (Sentinel/Vigil/Watcher/Steward) hold **zero** Redis connections
 | C4 | **KG surfaced dedup** (`kg_surfaced:*`, `enrichments.py:1583-1616`) — **NEW, missed in v0** | ❌ Redis sole store (fail-open) | Drop → duplicate KG notifications every check-in. Behavioral regression, not correctness. | **S** |
 | D | Metadata cache (`src/cache/metadata_cache.py`) | ✅ clean direct-PG fallback (verified) | ~~Delete module~~ **KEEP — cross-worker cache under multi-process (see topology decision); in-process copy = N× hydrate tax + stale skew** | ~~Trivial — safe now~~ **not a deletion** |
 | E | Distributed lock (`src/cache/distributed_lock.py`) | ✅ `fcntl` file fallback is the single-node path | ~~Delete Redis branch~~ **KEEP — `fcntl` is single-node only; this is the correct cross-process primitive once workers contend** | ~~Trivial — safe now~~ **not a deletion** |
-| F | Circuit breaker / metrics (`redis_client.py`) | n/a | Vanishes with Redis | **Free** |
+| F | Circuit breaker / metrics (`redis_client.py`) | n/a | Lives *inside* `redis_client.py`, still used by session cache → **cannot delete until Phase 2 (with Redis itself)** | **Phase 2, not Phase 0** |
 
 `identity_notifications:*` (read at `enrichments.py:1795`) is **dead code** — no writer exists. Remove on cleanup, no migration needed.
+
+> **Correction (2026-06-27, caller grep): Phase 0 is NOT "trivial safe deletions."** The v0/v1 framing was wrong on all three:
+> - **D — metadata cache is performance-load-bearing, not dead.** ~6 production call sites (`agent_metadata_persistence.py:230-239` bulk-hydrates ~3000 agents; `lifecycle/query.py:945,1029` read/set; `.invalidate()` at `persistence.py:818`, `handlers.py:1929`, `helpers.py:180`). The comment at `agent_metadata_persistence.py:99` ties it to a **~17s first-call tax on observe** it was added to fix. Deleting it risks regressing that. Correct move: make it Redis-free by swapping its backend to in-process (it already degrades to in-process), not deleting it — that's Phase 1/2 work, not a quick win.
+> - **E — no real lock-acquisition caller** (only `runtime_queries.py:703-714` health output + the `__init__` export + status strings). Removing it means updating the health surface, not a no-op.
+> - **F — the circuit breaker lives in `redis_client.py`**, which the session cache still imports. It can't be deleted until Redis itself goes (Phase 2).
+>
+> **Net: there is no genuinely-free Phase 0 deletion.** The only safe-now item is the prep fix (next section, shipped as PR #1122). Everything else carries a real (if small) caller update or perf consideration. The deletions belong in Phase 2, after the mirror lands.
 
 ## Why Surface A is NOT near-free (the v0 error)
 
@@ -61,7 +68,7 @@ Additionally, the Redis session payload carries `trajectory_required`, `spawn_re
 
 ## Corrected sequencing
 
-**Phase 0 — safe deletions now (no data path):** D + E + F. Zero behavior change, shrinks dependency surface, proves the harness. Also delete the false "PostgreSQL backend will enforce" comment in `rate_limiter.py` and the dead `identity_notifications` reader.
+**Phase 0 — REVISED: there is no free deletion (see correction above).** The only safe-now change is the **prep fix** (check `create_session`'s return value + log PG-layer session collisions) — **shipped as PR #1122**. The D/E/F deletions move to Phase 2 (after the mirror lands), because D is perf-load-bearing, E touches the health surface, and F lives inside the still-used `redis_client.py`. The harmless cleanups (delete the false "PostgreSQL backend will enforce" comment in `rate_limiter.py`, remove the dead `identity_notifications` reader) can ride along with the prep fix or Phase 2.
 
 **Phase 1 — build the durable mirror (the real work, Redis stays up):**
 1. Make every resolve path (including `persist=False`) write-through to `core.sessions` (or a purpose-built `core.session_bindings`) with the rich fields (`spawn_reason`, `bind_ip_ua`, `trajectory_required`) and UUID-typed `agent_id`.


### PR DESCRIPTION
Re-lands `claude/redis-retirement-proposal-r7k3`'s three post-#1115-merge commits: the Phase 1 implementation plan (v1.1, council-revised) and the Phase 0 correction (no free deletion; prep fix = #1122).

Conflict resolution note: master's Surface D/E table rows were kept (the newer 2026-06-28 topology-decision framing); the Phase 0 body text — which still offered D+E+F as 'safe deletions now' in contradiction with that decision — is replaced by the correction. The dated correction block (2026-06-27) predates the topology decision above it; read chronologically.

https://claude.ai/code/session_0161HZuyx8XREX5AMZtrk71C