### PR TITLE
scope-guard: reframe metered-model rule as user-agnostic (opt-in, not banned) (re-land)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ The installable Codex/Claude adapter bundle is canonical in the companion `unita
 
 ## Execution-cost policy (read first)
 
-- **No metered model-API dependencies.** Do not propose, scaffold, or depend on solutions that require an `ANTHROPIC_API_KEY` or any other paid model API — this rules out `anthropics/claude-code-action` and any CI/automation that calls a metered API. This project targets free / self-hosted execution paths: the local Ollama detector for Watcher, `GITHUB_TOKEN`-only CI, and deterministic CLI tools (ruff, the doctor, the surfacing collectors). If a feature genuinely needs a paid API, surface it as a *deferred, opt-in* option and do not build it inert "just in case."
+- **The core must run free / self-hosted — no *required* metered model-API dependency.** unitares is user/agent-agnostic, so a metered API (Anthropic / OpenAI / …) must never sit on the *required* default path: the server, CI, and residents must run with no paid key (local Ollama for Watcher, `GITHUB_TOKEN`-only CI, deterministic CLI tools — ruff, the doctor, the surfacing collectors). The guarantee is for *every* installer, not just a funded one: someone with no model budget can always run it. Metered models are **welcome as an opt-in, off-by-default backend** — config-gated (e.g. a `base_url` / key from env) so an operator with credits enables them and an operator without stays free. What's forbidden is *forcing* a paid API on everyone: a hardcoded metered endpoint, a metered CI action (`anthropics/claude-code-action`), or a hard SDK import with no local fallback. Add a metered path only as deferred / opt-in, and never build it inert "just in case." (`scripts/dev/check-repo-scope.sh` Rule 6 enforces this.)
 
 ## Claude-specific wiring
 

--- a/docs/REPO_SCOPE.md
+++ b/docs/REPO_SCOPE.md
@@ -36,17 +36,19 @@ agent (or no agent) against it.
 
 ## Metered model-cloud dependencies
 
-The execution-cost policy (`CLAUDE.md` → *Execution-cost policy*) keeps this repo
-free / self-hosted: no dependency that requires a paid model API. The guard makes
-the policy's most concrete clauses executable, flagging only **unambiguously
-cloud-billed** signals in changed files: `anthropics/claude-code-action` in a
-`.github/workflows/` file, an `import`/`from anthropic` SDK import (no local
-equivalent exists), and a hardcoded `api.openai.com` / `api.anthropic.com`
-endpoint. It deliberately does **not** flag the sanctioned free paths — the
-`openai` client is allowed because it also drives a **local Ollama** server via a
-`base_url` override, and the agent orchestrator may spawn the `claude` CLI by
-design. A feature that genuinely needs a paid API should be a *deferred, opt-in*
-option (or live outside this repo), per the policy.
+The execution-cost policy (`CLAUDE.md` → *Execution-cost policy*) keeps the repo
+**user-agnostic**: the core must run free / self-hosted, so a metered model API
+is never *required* on the default path (an installer without a paid key — a solo
+dev, not just a funded company — can always run it). Metered models are welcome
+as an **opt-in, off-by-default backend**; what's forbidden is *forcing* a paid
+API on every installer. The guard makes that line executable, flagging only the
+"forces it on everyone" signals in changed files: `anthropics/claude-code-action`
+in a `.github/workflows/` file, an `import`/`from anthropic` SDK import (no local
+fallback), and a **hardcoded** `api.openai.com` / `api.anthropic.com` endpoint. It
+deliberately does **not** flag the free/opt-in paths — a config-driven `base_url`
+(env override) passes, the `openai` client is allowed (it also drives a **local
+Ollama** server), and the orchestrator may spawn the `claude` CLI by design. A
+deliberate opt-in metered backend can register in `repo-scope-allow.txt`.
 
 ## Why a guard, not just this doc
 

--- a/scripts/dev/check-repo-scope.sh
+++ b/scripts/dev/check-repo-scope.sh
@@ -139,30 +139,30 @@ while IFS= read -r f; do
       ;;
   esac
 
-  # Rule 6: net-new metered model-CLOUD dependency. The execution-cost policy
-  # (CLAUDE.md "No metered model-API dependencies ... rules out
-  # anthropics/claude-code-action and any CI/automation that calls a metered
-  # API") is written but was previously enforced only by humans reading it.
-  # PRECISE, near-zero-false-positive signals ONLY — we deliberately do NOT flag
-  # the sanctioned free paths: the `openai` client is allowed (it talks to LOCAL
-  # Ollama via a base_url override), and the orchestrator may spawn the `claude`
-  # CLI by design. We flag only the unambiguously cloud-billed ones.
+  # Rule 6: a metered model-API on the REQUIRED default path. unitares is
+  # user/agent-agnostic and must run free/self-hosted with no paid key — so a
+  # metered API (Anthropic / OpenAI / ...) must never be FORCED on every
+  # installer. Metered models are welcome as an OPT-IN, off-by-default backend:
+  # a config-driven `base_url` (env override) is NOT flagged, and the existing
+  # `openai` client (drives LOCAL Ollama) and orchestrator-spawned `claude` CLI
+  # pass. We flag only the "forces it on everyone" signals — and an intentional
+  # opt-in metered backend can register in repo-scope-allow.txt.
   if [[ "$f" == .github/workflows/*.yml || "$f" == .github/workflows/*.yaml ]]; then
     if grep -nIE 'anthropics/claude-code-action' "$f" >/dev/null 2>&1; then
-      report "$f" "CI uses anthropics/claude-code-action — a metered model API. The execution-cost policy forbids metered deps; keep CI GITHUB_TOKEN-only / local Ollama."
+      report "$f" "CI uses anthropics/claude-code-action — a metered model API forced on everyone who runs CI. Keep CI free-runnable (GITHUB_TOKEN-only / local Ollama); a metered CI step must be opt-in, not the default."
     fi
   fi
   case "$bn" in
     *.py)
       if grep -nIE '^[[:space:]]*(import|from)[[:space:]]+anthropic([[:space:].]|$)' "$f" >/dev/null 2>&1; then
-        report "$f" "Imports the anthropic SDK — there is no local equivalent, so this is a metered Anthropic API dependency. Forbidden by the execution-cost policy (use a local model via the openai client, or make it a deferred opt-in outside the repo)."
+        report "$f" "Imports the anthropic SDK (no local fallback) — a metered dependency on the default path. Core must run free/self-hosted; expose metered models as an opt-in, off-by-default backend (config-gated), then allowlist this file in scripts/dev/repo-scope-allow.txt."
       fi
       ;;
   esac
   case "$bn" in
     *.py|*.sh|*.bash|*.yml|*.yaml|*.toml)
       if grep -nIE 'api\.(openai|anthropic)\.com' "$f" >/dev/null 2>&1; then
-        report "$f" "Targets a metered model cloud endpoint (api.openai.com / api.anthropic.com) — point at a local/self-hosted base_url, or make it a deferred opt-in per the execution-cost policy."
+        report "$f" "Hardcodes a metered model cloud endpoint (api.openai.com / api.anthropic.com) — that forces a paid API on every installer. Make base_url config-driven (env) so metered stays opt-in, or allowlist a deliberate opt-in backend."
       fi
       ;;
   esac


### PR DESCRIPTION
Re-lands `claude/scope-guard-metered-cloud`'s post-#1257-merge commit: the execution-cost policy is reframed from 'no metered model APIs' to 'the core must run free/self-hosted — metered backends welcome as opt-in, off-by-default' across CLAUDE.md, docs/REPO_SCOPE.md, and the Rule 6 guard. Shared-contract check green (policy section is above the shared block). **Held as draft — policy register, operator merge.**

https://claude.ai/code/session_0161HZuyx8XREX5AMZtrk71C