### PR TITLE
feat(cohort-prior): per-class aggregation source + shadow-observe on resume

### DIFF
--- a/docs/proposals/exponential-growth-dynamics-v0.md
+++ b/docs/proposals/exponential-growth-dynamics-v0.md
@@ -1,8 +1,9 @@
 # Exponential / growth dynamics for UNITARES — scoping + council review (v0)
 
-**Status:** scoping. Site B (cohort priors) has a shadow, read-only primitive landed
-(`src/cohort_prior.py` + `tests/test_cohort_prior.py`); live wiring is deferred and
-out of scope here. Sites A and C are **reviewed and rejected** as framed.
+**Status:** Site B (cohort priors) landed in shadow, read-only form — the pure primitive
+(PR #1334, merged), the per-class aggregation source, and a non-mutating shadow-observe hook
+on the cold-start resume path (this PR). Live-apply is the next promotion, gated on
+shadow-observe validation data. Sites A and C are **reviewed and rejected** as framed.
 
 ## Question
 
@@ -86,16 +87,35 @@ observations cross the gate.
 
 ## What landed here
 
+**Primitive (PR #1334, merged):**
 - `src/cohort_prior.py` — pure, read-only `CohortPrior` aggregator + guardrailed
   `seed_welford` / `seed_baseline`. `cohort_prior_enabled()` flag defaults OFF.
 - `tests/test_cohort_prior.py` — 15 tests, including the anti-poisoning invariant and a
   guard that keeps `Z_SCORE_ACTIVATION_COUNT` in sync with the real Welford gate.
 
-## Deferred (explicitly out of scope, separate PRs)
+**Aggregation source + shadow-observe (this PR):**
+- `src/cohort_prior_source.py` — bulk-loads stored baselines and groups them by
+  calibration class (same `classify_agent` logic the rest of the system uses) into one
+  `CohortPrior` per class. Named residents (N=1 classes) correctly get no prior. Adds a
+  coarse in-process TTL cache (`get_cached_cohort_priors`) so the cold-start path never
+  bulk-loads on every resume, and `observe_seed_gap` describing the seed a class would
+  receive.
+- `src/db/mixins/baseline.py` — `load_all_behavioral_baselines()`, a read-only bulk SELECT.
+- `src/agent_behavioral_baseline.py` — `_maybe_observe_cohort_seed()` on the cold-start
+  branch of `ensure_baseline_loaded`. **Shadow-only:** no-op unless the flag is enabled;
+  when enabled it *logs* the would-be seed and **never mutates** the fresh baseline
+  (`test_flag_on_observes_without_mutating`).
+- `tests/test_cohort_prior_source.py` — grouping, per-class build, N=1 exclusion, TTL cache,
+  and the flag-off-noop / flag-on-non-mutating shadow-hook invariants.
 
-1. **Cohort aggregation source.** A per-class EISV aggregator over stored baselines
-   (`core.agent_behavioral_baselines`) does not exist yet. Build it as a shadow, read-only
-   query first and validate that seeded cold-start calibration actually improves.
-2. **Live wiring.** Consuming a seed in the baseline-load path
-   (`ensure_baseline_loaded`) is a **coupled identity/onboarding single-writer surface**
-   (`CLAUDE.md`). Requires its own coordination + draft PR; do not wire it in parallel.
+This is the "build it as a shadow, read-only query first and validate calibration lift
+before applying" step. Live-apply is the next promotion, gated on that validation data.
+
+## Deferred (next promotion)
+
+**Live-apply.** Actually seeding the fresh baseline from the class cohort prior on cold
+start (still behind `cohort_prior_enabled()`, still a **coupled identity/onboarding
+single-writer surface** per `CLAUDE.md`). Promote only once the shadow-observe logs show a
+real cold-start calibration lift, and re-check for in-flight work on the baseline/identity
+surface before starting. This will also want a background refresh for the prior cache
+rather than the lazy TTL rebuild used for shadow.

--- a/src/agent_behavioral_baseline.py
+++ b/src/agent_behavioral_baseline.py
@@ -165,7 +165,45 @@ async def ensure_baseline_loaded(agent_id: str) -> AgentBehavioralBaseline:
 
     # Fall through: create fresh baseline
     _baselines[agent_id] = AgentBehavioralBaseline()
+    await _maybe_observe_cohort_seed(agent_id)
     return _baselines[agent_id]
+
+
+async def _maybe_observe_cohort_seed(agent_id: str) -> None:
+    """Shadow-only: log the cohort seed a cold-start agent WOULD receive.
+
+    No-op unless ``UNITARES_COHORT_PRIOR`` is enabled (default OFF). Never
+    mutates the just-created baseline — this only surfaces validation data
+    (calibration lift) so an operator can decide whether to promote to
+    live-apply later. Best-effort: any failure is swallowed at debug level so a
+    resume never breaks on it. Imports are deferred to avoid a circular import
+    (cohort_prior_source imports this module).
+    """
+    try:
+        from src.cohort_prior import cohort_prior_enabled
+
+        if not cohort_prior_enabled():
+            return
+
+        from src.db import get_db
+        from src.cohort_prior_source import (
+            default_classifier,
+            get_cached_cohort_priors,
+            observe_seed_gap,
+        )
+
+        agent_class = default_classifier()(agent_id)
+        if agent_class is None:
+            return
+        priors = await get_cached_cohort_priors(get_db())
+        observed = observe_seed_gap(agent_class, priors)
+        if observed:
+            _logger.info(
+                "cohort-prior shadow: agent=%s class=%s would_seed=%s",
+                agent_id, agent_class, observed,
+            )
+    except Exception:
+        _logger.debug("cohort-prior shadow observation failed for %s", agent_id, exc_info=True)
 
 
 def schedule_baseline_save(agent_id: str) -> None:

--- a/src/cohort_prior_source.py
+++ b/src/cohort_prior_source.py
@@ -1,0 +1,201 @@
+"""Shadow, read-only source that assembles per-class cohort priors.
+
+Follow-up to `src/cohort_prior.py` (the pure primitive). This module does the
+DB-touching + classification legwork the primitive deliberately does not: it
+bulk-loads stored Welford baselines, groups them by calibration class using the
+*same* `classify_agent` logic the rest of the system uses, and hands back one
+`CohortPrior` per class.
+
+Read-only end to end: it never mutates a baseline, never persists, and is on no
+live path unless a caller opts in. Wiring a seed into the resume path is gated
+separately behind `cohort_prior.cohort_prior_enabled()` (default OFF); this
+module is the source those consumers would read from.
+
+Class grouping notes
+--------------------
+- Classes are the calibration classes from `src.grounding.class_indicator`
+  (`ephemeral`, `resident_persistent`, `embodied`, ..., `default`).
+- Named residents are N=1 classes by construction (class == agent), so they can
+  never reach the `min_contributors` floor and correctly get no cohort prior —
+  you cannot warm-start a unique resident from itself.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Callable, Dict, List, Optional
+
+from src.agent_behavioral_baseline import AgentBehavioralBaseline
+from src.cohort_prior import (
+    CohortPrior,
+    DEFAULT_MIN_AGENT_COUNT,
+    DEFAULT_PSEUDO_COUNT,
+    DEFAULT_WIDEN,
+    MIN_CONTRIBUTORS,
+)
+
+# agent_id -> class name (or None to exclude the agent from any cohort).
+ClassifyFn = Callable[[str], Optional[str]]
+
+
+def default_classifier() -> ClassifyFn:
+    """Return an `agent_id -> class` function backed by the metadata cache.
+
+    Mirrors `governance_monitor._resolve_agent_class` production path: the
+    `agent_metadata` cache carries each agent's label/tags, and `classify_agent`
+    maps those to a calibration class. An agent absent from the cache classifies
+    as `None` and is excluded from cohorts (we do not guess a class for it).
+
+    Falls back to a classify-nothing function if the imports are unavailable
+    (e.g. a minimal test process), so callers never crash on import.
+    """
+    try:
+        from src.agent_state import agent_metadata
+        from src.grounding.class_indicator import classify_agent
+    except Exception:
+        return lambda _agent_id: None
+
+    def _classify(agent_id: str) -> Optional[str]:
+        meta = agent_metadata.get(agent_id)
+        if meta is None:
+            return None
+        return classify_agent(meta)
+
+    return _classify
+
+
+def group_baselines_by_class(
+    baselines_by_agent: Dict[str, dict],
+    classify: ClassifyFn,
+) -> Dict[str, List[AgentBehavioralBaseline]]:
+    """Reconstruct stored baselines and bucket them by class. Pure.
+
+    Agents that classify as `None` are dropped rather than pooled into a
+    catch-all — an unknown-class agent should not shape any cohort's prior.
+    """
+    grouped: Dict[str, List[AgentBehavioralBaseline]] = {}
+    for agent_id, stats in baselines_by_agent.items():
+        cls = classify(agent_id)
+        if cls is None:
+            continue
+        grouped.setdefault(cls, []).append(AgentBehavioralBaseline.from_dict(stats))
+    return grouped
+
+
+def build_cohort_priors(
+    baselines_by_agent: Dict[str, dict],
+    classify: ClassifyFn,
+    *,
+    min_agent_count: int = DEFAULT_MIN_AGENT_COUNT,
+    min_contributors: int = MIN_CONTRIBUTORS,
+) -> Dict[str, CohortPrior]:
+    """Build one `CohortPrior` per class from raw stored baselines. Pure.
+
+    A class with too few characterized contributors yields a `CohortPrior` with
+    no signals (the primitive's own `min_contributors` guard), so a caller can
+    always look up `priors.get(cls)` and get either a usable prior or an empty
+    one — never a `KeyError`-shaped surprise.
+    """
+    grouped = group_baselines_by_class(baselines_by_agent, classify)
+    return {
+        cls: CohortPrior.build(
+            members,
+            min_agent_count=min_agent_count,
+            min_contributors=min_contributors,
+        )
+        for cls, members in grouped.items()
+    }
+
+
+async def load_cohort_priors(
+    db,
+    *,
+    classify: Optional[ClassifyFn] = None,
+    min_agent_count: int = DEFAULT_MIN_AGENT_COUNT,
+    min_contributors: int = MIN_CONTRIBUTORS,
+) -> Dict[str, CohortPrior]:
+    """Bulk-load stored baselines from `db` and build per-class priors.
+
+    Read-only. `classify` defaults to `default_classifier()`. Returns `{}` if
+    there are no stored baselines.
+    """
+    baselines_by_agent = await db.load_all_behavioral_baselines()
+    if not baselines_by_agent:
+        return {}
+    return build_cohort_priors(
+        baselines_by_agent,
+        classify or default_classifier(),
+        min_agent_count=min_agent_count,
+        min_contributors=min_contributors,
+    )
+
+
+# --- Shadow-observe path (cold-start resume) --------------------------------
+#
+# When cohort priors are ENABLED (opt-in, default OFF), a cold-start agent's
+# resume logs the seed it WOULD receive so an operator can validate calibration
+# lift before anything is applied. Nothing here mutates or persists a baseline.
+
+_CACHE_TTL_S = 300.0
+_cache: Dict[str, object] = {"priors": None, "built_at": 0.0}
+
+
+async def get_cached_cohort_priors(
+    db,
+    *,
+    ttl_s: float = _CACHE_TTL_S,
+    classify: Optional[ClassifyFn] = None,
+) -> Dict[str, CohortPrior]:
+    """Per-class priors with a coarse in-process TTL cache.
+
+    Avoids a full bulk-load on every cold-start resume without standing up a
+    background refresh task. `time.monotonic()` is used so a clock change can't
+    wedge the TTL. Not thread-safe by design — a redundant concurrent rebuild is
+    harmless (both produce the same read-only snapshot).
+    """
+    now = time.monotonic()
+    priors = _cache.get("priors")
+    if priors is not None and (now - float(_cache["built_at"])) < ttl_s:
+        return priors  # type: ignore[return-value]
+    priors = await load_cohort_priors(db, classify=classify)
+    _cache["priors"] = priors
+    _cache["built_at"] = now
+    return priors
+
+
+def reset_cohort_prior_cache() -> None:
+    """Clear the TTL cache (tests, or after a known baseline-population change)."""
+    _cache["priors"] = None
+    _cache["built_at"] = 0.0
+
+
+def observe_seed_gap(
+    agent_class: str,
+    priors: Dict[str, CohortPrior],
+    *,
+    pseudo_count: int = DEFAULT_PSEUDO_COUNT,
+    widen: float = DEFAULT_WIDEN,
+) -> Optional[Dict[str, dict]]:
+    """Describe the seed a cold-start agent of `agent_class` WOULD receive.
+
+    Returns per-signal `{seed_mean, seed_std, contributors, samples}`, or `None`
+    if the class has no usable prior. Pure and read-only — this is the datum the
+    shadow path logs, not a mutation.
+    """
+    prior = priors.get(agent_class)
+    if prior is None:
+        return None
+    obs: Dict[str, dict] = {}
+    for signal in AgentBehavioralBaseline.TRACKED_SIGNALS:
+        p = prior.prior_for(signal)
+        if p is None:
+            continue
+        _mean, _std, total, n = p
+        seed = prior.seed_welford(signal, pseudo_count=pseudo_count, widen=widen)
+        obs[signal] = {
+            "seed_mean": round(seed.mean, 6),
+            "seed_std": round(seed.std, 6),
+            "contributors": n,
+            "samples": total,
+        }
+    return obs or None

--- a/src/db/mixins/baseline.py
+++ b/src/db/mixins/baseline.py
@@ -120,3 +120,28 @@ class BaselineMixin:
         except Exception as e:
             logger.warning(f"Failed to load behavioral baseline for {agent_id}: {e}")
             return None
+
+    async def load_all_behavioral_baselines(self) -> Dict[str, Dict[str, Any]]:
+        """Bulk-load every agent's Welford stats as ``{agent_id: stats}``.
+
+        Read-only. Feeds the shadow cohort-prior aggregator
+        (``src/cohort_prior_source.py``), which pools these into per-class priors.
+        Returns ``{}`` on error so a callsite degrades to "no cohort prior"
+        rather than raising.
+        """
+        import json as _json
+        out: Dict[str, Dict[str, Any]] = {}
+        try:
+            async with self.acquire() as conn:
+                rows = await conn.fetch(
+                    "SELECT agent_id, stats FROM core.agent_behavioral_baselines"
+                )
+            for row in rows:
+                stats = row["stats"]
+                if isinstance(stats, str):
+                    stats = _json.loads(stats)
+                if stats:
+                    out[row["agent_id"]] = dict(stats)
+        except Exception as e:
+            logger.warning(f"Failed to bulk-load behavioral baselines: {e}")
+        return out

--- a/tests/test_cohort_prior_source.py
+++ b/tests/test_cohort_prior_source.py
@@ -1,0 +1,194 @@
+"""Tests for cohort_prior_source.py — per-class cohort prior assembly (shadow, read-only)."""
+
+from unittest.mock import patch
+
+import pytest
+
+from src.agent_behavioral_baseline import AgentBehavioralBaseline
+from src.cohort_prior import CohortPrior
+from src.cohort_prior_source import (
+    build_cohort_priors,
+    get_cached_cohort_priors,
+    group_baselines_by_class,
+    load_cohort_priors,
+    observe_seed_gap,
+    reset_cohort_prior_cache,
+)
+
+SIGNAL = "coherence"
+
+
+def _stats(values):
+    b = AgentBehavioralBaseline()
+    for v in values:
+        b.update(SIGNAL, v)
+    return b.to_dict()
+
+
+def _fixed_classifier(mapping):
+    return lambda agent_id: mapping.get(agent_id)
+
+
+class TestGrouping:
+    def test_buckets_by_class(self):
+        baselines = {
+            "a": _stats([0.5] * 8),
+            "b": _stats([0.6] * 8),
+            "c": _stats([0.9] * 8),
+        }
+        classify = _fixed_classifier({"a": "ephemeral", "b": "ephemeral", "c": "default"})
+        grouped = group_baselines_by_class(baselines, classify)
+        assert set(grouped) == {"ephemeral", "default"}
+        assert len(grouped["ephemeral"]) == 2
+        assert len(grouped["default"]) == 1
+
+    def test_unclassified_agents_dropped(self):
+        baselines = {"a": _stats([0.5] * 8), "ghost": _stats([0.5] * 8)}
+        classify = _fixed_classifier({"a": "ephemeral"})  # ghost -> None
+        grouped = group_baselines_by_class(baselines, classify)
+        assert set(grouped) == {"ephemeral"}
+        assert len(grouped["ephemeral"]) == 1
+
+
+class TestBuild:
+    def test_prior_per_class(self):
+        baselines = {
+            f"e{i}": _stats([0.5 + 0.01 * i] * 8) for i in range(3)
+        }
+        baselines["solo"] = _stats([0.9] * 8)
+        classify = _fixed_classifier(
+            {"e0": "ephemeral", "e1": "ephemeral", "e2": "ephemeral", "solo": "embodied"}
+        )
+        priors = build_cohort_priors(baselines, classify)
+
+        # ephemeral has 3 contributors -> usable prior
+        assert priors["ephemeral"].prior_for(SIGNAL) is not None
+        mean, _std, _total, n = priors["ephemeral"].prior_for(SIGNAL)
+        assert n == 3
+        assert mean == pytest.approx(0.51, abs=1e-6)
+
+        # embodied is N=1 -> below min_contributors -> empty prior, no KeyError
+        assert priors["embodied"].prior_for(SIGNAL) is None
+
+    def test_named_resident_n1_gets_no_prior(self):
+        """A resident class (population of one) can never form a cohort prior."""
+        baselines = {"Lumen": _stats([0.5] * 30)}
+        priors = build_cohort_priors(baselines, _fixed_classifier({"Lumen": "Lumen"}))
+        assert priors["Lumen"].prior_for(SIGNAL) is None
+
+    def test_undercharacterized_contributor_excluded(self):
+        baselines = {
+            "a": _stats([0.5] * 8),
+            "b": _stats([0.5] * 8),
+            "thin": _stats([0.5, 0.5]),  # count 2 < gate
+        }
+        classify = _fixed_classifier({"a": "ephemeral", "b": "ephemeral", "thin": "ephemeral"})
+        priors = build_cohort_priors(baselines, classify)
+        _, _, total, n = priors["ephemeral"].prior_for(SIGNAL)
+        assert n == 2  # thin excluded
+        assert total == 16
+
+
+class TestLoad:
+    @pytest.mark.asyncio
+    async def test_load_reads_db_and_builds(self):
+        class FakeDB:
+            async def load_all_behavioral_baselines(self):
+                return {
+                    "a": _stats([0.5] * 8),
+                    "b": _stats([0.52] * 8),
+                }
+
+        classify = _fixed_classifier({"a": "ephemeral", "b": "ephemeral"})
+        priors = await load_cohort_priors(FakeDB(), classify=classify)
+        assert isinstance(priors["ephemeral"], CohortPrior)
+        assert priors["ephemeral"].prior_for(SIGNAL) is not None
+
+    @pytest.mark.asyncio
+    async def test_load_empty_db_returns_empty(self):
+        class EmptyDB:
+            async def load_all_behavioral_baselines(self):
+                return {}
+
+        priors = await load_cohort_priors(EmptyDB(), classify=_fixed_classifier({}))
+        assert priors == {}
+
+
+class TestObserveSeedGap:
+    def _priors(self):
+        baselines = {f"e{i}": _stats([0.5 + 0.01 * i] * 8) for i in range(3)}
+        return build_cohort_priors(
+            baselines, _fixed_classifier({f"e{i}": "ephemeral" for i in range(3)})
+        )
+
+    def test_reports_seed_for_known_class(self):
+        obs = observe_seed_gap("ephemeral", self._priors())
+        assert SIGNAL in obs
+        assert obs[SIGNAL]["contributors"] == 3
+        assert obs[SIGNAL]["samples"] == 24
+        assert obs[SIGNAL]["seed_std"] >= 0.0
+
+    def test_none_for_unknown_or_thin_class(self):
+        priors = self._priors()
+        assert observe_seed_gap("nonesuch", priors) is None
+
+
+class TestCache:
+    @pytest.mark.asyncio
+    async def test_ttl_cache_avoids_second_db_load(self):
+        reset_cohort_prior_cache()
+        calls = {"n": 0}
+
+        class CountingDB:
+            async def load_all_behavioral_baselines(db_self):
+                calls["n"] += 1
+                return {"a": _stats([0.5] * 8), "b": _stats([0.5] * 8)}
+
+        classify = _fixed_classifier({"a": "ephemeral", "b": "ephemeral"})
+        db = CountingDB()
+        await get_cached_cohort_priors(db, classify=classify)
+        await get_cached_cohort_priors(db, classify=classify)
+        assert calls["n"] == 1  # second call served from cache
+        reset_cohort_prior_cache()
+        await get_cached_cohort_priors(db, classify=classify)
+        assert calls["n"] == 2  # reset forces a rebuild
+
+
+class TestShadowHook:
+    @pytest.mark.asyncio
+    async def test_flag_off_is_noop_and_baseline_stays_cold(self, monkeypatch):
+        """Default (flag OFF): resume creates a cold baseline, no observation."""
+        monkeypatch.delenv("UNITARES_COHORT_PRIOR", raising=False)
+        from src import agent_behavioral_baseline as abl
+
+        abl._baselines.pop("cold-agent", None)
+        with patch("src.db.get_db") as get_db:
+            await abl._maybe_observe_cohort_seed("cold-agent")
+            get_db.assert_not_called()  # flag gate short-circuits before any DB touch
+
+    @pytest.mark.asyncio
+    async def test_flag_on_observes_without_mutating(self, monkeypatch, caplog):
+        monkeypatch.setenv("UNITARES_COHORT_PRIOR", "on")
+        reset_cohort_prior_cache()
+        from src import agent_behavioral_baseline as abl
+
+        class FakeDB:
+            async def load_all_behavioral_baselines(self):
+                return {f"e{i}": _stats([0.5] * 8) for i in range(3)}
+
+        # Create the fresh (cold) baseline exactly as the resume path does.
+        abl._baselines["new-eph"] = AgentBehavioralBaseline()
+        with patch("src.db.get_db", return_value=FakeDB()), patch(
+            "src.cohort_prior_source.default_classifier",
+            return_value=_fixed_classifier(
+                {"new-eph": "ephemeral", "e0": "ephemeral", "e1": "ephemeral", "e2": "ephemeral"}
+            ),
+        ):
+            await abl._maybe_observe_cohort_seed("new-eph")
+
+        # The observed agent's baseline is UNCHANGED — still cold, still inert.
+        b = abl._baselines["new-eph"]
+        assert b.sample_count == 0
+        assert b.z_score(SIGNAL, 100.0) == 0.0
+        abl._baselines.pop("new-eph", None)
+        reset_cohort_prior_cache()


### PR DESCRIPTION
## What / why

The two follow-ups deferred by the merged cohort-prior primitive (#1334). Both are **shadow / read-only** — this is the "build the aggregation source and validate calibration lift *before* applying" step the council required. Live-apply remains the next promotion.

## 1. Per-class aggregation source — `src/cohort_prior_source.py`

- Bulk-loads stored Welford baselines via a new read-only `load_all_behavioral_baselines()` on the DB baseline mixin, and groups them by **calibration class** using the same `classify_agent` logic the rest of the system uses → one `CohortPrior` per class.
- Named residents (N=1 classes) correctly get **no prior** — you can't warm-start a unique resident from itself; the primitive's `min_contributors=2` guard handles this.
- Coarse in-process **TTL cache** (`get_cached_cohort_priors`) so the cold-start path never bulk-loads on every resume, without standing up a background task.

## 2. Shadow-observe hook — `ensure_baseline_loaded`

- On the cold-start branch, when `UNITARES_COHORT_PRIOR` is enabled (**default OFF**), logs the seed the agent *would* receive vs its cold default and **never mutates** the fresh baseline.
- Best-effort with lazy imports (avoids a circular import; `cohort_prior_source` imports this module) — a resume never breaks on it.

## Safety

- Read-only end to end; the observed baseline stays cold (`test_flag_on_observes_without_mutating`).
- Flag OFF by default → zero change to production behavior; the flag gate short-circuits before any DB touch (`test_flag_off_is_noop_and_baseline_stays_cold`).
- No new env flags; `docs/FLAGS.md` unchanged.
- Checked for in-flight work on the baseline/identity single-writer surface before starting — none open.

## Deferred (next promotion)

**Live-apply**: actually seed the fresh baseline from the class cohort prior on cold start (still flag-gated, still a coupled identity single-writer surface). Promote only once shadow-observe logs show a real cold-start calibration lift; will also want a background refresh for the prior cache rather than the lazy TTL rebuild.

## Tests

`tests/test_cohort_prior_source.py` — class grouping, per-class build, N=1 exclusion, under-characterized-contributor exclusion, TTL cache hit/reset, and the two shadow-hook invariants. **53 passed** across the cohort + baseline suites (`test_cohort_prior_source`, `test_cohort_prior`, `test_agent_behavioral_baseline`). Ruff clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWN6kEvtJXcrCaqntdAnHx)_