### PR TITLE
feat(cohort-prior): shadow read-only cohort warm-start for agent baselines

### DIFF
--- a/docs/FLAGS.md
+++ b/docs/FLAGS.md
@@ -14,7 +14,7 @@ For *consequential, flag-gated capabilities* and their **wake conditions**, see
 `docs/operations/dormant-capability-registry.md` (Theme 6) — this file is the flat
 index; that one is the curated decision record.
 
-**97 flags.**
+**98 flags.**
 
 | Flag | Default | Purpose | Read at |
 |---|---|---|---|
@@ -37,6 +37,7 @@ index; that one is the curated decision record.
 | `UNITARES_BASELINE_CACHE_MAXLEN` | `'1000'` | — | governance_core/ethical_drift.py |
 | `UNITARES_CALIBRATION_BACKEND` | `'postgres'` | Initialize calibration checker with confidence bins | src/calibration.py |
 | `UNITARES_CLASS_CALIBRATION` | `''` | Merge a deployment-local per-class calibration overlay into the class-keyed dicts, if ``UNITARES_CLASS_CALIBRATION`` names a JSON file | config/governance_config.py |
+| `UNITARES_COHORT_PRIOR` | `(required)` | Whether cohort-prior warm-start is active | src/cohort_prior.py |
 | `UNITARES_CONNECT_RETRIES` | `'1'` | read by __init__() | agents/sdk/src/unitares_sdk/client.py |
 | `UNITARES_CONNECT_TIMEOUT` | `'10'` | read by __init__() | agents/sdk/src/unitares_sdk/client.py |
 | `UNITARES_CONTINUITY_TOKEN_SECRET` | `(required)` | Return continuity token support details for diagnostics. | src/mcp_handlers/identity/session.py |

