### PR TITLE
feat(analysis): emit the §6.3 residual-vs-Φ AUC from the Stage-B probe (floor crossed at 25)

### DIFF
--- a/scripts/analysis/stage_b_viability.py
+++ b/scripts/analysis/stage_b_viability.py
@@ -16,8 +16,8 @@ regression guard: when the overlap appears, it starts emitting the AUC.
 from __future__ import annotations
 
 import argparse
+import json
 import sys
-import psycopg2
 
 DIAG = {
     "anchored outcomes (external_signal)":
@@ -47,10 +47,138 @@ DIAG = {
 }
 
 
+# One row per anchored outcome, joined to the LAST baselined state at-or-before
+# the outcome timestamp (the residual's information set — no lookahead).
+JOIN_SQL = """
+SELECT e.is_bad, e.eisv_phi, s.beh, s.state_ts
+FROM audit.outcome_events e
+JOIN core.identities i ON i.agent_id = e.agent_id
+JOIN LATERAL (
+    SELECT s.state_json->'behavioral_eisv' AS beh, s.recorded_at AS state_ts
+    FROM core.agent_state s
+    WHERE s.identity_id = i.identity_id AND s.recorded_at <= e.ts
+      AND s.state_json->'behavioral_eisv'->'warmup'->>'is_baselined' = 'true'
+    ORDER BY s.recorded_at DESC LIMIT 1
+) s ON true
+WHERE e.verification_source = 'external_signal'
+"""
+
+CHANNELS = ("E", "I", "S", "V")
+
+
+def residual_z_norm(beh: dict) -> float | None:
+    """RMS of per-channel self-relative z-scores against the agent's own
+    Welford baseline (roadmap §4/§6: residual = measurement − own reference,
+    scaled by own spread). None when no channel has a usable baseline."""
+    stats = beh.get("baseline_stats") or {}
+    zs = []
+    for ch in CHANNELS:
+        x = beh.get(ch)
+        st = stats.get(ch) or {}
+        mean, m2, n = st.get("mean"), st.get("m2"), st.get("count") or 0
+        if x is None or mean is None or m2 is None or n < 2:
+            continue
+        var = m2 / (n - 1)
+        if var <= 0:
+            continue
+        zs.append((float(x) - float(mean)) / var ** 0.5)
+    if not zs:
+        return None
+    return (sum(z * z for z in zs) / len(zs)) ** 0.5
+
+
+def auc(scores: list[float], labels: list[bool]) -> float | None:
+    """Mann-Whitney AUC — P(score_bad > score_good), average-rank ties.
+    Direction: higher score should mean worse (is_bad=True)."""
+    n_bad = sum(labels)
+    n_good = len(labels) - n_bad
+    if n_bad == 0 or n_good == 0:
+        return None
+    order = sorted(range(len(scores)), key=lambda k: scores[k])
+    ranks = [0.0] * len(scores)
+    i = 0
+    while i < len(order):
+        j = i
+        while j + 1 < len(order) and scores[order[j + 1]] == scores[order[i]]:
+            j += 1
+        avg = (i + j) / 2 + 1  # 1-based average rank across the tie block
+        for k in range(i, j + 1):
+            ranks[order[k]] = avg
+        i = j + 1
+    rank_sum_bad = sum(r for r, is_bad in zip(ranks, labels) if is_bad)
+    return (rank_sum_bad - n_bad * (n_bad + 1) / 2) / (n_bad * n_good)
+
+
+def permutation_p(scores: list[float], labels: list[bool], observed: float,
+                  n_perm: int = 10000, seed: int = 0) -> float:
+    """One-sided permutation p: chance of an AUC >= observed under shuffled
+    labels. With very few positives this is the honest significance measure."""
+    import random
+    rng = random.Random(seed)
+    lab = list(labels)
+    hits = 0
+    for _ in range(n_perm):
+        rng.shuffle(lab)
+        a = auc(scores, lab)
+        if a is not None and a >= observed:
+            hits += 1
+    return (hits + 1) / (n_perm + 1)
+
+
+def emit_auc(conn) -> None:
+    with conn.cursor() as cur:
+        cur.execute(JOIN_SQL)
+        rows = cur.fetchall()
+
+    residuals, phis, labels, clusters = [], [], [], []
+    skipped = 0
+    for is_bad, phi, beh, state_ts in rows:
+        if isinstance(beh, str):
+            beh = json.loads(beh)
+        r = residual_z_norm(beh or {})
+        if r is None or phi is None:
+            skipped += 1
+            continue
+        residuals.append(r)
+        phis.append(float(phi))
+        labels.append(bool(is_bad))
+        clusters.append(state_ts)
+
+    n, n_bad = len(labels), sum(labels)
+    n_clusters = len(set(clusters))
+    bad_clusters = len({c for c, is_bad in zip(clusters, labels) if is_bad})
+    print()
+    print("=== §6.3 falsifier — residual vs Φ on externally-anchored outcomes ===")
+    print(f"  usable rows {n} ({n_bad} bad / {n - n_bad} good; {skipped} skipped: no residual/Φ)")
+    print(f"  distinct prior-state snapshots joined: {n_clusters} "
+          f"({bad_clusters} carrying the bad labels)")
+    a_res = auc(residuals, labels)
+    a_phi = auc(phis, labels)
+    if a_res is None or a_phi is None:
+        print("  AUC undefined — need at least one bad and one good label.")
+        return
+    p_res = permutation_p(residuals, labels, a_res)
+    p_phi = permutation_p(phis, labels, a_phi)
+    print(f"  AUC(residual z-norm) = {a_res:.3f}   (perm p={p_res:.3f})")
+    print(f"  AUC(absolute Φ)      = {a_phi:.3f}   (perm p={p_phi:.3f})")
+    print()
+    lead = "residual > Φ" if a_res > a_phi else ("Φ > residual" if a_phi > a_res else "tie")
+    print(f"  Direction on this sample: {lead}. CAVEATS: rows sharing a prior-state")
+    print(f"  snapshot are NOT independent — adjudication batches join to one state,")
+    print(f"  so the effective sample is ~{n_clusters} clusters (bad labels in "
+          f"{bad_clusters}), and the")
+    print("  permutation p above ignores that clustering (anti-conservative).")
+    print("  Labels are single-channel (Watcher adjudications), effectively")
+    print("  single-agent. This is an instrument check, not a verdict on B —")
+    print("  the gate needs breadth (more residents, channels, and adjudication")
+    print("  batches) before either direction is claimable.")
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--db-url", default="postgresql://postgres:postgres@localhost:5432/governance")
     args = ap.parse_args()
+    import psycopg2  # lazy: keeps the pure math importable in test envs without the driver
     conn = psycopg2.connect(args.db_url)
 
     print("=== Stage B viability: EISV ∩ exogenous-anchor population overlap ===")
@@ -62,17 +190,19 @@ def main():
             print(f"  {label:<52} {v}")
             if label.startswith("OVERLAP"):
                 overlap = v
-    conn.close()
 
     print()
     if overlap < 20:
+        conn.close()
         print(f"VERDICT: B not yet falsifiable — overlap={overlap}. The anchored-outcome")
         print("population and the EISV/baseline population are effectively disjoint.")
         print("Prerequisite (deeper than 'wire test_failed'): EISV-bearing agents must")
         print("RECEIVE and SNAPSHOT externally-anchored outcomes. Until then B's §6.3 gate")
         print("is structurally uncomputable — the validation-gap pathology, by construction.")
         return 0
-    print(f"overlap={overlap} ≥ 20 — residual-vs-Φ AUC is now computable; wire it here.")
+    print(f"overlap={overlap} ≥ 20 — computing the residual-vs-Φ AUC.")
+    emit_auc(conn)
+    conn.close()
     return 0
 
 

--- a/tests/test_stage_b_viability.py
+++ b/tests/test_stage_b_viability.py
@@ -1,0 +1,91 @@
+"""Deterministic checks for the Stage-B falsifier math (no DB).
+
+residual_z_norm / auc / permutation_p are pure; drive them with hand-built
+inputs so the §6.3 emission is verified on known values. The DB join itself is
+exercised by running the probe against a live governance DB, not here.
+"""
+import math
+
+from scripts.analysis.stage_b_viability import auc, permutation_p, residual_z_norm
+
+
+def _beh(values: dict, mean: float, var: float, count: int = 100) -> dict:
+    m2 = var * (count - 1)
+    return {
+        **values,
+        "baseline_stats": {
+            ch: {"mean": mean, "m2": m2, "count": count} for ch in ("E", "I", "S", "V")
+        },
+    }
+
+
+def test_residual_z_norm_known_value():
+    # every channel exactly 2 std above its mean -> RMS z == 2
+    beh = _beh({"E": 0.7, "I": 0.7, "S": 0.7, "V": 0.7}, mean=0.5, var=0.01)
+    assert math.isclose(residual_z_norm(beh), 2.0, rel_tol=1e-9)
+
+
+def test_residual_z_norm_at_baseline_is_zero():
+    beh = _beh({"E": 0.5, "I": 0.5, "S": 0.5, "V": 0.5}, mean=0.5, var=0.01)
+    assert residual_z_norm(beh) == 0.0
+
+
+def test_residual_z_norm_none_without_baseline():
+    assert residual_z_norm({"E": 0.5}) is None
+    assert residual_z_norm({}) is None
+    # count < 2 or zero variance -> unusable channel
+    assert residual_z_norm(
+        {"E": 0.5, "baseline_stats": {"E": {"mean": 0.5, "m2": 0.0, "count": 1}}}
+    ) is None
+
+
+def test_residual_z_norm_skips_unusable_channels():
+    # only E has a usable baseline; z_E = 3 -> RMS over 1 channel == 3
+    beh = {
+        "E": 0.8, "I": 0.5,
+        "baseline_stats": {
+            "E": {"mean": 0.5, "m2": 0.01 * 99, "count": 100},
+            "I": {"mean": 0.5, "m2": 0.0, "count": 1},
+        },
+    }
+    assert math.isclose(residual_z_norm(beh), 3.0, rel_tol=1e-9)
+
+
+def test_auc_perfect_separation():
+    assert auc([1.0, 2.0, 9.0, 10.0], [False, False, True, True]) == 1.0
+
+
+def test_auc_anti_predictive():
+    assert auc([9.0, 10.0, 1.0, 2.0], [False, False, True, True]) == 0.0
+
+
+def test_auc_all_tied_is_half():
+    assert auc([5.0, 5.0, 5.0, 5.0], [False, True, False, True]) == 0.5
+
+
+def test_auc_partial_tie_average_rank():
+    # bad tied with one good above one good: ranks (1, 2.5, 2.5, 4)
+    a = auc([1.0, 3.0, 3.0, 4.0], [False, False, True, True])
+    assert math.isclose(a, (2.5 + 4 - 3) / 4, rel_tol=1e-9)  # U/(n1*n2) = 3.5/4
+
+
+def test_auc_single_class_undefined():
+    assert auc([1.0, 2.0], [True, True]) is None
+    assert auc([1.0, 2.0], [False, False]) is None
+
+
+def test_permutation_p_bounds_and_determinism():
+    scores = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    labels = [False, False, False, False, True, True]
+    observed = auc(scores, labels)
+    p1 = permutation_p(scores, labels, observed, n_perm=2000, seed=0)
+    p2 = permutation_p(scores, labels, observed, n_perm=2000, seed=0)
+    assert p1 == p2  # seeded -> reproducible
+    assert 0.0 < p1 < 0.2  # perfect separation on 2-of-6 is rare under shuffle
+
+
+def test_permutation_p_null_is_large_for_random_scores():
+    scores = [1.0, 2.0, 3.0, 4.0]
+    labels = [True, False, True, False]  # observed AUC = 0.5
+    p = permutation_p(scores, labels, auc(scores, labels), n_perm=500, seed=1)
+    assert p > 0.3


### PR DESCRIPTION
The Stage-B falsifier is computable for the first time: overlap crossed its ≥20 floor (25 today, 0 on 06-25) via the #1210 snapshot bridge + #1214 Sentinel channel accrual. This wires the actual comparison into `stage_b_viability.py`:

- **Residual** = RMS self-relative z-score against the agent's own Welford baseline, taken from the last baselined state at-or-before the outcome (no lookahead), per the roadmap §4/§6 semantics.
- **Comparator** = absolute Φ (the outcome row's snapshot). Mann-Whitney AUC with average-rank ties + a seeded permutation p. No new dependencies; psycopg2 import made lazy so the pure math is unit-testable (11 tests).

**First emission (2026-07-02):** `AUC(residual)=0.909 (p=.009)` vs `AUC(Φ)=0.045` — with the crucial self-disclosed caveat the probe now prints: adjudication batches join to a single prior-state snapshot, so 25 rows ≈ **10 effective clusters and all 3 bad labels sit in ONE cluster**. This is an instrument check proving the pipeline end-to-end, not a verdict on B. The number to grow is independent adjudication batches across more residents/channels.

For the SBIR pitch this is the sentence upgrade from "the falsifier is computable" to "the falsifier runs and reports its own statistical limits."

https://claude.ai/code/session_0161HZuyx8XREX5AMZtrk71C