### PR TITLE
feat(dashboard): Adjudication pane — daily one-click Sentinel verdicts feeding the EISV falsifier

### DIFF
--- a/dashboard/redesign/app.html
+++ b/dashboard/redesign/app.html
@@ -17,6 +17,46 @@
     animation: live-pulse 2s var(--ease) infinite; }
   .live-pill.paused .dot { background: var(--faint); animation: none; }
   @keyframes live-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.25; } }
+
+  /* Adjudication section */
+  .adj-top { display: flex; align-items: baseline; gap: var(--space-3); }
+  .adj-top .pending { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--muted); }
+  .adj-blurb { color: var(--muted); font-size: var(--text-sm); max-width: 62ch; }
+  .adj-progress { display: flex; flex-wrap: wrap; gap: var(--space-4); align-items: baseline;
+    font-family: var(--font-mono); font-size: var(--text-xs); color: var(--muted);
+    padding: var(--space-3) 0; border-bottom: 1px solid var(--line); margin-bottom: var(--space-4); }
+  .adj-progress .stat b { color: var(--ink-2); font-weight: 500; }
+  .adj-progress .stat.ok b { color: var(--ok); }
+  .adj-progress .hint { flex-basis: 100%; color: var(--faint); }
+  .adj-token-hint { background: color-mix(in srgb, var(--warn) 10%, transparent);
+    border: 1px solid color-mix(in srgb, var(--warn) 30%, transparent);
+    border-radius: var(--radius-sm); padding: var(--space-3); font-size: var(--text-sm);
+    margin-bottom: var(--space-4); }
+  .adj-card { border: 1px solid var(--line); border-radius: var(--radius-sm);
+    padding: var(--space-4); margin-bottom: var(--space-3); background: var(--surface-2);
+    transition: opacity 0.4s var(--ease); }
+  .adj-card.done { opacity: 0.35; }
+  .adj-head { display: flex; gap: var(--space-3); align-items: baseline;
+    font-family: var(--font-mono); font-size: var(--text-xs); margin-bottom: var(--space-2); }
+  .adj-head .sev { padding: 1px 6px; border-radius: var(--radius-sm); }
+  .adj-head .sev-critical { color: var(--bad, #d33); background: color-mix(in srgb, var(--bad, #d33) 12%, transparent); }
+  .adj-head .sev-high { color: var(--warn); background: color-mix(in srgb, var(--warn) 12%, transparent); }
+  .adj-head .type { color: var(--muted); }
+  .adj-head .when { color: var(--faint); margin-left: auto; }
+  .adj-msg { font-size: var(--text-sm); margin-bottom: var(--space-3); word-break: break-word; }
+  .adj-actions { display: flex; flex-wrap: wrap; gap: var(--space-2); align-items: center; }
+  .adj-actions .btn { font: inherit; font-size: var(--text-xs); padding: 4px 10px;
+    border: 1px solid var(--line-2); border-radius: var(--radius-sm); background: var(--surface);
+    color: var(--ink-2); cursor: pointer; }
+  .adj-actions .btn:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
+  .adj-actions .btn:disabled { opacity: 0.5; cursor: default; }
+  .adj-actions .btn.confirm:hover:not(:disabled) { border-color: var(--ok); color: var(--ok); }
+  .adj-actions .btn.fp:hover:not(:disabled) { border-color: var(--warn); color: var(--warn); }
+  .adj-actions .dismiss-group { display: inline-flex; gap: var(--space-2); align-items: center; margin-left: auto; }
+  .adj-actions select.reason { font: inherit; font-size: var(--text-xs); padding: 3px 6px;
+    border: 1px solid var(--line); border-radius: var(--radius-sm); background: var(--surface); color: var(--muted); }
+  .adj-note { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--muted); margin-top: var(--space-2); }
+  .adj-empty { color: var(--muted); font-size: var(--text-sm); padding: var(--space-5) 0; }
 </style>
 </head>
 <body>
@@ -42,6 +82,7 @@
     <a href="#metrics" data-section="metrics">Metrics</a>
     <a href="#residents" data-section="residents">Residents</a>
     <a href="#automations" data-section="automations">Automations</a>
+    <a href="#adjudication" data-section="adjudication">Adjudication</a>
   </nav>
 
   <main id="main">
@@ -118,6 +159,10 @@
       <h2 class="section-title">Automations</h2>
       <div id="auto-mount"><div class="loading-skeleton"><div class="skeleton" style="width:35%"></div><div class="skeleton" style="width:88%"></div><div class="skeleton" style="width:72%"></div><div class="skeleton" style="width:80%"></div></div></div>
     </section>
+
+    <section class="section" data-pane="adjudication" hidden>
+      <div id="adj-mount"><div class="loading-skeleton"><div class="skeleton" style="width:35%"></div><div class="skeleton" style="width:88%"></div><div class="skeleton" style="width:72%"></div><div class="skeleton" style="width:80%"></div></div></div>
+    </section>
   </main>
 
   <p class="footnote" id="foot"></p>
@@ -136,6 +181,7 @@
 <script src="./sections/metrics.js"></script>
 <script src="./sections/residents.js"></script>
 <script src="./sections/automations.js"></script>
+<script src="./sections/adjudication.js"></script>
 <script>
 // theme toggle
 const themeBtn = document.getElementById("themeBtn");
@@ -189,6 +235,7 @@ function lazyLoad(id) {
   if (id === "metrics" && window.Metrics) { loaded[id] = true; window.Metrics.load(); }
   if (id === "residents" && window.Residents) { loaded[id] = true; window.Residents.load(); }
   if (id === "automations" && window.Automations) { loaded[id] = true; window.Automations.load(); }
+  if (id === "adjudication" && window.Adjudication) { loaded[id] = true; window.Adjudication.load(); }
 }
 
 // ── auto-refresh: keep the monitor views live ──────────────────────────────

--- a/dashboard/redesign/data.js
+++ b/dashboard/redesign/data.js
@@ -21,6 +21,23 @@
     } catch { return null; }
   }
 