--- a/docs/proposals/exponential-growth-dynamics-v0.md
+++ b/docs/proposals/exponential-growth-dynamics-v0.md
@@ -1,0 +1,101 @@
+# Exponential / growth dynamics for UNITARES — scoping + council review (v0)
+
+**Status:** scoping. Site B (cohort priors) has a shadow, read-only primitive landed
+(`src/cohort_prior.py` + `tests/test_cohort_prior.py`); live wiring is deferred and
+out of scope here. Sites A and C are **reviewed and rejected** as framed.
+
+## Question
+
+UNITARES is contractive by construction — every place "exponential" appears in the
+codebase is damping, not growth (EMA smoothing, `e^{-αt}` contraction bounds in
+`governance_core/dynamics.py:485`, the leaky `V` accumulator in `docs/ontology/v7-fhat-spec.md:188`,
+retry backoff). The question: can a genuine *compounding* ("exponential") dynamic be
+added **without** weakening the governor?
+
+## Framing that survived review
+
+There are two regimes, and only one may carry growth:
+
+- **The governor** — verdict cut, CIRS oscillation governor (`src/cirs.py`), drift→entropy
+  coupling. Must stay contractive. Non-negotiable.
+- **The substrate it governs** — knowledge graph, lineage, per-agent baselines. Compounding
+  is legitimate here and does not touch the verdict path.
+
+## Three candidate sites and the council verdict
+
+A five-lens council (control-theory, safety/governance, codebase-fit, research-theory,
+red-team) reviewed the plan against the actual code. Summary:
+
+### Site A — growth term in the ODE E-derivative — REJECTED as framed
+
+Proposed: add `+ρ·E·(1−E)` to `dE/dt`, gated OFF by default, "safe because the ODE is
+diagnostic-only." **The council falsified the safety premise.** "Diagnostic-only" is a
+runtime *flag posture*, not a structural partition. The ODE `E` leaks into enforcement on
+the default config:
+
+- `velocity_risk` is computed from `state.E_history` (the ODE-evolved E) and added to
+  `risk_score` even on the behavioral-primary branch (`src/monitor_risk.py`, history
+  appended `governance_monitor.py:709`).
+- At cold start (behavioral confidence < 0.3, `governance_monitor.py:1306`) the verdict
+  falls back to `phi_objective(state.unitaires_state)` which rewards E, and
+  `runtime_queries.py:93` sets `primary_source=ode_fallback` — the ODE *is* the reported
+  state for low-history agents.
+- `coherence(self.state.V)` feeds CIRS.
+- `sensor_coupling_enabled()` defaults ON (`governance_core/parameters.py:184`), so the ODE
+  is spring-pulled toward the measured curve — which contaminates Site A's own falsification
+  signal.
+
+Additionally: the v7-F̂ spike **already ran the rigorous version of this experiment** (an
+independent ODE-prior predictor compared against observations) and SC2 tripped at Pearson
+r = 0.9949 (denoising-collapse) — the model added no predictive information
+(`docs/ontology/v7-fhat-spec.md §9`, which also **retired FEP grounding for E and V**).
+Logistic `ρ·E(1−E)` also vanishes as `E→1`, exactly where healthy agents live, so
+"divergence stayed low" is guaranteed and proves nothing.
+
+*Salvage bar (not pursued):* only viable rebuilt around a **shadow ODE E** used solely for
+`eisv_divergence`, never written to `self.state.E`.
+
+### Site C — v7 class-scale-constants as cohort meta-learning — REJECTED for now
+
+Builds on the FEP machinery `§9` already retired for E and V. Derivation-heavy, least
+grounded. Revisit only if the F̂ grounding is re-established.
+
+### Site B — cohort priors for per-agent baselines — ACCEPTED (shadow first)
+
+The one growth-shaped move that is also coherent: warm-start a fresh agent's Welford/EMA
+baseline from a **cohort prior** so it starts near-calibrated instead of cold
+(`docs/UNIFIED_ARCHITECTURE.md §2`, "~30 check-ins from scratch"). A sharper prior *reduces*
+surprise → contractive-compatible → never touches the governor. Note it is a **one-time
+cold-start offset, not an exponential** — "slow exponential" was oversold; we keep the honest
+label.
+
+**Conditions the council attached, and how the primitive enforces them:**
+
+| Council condition | Enforcement in `src/cohort_prior.py` |
+|---|---|
+| Seed prior mean/std only; never flip the agent to "baselined" | `WelfordStats.z_score` is inert while `count < 5`. `seed_welford` requires `2 ≤ pseudo_count < 5` and raises otherwise, so a seeded agent **cannot z-score until it logs its own real observations**. Proven by `test_seed_stays_inert_until_agent_earns_it`. |
+| Only *widen* the seeded std | `widen ≥ 1.0` enforced; pooled variance combines within-agent + between-agent spread, so the prior is never narrower than a contributor. |
+| Small pseudo-count | Default 2 (smallest count with defined variance). |
+| One cohort can't *be* the prior | `min_contributors = 2`; under-characterized agents (count < 5) excluded. |
+| Shadow / seeded-not-earned | Module is read-only, persists nothing, is wired into no handler. `test_seed_never_persists` guards it. |
+
+**Why this protects the governor:** the seed biases the *mean estimate*, never the
+*decision to start deciding*. A bad or cohort-correlated cohort therefore cannot silence a
+newcomer's early drift signal — the newcomer stays inert to z-scoring until its own
+observations cross the gate.
+
+## What landed here
+
+- `src/cohort_prior.py` — pure, read-only `CohortPrior` aggregator + guardrailed
+  `seed_welford` / `seed_baseline`. `cohort_prior_enabled()` flag defaults OFF.
+- `tests/test_cohort_prior.py` — 15 tests, including the anti-poisoning invariant and a
+  guard that keeps `Z_SCORE_ACTIVATION_COUNT` in sync with the real Welford gate.
+
+## Deferred (explicitly out of scope, separate PRs)
+
+1. **Cohort aggregation source.** A per-class EISV aggregator over stored baselines
+   (`core.agent_behavioral_baselines`) does not exist yet. Build it as a shadow, read-only
+   query first and validate that seeded cold-start calibration actually improves.
+2. **Live wiring.** Consuming a seed in the baseline-load path
+   (`ensure_baseline_loaded`) is a **coupled identity/onboarding single-writer surface**
+   (`CLAUDE.md`). Requires its own coordination + draft PR; do not wire it in parallel.

