### PR TITLE
fix(watcher): atomic writes for dedup + findings files

### DIFF
--- a/agents/watcher/findings.py
+++ b/agents/watcher/findings.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import subprocess
+import time
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -103,6 +105,10 @@ class Finding:
 # ---------------------------------------------------------------------------
 
 
+def _unique_tmp_path(target: Path) -> Path:
+    return target.with_suffix(f"{target.suffix}.tmp.{os.getpid()}.{time.monotonic_ns()}")
+
+
 def load_dedup() -> dict[str, str]:
     """Return mapping of fingerprint → detected_at timestamp."""
     if not DEDUP_FILE.exists():
@@ -114,8 +120,25 @@ def load_dedup() -> dict[str, str]:
 
 
 def save_dedup(dedup: dict[str, str]) -> None:
+    """Atomically persist ``dedup.json``.
+
+    The scan hook can overlap with itself across fast edit bursts, so direct
+    ``write_text`` is too fragile: a crash or colliding writer can leave a
+    truncated dedup gate. Use the same tmp+rename discipline as the other
+    Watcher state files, with a unique temp name per writer.
+    """
     STATE_DIR.mkdir(parents=True, exist_ok=True)
-    DEDUP_FILE.write_text(json.dumps(dedup, indent=2))
+    tmp = _unique_tmp_path(DEDUP_FILE)
+    try:
+        with tmp.open("w") as fh:
+            json.dump(dedup, fh, indent=2, sort_keys=True)
+        tmp.replace(DEDUP_FILE)
+    except BaseException:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
 
 
 def sweep_stale_dedup(
@@ -247,11 +270,18 @@ def _write_findings_atomic(findings: list[dict[str, Any]]) -> None:
     sibling temp file and renames, so a crash mid-write cannot corrupt the
     findings feed."""
     STATE_DIR.mkdir(parents=True, exist_ok=True)
-    tmp = FINDINGS_FILE.with_suffix(FINDINGS_FILE.suffix + ".tmp")
-    with tmp.open("w") as fh:
-        for f in findings:
-            fh.write(json.dumps(f) + "\n")
-    tmp.replace(FINDINGS_FILE)
+    tmp = _unique_tmp_path(FINDINGS_FILE)
+    try:
+        with tmp.open("w") as fh:
+            for f in findings:
+                fh.write(json.dumps(f) + "\n")
+        tmp.replace(FINDINGS_FILE)
+    except BaseException:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
 
 
 # ---------------------------------------------------------------------------

--- a/agents/watcher/tests/test_agent.py
+++ b/agents/watcher/tests/test_agent.py
@@ -286,6 +286,52 @@ def test_sweep_boundary_exactly_at_ttl_is_kept(watcher_module):
     assert "boundary" in pruned
 
 
+def test_save_dedup_crash_leaves_previous_file_intact(
+    watcher_module, monkeypatch
+):
+    """dedup.json is the scan de-dup gate; a mid-write crash must not corrupt
+    the live file and turn future repeats into noisy rediscoveries."""
+    from agents.watcher import findings as watcher_findings
+
+    watcher_module.save_dedup({"old": "2026-04-11T00:00:00Z"})
+    before = watcher_module.DEDUP_FILE.read_text()
+
+    def crashing_dump(obj, fp, *args, **kwargs):
+        fp.write('{"partial"')
+        raise IOError("simulated mid-write crash")
+
+    monkeypatch.setattr(watcher_findings.json, "dump", crashing_dump)
+    with pytest.raises(IOError):
+        watcher_module.save_dedup({"new": "2026-04-12T00:00:00Z"})
+
+    assert watcher_module.DEDUP_FILE.read_text() == before
+    assert watcher_module.load_dedup() == {"old": "2026-04-11T00:00:00Z"}
+    assert not list(watcher_module.DEDUP_FILE.parent.glob("dedup.json.tmp.*"))
+
+
+def test_write_findings_atomic_crash_leaves_previous_file_intact(
+    watcher_module, monkeypatch
+):
+    """The rewrite path is used by resolve/dismiss/sweep/compact. A failed
+    rewrite should leave the prior feed readable."""
+    from agents.watcher import findings as watcher_findings
+
+    old_rows = [{"fingerprint": "old", "status": "open"}]
+    watcher_module._write_findings_atomic(old_rows)
+    before = watcher_module.FINDINGS_FILE.read_text()
+
+    def crashing_dumps(obj, *args, **kwargs):
+        raise IOError("simulated serialization failure")
+
+    monkeypatch.setattr(watcher_findings.json, "dumps", crashing_dumps)
+    with pytest.raises(IOError):
+        watcher_module._write_findings_atomic([{"fingerprint": "new", "status": "open"}])
+
+    assert watcher_module.FINDINGS_FILE.read_text() == before
+    assert watcher_module._iter_findings_raw() == old_rows
+    assert not list(watcher_module.FINDINGS_FILE.parent.glob("findings.jsonl.tmp.*"))
+
+
 # ---------------------------------------------------------------------------
 # persist_findings — end-to-end dedup with TTL enforcement
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Recovered from the stash-triage sweep (stash `2c2c718a`, codex-housekeeping 2026-06-11 — the only surviving copy of this fix). `save_dedup` still does a bare non-atomic `write_text` and `_write_findings_atomic` uses a fixed collision-prone `.tmp` name with no crash cleanup — a corruption hazard when overlapping PostToolUse scan hooks race. Adds pid+monotonic unique tmp names, tmp+rename for both writers, cleanup-on-exception, and two crash-safety regression tests. Watcher suite 159/159 green.

https://claude.ai/code/session_0161HZuyx8XREX5AMZtrk71C