### PR TITLE
docs(readme): federation research-direction section + coherence pass on README-linked docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ UNITARES runs **alongside** your evals and guardrails — it doesn't replace eit
 
 UNITARES is not an agent framework or chat interface. Hermes, Claude Code, Codex, Goose, Discord dispatchers, SDK residents, and local-model hosts provide the hands: prompts, tools, files, terminals, browsers, scheduled work, and operator UX. UNITARES provides the governed continuity underneath — the loop and organs above. For one-off chat or local coding, skip the governance loop; for persistent, multi-agent, high-side-effect, or resident work, mount the client through MCP/REST/SDK or a lifecycle adapter.
 
+### Where it's going: accountability without a trusted center
+
+Everything above describes the deployed system: **one governor, one operator**. The identity layer already enforces the posture a multi-party world needs — identity is per-process, credentials structurally refuse cross-principal resume, and declared lineage is recorded as *provisional* rather than trusted on assertion. The active research direction extends this to genuinely **multi-principal** deployments: mutually-distrusting principals each running their own governor, with cross-principal delegation and shared-infrastructure effects mediated by verifiable attestation between governors rather than authorized by any central party. No multi-host, multi-party deployment exists yet — that is the research, not a shipped claim. A testbed-and-benchmark paper is in preparation (arXiv, expected August 2026).
+
 ## How it works
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Want to act on *why*, not just the policy action? Each check-in also returns fou
 | **S** · Entropy / drift | drifting from its own normal? | erratic, divergent behavior |
 | **V** · Valence | derived: energy vs integrity | motion without coherence (or vice-versa) |
 
-The baseline takes ~30 check-ins to establish. Until then the policy action falls back to self-reported signals and fixed thresholds, so it is *not yet* discriminative of absolute drift magnitude — a worsening drift vector will not, on its own, move the action during warmup. After baselining, the per-agent behavioral assessment is combined into the action and can escalate it. A pause is enforced (the runtime boundary marks the agent `paused` and blocks further writes until recovery), not merely advisory.
+The baseline takes ~30 check-ins to establish. Until then the policy action falls back to a cold-start prior computed mostly from server-derived signals (complexity divergence, coherence, calibration — self-reported drift is a capped ≤30% blend), so it is *not yet* discriminative of absolute drift magnitude — a worsening drift vector will not, on its own, move the action during warmup. After baselining, the per-agent behavioral assessment is combined into the action and can escalate it. A pause is enforced (the runtime boundary marks the agent `paused` and blocks further writes until recovery), not merely advisory.
 
 </details>
 
