### PR TITLE
feat(cohort-prior): live-apply mode behind explicit second opt-in

### DIFF
--- a/docs/FLAGS.md
+++ b/docs/FLAGS.md
@@ -14,7 +14,7 @@ For *consequential, flag-gated capabilities* and their **wake conditions**, see
 `docs/operations/dormant-capability-registry.md` (Theme 6) — this file is the flat
 index; that one is the curated decision record.
 
-**98 flags.**
+**99 flags.**
 
 | Flag | Default | Purpose | Read at |
 |---|---|---|---|
@@ -37,7 +37,8 @@ index; that one is the curated decision record.
 | `UNITARES_BASELINE_CACHE_MAXLEN` | `'1000'` | — | governance_core/ethical_drift.py |
 | `UNITARES_CALIBRATION_BACKEND` | `'postgres'` | Initialize calibration checker with confidence bins | src/calibration.py |
 | `UNITARES_CLASS_CALIBRATION` | `''` | Merge a deployment-local per-class calibration overlay into the class-keyed dicts, if ``UNITARES_CLASS_CALIBRATION`` names a JSON file | config/governance_config.py |
-| `UNITARES_COHORT_PRIOR` | `(required)` | Whether cohort-prior warm-start is active | src/cohort_prior.py |
+| `UNITARES_COHORT_PRIOR` | `(required)` | Whether cohort-prior warm-start is active at all | src/cohort_prior.py |
+| `UNITARES_COHORT_PRIOR_MODE` | `(required)` | Behavior when cohort priors are enabled: 'observe' (default) or 'apply' | src/cohort_prior.py |
 | `UNITARES_CONNECT_RETRIES` | `'1'` | read by __init__() | agents/sdk/src/unitares_sdk/client.py |
 | `UNITARES_CONNECT_TIMEOUT` | `'10'` | read by __init__() | agents/sdk/src/unitares_sdk/client.py |
 | `UNITARES_CONTINUITY_TOKEN_SECRET` | `(required)` | Return continuity token support details for diagnostics. | src/mcp_handlers/identity/session.py |

--- a/docs/proposals/exponential-growth-dynamics-v0.md
+++ b/docs/proposals/exponential-growth-dynamics-v0.md
@@ -1,9 +1,11 @@
 # Exponential / growth dynamics for UNITARES — scoping + council review (v0)
 