+  // Operator write credential (X-Unitares-Operator). Provision once via
+  // ?operator_token=… — persisted to localStorage and scrubbed from the URL
+  // (same handoff pattern the classic dashboard used, #643).
+  function operatorToken() {
+    try {
+      const params = new URLSearchParams(location.search);
+      const fromUrl = params.get("operator_token");
+      if (fromUrl) {
+        localStorage.setItem("unitares_operator_token", fromUrl);
+        params.delete("operator_token");
+        const qs = params.toString();
+        history.replaceState(null, "", location.pathname + (qs ? "?" + qs : "") + location.hash);
+      }
+      return localStorage.getItem("unitares_operator_token") || null;
+    } catch { return null; }
+  }
+
   async function authFetch(path, opts) {
     opts = opts || {};
     const headers = Object.assign({}, opts.headers);
@@ -335,6 +352,36 @@
         const h = (S().agentHistory || {})[id];
         return h ? { points: h, total: h.length, mode: "all" } : { points: [], total: 0, mode: "recent" };
       });
+    },
+
+    operatorToken,
+
+    // Daily adjudication queue + falsifier progress. Small on purpose —
+    // verdicts on separate days beat batches (cluster statistics).
+    async adjudicationQueue() {
+      return withFallback(
+        async () => {
+          const j = await authFetch("/v1/sentinel/adjudication-queue?limit=5");
+          return j && j.success ? j : null;
+        },
+        () => S().adjudication,
+      );
+    },
+
+    // POST an operator verdict. Throws on non-2xx (message carries the status
+    // code so the view can distinguish 403 token / 409 already-adjudicated).
+    async adjudicate(fingerprint, status, reason) {
+      const headers = { "Content-Type": "application/json" };
+      const op = operatorToken();
+      if (op) headers["X-Unitares-Operator"] = op;
+      const t = token();
+      if (t) headers["Authorization"] = "Bearer " + t;
+      const r = await fetch("/v1/sentinel/adjudicate", {
+        method: "POST", headers,
+        body: JSON.stringify({ fingerprint, status, reason: reason || undefined }),
+      });
+      if (!r.ok) throw new Error("/v1/sentinel/adjudicate -> " + r.status);
+      return r.json();
     },
 
     async residentPanels() {

--- a/dashboard/redesign/sections/adjudication.js
+++ b/dashboard/redesign/sections/adjudication.js
@@ -1,0 +1,177 @@
+/*
+ * Adjudication section — the daily ground-truth ritual.
+ *
+ * Surfaces a small unadjudicated slice of the Sentinel backlog with one-click
+ * operator verdicts (confirm / false-positive / dismiss-with-reason). Each
+ * verdict posts /v1/sentinel/adjudicate → an external_signal outcome_event
+ * attributed to Sentinel's UUID — the label feed for the EISV §6.3
+ * residual-vs-Φ falsifier.
+ *
+ * Deliberately small queue: outcomes join to the last prior state snapshot,
+ * so a batch sweep collapses into ONE statistical cluster. A few verdicts a
+ * day on separate days is worth more than fifty in one sitting — the progress
+ * strip tracks exactly that (independent days, bad-label days vs target).
+ *
+ * Writes require the operator credential (X-Unitares-Operator); the data
+ * layer picks it up from ?operator_token= (persisted + scrubbed) or
+ * localStorage. Without it the section still renders read-only with a hint.
+ */
+(function () {
+  "use strict";
+
+  const mountSel = "#adj-mount";
+  let mounted = false;
+
+  const esc = (s) => String(s == null ? "" : s)
+    .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+
+  function age(ts) {
+    const d = new Date(ts);
+    if (isNaN(d)) return "";
+    const h = Math.max(0, (Date.now() - d.getTime()) / 36e5);
+    if (h < 1) return Math.round(h * 60) + "m ago";
+    if (h < 48) return Math.round(h) + "h ago";
+    return Math.round(h / 24) + "d ago";
+  }
+
+  function progressHtml(p) {
+    if (!p) return "";
+    const badDays = p.bad_days ?? 0, target = p.bad_days_target ?? 3;
+    const onTarget = badDays >= target;
+    return `
+      <div class="adj-progress">
+        <span class="stat"><b>${p.outcomes ?? 0}</b> labels</span>
+        <span class="stat"><b>${p.bad ?? 0}</b> bad</span>
+        <span class="stat"><b>${p.days ?? 0}</b> independent days</span>
+        <span class="stat ${onTarget ? "ok" : ""}"><b>${badDays}/${target}</b> bad-label days</span>
+        <span class="hint">independent days = statistical power; verdicts on separate days beat batches</span>
+      </div>`;
+  }
+
+  function cardHtml(f, reasons) {
+    const opts = (reasons || [])
+      .filter((r) => r !== "fp")
+      .map((r) => `<option value="${esc(r)}">${esc(r.replace(/_/g, " "))}</option>`)
+      .join("");
+    return `
+      <div class="adj-card" data-fp="${esc(f.fingerprint)}">
+        <div class="adj-head">
+          <span class="sev sev-${esc(f.severity)}">${esc(f.severity)}</span>
+          <span class="type">${esc(f.finding_type || "")}</span>
+          <span class="when">${esc(age(f.timestamp))}</span>
+        </div>
+        <div class="adj-msg">${esc(f.message || "(no message)")}</div>
+        <div class="adj-actions">
+          <button class="btn confirm" data-act="confirm">✓ Confirm — Sentinel was right</button>
+          <button class="btn fp" data-act="fp">✗ False positive</button>
+          <span class="dismiss-group">
+            <select class="reason">${opts}</select>
+            <button class="btn dismiss" data-act="dismiss">Dismiss</button>
+          </span>
+        </div>
+        <div class="adj-note" hidden></div>
+      </div>`;
+  }
+
+  function shell() {
+    return `
+      <div class="adj-wrap">
+        <div class="adj-top">
+          <h2>Adjudication <span class="src-badge" id="adj-src"></span></h2>
+          <span id="adj-pending" class="pending"></span>
+        </div>
+        <p class="adj-blurb">Your verdict on each finding becomes an external-truth
+        label attributed to Sentinel — the ground truth the EISV falsifier needs.
+        A few per day, on separate days, is the ideal cadence.</p>
+        <div id="adj-progress-slot"></div>
+        <div id="adj-token-hint" class="adj-token-hint" hidden>
+          Operator token missing — open the dashboard once with
+          <code>?operator_token=…</code> to enable verdicts (it persists locally).
+        </div>
+        <div id="adj-queue"></div>
+      </div>`;
+  }
+
+  async function verdict(card, status, reason) {
+    const fp = card.getAttribute("data-fp");
+    const note = card.querySelector(".adj-note");
+    card.querySelectorAll("button").forEach((b) => (b.disabled = true));
+    try {
+      const r = await window.DATA.adjudicate(fp, status, reason);
+      note.hidden = false;
+      note.textContent = status === "confirmed"
+        ? "Recorded: confirmed (good label)."
+        : reason === "fp"
+          ? "Recorded: false positive (bad label)."
+          : `Recorded: dismissed (${reason}) — valid finding, not actioned.`;
+      card.classList.add("done");
+      if (r && r.progress) {
+        const slot = document.querySelector("#adj-progress-slot");
+        if (slot) slot.innerHTML = progressHtml(r.progress);
+      }
+      setTimeout(() => { card.remove(); refreshPendingCount(-1); }, 900);
+    } catch (e) {
+      note.hidden = false;
+      const msg = String(e && e.message || e);
+      if (msg.includes("403")) {
+        note.textContent = "Operator credential required — see the token hint above.";
+        const hint = document.querySelector("#adj-token-hint");
+        if (hint) hint.hidden = false;
+      } else if (msg.includes("409")) {
+        note.textContent = "Already adjudicated elsewhere — removing.";
+        setTimeout(() => card.remove(), 900);
+      } else {
+        note.textContent = "Failed: " + msg;
+      }
+      card.querySelectorAll("button").forEach((b) => (b.disabled = false));
+    }
+  }
+
+  function refreshPendingCount(delta) {
+    const el = document.querySelector("#adj-pending");
+    if (!el) return;
+    const m = /(\d+)/.exec(el.textContent || "");
+    if (m) {
+      const n = Math.max(0, parseInt(m[1], 10) + delta);
+      el.textContent = n + " pending";
+    }
+  }
+
+  async function load() {
+    const mount = document.querySelector(mountSel);
+    if (!mount) return;
+    if (!mounted) { mount.innerHTML = shell(); mounted = true; }
+
+    const { source, data } = await window.DATA.adjudicationQueue();
+    const badge = document.querySelector("#adj-src");
+    if (badge) { badge.textContent = source; badge.className = "src-badge " + source; }
+
+    const slot = document.querySelector("#adj-progress-slot");
+    if (slot) slot.innerHTML = progressHtml(data.progress);
+    const pending = document.querySelector("#adj-pending");
+    if (pending) pending.textContent = (data.pending_total ?? 0) + " pending";
+    const hint = document.querySelector("#adj-token-hint");
+    if (hint) hint.hidden = !!window.DATA.operatorToken();
+
+    const queueEl = document.querySelector("#adj-queue");
+    if (!queueEl) return;
+    const items = data.queue || [];
+    if (!items.length) {
+      queueEl.innerHTML = `<div class="adj-empty">Queue clear — nothing awaiting a verdict.
+        New Sentinel findings land here as they fire. Come back tomorrow.</div>`;
+      return;
+    }
+    queueEl.innerHTML = items.map((f) => cardHtml(f, data.dismiss_reasons)).join("");
+    queueEl.querySelectorAll(".adj-card").forEach((card) => {
+      card.querySelector('[data-act="confirm"]').addEventListener("click", () => verdict(card, "confirmed", null));
+      card.querySelector('[data-act="fp"]').addEventListener("click", () => verdict(card, "dismissed", "fp"));
+      card.querySelector('[data-act="dismiss"]').addEventListener("click", () => {
+        const sel = card.querySelector("select.reason");
+        verdict(card, "dismissed", sel ? sel.value : "unclear");
+      });
+    });
+  }
+
+  window.Adjudication = { load };
+})();

--- a/dashboard/redesign/snapshot.js
+++ b/dashboard/redesign/snapshot.js
@@ -201,4 +201,22 @@ window.SNAPSHOT = {
       ],
     },
   },
