### PR TITLE
fix(octopus_rollup): coalesce thread_id from core.agents column, not just metadata (re-land)

### DIFF
--- a/scripts/dev/octopus_rollup.py
+++ b/scripts/dev/octopus_rollup.py
@@ -48,11 +48,19 @@ def fetch_rows(db: str, include_all: bool) -> list[tuple[str, str, str]]:
     Fields are uuids or empty — no embedded tabs — so a tab-separated read is
     unambiguous.
     """
-    where = "" if include_all else "where status = 'active'"
+    # thread_id lives in TWO places that drift: identities.metadata->>'thread_id'
+    # and the core.agents.thread_id column. Some rows carry it in one but not the
+    # other (a dual-store artifact), so coalesce both — reading only metadata
+    # undercounts thread connectivity and inflates the principal count with
+    # false singletons (council live-verify, 2026-06-18).
+    where = "" if include_all else "where i.status = 'active'"
     sql = (
-        "select agent_id, coalesce(metadata->>'thread_id',''), "
-        "coalesce(parent_agent_id::text,'') "
-        f"from core.identities {where}"
+        "select i.agent_id, "
+        "coalesce(i.metadata->>'thread_id', a.thread_id, ''), "
+        "coalesce(i.parent_agent_id::text, '') "
+        "from core.identities i "
+        "left join core.agents a on a.id = i.agent_id "
+        f"{where}"
     )
     proc = subprocess.run(
         ["psql", "-d", db, "-tAF", "\t", "-c", sql],


### PR DESCRIPTION
Stranded post-#877 commit found by the new audit (`scripts/dev/stranded_work_audit.py`, PR #1338): thread_id lives in both `identities.metadata` and the `core.agents.thread_id` column and the two drift; reading only metadata undercounts thread connectivity and inflates the principal count with false singletons. Applied clean onto master.

https://claude.ai/code/session_0161HZuyx8XREX5AMZtrk71C