-**Status:** Site B (cohort priors) landed in shadow, read-only form — the pure primitive
-(PR #1334, merged), the per-class aggregation source, and a non-mutating shadow-observe hook
-on the cold-start resume path (this PR). Live-apply is the next promotion, gated on
-shadow-observe validation data. Sites A and C are **reviewed and rejected** as framed.
+**Status:** Site B (cohort priors) is fully wired — the pure primitive (PR #1334, merged),
+the per-class aggregation source + non-mutating shadow-observe hook (PR #1344, merged), and
+now live-apply behind an explicit second opt-in (this PR). Enabling the feature still
+*defaults to observe*; `UNITARES_COHORT_PRIOR_MODE=apply` is required to seed for real, so
+the "validate calibration lift first" gate is encoded as the default rather than left to
+discipline. Sites A and C remain **reviewed and rejected** as framed.
 
 ## Question
 
@@ -108,14 +110,25 @@ observations cross the gate.
 - `tests/test_cohort_prior_source.py` — grouping, per-class build, N=1 exclusion, TTL cache,
   and the flag-off-noop / flag-on-non-mutating shadow-hook invariants.
 
-This is the "build it as a shadow, read-only query first and validate calibration lift
-before applying" step. Live-apply is the next promotion, gated on that validation data.
+This was the "build it as a shadow, read-only query first" step.
 
-## Deferred (next promotion)
+**Live-apply (this PR):**
+- `src/cohort_prior.py` — `cohort_prior_mode()`: `observe` (default) vs `apply`. Enabling
+  the feature alone stays in observe; `UNITARES_COHORT_PRIOR_MODE=apply` is the deliberate
+  second opt-in.
+- `src/agent_behavioral_baseline.py` — the cold-start hook (`_maybe_seed_cohort_prior`) now
+  branches on mode: `observe` logs the would-be seed and does not mutate; `apply` replaces
+  the fresh baseline with `prior.seed_baseline()`. **The anti-poisoning invariant holds in
+  apply mode too** — the seed's count stays below the activation gate, so a seeded agent
+  still cannot z-score until it logs its own observations
+  (`test_apply_mode_seeds_but_stays_inert_until_earned`).
 
-**Live-apply.** Actually seeding the fresh baseline from the class cohort prior on cold
-start (still behind `cohort_prior_enabled()`, still a **coupled identity/onboarding
-single-writer surface** per `CLAUDE.md`). Promote only once the shadow-observe logs show a
-real cold-start calibration lift, and re-check for in-flight work on the baseline/identity
-surface before starting. This will also want a background refresh for the prior cache
-rather than the lazy TTL rebuild used for shadow.
+## Deferred / operational
+
+1. **Turn on `apply` only after observe validates.** The default guards this, but the real
+   gate is data: run `observe` in a deployment, confirm the `cohort-prior shadow` logs show
+   a genuine cold-start calibration lift, *then* flip `MODE=apply`.
+2. **Background refresh for the prior cache.** Apply currently relies on the lazy TTL rebuild
+   (`get_cached_cohort_priors`). A steadily-enabled `apply` deployment would want a
+   background refresh task instead, so no cold-start resume ever pays the bulk-load.
+3. **Re-check the single-writer surface** (baseline/identity) before any further change here.

--- a/src/agent_behavioral_baseline.py
+++ b/src/agent_behavioral_baseline.py
@@ -165,22 +165,29 @@ async def ensure_baseline_loaded(agent_id: str) -> AgentBehavioralBaseline:
 
     # Fall through: create fresh baseline
     _baselines[agent_id] = AgentBehavioralBaseline()
-    await _maybe_observe_cohort_seed(agent_id)
+    await _maybe_seed_cohort_prior(agent_id)
     return _baselines[agent_id]
 
 
-async def _maybe_observe_cohort_seed(agent_id: str) -> None:
-    """Shadow-only: log the cohort seed a cold-start agent WOULD receive.
+async def _maybe_seed_cohort_prior(agent_id: str) -> None:
+    """Cohort-prior warm-start for a cold-start agent. No-op unless enabled.
 
-    No-op unless ``UNITARES_COHORT_PRIOR`` is enabled (default OFF). Never
-    mutates the just-created baseline — this only surfaces validation data
-    (calibration lift) so an operator can decide whether to promote to
-    live-apply later. Best-effort: any failure is swallowed at debug level so a
-    resume never breaks on it. Imports are deferred to avoid a circular import
-    (cohort_prior_source imports this module).
+    Gated by ``UNITARES_COHORT_PRIOR`` (default OFF). When enabled, behavior
+    depends on ``cohort_prior_mode()``:
+
+    - ``observe`` (default): log the seed the agent WOULD receive; do NOT mutate
+      the fresh baseline. Surfaces calibration-lift data for validation.
+    - ``apply``: replace the fresh baseline with one seeded from the class cohort
+      prior. The seed keeps its count below the z-score activation gate, so the
+      agent still cannot z-score until it logs its own observations — the
+      anti-poisoning invariant is preserved.
+
+    Best-effort: any failure is swallowed at debug level so a resume never breaks
+    on it. Imports are deferred to avoid a circular import (cohort_prior_source
+    imports this module).
     """
     try:
-        from src.cohort_prior import cohort_prior_enabled
+        from src.cohort_prior import cohort_prior_enabled, cohort_prior_mode
 
         if not cohort_prior_enabled():
             return
@@ -197,13 +204,24 @@ async def _maybe_observe_cohort_seed(agent_id: str) -> None:
             return
         priors = await get_cached_cohort_priors(get_db())
         observed = observe_seed_gap(agent_class, priors)
-        if observed:
+        if not observed:
+            return
+
+        if cohort_prior_mode() == "apply":
+            prior = priors.get(agent_class)
+            if prior is not None:
+                _baselines[agent_id] = prior.seed_baseline()
+                _logger.info(
+                    "cohort-prior apply: agent=%s class=%s seeded=%s",
+                    agent_id, agent_class, observed,
+                )
+        else:
             _logger.info(
                 "cohort-prior shadow: agent=%s class=%s would_seed=%s",
                 agent_id, agent_class, observed,
             )
     except Exception:
-        _logger.debug("cohort-prior shadow observation failed for %s", agent_id, exc_info=True)
+        _logger.debug("cohort-prior seed/observe failed for %s", agent_id, exc_info=True)
 
 
 def schedule_baseline_save(agent_id: str) -> None:

--- a/src/cohort_prior.py
+++ b/src/cohort_prior.py
@@ -71,16 +71,35 @@ MIN_CONTRIBUTORS = 2
 
 
 def cohort_prior_enabled() -> bool:
-    """Whether cohort-prior warm-start is active. Default OFF.
+    """Whether cohort-prior warm-start is active at all. Default OFF.
 
-    This module is shadow-only regardless; the flag exists so any future live
-    wiring is opt-in from day one. Enable with UNITARES_COHORT_PRIOR in
-    {1, true, on, yes}.
+    Enabling this alone runs in *observe* mode (see ``cohort_prior_mode``): the
+    cold-start path logs the seed an agent would get but does not mutate.
+    Enable with UNITARES_COHORT_PRIOR in {1, true, on, yes}.
     """
     val = os.getenv("UNITARES_COHORT_PRIOR")
     if val is None:
         return False
     return val.strip().lower() in {"1", "true", "on", "yes"}
+
+
+def cohort_prior_mode() -> str:
+    """Behavior when cohort priors are enabled: 'observe' (default) or 'apply'.
+
+    'observe' — shadow: log the seed a cold-start agent WOULD receive; do not
+    mutate the baseline. This is the default even when the feature is enabled.
+
+    'apply' — live: actually seed the fresh baseline from the class cohort prior.
+    Requires the explicit second opt-in ``UNITARES_COHORT_PRIOR_MODE=apply`` so an
+    operator validates calibration lift from the observe logs *before* seeding for
+    real. Any other value (including unset) falls back to 'observe'. The
+    anti-poisoning invariant holds in both modes: a seeded baseline still cannot
+    z-score until the agent logs its own observations past the activation gate.
+    """
+    val = os.getenv("UNITARES_COHORT_PRIOR_MODE")
+    if val is None:
+        return "observe"
+    return "apply" if val.strip().lower() == "apply" else "observe"
 
 
 # (mean, std, total_count, n_contributors)

--- a/tests/test_cohort_prior.py
+++ b/tests/test_cohort_prior.py
@@ -15,6 +15,7 @@ from src.cohort_prior import (
     Z_SCORE_ACTIVATION_COUNT,
     DEFAULT_PSEUDO_COUNT,
     cohort_prior_enabled,
+    cohort_prior_mode,
 )
 
 SIGNAL = "coherence"
@@ -155,6 +156,18 @@ class TestFlag:
     def test_opt_in(self, monkeypatch):
         monkeypatch.setenv("UNITARES_COHORT_PRIOR", "on")
         assert cohort_prior_enabled() is True
+
+    def test_mode_defaults_to_observe(self, monkeypatch):
+        monkeypatch.delenv("UNITARES_COHORT_PRIOR_MODE", raising=False)
+        assert cohort_prior_mode() == "observe"
+
+    def test_mode_apply_is_explicit(self, monkeypatch):
+        monkeypatch.setenv("UNITARES_COHORT_PRIOR_MODE", "apply")
+        assert cohort_prior_mode() == "apply"
+
+    def test_mode_unknown_falls_back_to_observe(self, monkeypatch):
+        monkeypatch.setenv("UNITARES_COHORT_PRIOR_MODE", "whatever")
+        assert cohort_prior_mode() == "observe"
 
     def test_seed_never_persists(self):
         """Building/seeding must not touch the global baseline registry."""

--- a/tests/test_cohort_prior_source.py
+++ b/tests/test_cohort_prior_source.py
@@ -154,41 +154,84 @@ class TestCache:
         assert calls["n"] == 2  # reset forces a rebuild
 
 
-class TestShadowHook:
+class TestSeedHook:
+    _CLASSIFY = {"new-eph": "ephemeral", "e0": "ephemeral", "e1": "ephemeral", "e2": "ephemeral"}
+
+    class _FakeDB:
+        async def load_all_behavioral_baselines(self):
+            return {f"e{i}": _stats([0.5] * 8) for i in range(3)}
+
+    def _patches(self):
+        return patch("src.db.get_db", return_value=self._FakeDB()), patch(
+            "src.cohort_prior_source.default_classifier",
+            return_value=_fixed_classifier(self._CLASSIFY),
+        )
+
     @pytest.mark.asyncio
     async def test_flag_off_is_noop_and_baseline_stays_cold(self, monkeypatch):
-        """Default (flag OFF): resume creates a cold baseline, no observation."""
+        """Default (flag OFF): resume creates a cold baseline, no DB touch."""
         monkeypatch.delenv("UNITARES_COHORT_PRIOR", raising=False)
         from src import agent_behavioral_baseline as abl
 
         abl._baselines.pop("cold-agent", None)
         with patch("src.db.get_db") as get_db:
-            await abl._maybe_observe_cohort_seed("cold-agent")
+            await abl._maybe_seed_cohort_prior("cold-agent")
             get_db.assert_not_called()  # flag gate short-circuits before any DB touch
 
     @pytest.mark.asyncio
-    async def test_flag_on_observes_without_mutating(self, monkeypatch, caplog):
+    async def test_observe_mode_is_default_and_does_not_mutate(self, monkeypatch):
+        """Flag ON, mode unset -> observe: logs, never mutates the baseline."""
         monkeypatch.setenv("UNITARES_COHORT_PRIOR", "on")
+        monkeypatch.delenv("UNITARES_COHORT_PRIOR_MODE", raising=False)
         reset_cohort_prior_cache()
         from src import agent_behavioral_baseline as abl
 
-        class FakeDB:
-            async def load_all_behavioral_baselines(self):
-                return {f"e{i}": _stats([0.5] * 8) for i in range(3)}
-
-        # Create the fresh (cold) baseline exactly as the resume path does.
         abl._baselines["new-eph"] = AgentBehavioralBaseline()
-        with patch("src.db.get_db", return_value=FakeDB()), patch(
-            "src.cohort_prior_source.default_classifier",
-            return_value=_fixed_classifier(
-                {"new-eph": "ephemeral", "e0": "ephemeral", "e1": "ephemeral", "e2": "ephemeral"}
-            ),
-        ):
-            await abl._maybe_observe_cohort_seed("new-eph")
+        p1, p2 = self._patches()
+        with p1, p2:
+            await abl._maybe_seed_cohort_prior("new-eph")
 
-        # The observed agent's baseline is UNCHANGED — still cold, still inert.
         b = abl._baselines["new-eph"]
-        assert b.sample_count == 0
+        assert b.sample_count == 0  # unchanged — still cold
         assert b.z_score(SIGNAL, 100.0) == 0.0
+        abl._baselines.pop("new-eph", None)
+        reset_cohort_prior_cache()
+
+    @pytest.mark.asyncio
+    async def test_apply_mode_seeds_but_stays_inert_until_earned(self, monkeypatch):
+        """Flag ON, mode=apply -> the fresh baseline is replaced with a seeded one,
+        carrying the cohort mean, yet STILL inert until the agent earns its own count."""
+        monkeypatch.setenv("UNITARES_COHORT_PRIOR", "on")
+        monkeypatch.setenv("UNITARES_COHORT_PRIOR_MODE", "apply")
+        reset_cohort_prior_cache()
+        from src import agent_behavioral_baseline as abl
+        from src.cohort_prior import DEFAULT_PSEUDO_COUNT
+
+        abl._baselines["new-eph"] = AgentBehavioralBaseline()
+        p1, p2 = self._patches()
+        with p1, p2:
+            await abl._maybe_seed_cohort_prior("new-eph")
+
+        b = abl._baselines["new-eph"]
+        seeded = b._stats[SIGNAL]
+        assert seeded.count == DEFAULT_PSEUDO_COUNT       # seeded, not cold
+        assert seeded.mean == pytest.approx(0.5, abs=1e-6)  # carries cohort mean
+        assert b.z_score(SIGNAL, 100.0) == 0.0            # but still inert (anti-poisoning)
+        abl._baselines.pop("new-eph", None)
+        reset_cohort_prior_cache()
+
+    @pytest.mark.asyncio
+    async def test_apply_mode_unknown_value_falls_back_to_observe(self, monkeypatch):
+        monkeypatch.setenv("UNITARES_COHORT_PRIOR", "on")
+        monkeypatch.setenv("UNITARES_COHORT_PRIOR_MODE", "yolo")  # not 'apply'
+        reset_cohort_prior_cache()
+        from src import agent_behavioral_baseline as abl
+
+        abl._baselines["new-eph"] = AgentBehavioralBaseline()
+        p1, p2 = self._patches()
+        with p1, p2:
+            await abl._maybe_seed_cohort_prior("new-eph")
+
+        assert abl._baselines["new-eph"].sample_count == 0  # observe: not mutated
         abl._baselines.pop("new-eph", None)
         reset_cohort_prior_cache()


### PR DESCRIPTION
## What / why

Completes Site B. The prior PRs (#1334, #1344) built the primitive, the per-class aggregation source, and a non-mutating shadow-observe hook. This adds **live-apply** — actually seeding a cold-start agent's baseline from its class cohort prior — but keeps the council's "validate before you seed for real" posture as the **default**, not a note.

## Design: two-step opt-in

- `UNITARES_COHORT_PRIOR` (existing, default OFF) — turns the feature on. **Enabling it alone runs in `observe` mode** (shadow: log the would-be seed, no mutation).
- `UNITARES_COHORT_PRIOR_MODE` (new, default `observe`) — set to `apply` to actually seed. Any other value falls back to `observe`.

So flipping the feature on is safe by default; live seeding requires a deliberate second flag an operator sets *after* reading the observe logs.

## Behavior

- **observe** (default): `_maybe_seed_cohort_prior` logs `cohort-prior shadow: … would_seed=…` and does not touch the baseline.
- **apply**: replaces the fresh baseline with `prior.seed_baseline()`.

## Anti-poisoning invariant holds in apply mode

The seed's `count` stays below the z-score activation gate, so a seeded agent carries the cohort mean/std but **still cannot z-score until it logs its own observations** — a bad or cohort-correlated cohort can't silence a newcomer's early drift. Proven by `test_apply_mode_seeds_but_stays_inert_until_earned`.

## Tests / lint

58 pass across `test_cohort_prior_source`, `test_cohort_prior`, `test_agent_behavioral_baseline`, including mode default/apply/fallback and the seed-but-stays-inert invariant. Ruff clean. `docs/FLAGS.md` updated (99 flags) — inserted surgically to avoid the 3.11-vs-3.12 generator drift on an unrelated row.

## Deferred / operational

1. **Flip `MODE=apply` only after `observe` validates** — the default guards it, but the real gate is data: run observe in a deployment, confirm a genuine cold-start calibration lift in the logs, then apply.
2. **Background prior-cache refresh** — a steadily-enabled apply deployment wants a background refresh task rather than the lazy TTL rebuild, so no resume pays the bulk-load.
3. **Re-check the baseline/identity single-writer surface** before further changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWN6kEvtJXcrCaqntdAnHx)_