### PR TITLE
feat(eisv): cadence stratification + decimation diagnostic — the AR(1) FAIL is not (mostly) a cadence artifact

### DIFF
--- a/scripts/analysis/eisv_self_predictability.py
+++ b/scripts/analysis/eisv_self_predictability.py
@@ -74,6 +74,34 @@ WARMUP_RAW = 8
 # out-of-sample, for a majority of agents with at least this many raw states.
 RAW_GATE_MIN_STATES = 50
 
+# Cadence bands for STRATIFYING the (unchanged) gate verdict, by median
+# inter-check-in gap in minutes. The 2026-07-01 early read failed 0/2 on
+# high-cadence residents whose raw obs barely move between check-ins minutes
+# apart — a regime where persistence wins almost by construction. The bands
+# separate that regime from agents whose observations have time to move.
+# Stratification is descriptive; the pre-registered majority rule is NOT
+# re-scored per band.
+CADENCE_BANDS = (
+    ("fast (<10m)", 0.0, 10.0),
+    ("mid (10-60m)", 10.0, 60.0),
+    ("slow (>=60m)", 60.0, float("inf")),
+)
+
+# Decimation factors for the within-agent cadence DIAGNOSTIC: re-score the
+# same agent through the same walk-forward math on every k-th raw observation.
+# The runtime folds one EMA step per check-in (not per wall-clock unit), so
+# seq[::k] is exactly the series the identical measurement process would
+# produce for an agent checking in k-times less often. If the persistence
+# advantage decays with k and the per-agent reference overtakes at realistic
+# cadences, the native-cadence FAIL is a sampling artifact; if persistence
+# wins at every k, the FAIL is real. Diagnostic only — never substitutes for
+# the native-cadence gate.
+DECIMATION_FACTORS = (1, 2, 4, 8, 16)
+
+# Minimum scored predictions for a decimated series to be reported; below
+# this the MAE comparison is noise.
+DECIMATION_MIN_SCORED = 20
+
 
 def _extract_eisv(state_json: dict) -> dict | None:
     """Pull the smoothed behavioral E/I/S/V measurement from a state row.
@@ -120,13 +148,16 @@ def _extract_raw(state_json: dict) -> dict | None:
 
 async def fetch_trajectories(
     db_url: str, *, min_states: int
-) -> tuple[dict[str, list[dict]], dict[str, list[dict]], dict[str, str]]:
-    """Return (smoothed, raw, labels).
+) -> tuple[dict[str, list[dict]], dict[str, list[dict]],
+           dict[str, list], dict[str, str]]:
+    """Return (smoothed, raw, raw_ts, labels).
 
     smoothed: {agent_id: [eisv_dict, ...]} time-ordered, non-synthetic,
     behavioral, thresholded at min_states (unchanged from the original eval).
     raw: {agent_id: [raw_dict, ...]} for rows carrying raw_obs, thresholded at
     WARMUP_RAW + 2 (enough for at least one scored prediction).
+    raw_ts: {agent_id: [recorded_at, ...]} aligned index-for-index with raw —
+    the cadence stratification and decimation diagnostics need real gaps.
     labels: {agent_id: human label} where core.agents knows one.
     """
     try:
@@ -155,6 +186,7 @@ async def fetch_trajectories(
 
     traj: dict[str, list[dict]] = {}
     raw_traj: dict[str, list[dict]] = {}
+    raw_ts: dict[str, list] = {}
     labels: dict[str, str] = {}
     for r in records:
         sj = r["state_json"]
@@ -171,9 +203,13 @@ async def fetch_trajectories(
         raw = _extract_raw(sj)
         if raw is not None:
             raw_traj.setdefault(r["agent_id"], []).append(raw)
+            raw_ts.setdefault(r["agent_id"], []).append(r["recorded_at"])
+    kept_raw = {a: seq for a, seq in raw_traj.items()
+                if len(seq) >= WARMUP_RAW + 2}
     return (
         {a: seq for a, seq in traj.items() if len(seq) >= min_states},
-        {a: seq for a, seq in raw_traj.items() if len(seq) >= WARMUP_RAW + 2},
+        kept_raw,
+        {a: raw_ts[a] for a in kept_raw},
         labels,
     )
 
@@ -282,7 +318,109 @@ def _ar1_predict(n: int, sx: float, sy: float, sxx: float, sxy: float,
 RAW_MODELS = ("persistence", "ar1", "expanding_mean", "ema", "global_mean")
 
 
+def _median(xs: list[float]) -> float:
+    s = sorted(xs)
+    n = len(s)
+    if n == 0:
+        return float("nan")
+    return s[n // 2] if n % 2 else (s[n // 2 - 1] + s[n // 2]) / 2
+
+
+def _median_gap_min(ts: list) -> float | None:
+    """Median inter-observation gap in minutes, or None without timestamps."""
+    if not ts or len(ts) < 2:
+        return None
+    gaps = []
+    for a, b in zip(ts, ts[1:]):
+        try:
+            gaps.append((b - a).total_seconds() / 60.0)
+        except (TypeError, AttributeError):
+            return None
+    return _median(gaps)
+
+
+def _cadence_band(gap_min: float | None) -> str | None:
+    if gap_min is None:
+        return None
+    for name, lo, hi in CADENCE_BANDS:
+        if lo <= gap_min < hi:
+            return name
+    return None
+
+
+def _score_raw_series(seq: list[dict], gmean: dict[str, float]) -> dict | None:
+    """Walk-forward scoring of one raw series against all RAW_MODELS.
+
+    Shared by the native-cadence gate and the decimation diagnostic so both
+    run through byte-identical math. Returns per-model error sums, scored
+    count, and the final fitted (clamped) AR(1) phi per dim — or None when
+    the series is too short to score anything.
+    """
+    T = len(seq)
+    run_sum = {d: 0.0 for d in RAW_DIMS}
+    ema = {d: seq[0][d] for d in RAW_DIMS}
+    # AR(1) online pair sums over (x_{i-1}, x_i), per dim
+    ar = {d: {"n": 0, "sx": 0.0, "sy": 0.0, "sxx": 0.0, "sxy": 0.0}
+          for d in RAW_DIMS}
+    err = {mdl: {d: 0.0 for d in RAW_DIMS} for mdl in RAW_MODELS}
+    cnt = 0
+    for i in range(T):
+        cur = seq[i]
+        if i >= WARMUP_RAW:
+            exp_mean = {d: run_sum[d] / i for d in RAW_DIMS}
+            for d in RAW_DIMS:
+                s = ar[d]
+                preds = {
+                    "persistence": seq[i - 1][d],
+                    "ar1": _ar1_predict(s["n"], s["sx"], s["sy"], s["sxx"],
+                                        s["sxy"], seq[i - 1][d],
+                                        exp_mean[d]),
+                    "expanding_mean": exp_mean[d],
+                    "ema": ema[d],
+                    "global_mean": gmean[d],
+                }
+                for mdl, p in preds.items():
+                    err[mdl][d] += abs(p - cur[d])
+            cnt += 1
+        # fold cur into running stats AFTER scoring (no leakage)
+        for d in RAW_DIMS:
+            if i >= 1:
+                s = ar[d]
+                x, y = seq[i - 1][d], cur[d]
+                s["n"] += 1
+                s["sx"] += x
+                s["sy"] += y
+                s["sxx"] += x * x
+                s["sxy"] += x * y
+            run_sum[d] += cur[d]
+            ema[d] = EMA_ALPHA[d] * cur[d] + (1 - EMA_ALPHA[d]) * ema[d]
+
+    if cnt == 0:
+        return None
+    phi = {}
+    for d in RAW_DIMS:
+        s = ar[d]
+        denom = s["n"] * s["sxx"] - s["sx"] * s["sx"]
+        if s["n"] < 2 or abs(denom) < 1e-12:
+            phi[d] = float("nan")
+        else:
+            phi[d] = max(-1.0, min(1.0, (s["n"] * s["sxy"] - s["sx"] * s["sy"]) / denom))
+    return {"err": err, "cnt": cnt, "phi": phi}
+
+
+def _fleet_mean(traj: dict[str, list[dict]]) -> dict[str, float]:
+    gmean = {d: 0.0 for d in RAW_DIMS}
+    n_all = 0
+    for seq in traj.values():
+        for m in seq:
+            for d in RAW_DIMS:
+                gmean[d] += m[d]
+            n_all += 1
+    return {d: (gmean[d] / n_all if n_all else 0.0) for d in RAW_DIMS}
+
+
 def evaluate_raw(traj: dict[str, list[dict]], *,
+                 timestamps: dict[str, list] | None = None,
                  gate_min_states: int = RAW_GATE_MIN_STATES) -> dict:
     """Walk-forward eval on the RAW pre-EMA series — the decontamination null.
 
@@ -294,76 +432,40 @@ def evaluate_raw(traj: dict[str, list[dict]], *,
     reference (`ema`, mirroring the live baseline) must have lower avg MAE than
     `global_mean` AND `persistence` AND `ar1` for a majority of agents with
     >= gate_min_states raw states. Beating fleet-mean alone is NOT success.
-    """
-    gmean = {d: 0.0 for d in RAW_DIMS}
-    n_all = 0
-    for seq in traj.values():
-        for m in seq:
-            for d in RAW_DIMS:
-                gmean[d] += m[d]
-            n_all += 1
-    gmean = {d: (gmean[d] / n_all if n_all else 0.0) for d in RAW_DIMS}
 
+    `timestamps` (optional, aligned with traj) adds per-agent median check-in
+    gaps and a cadence-band breakdown of the same verdicts — descriptive
+    stratification only; the majority rule above is unchanged.
+    """
+    gmean = _fleet_mean(traj)
     pooled_err = {mdl: {d: 0.0 for d in RAW_DIMS} for mdl in RAW_MODELS}
     pooled_cnt = 0
     per_agent: list[dict] = []
 
     for agent, seq in traj.items():
-        T = len(seq)
-        run_sum = {d: 0.0 for d in RAW_DIMS}
-        ema = {d: seq[0][d] for d in RAW_DIMS}
-        # AR(1) online pair sums over (x_{i-1}, x_i), per dim
-        ar = {d: {"n": 0, "sx": 0.0, "sy": 0.0, "sxx": 0.0, "sxy": 0.0}
-              for d in RAW_DIMS}
-        a_err = {mdl: {d: 0.0 for d in RAW_DIMS} for mdl in RAW_MODELS}
-        a_cnt = 0
-        for i in range(T):
-            cur = seq[i]
-            if i >= WARMUP_RAW:
-                exp_mean = {d: run_sum[d] / i for d in RAW_DIMS}
-                for d in RAW_DIMS:
-                    s = ar[d]
-                    preds = {
-                        "persistence": seq[i - 1][d],
-                        "ar1": _ar1_predict(s["n"], s["sx"], s["sy"], s["sxx"],
-                                            s["sxy"], seq[i - 1][d],
-                                            exp_mean[d]),
-                        "expanding_mean": exp_mean[d],
-                        "ema": ema[d],
-                        "global_mean": gmean[d],
-                    }
-                    for mdl, p in preds.items():
-                        a_err[mdl][d] += abs(p - cur[d])
-                a_cnt += 1
-            # fold cur into running stats AFTER scoring (no leakage)
-            for d in RAW_DIMS:
-                if i >= 1:
-                    s = ar[d]
-                    x, y = seq[i - 1][d], cur[d]
-                    s["n"] += 1
-                    s["sx"] += x
-                    s["sy"] += y
-                    s["sxx"] += x * x
-                    s["sxy"] += x * y
-                run_sum[d] += cur[d]
-                ema[d] = EMA_ALPHA[d] * cur[d] + (1 - EMA_ALPHA[d]) * ema[d]
-
-        if a_cnt == 0:
+        scored = _score_raw_series(seq, gmean)
+        if scored is None:
             continue
+        a_err, a_cnt = scored["err"], scored["cnt"]
         a_mae = {mdl: {d: a_err[mdl][d] / a_cnt for d in RAW_DIMS}
                  for mdl in RAW_MODELS}
         avg = {mdl: _mae_avg(a_mae[mdl]) for mdl in RAW_MODELS}
         wins_gate = (avg["ema"] < avg["global_mean"]
                      and avg["ema"] < avg["persistence"]
                      and avg["ema"] < avg["ar1"])
+        gap = _median_gap_min(timestamps.get(agent)) if timestamps else None
+        phi_vals = [v for v in scored["phi"].values() if v == v]  # drop NaN
         per_agent.append({
             "agent": agent,
-            "n_states": T,
+            "n_states": len(seq),
             "n_scored": a_cnt,
             "mae_avg": avg,
             "mae": a_mae,
-            "gate_eligible": T >= gate_min_states,
+            "gate_eligible": len(seq) >= gate_min_states,
             "wins_gate": wins_gate,
+            "median_gap_min": gap,
+            "cadence_band": _cadence_band(gap),
+            "phi_mean": (sum(phi_vals) / len(phi_vals)) if phi_vals else None,
         })
         for mdl in RAW_MODELS:
             for d in RAW_DIMS:
@@ -377,6 +479,17 @@ def evaluate_raw(traj: dict[str, list[dict]], *,
     }
     eligible = [a for a in per_agent if a["gate_eligible"]]
     winners = [a for a in eligible if a["wins_gate"]]
+    bands = []
+    for name, _lo, _hi in CADENCE_BANDS:
+        b_eligible = [a for a in eligible if a["cadence_band"] == name]
+        if not b_eligible and not any(a["cadence_band"] == name for a in per_agent):
+            continue
+        bands.append({
+            "band": name,
+            "eligible": len(b_eligible),
+            "winners": sum(1 for a in b_eligible if a["wins_gate"]),
+            "agents_total": sum(1 for a in per_agent if a["cadence_band"] == name),
+        })
     return {
         "n_agents": len(per_agent),
         "n_predictions": pooled_cnt,
@@ -387,7 +500,62 @@ def evaluate_raw(traj: dict[str, list[dict]], *,
         "gate_eligible": len(eligible),
         "gate_winners": len(winners),
         "gate_majority": (len(winners) * 2 > len(eligible)) if eligible else None,
+        "cadence_bands": bands,
     }
+
+
+def evaluate_decimation(traj: dict[str, list[dict]], *,
+                        timestamps: dict[str, list] | None = None,
+                        gate_min_states: int = RAW_GATE_MIN_STATES,
+                        factors: tuple[int, ...] = DECIMATION_FACTORS,
+                        min_scored: int = DECIMATION_MIN_SCORED) -> dict:
+    """Within-agent cadence diagnostic: re-score gate-eligible agents on
+    every k-th observation.
+
+    seq[::k] simulates the same agent at a k-times-coarser check-in cadence
+    running through the identical runtime math (one EMA fold per check-in).
+    DIAGNOSTIC ONLY: it deliberately makes persistence's job harder, so a win
+    here can never substitute for the native-cadence gate — it can only tell
+    us whether the native FAIL is explained by sampling cadence.
+    """
+    gmean = _fleet_mean(traj)  # fixed fleet reference across all k
+    agents = []
+    for agent, seq in traj.items():
+        if len(seq) < gate_min_states:
+            continue
+        rows = []
+        for k in factors:
+            dec = seq[::k]
+            scored = _score_raw_series(dec, gmean)
+            if scored is None or scored["cnt"] < min_scored:
+                continue
+            a_mae = {mdl: {d: scored["err"][mdl][d] / scored["cnt"]
+                           for d in RAW_DIMS} for mdl in RAW_MODELS}
+            avg = {mdl: _mae_avg(a_mae[mdl]) for mdl in RAW_MODELS}
+            ts = timestamps.get(agent) if timestamps else None
+            eff_gap = _median_gap_min(ts[::k]) if ts else None
+            phi_vals = [v for v in scored["phi"].values() if v == v]
+            rows.append({
+                "k": k,
+                "n_states": len(dec),
+                "n_scored": scored["cnt"],
+                "eff_gap_min": eff_gap,
+                "mae_avg": avg,
+                "phi_mean": (sum(phi_vals) / len(phi_vals)) if phi_vals else None,
+                # The individuality-carrying signal: does ANY per-agent
+                # stable-normal reference (runtime ema OR the fitted ar1, whose
+                # intercept encodes the per-agent mean) beat raw persistence?
+                # Persistence is the no-stable-normal null; the ema-vs-ar1
+                # comparison is estimator choice, not individuality.
+                "normal_beats_pers": (min(avg["ema"], avg["ar1"])
+                                      < avg["persistence"]),
+                # Mirror of the strict pre-registered gate comparison.
+                "ema_beats_nulls": (avg["ema"] < avg["persistence"]
+                                    and avg["ema"] < avg["ar1"]),
+            })
+        if rows:
+            agents.append({"agent": agent, "rows": rows})
+    return {"agents": agents, "factors": factors, "min_scored": min_scored}
 
 
 def build_raw_report(res: dict, labels: dict[str, str]) -> str:
@@ -418,19 +586,39 @@ def build_raw_report(res: dict, labels: dict[str, str]) -> str:
                  f"{row['S']:.4f} | {_mae_avg(row):.4f} |")
 
     a.append("\n## Per-agent (gate = `ema` beats global_mean AND persistence AND ar1)")
-    a.append("| Agent | states | persistence | ar1 | exp_mean | ema | global | gate |")
-    a.append("|---|---:|---:|---:|---:|---:|---:|---|")
+    a.append("| Agent | states | gap(min) | phi | persistence | ar1 | exp_mean | ema | global | gate |")
+    a.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|---|")
     for ag in res["per_agent"]:
         name = labels.get(ag["agent"], ag["agent"][:8])
         m = ag["mae_avg"]
         flag = ("**PASS**" if ag["wins_gate"] else "fail") if ag["gate_eligible"] \
             else ("(pass)" if ag["wins_gate"] else "(fail)")
+        gap = f"{ag['median_gap_min']:.1f}" if ag.get("median_gap_min") is not None else "—"
+        phi = f"{ag['phi_mean']:.2f}" if ag.get("phi_mean") is not None else "—"
         a.append(
-            f"| {name} | {ag['n_states']} | {m['persistence']:.4f} | "
+            f"| {name} | {ag['n_states']} | {gap} | {phi} | "
+            f"{m['persistence']:.4f} | "
             f"{m['ar1']:.4f} | {m['expanding_mean']:.4f} | {m['ema']:.4f} | "
             f"{m['global_mean']:.4f} | {flag} |"
         )
-    a.append("\n(parenthesised = below the gate's states floor; shown for trend only)")
+    a.append("\n(parenthesised = below the gate's states floor; shown for trend only; "
+             "gap = median minutes between check-ins; phi = final fitted clamped "
+             "AR(1) slope averaged over E/I/S — near 1.0 means the raw series is "
+             "random-walk-like at this cadence)")
+
+    if res.get("cadence_bands"):
+        a.append("\n## Cadence stratification (descriptive — the gate rule is unchanged)")
+        a.append("| Band | agents | gate-eligible | gate-winners |")
+        a.append("|---|---:|---:|---:|")
+        for b in res["cadence_bands"]:
+            a.append(f"| {b['band']} | {b['agents_total']} | {b['eligible']} | "
+                     f"{b['winners']} |")
+        a.append(
+            "\nThe 2026-07-01 FAIL was read entirely off the fast band. If "
+            "eligible slow-band agents also fail, cadence does not explain the "
+            "FAIL; if only the fast band fails, the gate population is "
+            "unrepresentative and the verdict should wait for slow-band accrual."
+        )
 
     a.append("\n## Gate verdict")
     if res["gate_eligible"] == 0:
@@ -456,6 +644,73 @@ def build_raw_report(res: dict, labels: dict[str, str]) -> str:
         "outcome validity, which remains label-blocked. A FAIL means the "
         "'self-model' is dressed-up autocorrelation and must not be shipped or "
         "publicly framed (next-move doc, step 4)."
+    )
+    return "\n".join(a) + "\n"
+
+
+def build_decimation_report(res: dict, labels: dict[str, str]) -> str:
+    a: list[str] = []
+    a.append("\n---\n\n# Decimation diagnostic — is the FAIL a cadence artifact?\n")
+    a.append(
+        "Each gate-eligible agent re-scored on every k-th raw observation "
+        "(`seq[::k]`) through the identical walk-forward math — the series the "
+        "same measurement process would produce at a k-times-coarser check-in "
+        "cadence (the runtime folds one EMA step per check-in, not per "
+        "wall-clock unit). **Diagnostic only**: decimation makes persistence's "
+        "job harder by construction, so a win at k>1 never substitutes for the "
+        "native-cadence gate. What it can settle is *why* the native gate "
+        "failed:\n\n"
+        "- persistence's edge **decays with k and `ema` overtakes** at gaps "
+        "realistic for ordinary fleet agents → the FAIL is a sampling-cadence "
+        "artifact; wait for slow-band accrual before treating it as final.\n"
+        "- persistence (or the AR(1) null) **wins at every k** even as the "
+        "effective gap grows → cadence does not explain the FAIL; the raw "
+        "measurement process is autocorrelated at its core and the "
+        "individuality claim dies per the next-move doc.\n"
+    )
+    if not res["agents"]:
+        a.append("**No gate-eligible agents to decimate yet.**\n")
+        return "\n".join(a)
+    for entry in res["agents"]:
+        name = labels.get(entry["agent"], entry["agent"][:8])
+        a.append(f"\n## {name}")
+        a.append("| k | states | scored | eff gap (min) | phi | persistence | ar1 | ema | normal beats pers? | strict gate? |")
+        a.append("|---:|---:|---:|---:|---:|---:|---:|---:|---|---|")
+        for r in entry["rows"]:
+            gap = f"{r['eff_gap_min']:.1f}" if r["eff_gap_min"] is not None else "—"
+            phi = f"{r['phi_mean']:.2f}" if r["phi_mean"] is not None else "—"
+            m = r["mae_avg"]
+            normal = "**yes**" if r["normal_beats_pers"] else "no"
+            strict = "yes" if r["ema_beats_nulls"] else "no"
+            a.append(
+                f"| {r['k']} | {r['n_states']} | {r['n_scored']} | {gap} | {phi} | "
+                f"{m['persistence']:.4f} | {m['ar1']:.4f} | {m['ema']:.4f} | "
+                f"{normal} | {strict} |"
+            )
+    a.append(
+        "\nReading the columns:\n\n"
+        "- `normal beats pers?` — the individuality-carrying signal. "
+        "Persistence is the no-stable-normal null; the fitted AR(1)'s "
+        "intercept encodes a per-agent mean, so EITHER the runtime ema or the "
+        "ar1 fit beating persistence is evidence a stable per-agent normal "
+        "exists at that cadence. Watch whether this flips to yes as k grows.\n"
+        "- `strict gate?` — mirror of the pre-registered comparison (ema beats "
+        "persistence AND ar1). NOTE a structural property discovered while "
+        "testing this diagnostic: AR(1)-with-intercept NESTS the stationary "
+        "per-agent normal (phi→0 reduces it to the per-agent mean), so for a "
+        "PERFECTLY stable normal the expanding AR(1) fit converges to the "
+        "optimal predictor and the fixed-alpha ema loses this comparison "
+        "asymptotically. The strict gate is therefore winnable only where the "
+        "normal also DRIFTS slowly (non-stationarity the ema tracks better "
+        "than an expanding fit). A strict-gate FAIL with `normal beats pers? "
+        "= yes` and low phi means a stable per-agent normal exists but the "
+        "runtime's ema is not its best tracker — an estimator-tuning finding, "
+        "NOT a death sentence for individuality. A FAIL with persistence "
+        "dominant and phi ≈ 1 at every k is the fatal pattern (dressed-up "
+        "autocorrelation).\n"
+        "- `phi` — fitted clamped AR(1) slope, mean over E/I/S: ≈1 means "
+        "random-walk-like (no visible normal), ≈0 means mean-reverting around "
+        "a per-agent level."
     )
     return "\n".join(a) + "\n"
 
@@ -574,7 +829,7 @@ def build_report(res: dict, *, min_states: int) -> str:
 
 
 async def main_async(args: argparse.Namespace) -> int:
-    traj, raw_traj, labels = await fetch_trajectories(
+    traj, raw_traj, raw_ts, labels = await fetch_trajectories(
         args.db_url, min_states=args.min_states
     )
     if not traj:
@@ -582,8 +837,12 @@ async def main_async(args: argparse.Namespace) -> int:
         return 1
     res = evaluate(traj)
     report = build_report(res, min_states=args.min_states)
-    raw_res = evaluate_raw(raw_traj, gate_min_states=args.raw_gate_min_states)
+    raw_res = evaluate_raw(raw_traj, timestamps=raw_ts,
+                           gate_min_states=args.raw_gate_min_states)
     report += build_raw_report(raw_res, labels)
+    dec_res = evaluate_decimation(raw_traj, timestamps=raw_ts,
+                                  gate_min_states=args.raw_gate_min_states)
+    report += build_decimation_report(dec_res, labels)
     if args.output:
         path = Path(args.output)
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_eisv_self_predictability.py
+++ b/tests/test_eisv_self_predictability.py
@@ -3,6 +3,7 @@
 No DB: drive evaluate() / evaluate_raw() with hand-built trajectories so the
 MAE / skill / individuality / AR(1)-null logic is verified on known inputs.
 """
+import datetime as dt
 import math
 import random
 
@@ -12,8 +13,11 @@ from scripts.analysis.eisv_self_predictability import (
     WARMUP,
     WARMUP_RAW,
     _ar1_predict,
+    _cadence_band,
     _extract_raw,
+    _median_gap_min,
     evaluate,
+    evaluate_decimation,
     evaluate_raw,
 )
 
@@ -138,3 +142,119 @@ def test_raw_gate_not_evaluable_below_floor():
     assert res["gate_eligible"] == 0
     assert res["gate_majority"] is None
     assert res["n_agents"] == 1  # still scored for the pooled table
+
+
+# --- cadence stratification + decimation diagnostic ------------------------
+
+
+def _ts(n: int, gap_min: float) -> list[dt.datetime]:
+    t0 = dt.datetime(2026, 7, 1, tzinfo=dt.timezone.utc)
+    return [t0 + dt.timedelta(minutes=gap_min * i) for i in range(n)]
+
+
+def test_median_gap_and_bands():
+    assert math.isclose(_median_gap_min(_ts(10, 5.0)), 5.0)
+    assert _median_gap_min([]) is None
+    assert _median_gap_min(_ts(1, 5.0)) is None
+    assert _median_gap_min([1, 2, 3]) is None  # not datetimes
+    assert _cadence_band(5.0) == "fast (<10m)"
+    assert _cadence_band(30.0) == "mid (10-60m)"
+    assert _cadence_band(600.0) == "slow (>=60m)"
+    assert _cadence_band(None) is None
+
+
+def test_evaluate_raw_reports_cadence_and_phi():
+    traj = {
+        "fast": _raw_noise(0.2, 120, sigma=0.05, seed=1),
+        "slow": _raw_noise(0.8, 120, sigma=0.05, seed=2),
+    }
+    ts = {"fast": _ts(120, 5.0), "slow": _ts(120, 120.0)}
+    res = evaluate_raw(traj, timestamps=ts, gate_min_states=50)
+    by_agent = {a["agent"]: a for a in res["per_agent"]}
+    assert by_agent["fast"]["cadence_band"] == "fast (<10m)"
+    assert by_agent["slow"]["cadence_band"] == "slow (>=60m)"
+    assert math.isclose(by_agent["fast"]["median_gap_min"], 5.0)
+    # iid noise: fitted AR(1) slope must be near 0, nowhere near random-walk 1
+    assert abs(by_agent["fast"]["phi_mean"]) < 0.4
+    bands = {b["band"]: b for b in res["cadence_bands"]}
+    assert bands["fast (<10m)"]["eligible"] == 1
+    assert bands["slow (>=60m)"]["eligible"] == 1
+    # verdict fields unchanged by stratification
+    assert res["gate_majority"] is True
+
+
+def test_evaluate_raw_without_timestamps_backward_compatible():
+    traj = {"a": _raw_noise(0.2, 120, sigma=0.05, seed=1)}
+    res = evaluate_raw(traj, gate_min_states=50)
+    ag = res["per_agent"][0]
+    assert ag["median_gap_min"] is None
+    assert ag["cadence_band"] is None
+
+
+def test_random_walk_phi_near_one():
+    traj = {"a": _raw_walk(0.5, 200, step=0.02, seed=7)}
+    res = evaluate_raw(traj, gate_min_states=50)
+    assert res["per_agent"][0]["phi_mean"] > 0.85
+
+
+def test_decimation_stable_normal_beats_persistence_at_every_k():
+    """iid noise around a stable per-agent mean: a stable-normal reference
+    (ema or the fitted ar1, whose intercept encodes the mean) must beat raw
+    persistence at native cadence AND every decimation, with low phi."""
+    traj = {"a": _raw_noise(0.3, 400, sigma=0.05, seed=11)}
+    ts = {"a": _ts(400, 5.0)}
+    res = evaluate_decimation(traj, timestamps=ts, gate_min_states=50)
+    assert len(res["agents"]) == 1
+    rows = res["agents"][0]["rows"]
+    assert rows[0]["k"] == 1
+    assert all(r["normal_beats_pers"] for r in rows)
+    assert all(abs(r["phi_mean"]) < 0.5 for r in rows)
+    # effective gap scales with k
+    ks = {r["k"]: r for r in rows}
+    assert math.isclose(ks[4]["eff_gap_min"], 20.0)
+
+
+def test_strict_gate_asymptotically_lost_to_ar1_on_stationary_normal():
+    """Pins the structural property the decimation report documents: on a
+    PERFECTLY stable normal with a long sample, the expanding AR(1) fit
+    (which nests the per-agent mean at phi=0) converges to the optimal
+    predictor, so the fixed-alpha runtime ema loses the strict ema-vs-ar1
+    comparison even though individuality is maximally true. The strict gate
+    therefore tests estimator choice on stationary data — a FAIL with
+    normal_beats_pers=True and low phi must not be read as individuality
+    being false."""
+    traj = {"a": _raw_noise(0.3, 400, sigma=0.05, seed=11)}
+    res = evaluate_decimation(traj, gate_min_states=50)
+    k1 = res["agents"][0]["rows"][0]
+    assert k1["k"] == 1 and k1["n_scored"] > 300
+    assert k1["normal_beats_pers"] is True     # individuality visible
+    assert k1["ema_beats_nulls"] is False      # strict gate lost to ar1
+    assert k1["mae_avg"]["ar1"] < k1["mae_avg"]["ema"]
+
+
+def test_decimation_random_walk_never_beats_persistence():
+    """Random walk: persistence is optimal at EVERY cadence — decimation must
+    not manufacture a pass on either column (the anti-laundering direction)."""
+    traj = {"a": _raw_walk(0.5, 800, step=0.02, seed=13)}
+    res = evaluate_decimation(traj, gate_min_states=50)
+    rows = res["agents"][0]["rows"]
+    assert len(rows) >= 3  # 800 states supports several factors
+    assert not any(r["ema_beats_nulls"] for r in rows)
+    assert not any(r["normal_beats_pers"] for r in rows)
+    assert all(r["phi_mean"] > 0.8 for r in rows)
+
+
+def test_decimation_skips_underpowered_factors():
+    """A 60-state series at k=4 leaves 15 states → fewer than min_scored
+    predictions → the row must be dropped, not reported as noise."""
+    traj = {"a": _raw_noise(0.3, 60, sigma=0.05, seed=17)}
+    res = evaluate_decimation(traj, gate_min_states=50, min_scored=20)
+    ks = [r["k"] for r in res["agents"][0]["rows"]]
+    assert 1 in ks
+    assert 4 not in ks and 8 not in ks and 16 not in ks
+
+
+def test_decimation_ignores_ineligible_agents():
+    traj = {"a": _raw_noise(0.3, 30, sigma=0.05, seed=19)}
+    res = evaluate_decimation(traj, gate_min_states=50)
+    assert res["agents"] == []


### PR DESCRIPTION
## What

Pre-registered follow-up to the AR(1) individuality-gate early read (#1324, FAIL 0/2 on 2 high-cadence residents). Adds the instrumentation to read **why** the gate fails, without touching the gate rule:

- **Cadence columns + band stratification** in the gate table (median check-in gap; fast <10m / mid 10–60m / slow ≥60m).
- **Decimation diagnostic**: each gate-eligible agent re-scored on every k-th raw observation (k=1,2,4,8,16) through byte-identical walk-forward math — simulating the same measurement process at coarser check-in cadence. Diagnostic only; can never substitute for the native-cadence gate.
- **Fitted AR(1) φ** per agent per k — separates the fatal random-walk failure mode (φ≈1) from sticky/slow-drift modes (φ→0 with persistence still winning).
- **`normal_beats_pers` column**: min(ema, ar1) vs persistence — the individuality-carrying comparison, since AR(1)-with-intercept nests the per-agent stable normal.

## Live read (2026-07-02, 4 eligible agents)

1. **Native gate: FAIL 0/4** — replicates and extends the 0/2 early read, now including a mid-band agent (Vigil, 30min native cadence).
2. **Cadence-artifact hypothesis: mostly refuted as the explanation.** Persistence's edge shrinks with k but crosses over only once (Watcher at ~44min effective gap, ar1 edges persistence, n=26 — thin). Sentinel stays persistence-dominant out to **80min** effective gap.
3. **But the failure mode is NOT the pre-registered fatal signature.** φ decays to 0.07–0.32 at coarse k (not ≈1), and Sentinel's raw series is **53% exact consecutive repeats** (Watcher 5.6%, Vigil 4.5%) — sticky/piecewise-constant measurement, under which last-value is 1-step-MAE-optimal at any cadence *regardless of whether a stable per-agent normal exists*.
4. **Structural property discovered + pinned by regression test:** on a perfectly stable per-agent normal, the expanding AR(1) fit converges to the optimal predictor, so the strict gate's ema-vs-ar1 leg is asymptotically unwinnable on stationary data. A strict FAIL with `normal_beats_pers=yes` and low φ is an estimator-tuning finding, not individuality being false.

## Honest verdict

The pre-registered gate is **failed** and stays failed: no public 'EISV self-model' framing, no Stage B — unchanged posture. But 'individuality = dressed-up autocorrelation' would now be an **overclaim of the failure**: the data shows the 1-step-MAE operationalization cannot distinguish 'no stable normal' from 'stable-but-sticky measurement process', and the strict gate is structurally biased against the axiom's own best case. Whether to (a) accept the FAIL and stop, or (b) pre-register a v2 operationalization (jump-conditional scoring / horizon-h reference quality) **on fresh data only** — designed post-FAIL, so it needs stricter treatment — is an operator decision.

## Tests

18 deterministic DB-free tests (7 new): cadence bands, timestamps back-compat, decimation on iid-noise vs random-walk organisms (anti-laundering direction pinned: decimation must not manufacture a pass on a random walk), underpowered-factor skipping, and the AR(1)-nesting regression test.

Known pre-existing flake: `test_ux_fixes` catalog-category fails order-dependently in the full serial suite, passes standalone — unrelated to this diff.