--- a/src/cohort_prior.py
+++ b/src/cohort_prior.py
@@ -1,0 +1,202 @@
+"""Cohort behavioral priors — shadow, read-only warm-start for per-agent baselines.
+
+Council-reviewed "Site B" of the exponential/growth-dynamics scoping
+(`docs/proposals/exponential-growth-dynamics-v0.md`). This is the ONE growth-shaped
+move the review endorsed: a sharper starting prior *reduces* surprise, so it is
+compatible with the contractive governor and never touches the verdict path.
+
+What this module is
+-------------------
+A pure, read-only aggregator. It pools many characterized agents' Welford
+baselines (`src.agent_behavioral_baseline.AgentBehavioralBaseline`) into a
+per-signal cohort prior, then hands out a *seed* an operator could use to
+warm-start a fresh agent's baseline so it starts near-calibrated instead of
+cold ("~30 check-ins from scratch every time" — `docs/UNIFIED_ARCHITECTURE.md` §2).
+
+What this module is NOT
+-----------------------
+It is not wired into any live path. It does not persist, does not mutate any
+existing baseline, and is not called by any handler. Wiring it into the live
+baseline-load path is a *separate*, coupled single-writer surface (see
+`CLAUDE.md` → identity/onboarding) and is intentionally out of scope here so the
+prior can be validated in shadow first.
+
+The anti-poisoning invariant (the whole point)
+----------------------------------------------
+`WelfordStats.z_score` returns ``0.0`` while ``count < 5``
+(`agent_behavioral_baseline.py`). That gate is what stops an
+uncharacterized agent from being scored against statistics it has not earned.
+The council's condition — "seed the prior mean/std, never flip the agent to
+'baselined'" — reduces to a hard, testable rule here:
+
+    a cohort seed MUST keep count below that activation gate.
+
+So a warm-started agent carries the cohort mean/std but STILL cannot z-score
+until it has logged its own real observations. That prevents a bad or
+cohort-correlated cohort from silencing a newcomer's early drift signal — the
+seed biases the *mean estimate*, never the *decision to start deciding*.
+`seed_welford` enforces this bound and raises if a caller asks to exceed it.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, Iterable, Optional, Tuple
+
+from src.agent_behavioral_baseline import (
+    AgentBehavioralBaseline,
+    WelfordStats,
+)
+
+# The count below which WelfordStats.z_score is inert (returns 0.0). Kept in
+# sync with `agent_behavioral_baseline.WelfordStats.z_score` by
+# `test_cohort_prior.py::test_activation_gate_matches_welford` — if that gate
+# ever moves, the test fails rather than this constant silently drifting.
+Z_SCORE_ACTIVATION_COUNT = 5
+
+# A seed must stay strictly below the gate. A pseudo-count of 2 is the smallest
+# value for which Welford variance is defined (needs count >= 2), so it is the
+# gentlest non-degenerate prior.
+DEFAULT_PSEUDO_COUNT = 2
+
+# Extra widening applied to the pooled std before seeding. >= 1.0. The council
+# said "only widen seeded std": a wider prior is conservative (it makes the
+# seeded agent slower to call something anomalous, never faster).
+DEFAULT_WIDEN = 1.5
+
+# Per-signal, only pool agents that are themselves characterized, and require
+# more than one contributor so a single agent can never *be* the cohort prior.
+DEFAULT_MIN_AGENT_COUNT = Z_SCORE_ACTIVATION_COUNT
+MIN_CONTRIBUTORS = 2
+
+
+def cohort_prior_enabled() -> bool:
+    """Whether cohort-prior warm-start is active. Default OFF.
+
+    This module is shadow-only regardless; the flag exists so any future live
+    wiring is opt-in from day one. Enable with UNITARES_COHORT_PRIOR in
+    {1, true, on, yes}.
+    """
+    val = os.getenv("UNITARES_COHORT_PRIOR")
+    if val is None:
+        return False
+    return val.strip().lower() in {"1", "true", "on", "yes"}
+
+
+# (mean, std, total_count, n_contributors)
+SignalPrior = Tuple[float, float, int, int]
+
+
+class CohortPrior:
+    """Per-signal pooled prior over a set of agent baselines.
+
+    Pooled variance combines *within*-agent variance and *between*-agent mean
+    spread (the standard parallel-variance / Chan combination), so the prior is
+    naturally at least as wide as any single contributor — pooling never
+    fabricates false confidence.
+    """
+
+    def __init__(self, priors: Dict[str, SignalPrior]):
+        self._priors = priors
+
+    @property
+    def signals(self) -> Tuple[str, ...]:
+        return tuple(self._priors.keys())
+
+    def prior_for(self, signal: str) -> Optional[SignalPrior]:
+        return self._priors.get(signal)
+
+    @classmethod
+    def build(
+        cls,
+        baselines: Iterable[AgentBehavioralBaseline],
+        *,
+        min_agent_count: int = DEFAULT_MIN_AGENT_COUNT,
+        min_contributors: int = MIN_CONTRIBUTORS,
+    ) -> "CohortPrior":
+        """Pool characterized agents into a per-signal prior.
+
+        Only an agent whose per-signal ``count >= min_agent_count`` contributes
+        to that signal. A signal with fewer than ``min_contributors`` qualifying
+        agents gets no prior (absent from the result) rather than a thin one.
+        """
+        baselines = list(baselines)
+        priors: Dict[str, SignalPrior] = {}
+
+        for signal in AgentBehavioralBaseline.TRACKED_SIGNALS:
+            stats = [
+                b._stats[signal]
+                for b in baselines
+                if signal in b._stats and b._stats[signal].count >= min_agent_count
+            ]
+            if len(stats) < min_contributors:
+                continue
+
+            total_count = sum(s.count for s in stats)
+            if total_count < 2:
+                continue
+
+            grand_mean = sum(s.count * s.mean for s in stats) / total_count
+            # Combined M2 = sum of within-agent M2 + between-agent mean spread.
+            combined_m2 = sum(
+                s.m2 + s.count * (s.mean - grand_mean) ** 2 for s in stats
+            )
+            pooled_variance = combined_m2 / (total_count - 1)
+            pooled_std = pooled_variance ** 0.5
+            priors[signal] = (grand_mean, pooled_std, total_count, len(stats))
+
+        return cls(priors)
+
+    def seed_welford(
+        self,
+        signal: str,
+        *,
+        pseudo_count: int = DEFAULT_PSEUDO_COUNT,
+        widen: float = DEFAULT_WIDEN,
+    ) -> Optional[WelfordStats]:
+        """Build a seed WelfordStats for one signal, or None if no prior exists.
+
+        The returned stats carry the cohort mean and a (widened) cohort std but a
+        deliberately small ``count`` that MUST stay below the z-score activation
+        gate — so the seed cannot make an un-observed agent start scoring.
+        """
+        if not (2 <= pseudo_count < Z_SCORE_ACTIVATION_COUNT):
+            raise ValueError(
+                f"pseudo_count must be in [2, {Z_SCORE_ACTIVATION_COUNT}) to stay "
+                f"below the z-score activation gate; got {pseudo_count}. Seeding at "
+                f"or above the gate would let an un-observed agent z-score against "
+                f"cohort stats it has not earned (baseline poisoning)."
+            )
+        if widen < 1.0:
+            raise ValueError(f"widen must be >= 1.0 (only widen seeded std); got {widen}")
+
+        prior = self._priors.get(signal)
+        if prior is None:
+            return None
+        mean, std, _total, _n = prior
+
+        s = WelfordStats()
+        s.count = pseudo_count
+        s.mean = mean
+        seed_variance = (std * widen) ** 2
+        s.m2 = seed_variance * (pseudo_count - 1)
+        return s
+
+    def seed_baseline(
+        self,
+        *,
+        pseudo_count: int = DEFAULT_PSEUDO_COUNT,
+        widen: float = DEFAULT_WIDEN,
+    ) -> AgentBehavioralBaseline:
+        """Build a fresh baseline warm-started on every signal that has a prior.
+
+        Signals without a cohort prior are left as cold Welford stats. The
+        result is a shadow object; the caller decides whether to use it. Nothing
+        here persists or mutates existing state.
+        """
+        baseline = AgentBehavioralBaseline()
+        for signal in baseline.TRACKED_SIGNALS:
+            seed = self.seed_welford(signal, pseudo_count=pseudo_count, widen=widen)
+            if seed is not None:
+                baseline._stats[signal] = seed
+        return baseline

--- a/tests/test_cohort_prior.py
+++ b/tests/test_cohort_prior.py
@@ -1,0 +1,167 @@
+"""Tests for cohort_prior.py — shadow, read-only cohort warm-start priors.
+
+The load-bearing test is `test_seed_stays_inert_until_agent_earns_it`: it proves
+the anti-poisoning invariant the council required — a warm-started agent still
+cannot z-score until it has logged its own real observations.
+"""
+
+import math
+
+import pytest
+
+from src.agent_behavioral_baseline import AgentBehavioralBaseline, WelfordStats
+from src.cohort_prior import (
+    CohortPrior,
+    Z_SCORE_ACTIVATION_COUNT,
+    DEFAULT_PSEUDO_COUNT,
+    cohort_prior_enabled,
+)
+
+SIGNAL = "coherence"
+
+
+def _baseline_with(signal: str, values) -> AgentBehavioralBaseline:
+    b = AgentBehavioralBaseline()
+    for v in values:
+        b.update(signal, v)
+    return b
+
+
+def _cohort(n_agents=4, per_agent=8, base=0.5, spread=0.1):
+    """A cohort of characterized agents whose `coherence` means straddle `base`."""
+    baselines = []
+    for i in range(n_agents):
+        centre = base + (i - (n_agents - 1) / 2) * spread
+        vals = [centre + 0.01 * (j - (per_agent - 1) / 2) for j in range(per_agent)]
+        baselines.append(_baseline_with(SIGNAL, vals))
+    return baselines
+
+
+class TestActivationGate:
+    def test_activation_gate_matches_welford(self):
+        """Our gate constant must equal WelfordStats' real inert threshold.
+
+        If z_score's `count < 5` guard ever moves, this fails loudly instead of
+        letting Z_SCORE_ACTIVATION_COUNT silently drift out of sync.
+        """
+        s = WelfordStats()
+        s.mean = 0.5
+        s.m2 = 1.0  # non-trivial variance
+        # Inert at gate-1, active at the gate.
+        s.count = Z_SCORE_ACTIVATION_COUNT - 1
+        assert s.z_score(10.0) == 0.0
+        s.count = Z_SCORE_ACTIVATION_COUNT
+        assert s.z_score(10.0) != 0.0
+
+
+class TestBuild:
+    def test_pools_grand_mean(self):
+        prior = CohortPrior.build(_cohort(base=0.5, spread=0.0))
+        mean, std, total, n = prior.prior_for(SIGNAL)
+        assert mean == pytest.approx(0.5, abs=1e-9)
+        assert n == 4
+        assert total == 32
+
+    def test_pooled_std_includes_between_agent_spread(self):
+        """A cohort whose agents disagree yields a wider prior than any single agent."""
+        baselines = _cohort(spread=0.2)
+        prior = CohortPrior.build(baselines)
+        _, pooled_std, _, _ = prior.prior_for(SIGNAL)
+        worst_single = max(b._stats[SIGNAL].std for b in baselines)
+        assert pooled_std > worst_single
+
+    def test_excludes_undercharacterized_agents(self):
+        """Agents below min_agent_count don't contribute."""
+        rich = _cohort(n_agents=2, per_agent=8)
+        thin = [_baseline_with(SIGNAL, [0.9, 0.9])]  # count=2 < gate
+        prior = CohortPrior.build(rich + thin)
+        _, _, total, n = prior.prior_for(SIGNAL)
+        assert n == 2  # thin agent excluded
+        assert total == 16
+
+    def test_requires_min_contributors(self):
+        """A single characterized agent is not enough to form a prior."""
+        prior = CohortPrior.build([_baseline_with(SIGNAL, [0.5] * 8)])
+        assert prior.prior_for(SIGNAL) is None
+
+    def test_empty_cohort_has_no_priors(self):
+        prior = CohortPrior.build([])
+        assert prior.signals == ()
+        assert prior.prior_for(SIGNAL) is None
+
+
+class TestSeed:
+    def test_seed_carries_mean_and_widened_std(self):
+        prior = CohortPrior.build(_cohort(base=0.5, spread=0.05))
+        mean, std, _, _ = prior.prior_for(SIGNAL)
+        seed = prior.seed_welford(SIGNAL, pseudo_count=3, widen=2.0)
+        assert seed.mean == pytest.approx(mean)
+        assert seed.std == pytest.approx(std * 2.0, rel=1e-9)
+        assert seed.count == 3
+
+    def test_seed_absent_signal_is_none(self):
+        prior = CohortPrior.build([])
+        assert prior.seed_welford(SIGNAL) is None
+
+    def test_pseudo_count_at_or_above_gate_rejected(self):
+        prior = CohortPrior.build(_cohort())
+        with pytest.raises(ValueError, match="activation gate"):
+            prior.seed_welford(SIGNAL, pseudo_count=Z_SCORE_ACTIVATION_COUNT)
+        with pytest.raises(ValueError):
+            prior.seed_welford(SIGNAL, pseudo_count=1)  # variance undefined
+
+    def test_widen_below_one_rejected(self):
+        prior = CohortPrior.build(_cohort())
+        with pytest.raises(ValueError, match="widen"):
+            prior.seed_welford(SIGNAL, widen=0.5)
+
+    def test_seed_stays_inert_until_agent_earns_it(self):
+        """THE anti-poisoning invariant.
+
+        A seeded baseline carries the cohort mean/std but must still return a
+        z-score of 0 for any value until the agent has logged >= gate of its OWN
+        observations. Otherwise a cohort-correlated bias would silence a
+        newcomer's early drift.
+        """
+        prior = CohortPrior.build(_cohort(base=0.5, spread=0.05))
+        seeded = prior.seed_baseline(pseudo_count=DEFAULT_PSEUDO_COUNT)
+
+        # Wildly off-baseline value scores 0 while still seeded-not-earned.
+        assert seeded.z_score(SIGNAL, 100.0) == 0.0
+        assert not seeded.is_anomalous(SIGNAL, 100.0)
+
+        # Feed real observations until the agent's OWN count crosses the gate.
+        needed = Z_SCORE_ACTIVATION_COUNT - DEFAULT_PSEUDO_COUNT
+        for _ in range(needed - 1):
+            seeded.update(SIGNAL, 0.5)
+            assert seeded.z_score(SIGNAL, 100.0) == 0.0  # still inert
+        seeded.update(SIGNAL, 0.5)  # now count == gate
+        assert seeded.z_score(SIGNAL, 100.0) != 0.0  # now it can flag drift
+
+    def test_seed_baseline_leaves_prior_less_signals_cold(self):
+        """Signals with no cohort prior are left as fresh Welford stats."""
+        # Cohort only characterizes `coherence`; other signals have no prior.
+        prior = CohortPrior.build(_cohort())
+        seeded = prior.seed_baseline()
+        assert seeded._stats["coherence"].count == DEFAULT_PSEUDO_COUNT
+        assert seeded._stats["tool_error_rate"].count == 0
+
+
+class TestFlag:
+    def test_default_off(self, monkeypatch):
+        monkeypatch.delenv("UNITARES_COHORT_PRIOR", raising=False)
+        assert cohort_prior_enabled() is False
+
+    def test_opt_in(self, monkeypatch):
+        monkeypatch.setenv("UNITARES_COHORT_PRIOR", "on")
+        assert cohort_prior_enabled() is True
+
+    def test_seed_never_persists(self):
+        """Building/seeding must not touch the global baseline registry."""
+        from src import cohort_prior  # noqa: F401
+        from src.agent_behavioral_baseline import _baselines
+
+        before = dict(_baselines)
+        prior = CohortPrior.build(_cohort())
+        prior.seed_baseline()
+        assert dict(_baselines) == before