+
+  // Adjudication queue mock — renders the section offline with two sample
+  // findings so the layout is reviewable without a live backlog.
+  adjudication: {
+    success: true,
+    window_hours: 336,
+    pending_total: 2,
+    dismiss_reasons: ["fp", "out_of_scope", "wont_fix", "dup", "unclear", "stale"],
+    progress: { outcomes: 25, bad: 3, days: 4, bad_days: 1, bad_days_target: 3 },
+    queue: [
+      { timestamp: "2026-06-28T04:26:14Z", severity: "high", finding_type: "ad_hoc",
+        violation_class: null, agent_name: "Sentinel", fingerprint: "snapshot-fp-1",
+        message: "forced release: td:/test/force-release-contract (lease 7be1c8fd)" },
+      { timestamp: "2026-06-27T22:11:03Z", severity: "critical", finding_type: "alarm",
+        violation_class: "resource", agent_name: "Sentinel", fingerprint: "snapshot-fp-2",
+        message: "lease-plane p95 breach sustained over two windows" },
+    ],
+  },
 };

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -2854,6 +2854,228 @@ async def http_sentinel_backlog(request):
         return JSONResponse({"success": False, "error": str(e), "findings": []}, status_code=500)
 
 
+# --- Sentinel finding adjudication (dashboard widget backend) ----------------
+#
+# The exogenous-anchor channel (#1214) made operator adjudication of Sentinel
+# findings the ground-truth feed for the EISV §6.3 falsifier — but the only
+# surface was the Sentinel CLI. These two endpoints give the dashboard a daily
+# queue + one-click verdicts. Cadence matters more than volume: outcomes join
+# to the last prior state snapshot, so a batch sweep collapses into ONE
+# statistical cluster — the queue is deliberately small (a few per day).
+
+_SENTINEL_ADJUDICATION_OUTCOME_TYPES = (
+    "sentinel_finding_confirmed", "sentinel_finding_dismissed",
+)
+# Mirrors agents/common/resolution_outcome.py semantics: only "fp" is a bad
+# label; the other reasons drop a finding that was still analytically right.
+_ADJUDICATION_DISMISS_REASONS = ("fp", "out_of_scope", "wont_fix", "dup", "unclear", "stale")
+_SENTINEL_SUBSTRATE_LABEL_PREFIX = "com.unitares.sentinel"
+
+
+async def _adjudicated_sentinel_fingerprints() -> set:
+    """Fingerprints already carrying a durable adjudication outcome (option A:
+    the outcome_event IS the adjudication record; backlog rows are immutable)."""
+    from src.db import get_db
+    db = get_db()
+    async with db.acquire() as conn:
+        rows = await conn.fetch(
+            """SELECT DISTINCT detail->>'fingerprint' AS fp
+               FROM audit.outcome_events
+               WHERE outcome_type = ANY($1::text[])
+                 AND detail->>'fingerprint' IS NOT NULL""",
+            list(_SENTINEL_ADJUDICATION_OUTCOME_TYPES),
+        )
+    return {r["fp"] for r in rows if r["fp"]}
+
+
+async def _sentinel_substrate_uuid() -> Optional[str]:
+    """Sentinel's UUID from the operator-enrolled substrate-claims registry.
+
+    This is deliberately NOT lookup-by-label identity resolution: the row is a
+    kernel-attested, operator-enrolled claim (single writer = the operator),
+    used here as configuration for which resident adjudication outcomes are
+    attributed to — the same UUID the Sentinel CLI path resolves to.
+    """
+    from src.db import get_db
+    db = get_db()
+    async with db.acquire() as conn:
+        row = await conn.fetchrow(
+            """SELECT agent_id FROM core.substrate_claims
+               WHERE expected_launchd_label LIKE $1
+               ORDER BY enrolled_at DESC LIMIT 1""",
+            _SENTINEL_SUBSTRATE_LABEL_PREFIX + "%",
+        )
+    return row["agent_id"] if row else None
+
+
+async def _adjudication_progress() -> dict:
+    """Falsifier-progress readout: independent adjudication DAYS are what buy
+    statistical power (rows sharing a prior-state snapshot are one cluster —
+    day granularity is the operational proxy the widget can act on)."""
+    from src.db import get_db
+    db = get_db()
+    async with db.acquire() as conn:
+        row = await conn.fetchrow(
+            """SELECT count(*) AS outcomes,
+                      count(*) FILTER (WHERE is_bad) AS bad,
+                      count(DISTINCT date(ts)) AS days,
+                      count(DISTINCT date(ts)) FILTER (WHERE is_bad) AS bad_days
+               FROM audit.outcome_events
+               WHERE verification_source = 'external_signal'
+                 AND (outcome_type LIKE 'sentinel_finding_%'
+                      OR outcome_type LIKE 'watcher_finding_%')""",
+        )
+    return {
+        "outcomes": row["outcomes"], "bad": row["bad"],
+        "days": row["days"], "bad_days": row["bad_days"],
+        # ≥3 independent bad days among ~11 day-clusters puts the permutation
+        # floor near p≈0.006 — the "quotable AUC" bar the widget tracks.
+        "bad_days_target": 3,
+    }
+
+
+async def http_sentinel_adjudication_queue(request):
+    """GET /v1/sentinel/adjudication-queue?limit=5&window_hours=336 — the daily
+    unadjudicated slice of the Sentinel backlog, plus falsifier progress."""
+    http_api_token = os.getenv("UNITARES_HTTP_API_TOKEN")
+    if not _check_http_auth(request, http_api_token=http_api_token):
+        return _http_unauthorized()
+    try:
+        try:
+            limit = int(request.query_params.get("limit", "5"))
+        except (TypeError, ValueError):
+            limit = 5
+        limit = max(1, min(limit, 25))
+        try:
+            window_hours = float(request.query_params.get("window_hours", "336"))
+        except (TypeError, ValueError):
+            window_hours = 336.0
+        window_hours = max(1.0, min(window_hours, 24 * 90))
+
+        from src.audit_db import query_audit_events_async
+        start_time = (
+            datetime.now(timezone.utc) - timedelta(hours=window_hours)
+        ).isoformat()
+        events = await query_audit_events_async(
+            event_types=list(_SENTINEL_FINDING_EVENT_TYPES),
+            start_time=start_time,
+            order="desc",
+            limit=1000,
+        )
+        adjudicated = await _adjudicated_sentinel_fingerprints()
+
+        seen: set = set()
+        queue = []
+        pending_total = 0
+        for e in events:
+            details = e.get("details") or {}
+            severity = details.get("severity")
+            if severity not in _SENTINEL_BACKLOG_DEFAULT_SEVERITIES:
+                continue
+            fp = details.get("fingerprint")
+            if not fp or fp in seen:
+                continue
+            seen.add(fp)
+            if fp in adjudicated:
+                continue
+            pending_total += 1
+            if len(queue) < limit:
+                queue.append({
+                    "timestamp": e.get("timestamp"),
+                    "severity": severity,
+                    "finding_type": details.get("finding_type") or details.get("alarm_kind"),
+                    "violation_class": details.get("violation_class"),
+                    "message": details.get("message"),
+                    "agent_name": details.get("agent_name"),
+                    "fingerprint": fp,
+                })
+
+        return JSONResponse({
+            "success": True,
+            "window_hours": window_hours,
+            "queue": queue,
+            "pending_total": pending_total,
+            "dismiss_reasons": list(_ADJUDICATION_DISMISS_REASONS),
+            "progress": await _adjudication_progress(),
+        })
+    except Exception as e:
+        logger.error(f"Error building adjudication queue: {e}")
+        return JSONResponse({"success": False, "error": str(e), "queue": []}, status_code=500)
+
+
+async def http_sentinel_adjudicate(request):
+    """POST /v1/sentinel/adjudicate {fingerprint, status, reason?} — operator-gated.
+
+    Records the operator verdict as an external-truth outcome_event attributed
+    to Sentinel's substrate UUID (same shared builder + semantics as the CLI
+    path in agents/sentinel/agent.py::adjudicate_finding). Idempotent per
+    fingerprint: a second verdict returns 409 rather than double-counting a
+    label the falsifier would read twice.
+    """
+    signals = _build_http_session_signals(request)
+    from src.mcp_handlers.identity.operator import is_operator_caller
+    if not is_operator_caller(signals):
+        return JSONResponse(
+            {"success": False,
+             "error": "operator credential required (X-Unitares-Operator header)"},
+            status_code=403,
+        )
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"success": False, "error": "invalid JSON body"}, status_code=400)
+
+    fingerprint = str(body.get("fingerprint") or "").strip()
+    status = str(body.get("status") or "").strip().lower()
+    reason = (str(body.get("reason") or "").strip().lower() or None)
+    if not fingerprint:
+        return JSONResponse({"success": False, "error": "fingerprint required"}, status_code=400)
+    if status not in ("confirmed", "dismissed"):
+        return JSONResponse(
+            {"success": False, "error": "status must be 'confirmed' or 'dismissed'"},
+            status_code=400,
+        )
+    if status == "dismissed" and reason not in _ADJUDICATION_DISMISS_REASONS:
+        return JSONResponse(
+            {"success": False,
+             "error": f"dismissal needs a reason: {', '.join(_ADJUDICATION_DISMISS_REASONS)}"},
+            status_code=400,
+        )
+
+    try:
+        if fingerprint in await _adjudicated_sentinel_fingerprints():
+            return JSONResponse(
+                {"success": False, "error": "already adjudicated", "fingerprint": fingerprint},
+                status_code=409,
+            )
+        sentinel_uuid = await _sentinel_substrate_uuid()
+        if not sentinel_uuid:
+            return JSONResponse(
+                {"success": False,
+                 "error": "no enrolled Sentinel substrate claim — cannot attribute outcome"},
+                status_code=503,
+            )
+
+        from agents.common.resolution_outcome import build_resolution_outcome_args
+        args = build_resolution_outcome_args(
+            "sentinel_finding", status, fingerprint, sentinel_uuid, reason
+        )
+        args["detail"]["adjudicated_via"] = "dashboard"
+
+        from src.mcp_handlers.observability.outcome_events import _record_outcome_event_inline
+        await _record_outcome_event_inline(args)
+        return JSONResponse({
+            "success": True,
+            "fingerprint": fingerprint,
+            "outcome_type": args["outcome_type"],
+            "is_bad": args["is_bad"],
+            "progress": await _adjudication_progress(),
+        })
+    except Exception as e:
+        logger.error(f"Error recording adjudication for {fingerprint}: {e}")
+        return JSONResponse({"success": False, "error": str(e)}, status_code=500)
+
+
 # Incident history endpoint (anomalies + stuck agents from audit log)
 async def http_incidents(request):
     """Return historical anomaly and stuck-agent incidents from the audit trail."""
