### PR TITLE
fix(calibration): remove tool-success feeder, disable backwards confidence corrector (#1321)

### DIFF
--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -749,25 +749,22 @@ def transform_inputs(ctx: UpdateContext) -> Optional[Sequence[TextContent]]:
         except Exception as e:
             logger.warning(f"Could not enforce complexity limit: {e}", exc_info=True)
 
-    # Confidence & Auto-Calibration (coerce to float — same str|float|None pattern)
+    # Confidence (coerce to float — same str|float|None pattern)
     raw_confidence = ctx.arguments.get("confidence")
     try:
         reported_confidence = float(raw_confidence) if raw_confidence is not None else None
     except (TypeError, ValueError):
         reported_confidence = None
     ctx.confidence = reported_confidence
+    # Auto-correction is OFF pending the #1321 rebuild. The tactical bins the
+    # corrector read were ~96% trained by the tool-invocation-success feeder
+    # (removed in monitor_calibration.py) whose inverted low-confidence scoring
+    # made the applied corrections run backwards — an honest 0.5–0.7 report was
+    # halved because the agent's tools succeeded. Identity is strictly less
+    # wrong than scaling against those bins. Re-enable only against
+    # hard-exogenous channels once the bins are re-versioned;
+    # apply_confidence_correction and its tests stay intact for that rebuild.
     ctx.calibration_correction_info = None
-
-    if reported_confidence is not None:
-        try:
-            from src.calibration import calibration_checker
-            corrected, correction_info = calibration_checker.apply_confidence_correction(reported_confidence)
-            if correction_info:
-                ctx.calibration_correction_info = correction_info
-                logger.info(f"Agent {ctx.agent_id}: {correction_info}")
-            ctx.confidence = corrected
-        except Exception as e:
-            logger.debug(f"Calibration correction skipped: {e}")
 
     # Epistemic class: forward-only storage label for the state row. Pydantic
     # validates the public schema; this fallback keeps non-schema internal

--- a/src/monitor_calibration.py
+++ b/src/monitor_calibration.py
@@ -17,8 +17,8 @@ def run_calibration_recording(monitor, confidence: float, decision: Dict, drift_
     """Retrospective trajectory validation + strategic/tactical calibration.
 
     Compares previous verdict to current drift norm to assess whether the
-    intervention improved the trajectory.  Records calibration signals for
-    both trajectory-based and tool-usage ground truth.
+    intervention improved the trajectory. Records a trajectory-based tactical
+    calibration signal only; the tool-usage feeder was removed (#1321).
 
     Mutates monitor._prev_verdict_action, monitor._prev_drift_norm,
     monitor._prev_confidence, monitor._prev_checkin_time.
@@ -73,43 +73,15 @@ def run_calibration_recording(monitor, confidence: float, decision: Dict, drift_
     # Mint a tactical prediction id
     monitor.register_tactical_prediction(confidence, decision_action=decision.get('action'))
 
-    # Record prediction for STRATEGIC calibration
-    predicted_correct = confidence >= 0.5
-    actual_correct = None
-
-    try:
-        from src.tool_usage_tracker import get_tool_usage_tracker
-        tracker = get_tool_usage_tracker()
-        stats = tracker.get_usage_stats(window_hours=1, agent_id=monitor.agent_id)
-        total_calls = stats.get('total_calls', 0)
-        if total_calls >= 3:
-            tools = stats.get('tools', {})
-            total_success = sum(t.get('success_count', 0) for t in tools.values())
-            tool_accuracy = float(total_success) / float(total_calls)
-            actual_correct = tool_accuracy
-    except Exception:
-        pass
-
-    if actual_correct is not None:
-        calibration_checker.record_prediction(
-            confidence=confidence,
-            predicted_correct=predicted_correct,
-            actual_correct=actual_correct
-        )
-
-        decision_action = decision['action']
-        outcome_was_good = actual_correct >= 0.6
-
-        if confidence >= 0.6:
-            immediate_outcome = outcome_was_good
-        else:
-            immediate_outcome = not outcome_was_good
-
-        if decision_action in ('proceed', 'pause'):
-            calibration_checker.record_tactical_decision(
-                confidence=confidence,
-                decision=decision_action,
-                immediate_outcome=immediate_outcome
-            )
+    # The former tool-usage feeder is deliberately gone (#1321). It graded
+    # reported confidence against the agent's MCP tool-invocation success rate
+    # over the last hour — a ~0.998 near-constant that measures infrastructure
+    # reliability, not task outcomes. Firing on every check-in, it supplied
+    # ~96% of the strategic/tactical bin mass, manufactured the fleet-wide
+    # −0.29 "underconfidence" artifact, and (via the inverted low-confidence
+    # scoring it used) taught the corrector to halve honest 0.5–0.7 reports.
+    # Calibration ground truth must come from outcome-graded events
+    # (evidence_weight-gated in outcome_events.py) — never from tool-call
+    # plumbing succeeding.
 
     return trajectory_validation

--- a/tests/test_monitor_calibration_unit.py
+++ b/tests/test_monitor_calibration_unit.py
@@ -153,7 +153,11 @@ class TestTacticalDecisionRecording:
 
 
 class TestStrategicPrediction:
-    def test_tool_stats_with_enough_calls_records_prediction(self):
+    def test_tool_stats_never_train_calibration(self):
+        """#1321: tool-invocation success is infrastructure reliability, not
+        task outcome. Even with abundant tool stats available, check-ins must
+        not write strategic or tactical calibration from them — reintroducing
+        this feeder re-contaminates the bins."""
         import time
         monitor = _make_monitor(
             prev_verdict=None, prev_checkin_time=time.monotonic(),
@@ -173,38 +177,8 @@ class TestStrategicPrediction:
                 decision={"action": "proceed"},
                 drift_vector=_drift(0.1),
             )
-        ccm.record_prediction.assert_called_once()
-        call = ccm.record_prediction.call_args
-        assert call.kwargs["confidence"] == 0.75
-        assert call.kwargs["predicted_correct"] is True
-        assert call.kwargs["actual_correct"] == pytest.approx(0.8)
-        # tool_accuracy 0.8 >= 0.6 → outcome_was_good True
-        # confidence 0.75 >= 0.6 → immediate_outcome = True
-        ccm.record_tactical_decision.assert_called_once()
-        assert ccm.record_tactical_decision.call_args.kwargs["immediate_outcome"] is True
-
-    def test_low_confidence_inverts_immediate_outcome(self):
-        import time
-        monitor = _make_monitor(
-            prev_verdict=None, prev_checkin_time=time.monotonic(),
-        )
-        fake_stats = {
-            "total_calls": 5,
-            "tools": {"t1": {"success_count": 1}},
-        }
-        tracker = MagicMock()
-        tracker.get_usage_stats = MagicMock(return_value=fake_stats)
-        with patch("src.monitor_calibration.calibration_checker") as ccm, \
-             patch("src.tool_usage_tracker.get_tool_usage_tracker",
-                   return_value=tracker):
-            run_calibration_recording(
-                monitor, confidence=0.3,
-                decision={"action": "proceed"},
-                drift_vector=_drift(0.1),
-            )
-        # tool_accuracy 0.2 < 0.6 → outcome_was_good False
-        # confidence 0.3 < 0.6 → immediate_outcome = not outcome_was_good = True
-        assert ccm.record_tactical_decision.call_args.kwargs["immediate_outcome"] is True
+        ccm.record_prediction.assert_not_called()
+        ccm.record_tactical_decision.assert_not_called()
 
     def test_too_few_calls_no_prediction(self):
         import time


### PR DESCRIPTION
Refs #1321 (stays open for the follow-ups below). Implements fix-direction items 1 + interim-off from [the analysis](https://github.com/cirwel/unitares/issues/1321#issuecomment-4866910849).

## What

1. **Remove the contaminating feeder** (`src/monitor_calibration.py`): on every check-in it graded reported confidence against the agent's MCP tool-invocation success rate over the last hour — fleet-wide **0.9982**, a near-constant measuring whether tool calls errored, not whether work succeeded. It supplied ~96% of strategic (48.7k) and tactical (50.7k) bin mass and manufactured the fleet-wide −0.29 'underconfidence'. Its low-confidence inversion (`conf<0.6 → NOT outcome_was_good`) scored every honest low-confidence check-in as a failed prediction. Trajectory-based tactical recording and prediction-id minting stay.

2. **Stop applying the corrector** (`src/mcp_handlers/updates/phases.py`): `apply_confidence_correction` read those same tactical bins with outcome-accuracy semantics, so it ran backwards — an honest 0.55 report was halved *because the agent's tools succeeded* (dogfood 0.50→0.26 = 0.50 × bin factor 0.521). Identity is strictly less wrong. The function and its ~25 regression tests are kept intact for the rebuild; only the live call site is removed. It also feeds #770's gate reads, which now see uncorrected (honest) confidences.

3. **Tests**: the two tests that locked in the removed behavior (including `test_low_confidence_inverts_immediate_outcome`) are replaced by `test_tool_stats_never_train_calibration` — a guard against reintroducing the feeder.

## Why the sign flips

Where real ground truth exists (externally_verified outcomes, n=1,725) the fleet is **+0.28 OVERconfident** (conf 0.986 vs success 0.709). The 'underconfidence' was the artifact; details and full bin splits in the issue comment.

## Verification

- Targeted files: 264 pass. Full suite (`pytest tests/ -q --no-cov`): **10,559 passed, 0 failed** on the branch; base commit 10,560 (one fewer test after consolidating the two feeder tests into one). A single order-dependent `test_ux_fixes` catalog failure appeared once under local coverage mode, reproduced on neither branch nor base in isolation nor in the plain full run — pre-existing local ordering artifact, unrelated (my diff touches no tool registration).

## Deliberately NOT in this PR (operator/follow-up)

- **Re-version/reset the cumulative bins** — `core.calibration` data is 96% contamination and can't be cleaned in place; needs an operator decision on reset vs re-version.
- **Unify `record_tactical_decision` semantics** (outcome-goodness vs prediction-correctness) — includes the remaining drift-improvement feeder.
- **Rebuild the corrector against `tactical_bins_by_channel`** (tests channel dark until #1345).

https://claude.ai/code/session_01DAAcGvQ2WqeeXK7HoohLCC