### PR DESCRIPTION
## What / why

Answers the "does unitares have the exponential?" thread. It doesn't — the system is contractive by construction (EMA smoothing, `e^{-αt}` bounds, leaky `V`). This PR lands the **one growth-shaped move a five-lens council endorsed**: a cohort prior that warm-starts a fresh agent's Welford baseline so it starts near-calibrated instead of cold (`~30 check-ins from scratch`, `UNIFIED_ARCHITECTURE.md §2`). A sharper prior *reduces* surprise → compatible with the contractive governor → never touches the verdict path. It's a one-time cold-start offset, **not** an exponential — we keep that label honest.

## Council outcome (full write-up in the proposal doc)

- **Site A** (growth term in the ODE E-derivative) — **rejected**. The "diagnostic-only ODE is inert" premise is false on the default config: ODE `E` leaks into enforcement via `velocity_risk` (`monitor_risk.py`), the cold-start `phi`/`ode_fallback` path, and `coherence(V)` → CIRS; sensor coupling defaults ON and contaminates the falsification signal. The v7-F̂ spike already ran the rigorous version and collapsed at r=0.9949 (`v7-fhat-spec.md §9`, which also retired FEP grounding for E and V).
- **Site C** (v7 class-scale meta-learning) — **rejected for now**; builds on the retired FEP machinery.
- **Site B** (this PR) — **accepted, shadow-first**.