@@ -3689,6 +3911,8 @@ def register_http_routes(
     app.routes.append(Route("/v1/substrate/observe", http_substrate_observe, methods=["POST"]))
     app.routes.append(Route("/v1/substrate/dark_sessions", http_substrate_dark_sessions, methods=["GET"]))
     app.routes.append(Route("/v1/sentinel/backlog", http_sentinel_backlog, methods=["GET"]))
+    app.routes.append(Route("/v1/sentinel/adjudication-queue", http_sentinel_adjudication_queue, methods=["GET"]))
+    app.routes.append(Route("/v1/sentinel/adjudicate", http_sentinel_adjudicate, methods=["POST"]))
     app.routes.append(Route("/v1/metrics", http_post_metric, methods=["POST"]))
     app.routes.append(Route("/v1/metrics/series", http_get_metrics, methods=["GET"]))
     app.routes.append(Route("/v1/metrics/catalog", http_get_metrics_catalog, methods=["GET"]))

--- a/tests/test_http_sentinel_adjudication.py
+++ b/tests/test_http_sentinel_adjudication.py
@@ -1,0 +1,199 @@
+"""Tests for the Sentinel adjudication endpoints (dashboard widget backend).
+
+A minimal Starlette app mounts just the two routes; DB helpers and the inline
+outcome recorder are patched so no live governance stack is needed. What's
+under test: the operator write gate, input validation, idempotency, and that
+a verdict produces exactly the outcome args the CLI path would (shared
+builder semantics — fp dismissal is the only bad label).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from src.http_api import (
+    http_sentinel_adjudicate,
+    http_sentinel_adjudication_queue,
+)
+
+OP_TOKEN = "test-operator-token"
+SENTINEL_UUID = "f92dcea8-4786-412a-a0eb-362c273382f5"
+PROGRESS = {"outcomes": 25, "bad": 3, "days": 4, "bad_days": 1, "bad_days_target": 3}
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("UNITARES_OPERATOR_TOKENS", OP_TOKEN)
+    monkeypatch.delenv("UNITARES_HTTP_API_TOKEN", raising=False)
+    app = Starlette(routes=[
+        Route("/v1/sentinel/adjudication-queue", http_sentinel_adjudication_queue, methods=["GET"]),
+        Route("/v1/sentinel/adjudicate", http_sentinel_adjudicate, methods=["POST"]),
+    ])
+    return TestClient(app)
+
+
+def _op_headers():
+    return {"X-Unitares-Operator": OP_TOKEN}
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/sentinel/adjudicate
+# ---------------------------------------------------------------------------
+
+class TestAdjudicateGate:
+    def test_no_operator_header_is_403(self, client):
+        r = client.post("/v1/sentinel/adjudicate",
+                        json={"fingerprint": "fp1", "status": "confirmed"})
+        assert r.status_code == 403
+        assert "operator" in r.json()["error"].lower()
+
+    def test_wrong_operator_token_is_403(self, client):
+        r = client.post("/v1/sentinel/adjudicate",
+                        json={"fingerprint": "fp1", "status": "confirmed"},
+                        headers={"X-Unitares-Operator": "not-the-token"})
+        assert r.status_code == 403
+
+
+class TestAdjudicateValidation:
+    def test_missing_fingerprint_400(self, client):
+        r = client.post("/v1/sentinel/adjudicate",
+                        json={"status": "confirmed"}, headers=_op_headers())
+        assert r.status_code == 400
+
+    def test_bad_status_400(self, client):
+        r = client.post("/v1/sentinel/adjudicate",
+                        json={"fingerprint": "fp1", "status": "maybe"},
+                        headers=_op_headers())
+        assert r.status_code == 400
+
+    def test_dismissal_without_reason_400(self, client):
+        r = client.post("/v1/sentinel/adjudicate",
+                        json={"fingerprint": "fp1", "status": "dismissed"},
+                        headers=_op_headers())
+        assert r.status_code == 400
+        assert "reason" in r.json()["error"]
+
+
+class TestAdjudicateRecording:
+    def _patches(self, already=frozenset(), uuid=SENTINEL_UUID):
+        return (
+            patch("src.http_api._adjudicated_sentinel_fingerprints",
+                  AsyncMock(return_value=set(already))),
+            patch("src.http_api._sentinel_substrate_uuid",
+                  AsyncMock(return_value=uuid)),
+            patch("src.http_api._adjudication_progress",
+                  AsyncMock(return_value=dict(PROGRESS))),
+            patch("src.mcp_handlers.observability.outcome_events._record_outcome_event_inline",
+                  AsyncMock(return_value={"success": True})),
+        )
+
+    def test_fp_dismissal_records_bad_label(self, client):
+        p1, p2, p3, rec = self._patches()
+        with p1, p2, p3, rec as recorder:
+            r = client.post("/v1/sentinel/adjudicate",
+                            json={"fingerprint": "fp1", "status": "dismissed", "reason": "fp"},
+                            headers=_op_headers())
+        assert r.status_code == 200
+        body = r.json()
+        assert body["success"] is True
+        assert body["outcome_type"] == "sentinel_finding_dismissed"
+        assert body["is_bad"] is True
+        assert body["progress"] == PROGRESS
+        args = recorder.call_args[0][0]
+        assert args["agent_id"] == SENTINEL_UUID
+        assert args["verification_source"] == "external_signal"
+        assert args["detail"]["fingerprint"] == "fp1"
+        assert args["detail"]["adjudicated_via"] == "dashboard"
+
+    def test_confirmation_is_good_label(self, client):
+        p1, p2, p3, rec = self._patches()
+        with p1, p2, p3, rec as recorder:
+            r = client.post("/v1/sentinel/adjudicate",
+                            json={"fingerprint": "fp2", "status": "confirmed"},
+                            headers=_op_headers())
+        assert r.status_code == 200
+        assert r.json()["outcome_type"] == "sentinel_finding_confirmed"
+        assert r.json()["is_bad"] is False
+        assert recorder.call_args[0][0]["is_bad"] is False
+
+    def test_non_fp_dismissal_is_not_bad(self, client):
+        p1, p2, p3, rec = self._patches()
+        with p1, p2, p3, rec:
+            r = client.post("/v1/sentinel/adjudicate",
+                            json={"fingerprint": "fp3", "status": "dismissed",
+                                  "reason": "out_of_scope"},
+                            headers=_op_headers())
+        assert r.status_code == 200
+        assert r.json()["is_bad"] is False
+
+    def test_double_adjudication_409(self, client):
+        p1, p2, p3, rec = self._patches(already={"fp1"})
+        with p1, p2, p3, rec as recorder:
+            r = client.post("/v1/sentinel/adjudicate",
+                            json={"fingerprint": "fp1", "status": "confirmed"},
+                            headers=_op_headers())
+        assert r.status_code == 409
+        recorder.assert_not_called()
+
+    def test_missing_substrate_claim_503(self, client):
+        p1, p2, p3, rec = self._patches(uuid=None)
+        with p1, p2, p3, rec as recorder:
+            r = client.post("/v1/sentinel/adjudicate",
+                            json={"fingerprint": "fp1", "status": "confirmed"},
+                            headers=_op_headers())
+        assert r.status_code == 503
+        recorder.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/sentinel/adjudication-queue
+# ---------------------------------------------------------------------------
+
+def _event(fp, severity="high", msg="m", ts="2026-07-01T00:00:00+00:00"):
+    return {"timestamp": ts, "agent_id": "sentinel", "event_id": fp + "-ev",
+            "details": {"severity": severity, "finding_type": "ad_hoc",
+                        "message": msg, "fingerprint": fp, "agent_name": "Sentinel"}}
+
+
+class TestAdjudicationQueue:
+    def test_filters_adjudicated_dedupes_and_counts(self, client):
+        events = [
+            _event("fp-a"),                      # pending
+            _event("fp-a"),                      # duplicate fingerprint -> deduped
+            _event("fp-done"),                   # already adjudicated -> excluded
+            _event("fp-b", severity="critical"), # pending
+            _event("fp-low", severity="low"),    # below default severities -> excluded
+            _event("fp-x") | {"details": {"severity": "high", "message": "no fp"}},  # no fingerprint
+        ]
+        with patch("src.audit_db.query_audit_events_async",
+                   AsyncMock(return_value=events)), \
+             patch("src.http_api._adjudicated_sentinel_fingerprints",
+                   AsyncMock(return_value={"fp-done"})), \
+             patch("src.http_api._adjudication_progress",
+                   AsyncMock(return_value=dict(PROGRESS))):
+            r = client.get("/v1/sentinel/adjudication-queue?limit=5")
+        assert r.status_code == 200
+        body = r.json()
+        fps = [q["fingerprint"] for q in body["queue"]]
+        assert fps == ["fp-a", "fp-b"]
+        assert body["pending_total"] == 2
+        assert body["progress"] == PROGRESS
+        assert "fp" in body["dismiss_reasons"]
+
+    def test_limit_caps_queue_but_not_pending_total(self, client):
+        events = [_event(f"fp-{i}") for i in range(8)]
+        with patch("src.audit_db.query_audit_events_async",
+                   AsyncMock(return_value=events)), \
+             patch("src.http_api._adjudicated_sentinel_fingerprints",
+                   AsyncMock(return_value=set())), \
+             patch("src.http_api._adjudication_progress",
+                   AsyncMock(return_value=dict(PROGRESS))):
+            r = client.get("/v1/sentinel/adjudication-queue?limit=3")
+        body = r.json()
+        assert len(body["queue"]) == 3
+        assert body["pending_total"] == 8


### PR DESCRIPTION
The daily ground-truth ritual as a dashboard pane (works on phone via the tunnel too — buildless, no new app surface).

**What it does**
- New nav tab **Adjudication**: shows up to 5 unadjudicated Sentinel findings (73 currently in the 7-day backlog) with three verdicts: **✓ Confirm** (good label), **✗ False positive** (the sole bad label, per the shared builder semantics), or **Dismiss** with a reason (out_of_scope / wont_fix / dup / unclear / stale — valid finding, not actioned, not bad).
- A **progress strip tracks what actually buys statistical power**: independent adjudication days and bad-label days vs the ≥3 target (the permutation floor math from the §6.3 first emission — batches collapse into one cluster, so the queue is deliberately small).
- Verdicts post to a new operator-gated endpoint that records the same `external_signal` outcome_event the Sentinel CLI path produces, attributed to Sentinel's operator-enrolled substrate-claims UUID. Idempotent per fingerprint (409 on repeat — the falsifier must never read a label twice).

**Provisioning (one-time)**: open the dashboard with `?operator_token=…` — persisted to localStorage and scrubbed from the URL (the #643 handoff pattern, now in the redesign's data layer). Without it the pane renders read-only with a hint.

**Backend**: `GET /v1/sentinel/adjudication-queue`, `POST /v1/sentinel/adjudicate` in http_api.py; gate = `is_operator_caller` (X-Unitares-Operator). 12 endpoint tests green (gate, validation, idempotency, label semantics, queue filtering/dedup).

Held as draft — new operator write surface, your merge. Endpoints go live on next deploy; the dashboard files themselves are read per-request.

https://claude.ai/code/session_0161HZuyx8XREX5AMZtrk71C