### PR TITLE
fix(updates): structured recovery payload for unresolved-identity check-ins

### DIFF
--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -317,7 +317,25 @@ async def resolve_identity_and_guards(ctx: UpdateContext) -> Optional[Sequence[T
 
     if not ctx.agent_uuid:
         logger.error("No agent_uuid in context - identity_v2 resolution failed at dispatch")
-        return [error_response("Identity not resolved. Try calling identity() first.")]
+        return [error_response(
+            "Identity not resolved for this check-in.",
+            recovery={
+                "action": (
+                    "If you already called onboard(), retry with the "
+                    "client_session_id returned by that onboard() call. "
+                    "Otherwise call onboard(force_new=true) first."
+                ),
+                "related_tools": ["onboard", "identity", "process_agent_update"],
+                "workflow": [
+                    "1. Call onboard(force_new=true) to mint this process-instance",
+                    "2. Save client_session_id from the onboard() response",
+                    "3. Pass that client_session_id to process_agent_update()",
+                ],
+            },
+            error_code="SESSION_ERROR",
+            error_category="auth_error",
+            arguments=ctx.arguments,
+        )]
 
     # #425 strict WRITE precondition (caller-proven binding required).
     #

--- a/tests/test_core_update.py
+++ b/tests/test_core_update.py
@@ -263,7 +263,9 @@ class TestProcessAgentUpdate:
             result = await handle_process_agent_update({"response_text": "test"})
 
             data = parse_result(result)
-            assert "error" in data or "Identity not resolved" in json.dumps(data)
+            assert data["error"] == "Identity not resolved for this check-in."
+            assert "client_session_id returned by that onboard() call" in data["recovery"]["action"]
+            assert data["recovery"]["related_tools"] == ["onboard", "identity", "process_agent_update"]
 
     @pytest.mark.asyncio
     async def test_require_strong_identity_rejects_weak_resolution(self, mock_server):

--- a/tests/test_http_endpoints.py
+++ b/tests/test_http_endpoints.py
@@ -162,6 +162,20 @@ class TestCallToolEndpoint:
         arguments = call_args[0][1]
         assert arguments.get("client_session_id") == "my-session-123"
 
+    def test_explicit_client_session_id_beats_session_header(self, client, mock_dispatch):
+        """HTTP header must not overwrite the session id returned by onboard()."""
+        client.post(
+            "/v1/tools/call",
+            json={
+                "tool_name": "test_tool",
+                "arguments": {"client_session_id": "agent-returned-by-onboard"},
+            },
+            headers={"x-session-id": "custom-rest-session"},
+        )
+        call_args = mock_dispatch.call_args
+        arguments = call_args[0][1]
+        assert arguments.get("client_session_id") == "agent-returned-by-onboard"
+
     def test_empty_arguments_defaults_to_dict(self, client, mock_dispatch):
         """Missing arguments field should default to empty dict."""
         client.post("/v1/tools/call", json={


### PR DESCRIPTION
Recovered from the stash-triage sweep (stash `26e00eb6`, 2026-06-11). The unresolved-identity check-in error was a bare string with no recovery route; now returns `error_code=SESSION_ERROR` + a 3-step recovery workflow + related_tools, and pins the existing explicit-`client_session_id`-beats-header precedence with a regression test. `test_core_update` + `test_http_endpoints` 98/98 green. **Check-in-path surface — operator merge.**

https://claude.ai/code/session_0161HZuyx8XREX5AMZtrk71C