## What's in the diff

- `src/cohort_prior.py` — pure, read-only `CohortPrior` aggregator + guardrailed `seed_welford` / `seed_baseline`. `cohort_prior_enabled()` defaults **OFF**. Persists nothing, wired into no handler.
- `tests/test_cohort_prior.py` — 15 tests.
- `docs/proposals/exponential-growth-dynamics-v0.md` — scoping + council decision record.

## Anti-poisoning invariant (the load-bearing bit)

`WelfordStats.z_score` is inert while `count < 5`. `seed_welford` requires `2 ≤ pseudo_count < 5` and raises otherwise, so a warm-started agent carries the cohort mean/std but **still cannot z-score until it logs its own real observations** — a bad or cohort-correlated cohort can't silence a newcomer's early drift. Proven by `test_seed_stays_inert_until_agent_earns_it`; a companion test keeps the gate constant in sync with the real Welford threshold.

## Scope / safety

- Read-only, off by default, not on any live path — no governor surface touched.
- **Deferred to separate PRs:** the per-class cohort aggregation source (build as shadow query, validate calibration lift first) and live wiring into `ensure_baseline_loaded` (a coupled identity/onboarding single-writer surface per `CLAUDE.md`).

## Tests

`tests/test_cohort_prior.py` — 15 passed. Ran alongside `tests/test_agent_behavioral_baseline.py` (41 passed total) to confirm the underlying baseline surface is undisturbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWN6kEvtJXcrCaqntdAnHx)_