### PR TITLE
ops(ci): weekly stranded-work audit — make marooned post-merge work self-announcing

### DIFF
--- a/.github/workflows/stranded-work.yml
+++ b/.github/workflows/stranded-work.yml
@@ -47,6 +47,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # self-provision the label (surface-findings.yml assumes it too, but it
+          # doesn't exist until something creates it)
+          gh label create ci-finding --description "Opened by a CI audit/collector" \
+            --color D93F0B 2>/dev/null || true
           marker='<!-- finding-fingerprint: stranded-work-audit -->'
           body_file=$(mktemp)
           {

--- a/.github/workflows/stranded-work.yml
+++ b/.github/workflows/stranded-work.yml
@@ -1,0 +1,73 @@
+name: Stranded Work Audit
+
+# Weekly sweep for branch work that silently never reached master — the
+# post-merge-commit failure mode (a PR merges, follow-up commits get pushed to
+# the same branch, no surface ever reports the gap; 2026-07-01 a manual sweep
+# found 10 branches carrying real marooned fixes). The audit itself is
+# scripts/dev/stranded_work_audit.py; this workflow is just the schedule plus
+# a deduped GitHub issue when STRANDED branches exist (same pattern as
+# surface-findings.yml: hidden fingerprint marker, ci-finding label).
+#
+# GITHUB_TOKEN-only — no metered APIs (execution-cost policy).
+
+on:
+  schedule:
+    - cron: "17 14 * * 1"   # Mondays 14:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history — the audit compares patch-ids across branches)
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Fetch all branch heads
+        run: git fetch origin '+refs/heads/*:refs/remotes/origin/*'
+
+      - name: Run stranded-work audit
+        id: audit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/dev/stranded_work_audit.py --repo "$GITHUB_REPOSITORY" | tee audit.txt
+          count=$(grep -c '^STRANDED' audit.txt || true)
+          echo "stranded=$count" >> "$GITHUB_OUTPUT"
+          { echo '## Stranded-work audit'; echo '```'; cat audit.txt; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open or update the audit issue (only when STRANDED work exists)
+        if: steps.audit.outputs.stranded != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          marker='<!-- finding-fingerprint: stranded-work-audit -->'
+          body_file=$(mktemp)
+          {
+            echo "$marker"
+            echo "The weekly stranded-work audit found branch work marooned off master."
+            echo "STRANDED = commits pushed after the branch's PR merged, patches not in master — re-land or explicitly discard."
+            echo
+            echo '```'
+            cat audit.txt
+            echo '```'
+            echo
+            echo "_Re-run locally: \`python3 scripts/dev/stranded_work_audit.py\`_"
+          } > "$body_file"
+          existing=$(gh issue list --label ci-finding --state open \
+                       --search 'stranded-work-audit in:body' \
+                       --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body-file "$body_file"
+          else
+            gh issue create \
+              --title "Stranded post-merge work on branches (weekly audit)" \
+              --label ci-finding \
+              --body-file "$body_file"
+          fi

--- a/scripts/dev/stranded_work_audit.py
+++ b/scripts/dev/stranded_work_audit.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Stranded-work audit — find branch work that silently never reached master.
+
+The failure mode this catches (bit the repo through 2026-07-01, when a sweep
+found 10 branches carrying it): a PR merges, then follow-up commits are pushed
+to the same branch. GitHub does not reopen the PR, auto-delete-on-merge does
+not fire (the re-push recreates the branch), and no surface ever reports the
+gap — so real fixes strand on merged-PR branches indefinitely. A common driver
+is a push rejected by a guard (e.g. the repo scope guard) late in a session:
+the commit stays on the branch, the session ends, nobody re-lands it.
+
+Classification per remote branch (skips master/main, archive/*, backup/*):
+
+  STRANDED  newest PR for the branch is MERGED, the branch HEAD advanced past
+            the merged head, and `git cherry` says some of those commits'
+            patches are NOT in master. Real work is marooned -> re-land or
+            explicitly discard. THE ALARM CLASS.
+  PRUNABLE  branch content is fully contained in master (merged ghost) -> safe
+            to delete, pure hygiene.
+  DANGLING  unique commits but no PR route (no PR ever, or newest PR CLOSED
+            unmerged). Informational: might be parked work, might be abandoned.
+  ACTIVE    newest PR is OPEN, or the branch tip is younger than --active-days.
+            Not reported.
+
+Uses only git + the `gh` CLI (GITHUB_TOKEN scope; no metered APIs).
+
+Usage:
+  python3 scripts/dev/stranded_work_audit.py [--repo owner/name] [--json]
+                                             [--check] [--active-days N]
+
+  --check exits 1 when any STRANDED branch is found (for CI gating).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+
+SKIP_EXACT = {"master", "main", "HEAD", "origin", "gh-pages"}  # "origin" = the origin/HEAD symref
+SKIP_PREFIXES = ("archive/", "backup/")
+
+
+def run(*cmd: str) -> str:
+    return subprocess.run(cmd, check=True, capture_output=True, text=True).stdout
+
+
+def remote_branches() -> list[str]:
+    out = run("git", "for-each-ref", "refs/remotes/origin",
+              "--format=%(refname:short)")
+    branches = []
+    for ref in out.splitlines():
+        name = ref.removeprefix("origin/")
+        if name in SKIP_EXACT or name.startswith(SKIP_PREFIXES):
+            continue
+        branches.append(name)
+    return branches
+
+
+def newest_pr(repo: str, branch: str) -> dict | None:
+    out = run("gh", "pr", "list", "--repo", repo, "--head", branch,
+              "--state", "all", "--limit", "1",
+              "--json", "number,state,headRefOid")
+    prs = json.loads(out)
+    return prs[0] if prs else None
+
+
+def unmerged_patch_count(branch: str, since: str | None = None) -> int:
+    """Commits on the branch whose patch-id is absent from origin/master.
+
+    `since` restricts to commits after a known-merged head (the post-merge
+    advance); without it the whole branch is compared.
+    """
+    args = ["git", "cherry", "origin/master", f"origin/{branch}"]
+    if since:
+        args.append(since)
+    out = run(*args)
+    return sum(1 for line in out.splitlines() if line.startswith("+"))
+
+
+def tip_age_days(branch: str) -> int:
+    ts = int(run("git", "log", "-1", "--format=%ct", f"origin/{branch}").strip())
+    return int((time.time() - ts) // 86400)
+
+
+def audit(repo: str, active_days: int) -> list[dict]:
+    findings = []
+    for branch in remote_branches():
+        sha = run("git", "rev-parse", f"origin/{branch}").strip()
+        pr = newest_pr(repo, branch)
+        age = tip_age_days(branch)
+
+        if pr and pr["state"] == "OPEN":
+            continue  # ACTIVE: the PR is the tracking surface
+
+        if pr and pr["state"] == "MERGED":
+            merged_head = pr["headRefOid"]
+            if merged_head == sha:
+                findings.append({"branch": branch, "class": "PRUNABLE",
+                                 "detail": f"PR #{pr['number']} merged at this exact head; "
+                                           "auto-delete missed it (likely re-push residue)"})
+                continue
+            # Branch advanced past the merged head — is the advance in master?
+            since = merged_head if _known_object(merged_head) else None
+            stranded = unmerged_patch_count(branch, since)
+            if stranded:
+                findings.append({"branch": branch, "class": "STRANDED",
+                                 "detail": f"{stranded} commit(s) pushed after PR "
+                                           f"#{pr['number']} merged; patches NOT in master"})
+            else:
+                findings.append({"branch": branch, "class": "PRUNABLE",
+                                 "detail": f"advanced past merged PR #{pr['number']} but all "
+                                           "patches landed in master"})
+            continue
+
+        # No PR, or newest PR closed-unmerged.
+        if age < active_days:
+            continue  # ACTIVE: recent tip, assume a session is still on it
+        unique = unmerged_patch_count(branch)
+        if unique == 0:
+            findings.append({"branch": branch, "class": "PRUNABLE",
+                             "detail": "no open route needed — content is in master"})
+        else:
+            route = f"PR #{pr['number']} CLOSED unmerged" if pr else "no PR ever opened"
+            findings.append({"branch": branch, "class": "DANGLING",
+                             "detail": f"{unique} unique commit(s), {route}, "
+                                       f"tip {age}d old"})
+    return findings
+
+
+def _known_object(sha: str) -> bool:
+    return subprocess.run(["git", "cat-file", "-e", f"{sha}^{{commit}}"],
+                          capture_output=True).returncode == 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo", default="cirwel/unitares")
+    ap.add_argument("--json", action="store_true", dest="as_json")
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if any STRANDED branch is found")
+    ap.add_argument("--active-days", type=int, default=7,
+                    help="tips younger than this with no merged PR are ACTIVE (default 7)")
+    args = ap.parse_args()
+
+    findings = audit(args.repo, args.active_days)
+    order = {"STRANDED": 0, "DANGLING": 1, "PRUNABLE": 2}
+    findings.sort(key=lambda f: (order[f["class"]], f["branch"]))
+
+    if args.as_json:
+        print(json.dumps(findings, indent=2))
+    elif not findings:
+        print("stranded-work audit: clean — no stranded/dangling/prunable branches.")
+    else:
+        width = max(len(f["branch"]) for f in findings)
+        for f in findings:
+            print(f"{f['class']:<9} {f['branch']:<{width}}  {f['detail']}")
+
+    stranded = sum(1 for f in findings if f["class"] == "STRANDED")
+    if stranded:
+        print(f"\n{stranded} STRANDED branch(es) — real work marooned off master; "
+              "re-land (fresh branch off master, cherry-pick, PR) or explicitly discard.",
+              file=sys.stderr)
+    return 1 if (args.check and stranded) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/stranded_work_audit.py
+++ b/scripts/dev/stranded_work_audit.py
@@ -105,7 +105,7 @@ def audit(repo: str, active_days: int) -> list[dict]:
             # Branch advanced past the merged head — is the advance in master?
             since = merged_head if _known_object(merged_head) else None
             stranded = unmerged_patch_count(branch, since)
-            if stranded:
+            if stranded and _end_state_differs(branch, since):
                 findings.append({"branch": branch, "class": "STRANDED",
                                  "detail": f"{stranded} commit(s) pushed after PR "
                                            f"#{pr['number']} merged; patches NOT in master"})
@@ -128,6 +128,23 @@ def audit(repo: str, active_days: int) -> list[dict]:
                              "detail": f"{unique} unique commit(s), {route}, "
                                        f"tip {age}d old"})
     return findings
+
+
+def _end_state_differs(branch: str, since: str | None) -> bool:
+    """Second opinion on a cherry '+': does the branch's END STATE of the files
+    it touched actually differ from master's? A patch can miss by patch-id
+    (different context after master evolved) while its content landed anyway —
+    without this check such branches read as STRANDED when they are PRUNABLE.
+    """
+    base = since or "origin/master"
+    try:
+        touched = run("git", "diff", "--name-only", base, f"origin/{branch}").split()
+        if not touched:
+            return False
+        delta = run("git", "diff", "origin/master", f"origin/{branch}", "--", *touched)
+        return bool(delta.strip())
+    except subprocess.CalledProcessError:
+        return True  # can't prove it landed -> keep the alarm
 
 
 def _known_object(sha: str) -> bool:


### PR DESCRIPTION
Mitigation for the failure mode behind today's 10-branch sweep: commits pushed to a branch **after its PR merges** reach origin but never master — nothing reopens the PR, auto-delete doesn't fire on the re-push, and no surface reports the gap (a scope-guard-rejected push late in a session is a common driver).

- `scripts/dev/stranded_work_audit.py` — classifies every origin branch via `gh` PR state + `git cherry` patch-ids: **STRANDED** (post-merge commits not in master — the alarm class), **DANGLING** (unique commits, no PR route), **PRUNABLE** (merged ghosts). `--check` exits 1 on STRANDED for gating; `--json` for agents.
- `.github/workflows/stranded-work.yml` — weekly cron + manual dispatch, GITHUB_TOKEN-only (execution-cost policy), job-summary table always, and a **deduped ci-finding issue** only when STRANDED work exists (same fingerprint-marker pattern as surface-findings.yml; self-provisions the label).

**First live run already caught 4 origin-only STRANDED branches today's manual sweep missed** (`claude/octopus-rollup` #877, `claude/principal-rollup-proposal` #878, `claude/pr-code-attribution-cloud-3m422q` #1039, `claude/proposal-triage-2026-06-22` #1009) — being triaged separately.

New standing automation → left as draft for operator merge.

https://claude.ai/code/session_0161HZuyx8XREX5AMZtrk71C