### PR TITLE
feat(effect-binding): producer wiring — canonical hash, SDK mint, per-type flags (#1252)

### DIFF
--- a/agents/sdk/src/unitares_sdk/lease_plane/canonical.py
+++ b/agents/sdk/src/unitares_sdk/lease_plane/canonical.py
@@ -1,0 +1,108 @@
+"""Canonical payload serialization for effect-binding (#1075 / #1252).
+
+An effect grant binds ``payload_sha256`` — a hash the proposer computes at
+mint time and the lease plane recomputes over the *parsed* payload when it
+forwards the grant to ``/v1/effect-veto``. Those two computations happen in
+different languages (Python producer here, Elixir plane in
+``UnitaresLeasePlane.CanonicalPayload``), so both sides must serialize the
+payload byte-identically before hashing. A mismatch fails CLOSED at the veto
+(the effect is blocked), never open — which is exactly why the canonical form
+has to be nailed down and pinned by the shared fixture
+``tests/vectors/effect_payload_canonical.json``.
+
+Canonical form:
+
+- JSON, UTF-8, compact separators (``,`` / ``:``), object keys sorted
+  bytewise. Python's ``sort_keys`` sorts ``str`` by codepoint, which equals
+  UTF-8 byte order, so both languages agree.
+- Non-ASCII characters are emitted raw (``ensure_ascii=False``), including
+  non-BMP.
+- Object keys must be strings. Values may be ``str``, ``int``, ``bool``,
+  ``None``, ``dict``, ``list``.
+- **Floats are rejected** (``CanonicalizationError``): float formatting is
+  not stable across languages, and a silent divergence would veto every
+  bound effect. Fail loudly at the producer instead.
+- **Control characters (U+0000–U+001F) in strings and keys are rejected**:
+  they are the one region where JSON escape spelling can differ between
+  encoders (``\\u001b`` vs ``\\u001B``); real payloads (paths, base64
+  content) never contain them, so refusing is cheaper than normalizing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping
+
+__all__ = [
+    "CanonicalizationError",
+    "canonical_payload_bytes",
+    "canonical_payload_sha256",
+]
+
+
+class CanonicalizationError(ValueError):
+    """Payload cannot be canonically serialized (float, control char, bad key)."""
+
+
+def _check_string(s: str, *, context: str) -> None:
+    for ch in s:
+        if ord(ch) < 0x20:
+            raise CanonicalizationError(
+                f"control character U+{ord(ch):04X} in {context}; canonical "
+                "payloads must not contain control characters"
+            )
+
+
+def _validate(value: Any, *, context: str) -> None:
+    # bool before int: bool is an int subclass but is always canonical.
+    if value is None or isinstance(value, bool):
+        return
+    if isinstance(value, float):
+        raise CanonicalizationError(
+            f"float in {context}; canonical payloads must not contain floats "
+            "(cross-language float formatting is not stable)"
+        )
+    if isinstance(value, int):
+        return
+    if isinstance(value, str):
+        _check_string(value, context=context)
+        return
+    if isinstance(value, Mapping):
+        for k, v in value.items():
+            if not isinstance(k, str):
+                raise CanonicalizationError(
+                    f"non-string key {k!r} in {context}; canonical payload "
+                    "object keys must be strings"
+                )
+            _check_string(k, context=f"key in {context}")
+            _validate(v, context=f"{context}.{k}")
+        return
+    if isinstance(value, (list, tuple)):
+        for i, item in enumerate(value):
+            _validate(item, context=f"{context}[{i}]")
+        return
+    raise CanonicalizationError(
+        f"unsupported type {type(value).__name__} in {context}"
+    )
+
+
+def canonical_payload_bytes(payload: Mapping[str, Any]) -> bytes:
+    """Serialize ``payload`` to its canonical UTF-8 byte form.
+
+    Raises :class:`CanonicalizationError` on floats, control characters,
+    non-string keys, or unsupported value types.
+    """
+    if not isinstance(payload, Mapping):
+        raise CanonicalizationError(
+            f"payload must be a mapping, got {type(payload).__name__}"
+        )
+    _validate(payload, context="payload")
+    return json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+
+
+def canonical_payload_sha256(payload: Mapping[str, Any]) -> str:
+    """Lowercase-hex SHA-256 of the canonical payload bytes."""
+    return hashlib.sha256(canonical_payload_bytes(payload)).hexdigest()

--- a/agents/sdk/src/unitares_sdk/lease_plane/client.py
+++ b/agents/sdk/src/unitares_sdk/lease_plane/client.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import random
 import time
 import urllib.error
@@ -61,6 +62,11 @@ class LeasePlaneClientConfig:
     # force_release(); release() rejects release_reason='forced' regardless.
     force_release_token: str | None = None
     timeout_s: float = 1.0
+    # Effect-binding (#1252): grants are minted at gov-mcp's REST surface, not
+    # the lease plane. None → UNITARES_GOVERNANCE_URL env → localhost:8767
+    # (loopback bypasses gov REST auth; the token is for non-loopback setups).
+    governance_url: str | None = None
+    governance_api_token: str | None = None
 
 
 @dataclass(frozen=True)
@@ -332,6 +338,7 @@ class LeasePlaneClient:
         ttl_s: int = 300,
         idempotency_key: str | None = None,
         encoding: str | None = None,
+        effect_binding: str = "auto",
     ) -> Mapping[str, Any]:
         """Propose a governed ``file_write`` effect on the lease plane.
 
@@ -349,12 +356,57 @@ class LeasePlaneClient:
         success, or an error envelope (e.g. ``proposer_invalid`` 422,
         ``governance_blocked`` 403, ``not_implemented`` 501 when the server
         flags are off). The bytes are committed only on ``ok: true``.
+
+        ``effect_binding`` (#1252 producer wiring) controls the pre-propose
+        grant mint at gov-mcp ``/v1/effect-grant``:
+
+        - ``"auto"`` (default): mint and attach ``proposer.effect_grant`` when
+          the server issues one; on ANY mint failure (binding flags off → 501,
+          tier refused → 403, gov unreachable) propose grantless — byte-
+          identical to the pre-binding envelope, so today's behavior is
+          unchanged until the operator enables minting server-side.
+        - ``"require"``: a failed mint returns an ``effect_grant_mint_failed``
+          error envelope WITHOUT proposing (no side effects). For producers
+          that must never submit an unbound effect once enforcement is on.
+        - ``"off"``: never mint (exact legacy envelope).
         """
+        if effect_binding not in ("auto", "require", "off"):
+            return {
+                "ok": False,
+                "error": "schema_invalid",
+                "detail": f"effect_binding must be auto|require|off, got {effect_binding!r}",
+            }
+
         fs_path = path[len("file://") :] if path.startswith("file://") else path
         surface = f"file://{fs_path}"
         payload: dict[str, Any] = {"path": fs_path, "content": content}
         if encoding:
             payload["encoding"] = encoding
+
+        # The grant binds the idempotency_key, so it must be fixed before mint.
+        idem = idempotency_key or f"fw-{uuid.uuid4().hex}"
+
+        proposer: dict[str, Any] = {
+            "agent_uuid": proposer_uuid,
+            "continuity_token": continuity_token,
+        }
+        if effect_binding != "off":
+            grant = self._mint_effect_grant(
+                proposer_uuid=proposer_uuid,
+                continuity_token=continuity_token,
+                payload=payload,
+                surface=surface,
+                custody_mode="execute",
+                idempotency_key=idem,
+            )
+            if grant:
+                proposer["effect_grant"] = grant
+            elif effect_binding == "require":
+                return {
+                    "ok": False,
+                    "error": "effect_grant_mint_failed",
+                    "detail": "effect_binding='require' and gov-mcp did not issue a grant",
+                }
 
         body = {
             "effect_type": "file_write",
@@ -362,11 +414,77 @@ class LeasePlaneClient:
             "surface": surface,
             "required_leases": [{"surface": surface, "ttl_s": ttl_s}],
             "payload": payload,
-            "proposer": {"agent_uuid": proposer_uuid, "continuity_token": continuity_token},
+            "proposer": proposer,
             "provenance": {"session_id": session_id},
-            "idempotency_key": idempotency_key or f"fw-{uuid.uuid4().hex}",
+            "idempotency_key": idem,
         }
         return self._request_json("POST", "/v1/effects", body)
+
+    def _mint_effect_grant(
+        self,
+        *,
+        proposer_uuid: str,
+        continuity_token: str,
+        payload: Mapping[str, Any],
+        surface: str,
+        custody_mode: str,
+        idempotency_key: str,
+    ) -> str | None:
+        """Best-effort grant mint at gov-mcp ``POST /v1/effect-grant``.
+
+        Returns the ``gnt.v1`` grant string, or None on any failure — the
+        caller decides whether grantless is acceptable (``auto``) or fatal
+        (``require``). The continuity_token is a credential: sent to gov-mcp
+        for §7 re-certification only, never logged. payload_sha256 uses the
+        shared cross-language canonical form (see ``.canonical``) so the hash
+        minted here equals the one the lease plane forwards to the veto.
+        """
+        from .canonical import CanonicalizationError, canonical_payload_sha256
+
+        try:
+            payload_sha = canonical_payload_sha256(payload)
+        except CanonicalizationError as e:
+            logger.debug("effect-grant mint skipped: payload not canonical (%s)", e)
+            return None
+
+        gov_base = (
+            self.config.governance_url
+            or os.getenv("UNITARES_GOVERNANCE_URL")
+            or "http://127.0.0.1:8767"
+        ).rstrip("/")
+        headers = {"Accept": "application/json", "Content-Type": "application/json"}
+        api_token = self.config.governance_api_token or os.getenv("UNITARES_HTTP_API_TOKEN")
+        if api_token:
+            headers["Authorization"] = f"Bearer {api_token}"
+
+        request = LeaseHTTPRequest(
+            method="POST",
+            url=gov_base + "/v1/effect-grant",
+            headers=headers,
+            json_body={
+                "proposer_agent_uuid": proposer_uuid,
+                "proposer_continuity_token": continuity_token,
+                "payload_sha256": payload_sha,
+                "surface": surface,
+                "custody_mode": custody_mode,
+                "idempotency_key": idempotency_key,
+            },
+            timeout_s=self.config.timeout_s,
+        )
+        try:
+            response = self._transport(request)
+        except Exception as e:  # noqa: BLE001 — mint is best-effort; caller decides
+            logger.debug("effect-grant mint unreachable: %s", e)
+            return None
+        if isinstance(response, Mapping) and response.get("ok") is True:
+            grant = response.get("grant")
+            if isinstance(grant, str) and grant:
+                return grant
+        if isinstance(response, Mapping):
+            logger.debug(
+                "effect-grant mint refused: %s", response.get("error") or "unknown_error"
+            )
+        return None
 
     def health_check(self, *, timeout_s: float | None = None) -> HealthResult:
         """Liveness probe against the BEAM lease-plane (Wave 2 Phase C).

--- a/agents/sdk/tests/test_canonical_vectors.py
+++ b/agents/sdk/tests/test_canonical_vectors.py
@@ -1,0 +1,57 @@
+"""Pins the Python half of the cross-language canonical payload form.
+
+Consumes the shared fixture ``tests/vectors/effect_payload_canonical.json``
+(repo root) — the same file the Elixir lease plane pins itself against in
+``elixir/lease_plane/test/canonical_payload_test.exs``. A green run on both
+sides is the byte-identity proof #1252 item 1 requires.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from unitares_sdk.lease_plane.canonical import (
+    CanonicalizationError,
+    canonical_payload_bytes,
+    canonical_payload_sha256,
+)
+
+_VECTORS = json.loads(
+    (Path(__file__).resolve().parents[3] / "tests" / "vectors"
+     / "effect_payload_canonical.json").read_text(encoding="utf-8")
+)
+
+
+@pytest.mark.parametrize(
+    "vector", _VECTORS["vectors"], ids=[v["name"] for v in _VECTORS["vectors"]]
+)
+def test_vector_reproduces_byte_identically(vector):
+    assert canonical_payload_bytes(vector["payload"]) == vector["canonical"].encode("utf-8")
+    assert canonical_payload_sha256(vector["payload"]) == vector["sha256"]
+
+
+@pytest.mark.parametrize(
+    "reject", _VECTORS["rejects"], ids=[r["name"] for r in _VECTORS["rejects"]]
+)
+def test_reject_vectors_refused(reject):
+    with pytest.raises(CanonicalizationError):
+        canonical_payload_sha256(reject["payload"])
+
+
+def test_non_mapping_and_unsupported_types_refused():
+    with pytest.raises(CanonicalizationError):
+        canonical_payload_bytes("nope")  # type: ignore[arg-type]
+    with pytest.raises(CanonicalizationError):
+        canonical_payload_sha256({"x": object()})
+    with pytest.raises(CanonicalizationError):
+        canonical_payload_sha256({1: "v"})  # type: ignore[dict-item]
+
+
+def test_deep_float_and_control_rejection():
+    with pytest.raises(CanonicalizationError):
+        canonical_payload_sha256({"a": [{"b": [1.0]}]})
+    with pytest.raises(CanonicalizationError):
+        canonical_payload_sha256({"a": [{"b": "x\x1by"}]})

--- a/agents/sdk/tests/test_effect_grant_mint.py
+++ b/agents/sdk/tests/test_effect_grant_mint.py
@@ -1,0 +1,121 @@
+"""propose_file_write effect-binding mint wiring (#1252 item 3).
+
+The mint is best-effort by default (``auto``): today, with every binding flag
+off server-side, the mint endpoint answers 501 and the proposed envelope must
+be byte-identical to the pre-binding shape — that inertness is what makes the
+producer wiring safe to land ahead of enforcement.
+"""
+
+from __future__ import annotations
+
+from unitares_sdk.lease_plane.canonical import canonical_payload_sha256
+from unitares_sdk.lease_plane.client import LeasePlaneClient, LeasePlaneClientConfig
+
+
+class RecordingTransport:
+    """Routes by URL: gov-mcp mint vs lease-plane effects."""
+
+    def __init__(self, mint_response):
+        self.mint_response = mint_response
+        self.requests = []
+
+    def __call__(self, request):
+        self.requests.append(request)
+        if request.url.endswith("/v1/effect-grant"):
+            if isinstance(self.mint_response, Exception):
+                raise self.mint_response
+            return self.mint_response
+        return {"ok": True, "effect_id": "e-1", "protocol_version": "v0.1"}
+
+    def mint_requests(self):
+        return [r for r in self.requests if r.url.endswith("/v1/effect-grant")]
+
+    def effect_requests(self):
+        return [r for r in self.requests if r.url.endswith("/v1/effects")]
+
+
+def _client(transport):
+    return LeasePlaneClient(
+        LeasePlaneClientConfig(governance_url="http://gov.test:8767"),
+        transport=transport,
+    )
+
+
+def _propose(client, **kwargs):
+    return client.propose_file_write(
+        path="/tmp/x.txt",
+        content="aGVsbG8=",
+        proposer_uuid="00000000-0000-0000-0000-000000000001",
+        continuity_token="v1.tok",
+        session_id="s-1",
+        idempotency_key="fw-fixed",
+        **kwargs,
+    )
+
+
+def test_auto_attaches_grant_when_minted():
+    transport = RecordingTransport({"ok": True, "grant": "gnt.v1.abc.def"})
+    result = _propose(_client(transport))
+    assert result["ok"] is True
+
+    (mint,) = transport.mint_requests()
+    expected_sha = canonical_payload_sha256({"path": "/tmp/x.txt", "content": "aGVsbG8="})
+    assert mint.json_body["payload_sha256"] == expected_sha
+    assert mint.json_body["idempotency_key"] == "fw-fixed"
+    assert mint.json_body["custody_mode"] == "execute"
+    assert mint.json_body["surface"] == "file:///tmp/x.txt"
+    assert mint.json_body["proposer_continuity_token"] == "v1.tok"
+
+    (effect,) = transport.effect_requests()
+    assert effect.json_body["proposer"]["effect_grant"] == "gnt.v1.abc.def"
+    assert effect.json_body["idempotency_key"] == "fw-fixed"
+
+
+def test_auto_proposes_grantless_on_mint_501():
+    transport = RecordingTransport({"ok": False, "error": "binding_not_enabled"})
+    result = _propose(_client(transport))
+    assert result["ok"] is True
+
+    (effect,) = transport.effect_requests()
+    # Byte-compat with the pre-binding envelope: no effect_grant key at all.
+    assert "effect_grant" not in effect.json_body["proposer"]
+
+
+def test_auto_proposes_grantless_on_transport_error():
+    transport = RecordingTransport(ConnectionError("gov down"))
+    result = _propose(_client(transport))
+    assert result["ok"] is True
+    (effect,) = transport.effect_requests()
+    assert "effect_grant" not in effect.json_body["proposer"]
+
+
+def test_require_fails_without_proposing():
+    transport = RecordingTransport({"ok": False, "error": "tier_recert_failed"})
+    result = _propose(_client(transport), effect_binding="require")
+    assert result["ok"] is False
+    assert result["error"] == "effect_grant_mint_failed"
+    assert transport.effect_requests() == []  # no side effects
+
+
+def test_off_never_mints():
+    transport = RecordingTransport({"ok": True, "grant": "gnt.v1.abc.def"})
+    result = _propose(_client(transport), effect_binding="off")
+    assert result["ok"] is True
+    assert transport.mint_requests() == []
+    (effect,) = transport.effect_requests()
+    assert "effect_grant" not in effect.json_body["proposer"]
+
+
+def test_invalid_mode_is_schema_invalid():
+    transport = RecordingTransport({"ok": True, "grant": "g"})
+    result = _propose(_client(transport), effect_binding="always")
+    assert result["ok"] is False
+    assert result["error"] == "schema_invalid"
+    assert transport.requests == []
+
+
+def test_mint_hits_governance_url_not_lease_plane():
+    transport = RecordingTransport({"ok": True, "grant": "gnt.v1.abc.def"})
+    _propose(_client(transport))
+    (mint,) = transport.mint_requests()
+    assert mint.url == "http://gov.test:8767/v1/effect-grant"

--- a/docs/FLAGS.md
+++ b/docs/FLAGS.md
@@ -14,7 +14,7 @@ For *consequential, flag-gated capabilities* and their **wake conditions**, see
 `docs/operations/dormant-capability-registry.md` (Theme 6) — this file is the flat
 index; that one is the curated decision record.
 
-**99 flags.**
+**98 flags.**
 
 | Flag | Default | Purpose | Read at |
 |---|---|---|---|
@@ -57,13 +57,12 @@ index; that one is the curated decision record.
 | `UNITARES_ENABLE_RERANKER` | `''` | Derive a config tag matching baseline filename suffix from env vars | agents/vigil/agent.py |
 | `UNITARES_FINDINGS_URL` | `'http://localhost:8767/api/fi…` | — | agents/common/findings.py |
 | `UNITARES_FIRST_RUN` | `(required)` | Resolve Watcher identity via proof-owned UUID-direct → fresh onboard | agents/watcher/agent.py, agents/sdk/src/unitares_sdk/agent.py |
-| `UNITARES_GOVERNANCE_URL` | `(required)` | read by _governance_url() | src/mcp_handlers/dialectic/orchestrator_dispatch.py, agents/dialectic_reviewer/reviewer.py |
-| `UNITARES_GOVERNED_EFFECT_BINDING` | `(required)` | POST /v1/effect-grant — mint a single-use, content-bound effect grant | src/http_api.py |
+| `UNITARES_GOVERNANCE_URL` | `(required)` | read by _governance_url() | src/mcp_handlers/dialectic/orchestrator_dispatch.py, agents/dialectic_reviewer/reviewer.py, agents/sdk/src/unitares_sdk/lease_plane/client.py |
 | `UNITARES_GROUNDING_APPLY` | `''` | Whether grounded E/I/S/coherence actually replace the ODE/heuristic values in the canonical metrics (UNITARES_GROUNDING_APPLY) | config/governance_config.py |
 | `UNITARES_GROUNDING_SHADOW` | `''` | Whether to shadow-compare grounded vs ungrounded canonical metrics each check-in (UNITARES_GROUNDING_SHADOW) | config/governance_config.py |
 | `UNITARES_HEALTH_PROBE_INTERVAL_SECONDS` | `(required)` | Periodically run the deep health check and cache the result | src/background_tasks.py |
 | `UNITARES_HOST_ADAPTER_ENABLED` | `''` | Opt-in flag | src/mcp_handlers/support/host_adapter.py |
-| `UNITARES_HTTP_API_TOKEN` | `(required)` | List all tools in OpenAI-compatible format Query params: mode: Tool mode filter - "minimal", "lite", "full" | src/http_api.py, src/mcp_handlers/identity/session.py (+2 more) |
+| `UNITARES_HTTP_API_TOKEN` | `(required)` | List all tools in OpenAI-compatible format Query params: mode: Tool mode filter - "minimal", "lite", "full" | src/http_api.py, src/mcp_handlers/identity/session.py (+3 more) |
 | `UNITARES_HTTP_CORS_ALLOW_ORIGIN` | `(required)` | Main entry point for governance MCP server. | src/mcp_server.py |
 | `UNITARES_IDENTITY_STRICT` | `'log'` | Runtime accessor — respects env changes set after module load | config/governance_config.py |
 | `UNITARES_INCLUDE_API_KEY_IN_RESPONSES` | `(required)` | Include onboarding guidance, API key hints, welcome message. | src/mcp_handlers/updates/enrichments.py |

--- a/elixir/lease_plane/lib/unitares_lease_plane/canonical_payload.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/canonical_payload.ex
@@ -1,0 +1,109 @@
+defmodule UnitaresLeasePlane.CanonicalPayload do
+  @moduledoc """
+  Canonical payload serialization for effect-binding (#1075 / #1252).
+
+  An effect grant binds `payload_sha256` — a hash the proposer computes at
+  mint time (Python, `unitares_sdk.lease_plane.canonical`) and this plane
+  recomputes over the parsed payload when it forwards the grant to
+  `/v1/effect-veto`. Both sides must serialize the payload byte-identically
+  before hashing; a mismatch fails CLOSED at the veto. The shared fixture
+  `tests/vectors/effect_payload_canonical.json` pins both implementations.
+
+  Canonical form:
+
+  - JSON, UTF-8, compact (no whitespace), object keys sorted bytewise
+    (binary term order on UTF-8 binaries equals codepoint order, matching
+    Python's `sort_keys`).
+  - Non-ASCII emitted raw (Jason's default), including non-BMP.
+  - Object keys must be strings. Values: string, integer, boolean, nil,
+    object, array.
+  - **Floats are rejected** (`{:error, :float_in_payload}`): float
+    formatting is not stable across languages.
+  - **Control characters (U+0000–U+001F) in strings/keys are rejected**
+    (`{:error, :control_char_in_payload}`): the one region where JSON
+    escape spelling can differ between encoders; real payloads (paths,
+    base64 content) never contain them.
+  """
+
+  @type reason ::
+          :not_a_map
+          | :float_in_payload
+          | :control_char_in_payload
+          | :non_string_key
+          | :unsupported_type
+
+  @doc "Canonical UTF-8 bytes of `payload`, or a fail-closed error."
+  @spec bytes(term()) :: {:ok, binary()} | {:error, reason()}
+  def bytes(payload) when is_map(payload) do
+    case canonicalize(payload) do
+      {:ok, canonical} -> {:ok, Jason.encode!(canonical)}
+      {:error, _} = err -> err
+    end
+  end
+
+  def bytes(_), do: {:error, :not_a_map}
+
+  @doc "Lowercase-hex SHA-256 of the canonical payload bytes."
+  @spec sha256(term()) :: {:ok, String.t()} | {:error, reason()}
+  def sha256(payload) do
+    with {:ok, bin} <- bytes(payload) do
+      {:ok, :crypto.hash(:sha256, bin) |> Base.encode16(case: :lower)}
+    end
+  end
+
+  # ---- recursive validate + sorted transform ----
+
+  defp canonicalize(map) when is_map(map) do
+    map
+    |> Enum.sort_by(fn {k, _v} -> k end)
+    |> Enum.reduce_while({:ok, []}, fn {k, v}, {:ok, acc} ->
+      with :ok <- check_key(k),
+           {:ok, cv} <- canonicalize(v) do
+        {:cont, {:ok, [{k, cv} | acc]}}
+      else
+        {:error, _} = err -> {:halt, err}
+      end
+    end)
+    |> case do
+      {:ok, pairs} -> {:ok, %Jason.OrderedObject{values: Enum.reverse(pairs)}}
+      {:error, _} = err -> err
+    end
+  end
+
+  defp canonicalize(list) when is_list(list) do
+    list
+    |> Enum.reduce_while({:ok, []}, fn item, {:ok, acc} ->
+      case canonicalize(item) do
+        {:ok, ci} -> {:cont, {:ok, [ci | acc]}}
+        {:error, _} = err -> {:halt, err}
+      end
+    end)
+    |> case do
+      {:ok, items} -> {:ok, Enum.reverse(items)}
+      {:error, _} = err -> err
+    end
+  end
+
+  defp canonicalize(f) when is_float(f), do: {:error, :float_in_payload}
+  defp canonicalize(b) when is_boolean(b), do: {:ok, b}
+  defp canonicalize(i) when is_integer(i), do: {:ok, i}
+  defp canonicalize(nil), do: {:ok, nil}
+
+  defp canonicalize(s) when is_binary(s) do
+    if has_control_char?(s), do: {:error, :control_char_in_payload}, else: {:ok, s}
+  end
+
+  defp canonicalize(_), do: {:error, :unsupported_type}
+
+  defp check_key(k) when is_binary(k) do
+    if has_control_char?(k), do: {:error, :control_char_in_payload}, else: :ok
+  end
+
+  defp check_key(_), do: {:error, :non_string_key}
+
+  # UTF-8 continuation bytes are always >= 0x80, so a raw byte scan for
+  # < 0x20 exactly detects control codepoints without decoding.
+  defp has_control_char?(<<b, _rest::binary>>) when b < 0x20, do: true
+  defp has_control_char?(<<_b, rest::binary>>), do: has_control_char?(rest)
+  defp has_control_char?(<<>>), do: false
+end

--- a/elixir/lease_plane/lib/unitares_lease_plane/governance_veto_client.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/governance_veto_client.ex
@@ -99,14 +99,20 @@ defmodule UnitaresLeasePlane.GovernanceVetoClient do
   end
 
   # Canonical payload hash — MUST match the proposer's mint-time payload_sha256
-  # so the grant's bound `psha` equals what gov-mcp verifies. Same computation as
-  # GovernedEffect.idempotency_digest's payload_hash: sha256 of the JSON-encoded
-  # payload, lowercase hex. (Cross-language canonicalization — Elixir Jason vs a
-  # Python proposer's json — is the slice-4 wiring integration item; a mismatch
-  # fails CLOSED at the veto, never open.)
+  # so the grant's bound `psha` equals what gov-mcp verifies. Uses the shared
+  # cross-language canonical form (UnitaresLeasePlane.CanonicalPayload here,
+  # unitares_sdk.lease_plane.canonical on the Python producer side; both pinned
+  # by tests/vectors/effect_payload_canonical.json). A payload the canonical
+  # form refuses (float / control char) forwards a sentinel that can never
+  # equal a minted hash, so the grant fails verification at gov-mcp and the
+  # effect is vetoed — fail closed, never open. Distinct from
+  # GovernedEffect.idempotency_digest, which keeps its original non-canonical
+  # payload hash so existing idempotency replay keys are untouched.
   defp payload_sha256(env) do
-    :crypto.hash(:sha256, Jason.encode!(Map.get(env, :payload, %{})))
-    |> Base.encode16(case: :lower)
+    case UnitaresLeasePlane.CanonicalPayload.sha256(Map.get(env, :payload, %{})) do
+      {:ok, hex} -> hex
+      {:error, reason} -> "canonicalization_refused:#{reason}"
+    end
   end
 
   defp parse(resp) do

--- a/elixir/lease_plane/test/canonical_payload_test.exs
+++ b/elixir/lease_plane/test/canonical_payload_test.exs
@@ -1,0 +1,49 @@
+defmodule UnitaresLeasePlane.CanonicalPayloadTest do
+  @moduledoc """
+  Pins the Elixir half of the cross-language canonical payload form against
+  the shared fixture `tests/vectors/effect_payload_canonical.json` (repo
+  root). The Python half (`unitares_sdk.lease_plane.canonical`) consumes the
+  same file — a green run on both sides is the byte-identity proof #1252
+  item 1 requires.
+  """
+  use ExUnit.Case, async: true
+
+  alias UnitaresLeasePlane.CanonicalPayload
+
+  @vectors_path Path.expand(
+                  "../../../tests/vectors/effect_payload_canonical.json",
+                  __DIR__
+                )
+
+  defp fixture do
+    @vectors_path |> File.read!() |> Jason.decode!()
+  end
+
+  test "reproduces every shared vector byte-identically" do
+    for %{"name" => name, "payload" => payload, "canonical" => canonical, "sha256" => sha} <-
+          fixture()["vectors"] do
+      assert {:ok, bytes} = CanonicalPayload.bytes(payload), "vector #{name}: bytes/1 refused"
+      assert bytes == canonical, "vector #{name}: canonical bytes diverge"
+      assert {:ok, ^sha} = CanonicalPayload.sha256(payload), "vector #{name}: sha256 diverges"
+    end
+  end
+
+  test "rejects every shared reject vector" do
+    for %{"name" => name, "payload" => payload} <- fixture()["rejects"] do
+      assert {:error, _} = CanonicalPayload.sha256(payload), "reject #{name}: was accepted"
+    end
+  end
+
+  test "rejects a non-map payload and unsupported types" do
+    assert {:error, :not_a_map} = CanonicalPayload.bytes("nope")
+    assert {:error, :unsupported_type} = CanonicalPayload.bytes(%{"pid" => self()})
+    assert {:error, :non_string_key} = CanonicalPayload.bytes(%{1 => "v"})
+  end
+
+  test "float and control-char rejection is deep" do
+    assert {:error, :float_in_payload} = CanonicalPayload.sha256(%{"a" => [%{"b" => [1.0]}]})
+
+    assert {:error, :control_char_in_payload} =
+             CanonicalPayload.sha256(%{"a" => [%{"b" => <<"x", 0x1B, "y">>}]})
+  end
+end

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -725,8 +725,10 @@ async def http_effect_grant(request):
 
     # Inert unless explicitly enabled. Fail-closed: off → not implemented, so a
     # premature caller is refused rather than silently issued a grant nothing
-    # verifies yet.
-    if not _http_bool(os.getenv("UNITARES_GOVERNED_EFFECT_BINDING")):
+    # verifies yet. Minting opens when the global flag OR any per-type flag is
+    # set (#1252 item 2): during a staged rollout producers must be able to
+    # mint before every type enforces.
+    if not _binding_mint_enabled():
         return JSONResponse(
             {"ok": False, "error": "binding_not_enabled",
              "detail": "effect-binding grant minting is disabled (Phase 1, inert)"},
@@ -796,6 +798,38 @@ async def http_effect_grant(request):
         )
 
     return JSONResponse({"ok": True, "grant": grant})
+
+
+_BINDING_FLAG = "UNITARES_GOVERNED_EFFECT_BINDING"
+
+
+def _binding_enforced(effect_type) -> bool:
+    """Is effect-binding enforced for this effect type? (#1252 item 2)
+
+    The global ``UNITARES_GOVERNED_EFFECT_BINDING`` enforces every type at
+    once — flipping it requires every producer to be minting simultaneously.
+    Per-type flags (``UNITARES_GOVERNED_EFFECT_BINDING_FILE_WRITE``,
+    ``.._AGENT_SPAWN``, derived generically from the forwarded effect_type)
+    stage the rollout: enforce+prove file_write first while agent_spawn's
+    ad-hoc producers stay unbound. The effect_type here is the one the lease
+    plane forwards in the veto body (trusted loopback forwarder, always set
+    by its validated envelope) — a missing type under per-type staging is
+    simply not yet enforced; the global flag remains the blanket lockdown.
+    """
+    if _http_bool(os.getenv(_BINDING_FLAG)):
+        return True
+    if not isinstance(effect_type, str) or not effect_type:
+        return False
+    suffix = "".join(c if c.isalnum() else "_" for c in effect_type).upper()
+    return _http_bool(os.getenv(f"{_BINDING_FLAG}_{suffix}"))
+
+
+def _binding_mint_enabled() -> bool:
+    """Grant minting opens when the global OR any per-type flag is set."""
+    if _http_bool(os.getenv(_BINDING_FLAG)):
+        return True
+    prefix = _BINDING_FLAG + "_"
+    return any(k.startswith(prefix) and _http_bool(v) for k, v in os.environ.items())
 
 
 async def _check_effect_binding(body: dict, proposer: str):
@@ -914,13 +948,16 @@ async def http_effect_veto(request):
     tier_reason = None if tier_ok else "tier_recert_failed:not_strong_identity"
 
     # §8 effect-binding (governed-effect-effect-binding-v0 §5 / #1075). ADDITIVE,
-    # flag-gated: when UNITARES_GOVERNED_EFFECT_BINDING is off (default), this is
-    # a no-op (binding_ok=True) and the live §6/§7 veto is byte-identical. When
-    # on, the forwarded grant must cover THIS exact effect and its nonce must be
-    # unconsumed — otherwise binding_ok is False and the effect is vetoed. Like
-    # §7, this gate applies on EVERY exit path below.
+    # flag-gated: with no binding flag set (default), this is a no-op
+    # (binding_ok=True) and the live §6/§7 veto is byte-identical. Enforcement
+    # is per effect type (#1252 item 2): the global flag covers every type,
+    # per-type flags (e.g. UNITARES_GOVERNED_EFFECT_BINDING_FILE_WRITE) stage
+    # the rollout one type at a time. When enforced, the forwarded grant must
+    # cover THIS exact effect and its nonce must be unconsumed — otherwise
+    # binding_ok is False and the effect is vetoed. Like §7, this gate applies
+    # on EVERY exit path below.
     binding_ok, binding_reason = True, None
-    if _http_bool(os.getenv("UNITARES_GOVERNED_EFFECT_BINDING")):
+    if _binding_enforced(body.get("effect_type")):
         binding_ok, binding_reason = await _check_effect_binding(body, proposer)
 
     try:

--- a/tests/test_effect_binding_per_type_flags.py
+++ b/tests/test_effect_binding_per_type_flags.py
@@ -1,0 +1,194 @@
+"""Per-effect-type binding flags (#1252 item 2).
+
+The global ``UNITARES_GOVERNED_EFFECT_BINDING`` enforces every effect type at
+once; per-type flags (``UNITARES_GOVERNED_EFFECT_BINDING_FILE_WRITE``, …,
+derived generically from the forwarded ``effect_type``) stage the rollout so
+``file_write`` can be enforced and proven while ``agent_spawn``'s ad-hoc
+producers stay unbound. Grant *minting* opens when the global OR any per-type
+flag is set — producers must be able to mint before every type enforces.
+
+Proven here so the staging is not a silent no-op in either direction:
+  - per-type flag on + matching effect_type + no grant → vetoed (enforced);
+  - per-type flag on + OTHER effect_type → allowed grantless (not enforced);
+  - per-type flag on + missing effect_type → not enforced (global remains the
+    blanket lockdown);
+  - global flag on → enforced regardless of type (back-compat);
+  - mint endpoint opens under a per-type flag alone, stays 501 with none.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from src.http_api import (
+    _binding_enforced,
+    _binding_mint_enabled,
+    http_effect_grant,
+    http_effect_veto,
+)
+from src.mcp_handlers.identity import session as session_mod
+
+PROPOSER = "00000000-0000-0000-0000-0000000000bb"
+TEST_SECRET = "test-continuity-secret-0123456789abcdef"
+
+_BASE_ENV = {
+    "UNITARES_CONTINUITY_TOKEN_SECRET": TEST_SECRET,
+    "UNITARES_MCP_BEARER_TOKENS": "",
+    "UNITARES_HTTP_API_TOKEN": "",
+    "UNITARES_GOVERNED_EFFECT_BINDING": "",
+    "UNITARES_GOVERNED_EFFECT_BINDING_FILE_WRITE": "",
+    "UNITARES_GOVERNED_EFFECT_BINDING_AGENT_SPAWN": "",
+}
+
+
+def _env(**flags):
+    return patch.dict(os.environ, {**_BASE_ENV, **flags})
+
+
+class _FakeConn:
+    async def fetchrow(self, *_a, **_k):
+        return None
+
+    async def execute(self, *_a, **_k):
+        return "INSERT 0 1"
+
+
+class _FakeAcquire:
+    async def __aenter__(self):
+        return _FakeConn()
+
+    async def __aexit__(self, *_a):
+        return False
+
+
+class _FakeDB:
+    def acquire(self):
+        return _FakeAcquire()
+
+
+def _post_veto(body):
+    with patch("src.db.get_db", return_value=_FakeDB()):
+        app = Starlette(routes=[Route("/v1/effect-veto", http_effect_veto, methods=["POST"])])
+        return TestClient(app).post("/v1/effect-veto", json=body)
+
+
+def _post_grant(body):
+    app = Starlette(routes=[Route("/v1/effect-grant", http_effect_grant, methods=["POST"])])
+    return TestClient(app).post("/v1/effect-grant", json=body)
+
+
+def _veto_body(effect_type):
+    body = {
+        "proposer_agent_uuid": PROPOSER,
+        "proposer_continuity_token": session_mod.create_continuity_token(
+            PROPOSER, f"sid-{PROPOSER[:8]}"
+        ),
+        "surface": "file://sandbox/x",
+        "custody_mode": "execute",
+        "idempotency_key": "idem-key-per-type",
+        "payload_sha256": "a" * 64,
+    }
+    if effect_type is not None:
+        body["effect_type"] = effect_type
+    return body
+
+
+# ── the flag helpers ─────────────────────────────────────────────────────────
+
+
+def test_binding_enforced_matrix():
+    with _env():
+        assert _binding_enforced("file_write") is False
+    with _env(UNITARES_GOVERNED_EFFECT_BINDING="1"):
+        assert _binding_enforced("file_write") is True
+        assert _binding_enforced("agent_spawn") is True
+        assert _binding_enforced(None) is True
+    with _env(UNITARES_GOVERNED_EFFECT_BINDING_FILE_WRITE="1"):
+        assert _binding_enforced("file_write") is True
+        assert _binding_enforced("agent_spawn") is False
+        assert _binding_enforced(None) is False
+        assert _binding_enforced("") is False
+
+
+def test_binding_mint_enabled_matrix():
+    with _env():
+        assert _binding_mint_enabled() is False
+    with _env(UNITARES_GOVERNED_EFFECT_BINDING="1"):
+        assert _binding_mint_enabled() is True
+    with _env(UNITARES_GOVERNED_EFFECT_BINDING_FILE_WRITE="1"):
+        assert _binding_mint_enabled() is True
+    with _env(UNITARES_GOVERNED_EFFECT_BINDING_AGENT_SPAWN="1"):
+        assert _binding_mint_enabled() is True
+
+
+# ── veto: per-type enforcement ───────────────────────────────────────────────
+
+
+def test_per_type_flag_enforces_matching_type():
+    with _env(UNITARES_GOVERNED_EFFECT_BINDING_FILE_WRITE="1"):
+        r = _post_veto(_veto_body("file_write"))
+    assert r.status_code == 200
+    j = r.json()
+    assert j["binding_ok"] is False
+    assert j["vetoed"] is True
+    assert "binding_absent" in (j.get("reason") or "")
+
+
+def test_per_type_flag_does_not_enforce_other_type():
+    with _env(UNITARES_GOVERNED_EFFECT_BINDING_FILE_WRITE="1"):
+        r = _post_veto(_veto_body("agent_spawn"))
+    assert r.status_code == 200
+    j = r.json()
+    assert j["binding_ok"] is True
+    assert j["vetoed"] is False
+
+
+def test_per_type_flag_missing_effect_type_not_enforced():
+    with _env(UNITARES_GOVERNED_EFFECT_BINDING_FILE_WRITE="1"):
+        r = _post_veto(_veto_body(None))
+    assert r.status_code == 200
+    assert r.json()["binding_ok"] is True
+
+
+def test_global_flag_enforces_every_type():
+    with _env(UNITARES_GOVERNED_EFFECT_BINDING="1"):
+        for effect_type in ("file_write", "agent_spawn", None):
+            r = _post_veto(_veto_body(effect_type))
+            assert r.status_code == 200
+            assert r.json()["binding_ok"] is False, f"type={effect_type}"
+
+
+# ── mint endpoint gating ─────────────────────────────────────────────────────
+
+
+def _grant_request():
+    return {
+        "proposer_agent_uuid": PROPOSER,
+        "proposer_continuity_token": session_mod.create_continuity_token(
+            PROPOSER, f"sid-{PROPOSER[:8]}"
+        ),
+        "payload_sha256": "a" * 64,
+        "surface": "file://sandbox/x",
+        "custody_mode": "execute",
+        "idempotency_key": "idem-key-mint",
+    }
+
+
+def test_mint_501_with_no_binding_flags():
+    with _env():
+        r = _post_grant(_grant_request())
+    assert r.status_code == 501
+    assert r.json()["error"] == "binding_not_enabled"
+
+
+def test_mint_opens_under_per_type_flag_alone():
+    with _env(UNITARES_GOVERNED_EFFECT_BINDING_FILE_WRITE="1"):
+        r = _post_grant(_grant_request())
+    assert r.status_code == 200
+    j = r.json()
+    assert j["ok"] is True
+    assert j["grant"].startswith("gnt.v1.")

--- a/tests/vectors/effect_payload_canonical.json
+++ b/tests/vectors/effect_payload_canonical.json
@@ -1,0 +1,126 @@
+{
+  "description": "Cross-language canonical payload vectors for effect-binding (#1252). Both the Python producer (unitares_sdk.lease_plane.canonical) and the Elixir lease plane (UnitaresLeasePlane.CanonicalPayload) MUST reproduce `canonical` (UTF-8) and `sha256` exactly for each vector, and MUST reject every entry in `rejects`.",
+  "vectors": [
+    {
+      "name": "file_write_basic",
+      "payload": {
+        "path": "/tmp/x.txt",
+        "content": "aGVsbG8gd29ybGQ="
+      },
+      "canonical": "{\"content\":\"aGVsbG8gd29ybGQ=\",\"path\":\"/tmp/x.txt\"}",
+      "sha256": "beb9bdcac3ba265610863075ae6610b67d911eaba2cad282924de54fed810f52"
+    },
+    {
+      "name": "file_write_with_encoding",
+      "payload": {
+        "path": "/tmp/data.bin",
+        "content": "AAECAwQ=",
+        "encoding": "base64"
+      },
+      "canonical": "{\"content\":\"AAECAwQ=\",\"encoding\":\"base64\",\"path\":\"/tmp/data.bin\"}",
+      "sha256": "2badc3d30c4f38d5183bc9a0c2b10df82ea6f10cb824149bc90d2ad6628fd229"
+    },
+    {
+      "name": "nested_unsorted_keys",
+      "payload": {
+        "zeta": {
+          "z": 1,
+          "a": [
+            1,
+            2,
+            {
+              "k": null
+            }
+          ]
+        },
+        "alpha": true,
+        "mid": [
+          {
+            "b": 2,
+            "a": 1
+          }
+        ]
+      },
+      "canonical": "{\"alpha\":true,\"mid\":[{\"a\":1,\"b\":2}],\"zeta\":{\"a\":[1,2,{\"k\":null}],\"z\":1}}",
+      "sha256": "e05e862bca8fd4be47f6a89a4f1ac8521d1d31d990b928391344e1ce4393f164"
+    },
+    {
+      "name": "unicode_raw",
+      "payload": {
+        "path": "/tmp/naïve-🚀.txt",
+        "note": "日本語"
+      },
+      "canonical": "{\"note\":\"日本語\",\"path\":\"/tmp/naïve-🚀.txt\"}",
+      "sha256": "b246c2a2ea34690afacf980554a8526545b1c2aa611b7e8be792c556d06d4909"
+    },
+    {
+      "name": "quotes_and_backslash",
+      "payload": {
+        "s": "he said \"hi\" \\ done",
+        "p": "C:\\tmp\\x"
+      },
+      "canonical": "{\"p\":\"C:\\\\tmp\\\\x\",\"s\":\"he said \\\"hi\\\" \\\\ done\"}",
+      "sha256": "5f9d1905aceefbd150f71603a356013b92a6b8066e3859c660135fbd4c4f7e62"
+    },
+    {
+      "name": "ints_bools_null",
+      "payload": {
+        "n": -42,
+        "big": 12345678901234567890,
+        "zero": 0,
+        "t": true,
+        "f": false,
+        "empty_s": "",
+        "nil": null,
+        "empty_list": [],
+        "empty_obj": {}
+      },
+      "canonical": "{\"big\":12345678901234567890,\"empty_list\":[],\"empty_obj\":{},\"empty_s\":\"\",\"f\":false,\"n\":-42,\"nil\":null,\"t\":true,\"zero\":0}",
+      "sha256": "cafcd702472cc73ecf8387f9152eba54bfc1d1f126d4b709a1e5d599a957db3c"
+    },
+    {
+      "name": "key_sort_bytewise",
+      "payload": {
+        "b": 1,
+        "B": 2,
+        "a": 3,
+        "A": 4,
+        "_": 5,
+        "0": 6,
+        "é": 7
+      },
+      "canonical": "{\"0\":6,\"A\":4,\"B\":2,\"_\":5,\"a\":3,\"b\":1,\"é\":7}",
+      "sha256": "d96ed29af299d962c83aed832e1bab86e12185ce2f1c494b753c275d9f97bed0"
+    }
+  ],
+  "rejects": [
+    {
+      "name": "float_value",
+      "payload": {
+        "x": 1.5
+      }
+    },
+    {
+      "name": "float_nested",
+      "payload": {
+        "a": [
+          {
+            "b": 2.0
+          }
+        ]
+      }
+    },
+    {
+      "name": "control_char_in_string",
+      "payload": {
+        "s": "a\u0001b"
+      }
+    },
+    {
+      "name": "control_char_in_key",
+      "payload": {
+        "bad\tkey": "v"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Builds the producer side of effect-binding Phase 1, closing items 1–3 of #1252 (item 0, producer discovery, is on the issue; item 4, activation, is an operator ops step). Everything here is **inert-safe if merged and deployed immediately**: all flags default off, and every new code path degrades to today's byte-identical behavior.

## Item 1 — cross-language canonical payload hash (load-bearing correctness fix)
One canonical serialization — UTF-8, bytewise-sorted keys, compact separators, **floats and control characters refused** (fail closed; the two regions where cross-language JSON formatting diverges) — implemented byte-identically in:
- Python producer: `unitares_sdk.lease_plane.canonical`
- Elixir plane: `UnitaresLeasePlane.CanonicalPayload`

Both are pinned by one shared fixture, `tests/vectors/effect_payload_canonical.json` (7 vectors incl. unicode/non-BMP, escapes, bytewise key sort, bignums; 4 reject vectors), consumed by pytest **and** mix test — a green run on both sides is the byte-identity proof. The veto client's grant-forward `payload_sha256` now uses the canonical form; a refused payload forwards a sentinel that can never match a minted grant (§8 fails closed). `GovernedEffect.idempotency_digest` is deliberately untouched so existing idempotency replay keys never change.

## Item 3 — SDK grant mint in `propose_file_write`
New `effect_binding="auto"|"require"|"off"` (default auto): mint at gov-mcp `/v1/effect-grant` with the canonical hash, attach `proposer.effect_grant`. On **any** mint failure (501 today, tier refusal, gov unreachable) auto proposes grantless — byte-identical to the pre-binding envelope, so the sole standing producer (Watcher floor writer) changes behavior only when minting is enabled server-side. `require` fails without proposing. The idempotency_key is fixed before mint because the grant binds it; the continuity_token is forwarded for §7 re-cert only, never logged.

## Item 2 — per-effect-type binding flags
`UNITARES_GOVERNED_EFFECT_BINDING_FILE_WRITE` / `.._AGENT_SPAWN` (derived generically from the forwarded effect_type) stage enforcement one type at a time; the global flag remains the blanket lockdown and back-compat path. Grant minting opens when the global **or any** per-type flag is set, so producers mint during the staged window (item 4's dry-run posture).

## Tests
- SDK: 255 passed (7 new mint tests, 13 canonical vector tests)
- gov-mcp: 57 passed across the binding/veto/grant suites (8 new per-type tests, all existing green)
- lease-plane: full `mix test` 283 tests + 14 properties, 0 failures (4 new canonical tests against the shared fixture)
- ruff clean

## Activation path (item 4, operator)
1. Merge + deploy (gov-mcp then lease plane; all inert).
2. Set `UNITARES_GOVERNED_EFFECT_BINDING_FILE_WRITE=1` on gov-mcp only → minting opens; Vigil's next governed floor write mints+carries a grant while enforcement proves against it.
3. Watch one real bound file_write commit clear the veto with `binding_ok=true`.
4. agent_spawn stays unenforced until its ad-hoc producers mint.

Closes the buildable scope of #1252.

https://claude.ai/code/session_01GtQtmkCMdFKSoYBqTkFtMt