### PR TITLE
doc-health: exempt self-labeled-historical docs from demotion list (re-land)

### DIFF
--- a/scripts/diagnostics/check_doc_health.py
+++ b/scripts/diagnostics/check_doc_health.py
@@ -441,6 +441,17 @@ _DEMOTION_SKIP_ONTOLOGY = {
     "README.md", "identity.md", "plan.md", "paper-positioning.md", "glossary.md",
 }
 
+# A doc that already labels itself historical/archived/superseded is honest
+# about its status — it is not a stale plan masquerading as current, so it is
+# not a demotion candidate even if it also says "shipped". (e.g. s10-fleet-
+# aggregation-plan.md: "archived implementation plan ... retained as design
+# provenance" — flagging it would be noise.)
+_ALREADY_HISTORICAL = re.compile(
+    r'\b(archived|superseded|withdrawn|retained as|design provenance|'
+    r'historical record|historical provenance|for provenance|deprecated)\b',
+    re.IGNORECASE,
+)
+
 _SHIPPED_MARKERS = re.compile(
     r'\b(shipped|deployed|landed|merged|in production|live in prod|'
     r'enforcement shipped|complete[d]?|resolved|done)\b',
@@ -498,6 +509,9 @@ def check_demotion_candidates(md_files: list[Path]) -> list[str]:
         lines = fpath.read_text(errors="replace").splitlines()
         header = "\n".join(lines[:15])
         if not _SHIPPED_MARKERS.search(header):
+            continue
+        # Already honest about being historical → not a stale-plan candidate.
+        if _ALREADY_HISTORICAL.search(header):
             continue
         loc = "ontology/ (identity tree)" if in_ontology else "proposals/"
         if _ACTIVE_REMAINING.search(header):

--- a/tests/test_doc_health_dead_refs.py
+++ b/tests/test_doc_health_dead_refs.py
@@ -457,6 +457,21 @@ def test_ontology_plan_flagged_with_location_hint(tmp_path, monkeypatch, doc_hea
     assert len(warnings) == 1 and "ontology/ (identity tree)" in warnings[0]
 
 
+def test_already_historical_doc_not_flagged(tmp_path, monkeypatch, doc_health):
+    """A doc that already self-labels as archived/provenance is honest, not stale.
+
+    Regression: s10-fleet-aggregation-plan.md says "archived implementation plan
+    ... retained as design provenance" yet was flagged because it also says
+    "shipped". Self-labeled-historical docs must be exempt.
+    """
+    warnings = _demotion_for(
+        tmp_path, monkeypatch, doc_health, "proposals/old-plan.md",
+        "# Old\n\n**Status:** archived implementation plan. Shipped in PR #471; "
+        "retained as design provenance.\n",
+    )
+    assert warnings == []
+
+
 def test_widely_referenced_doc_exempt_as_living_reference(tmp_path, monkeypatch, doc_health):
     """A doc cited by >= threshold other docs is a living reference, not a stale plan."""
     target_rel = "proposals/contract-v0.md"


### PR DESCRIPTION
Re-lands the post-#1206-merge commit from `claude/doc-health-demotion-lint`: a doc whose header already says archived/superseded/retained-as-provenance is honest about its status and should not be flagged as a stale plan (regression case: s10-fleet-aggregation-plan.md). Includes test; `tests/test_doc_health_dead_refs.py` 35/35 green.

https://claude.ai/code/session_0161HZuyx8XREX5AMZtrk71C