### PR TITLE
fix(dialectic): cap applied conditions at 20 (unbounded-growth surface)

### DIFF
--- a/src/mcp_handlers/support/condition_parser.py
+++ b/src/mcp_handlers/support/condition_parser.py
@@ -10,6 +10,20 @@ from datetime import datetime
 from src.logging_utils import get_logger
 logger = get_logger(__name__)
 
+MAX_DIALECTIC_CONDITIONS = 20
+
+
+def _append_dialectic_condition(meta, condition: Dict[str, Any]) -> None:
+    """Append a condition while keeping the runtime list bounded."""
+    conditions = getattr(meta, "dialectic_conditions", None)
+    if not isinstance(conditions, list):
+        conditions = []
+        meta.dialectic_conditions = conditions
+    conditions.append(condition)
+    if len(conditions) > MAX_DIALECTIC_CONDITIONS:
+        del conditions[:-MAX_DIALECTIC_CONDITIONS]
+
+
 class ParsedCondition:
     """Structured representation of a parsed condition"""
     
@@ -186,7 +200,7 @@ async def apply_condition(parsed: ParsedCondition, agent_id: str, mcp_server) ->
         if parsed.action == "set":
             if parsed.target == "complexity":
                 # Persist a complexity cap for subsequent updates (enforced in process_agent_update)
-                meta.dialectic_conditions.append({
+                _append_dialectic_condition(meta, {
                     "type": "complexity_limit",
                     "value": parsed.value,
                     "applied_at": datetime.now().isoformat()
@@ -194,7 +208,7 @@ async def apply_condition(parsed: ParsedCondition, agent_id: str, mcp_server) ->
                 result["changes"]["complexity_limit"] = parsed.value
             elif parsed.target == "risk_score":
                 # Can't directly set risk_score (it's computed), but can note it
-                meta.dialectic_conditions.append({
+                _append_dialectic_condition(meta, {
                     "type": "risk_target",
                     "value": parsed.value,
                     "applied_at": datetime.now().isoformat()
@@ -202,7 +216,7 @@ async def apply_condition(parsed: ParsedCondition, agent_id: str, mcp_server) ->
                 result["changes"]["risk_target"] = parsed.value
             elif parsed.target == "coherence":
                 # Can't directly set coherence (it's computed), but can note it
-                meta.dialectic_conditions.append({
+                _append_dialectic_condition(meta, {
                     "type": "coherence_target",
                     "value": parsed.value,
                     "applied_at": datetime.now().isoformat()
@@ -215,7 +229,7 @@ async def apply_condition(parsed: ParsedCondition, agent_id: str, mcp_server) ->
                 duration_hours = parsed.value
                 if parsed.unit == "minutes":
                     duration_hours = parsed.value / 60.0
-                meta.dialectic_conditions.append({
+                _append_dialectic_condition(meta, {
                     "type": "monitoring_duration",
                     "value": duration_hours,
                     "unit": "hours",
@@ -225,7 +239,7 @@ async def apply_condition(parsed: ParsedCondition, agent_id: str, mcp_server) ->
         
         elif parsed.action == "limit":
             # Store limit condition
-            meta.dialectic_conditions.append({
+            _append_dialectic_condition(meta, {
                 "type": f"{parsed.target}_limit",
                 "value": parsed.value,
                 "direction": parsed.unit,  # "below" or "above"
@@ -235,7 +249,7 @@ async def apply_condition(parsed: ParsedCondition, agent_id: str, mcp_server) ->
         
         elif parsed.action in ["reduce", "increase"]:
             # Store adjustment condition
-            meta.dialectic_conditions.append({
+            _append_dialectic_condition(meta, {
                 "type": f"{parsed.target}_adjustment",
                 "action": parsed.action,
                 "target_value": parsed.value,
@@ -257,4 +271,3 @@ async def apply_condition(parsed: ParsedCondition, agent_id: str, mcp_server) ->
         logger.error(f"Error applying condition to agent '{agent_id}': {e}", exc_info=True)
     
     return result
-

--- a/tests/test_remaining_modules.py
+++ b/tests/test_remaining_modules.py
@@ -25,6 +25,7 @@ from src.mcp_handlers.support.condition_parser import (
     parse_condition,
     _normalize_target,
     apply_condition,
+    MAX_DIALECTIC_CONDITIONS,
 )
 
 
@@ -187,6 +188,20 @@ class TestApplyCondition:
         result = await apply_condition(pc, "agent-1", mock_server)
         assert result["status"] == "applied"
         assert "complexity_adjustment" in result["changes"]
+
+    @pytest.mark.asyncio
+    async def test_applied_conditions_are_capped(self, mock_server):
+        meta = mock_server.agent_metadata["agent-1"]
+        meta.dialectic_conditions = [
+            {"type": "old", "value": idx}
+            for idx in range(MAX_DIALECTIC_CONDITIONS + 2)
+        ]
+        pc = parse_condition("Set complexity to 0.3")
+        result = await apply_condition(pc, "agent-1", mock_server)
+        assert result["status"] == "applied"
+        assert len(meta.dialectic_conditions) == MAX_DIALECTIC_CONDITIONS
+        assert meta.dialectic_conditions[0]["value"] == 3
+        assert meta.dialectic_conditions[-1]["type"] == "complexity_limit"
 
     @pytest.mark.asyncio
     async def test_agent_not_found(self, mock_server):


### PR DESCRIPTION
Recovered from the stash-triage sweep (stash `3b364e8d`, 2026-05-05 — never landed in any form). All `meta.dialectic_conditions.append` sites route through `_append_dialectic_condition`, which keeps the newest `MAX_DIALECTIC_CONDITIONS=20` — previously unbounded growth on long-lived agents. Regression test included; `tests/test_remaining_modules.py` 196/196 green. **Check-in-path surface — operator merge.**

https://claude.ai/code/session_0161HZuyx8XREX5AMZtrk71C