@@ -188,7 +188,7 @@ For long-running or scheduled agents, the [SDK](agents/sdk/README.md) handles co
 
 **Evaluating with an agent?** On a fresh clone, the [falsifiability harness](docs/REVIEWER_GUIDE.md#falsifiability-grade-eisv-yourself-dont-trust-this-doc) grades whether the four-score state telemetry beats deliberately dumb baselines (AUC, Brier) on externally labeled task/result evidence, reporting each slice honestly rather than asserting it. Most projects don't ship the means to disprove them; this one does. ([Reviewer Guide →](docs/REVIEWER_GUIDE.md))
 
-**Auditable, not a black box.** Policy actions come from an inspectable behavioral model ([`behavioral_assessment.py`](src/behavioral_assessment.py)); the information-theoretic formulation in [Paper v6](https://github.com/cirwel/unitares-paper-v6) is the research roadmap, not a claim about the current decision path ([how the four scores are computed](docs/EISV_COMPUTATION.md)).
+**Auditable, not a black box.** Once a baseline exists, policy actions come from an inspectable behavioral model ([`behavioral_assessment.py`](src/behavioral_assessment.py)); before that, from a mostly server-derived cold-start prior. The information-theoretic formulation in [Paper v6](https://github.com/cirwel/unitares-paper-v6) is the research roadmap, not a claim about the post-warmup decision path ([how the four scores are computed](docs/EISV_COMPUTATION.md)).
 
 Human evaluators start with the [Reviewer Guide](docs/REVIEWER_GUIDE.md).
 

--- a/docs/EISV_COMPUTATION.md
+++ b/docs/EISV_COMPUTATION.md
@@ -87,7 +87,7 @@ identity of EISV itself.
 *"No sigmoid/phi black box. Each risk component has a clear source and weight. Assessment is auditable — you can trace exactly why a verdict was issued."* (module docstring.)
 
 - Total risk = sum of named components (`low_E`, `low_I`, high-`S`, `|V|`, …), each with an explicit weight.
-- **Warmup** (first ~30 check-ins): fixed universal thresholds.
+- **Warmup** (first ~30 check-ins): the behavioral track scores against fixed universal thresholds, while the *live verdict* comes from the cold-start prior (≥70% server-derived drift signals; see [SCOPE_AND_THREAT_MODEL.md](SCOPE_AND_THREAT_MODEL.md)). The behavioral assessment becomes the verdict authority once its confidence clears the bar.
 - **After warmup**: self-relative z-score deviations from the agent's *own* behavioral baseline.
 - **Absolute safety floors always apply**, overriding the baseline.
 - Self-relative deviation risk is **gated by absolute basin health** (issue #689): inside the healthy basin a deviation from your own norm is treated as information, not danger; the gate opens only as a dimension leaves the basin toward its absolute floor. (This replaced a flat σ-floor that was false-pausing ultra-stable agents.)

--- a/docs/PRODUCTION_SNAPSHOT.md
+++ b/docs/PRODUCTION_SNAPSHOT.md
@@ -37,7 +37,7 @@ they don't show:* product-market traction. External adoption is the open questio
 <p align="center">
   <img src="assets/dashboard-eisv.png" width="80%" alt="EISV — live fleet trajectory charts"/>
 </p>
-<p align="center"><em>EISV — live fleet trajectory: Energy · Integrity · Coherence and Entropy · Valence over time</em></p>
+<p align="center"><em>Live fleet trajectory over time — the four EISV scores (Energy · Integrity · Entropy · Valence) plus the coherence input</em></p>
 
 <p align="center">
   <img src="assets/dashboard-discoveries.png" width="80%" alt="Discoveries — shared knowledge graph"/>

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -153,7 +153,7 @@ tail -f data/logs/mcp_server_error.log
    brew services restart redis
    ```
 
-3. **Note:** Redis is optional. If unavailable, the server falls back to in-memory session cache (sessions won't persist across restarts).
+3. **Note:** the server boots without Redis in a degraded local-only mode (in-memory session cache; sessions won't persist across restarts) — but in production Redis is the de-facto primary session store, so treat an unavailable Redis as an incident to fix, not a config option.
 
 ---
 

--- a/docs/operations/DEFINITIVE_PORTS.md
+++ b/docs/operations/DEFINITIVE_PORTS.md
@@ -12,8 +12,8 @@ this table cannot silently disagree with the code.
 
 | Port | Service | Host | Canonical source |
 |------|---------|------|------------------|
-| `8766` | Anima MCP (physical edge testbed) | Pi / Lumen host | `anima-mcp` service config (external repo) |
-| `8767` | UNITARES governance MCP | governance host (Mac) | `src/mcp_server.py` — `DEFAULT_PORT` |
+| `8766` | Anima MCP (physical edge testbed) | edge host (Raspberry Pi) | `anima-mcp` service config (external repo) |
+| `8767` | UNITARES governance MCP | governance host | `src/mcp_server.py` — `DEFAULT_PORT` |
 | `8768` | Gateway (weak external tier only) | governance host | `src/gateway/constants.py` — `GATEWAY_PORT` (`GATEWAY_PORT` env, default 8768) |
 | `8788` | Surface lease plane + governed-effect plane (BEAM) | governance host | `LEASE_PLANE_BASE_URL` default — `src/services/runtime_queries.py` |
 | `8789` | Agent orchestrator (BEAM) | governance host | `AGENT_ORCHESTRATOR_URL` default — `src/mcp_handlers/dialectic/orchestrator_dispatch.py` |

--- a/scripts/dev/ports_catalog.py
+++ b/scripts/dev/ports_catalog.py
@@ -35,14 +35,14 @@ PORTS = [
     {
         "port": 8766,
         "service": "Anima MCP (physical edge testbed)",
-        "host": "Pi / Lumen host",
+        "host": "edge host (Raspberry Pi)",
         "source": "`anima-mcp` service config (external repo)",
         "verify": None,
     },
     {
         "port": 8767,
         "service": "UNITARES governance MCP",
-        "host": "governance host (Mac)",
+        "host": "governance host",
         "source": "`src/mcp_server.py` — `DEFAULT_PORT`",
         "verify": "src/mcp_server.py",
     },


### PR DESCRIPTION
Two related documentation changes:

**1. Research-direction section** (after "How it relates to agent clients"): the deployed system is one governor / one operator; the identity layer already enforces per-process identity, non-transferable credential resume, and provisional lineage; the multi-principal (federated) extension is stated explicitly as active research, not a shipped claim. Mentions the testbed/benchmark paper in preparation (arXiv, expected Aug 2026).

**2. Coherence pass** — link-audit of the README against all linked docs (all local targets exist, all external links 200; these are content fixes):
- README warmup sentence said the action "falls back to self-reported signals" — inverted; it is the cold-start prior, ≥70% server-derived with self-report capped at ≤30% (matches src/monitor_result.py and the PR #1235 correction).
- README "not a claim about the current decision path" scoped to *post-warmup* decision path; pre-warmup the cold-start prior is the live path.
- TROUBLESHOOTING said "Redis is optional" — contradicted README and UNIFIED_ARCHITECTURE (de-facto primary session store); now consistent.
- EISV_COMPUTATION warmup bullet now distinguishes the behavioral track's fixed thresholds from the verdict source during warmup (was contradicting SCOPE_AND_THREAT_MODEL).
- PRODUCTION_SNAPSHOT chart caption no longer reads as if Coherence were an EISV letter.
- DEFINITIVE_PORTS host column made generic (edge host / governance host) — public doc, defaults not operator machines.