### PR TITLE
fix(effect-binding): admit short-escape controls in canonical payloads (#1075)

### DIFF
--- a/agents/sdk/src/unitares_sdk/lease_plane/canonical.py
+++ b/agents/sdk/src/unitares_sdk/lease_plane/canonical.py
@@ -22,10 +22,15 @@ Canonical form:
 - **Floats are rejected** (``CanonicalizationError``): float formatting is
   not stable across languages, and a silent divergence would veto every
   bound effect. Fail loudly at the producer instead.
-- **Control characters (U+0000–U+001F) in strings and keys are rejected**:
-  they are the one region where JSON escape spelling can differ between
-  encoders (``\\u001b`` vs ``\\u001B``); real payloads (paths, base64
-  content) never contain them, so refusing is cheaper than normalizing.
+- **Control characters in strings and keys are rejected, EXCEPT the five
+  short-escape characters** ``\\b \\t \\n \\f \\r`` (U+0008, U+0009,
+  U+000A, U+000C, U+000D). Both encoders spell those five identically
+  (verified byte-for-byte; pinned by the shared fixture), and real text
+  content — the payload of every real ``file_write`` — contains them.
+  The remaining C0 controls (U+0000–U+0007, U+000B, U+000E–U+001F) are
+  the genuinely divergent region — Python spells ``\\u000b`` in lowercase
+  hex where Jason spells ``\\u000B`` in uppercase — so they stay rejected
+  (fail closed at the producer, sentinel-hash at the plane).
 """
 
 from __future__ import annotations
@@ -45,12 +50,20 @@ class CanonicalizationError(ValueError):
     """Payload cannot be canonically serialized (float, control char, bad key)."""
 
 
+# The five C0 controls with a JSON short escape (\b \t \n \f \r). Python's
+# json.dumps and Jason emit these byte-identically; every other C0 control is
+# spelled "\\u000b" by Python (lowercase hex) but "\\u000B" by Jason, and must
+# stay rejected or the two sides silently hash different bytes.
+_SHORT_ESCAPE_OK = frozenset("\b\t\n\f\r")
+
+
 def _check_string(s: str, *, context: str) -> None:
     for ch in s:
-        if ord(ch) < 0x20:
+        if ord(ch) < 0x20 and ch not in _SHORT_ESCAPE_OK:
             raise CanonicalizationError(
                 f"control character U+{ord(ch):04X} in {context}; canonical "
-                "payloads must not contain control characters"
+                "payloads only admit control characters with a cross-language "
+                "stable short escape (\\b \\t \\n \\f \\r)"
             )
 
 

--- a/agents/sdk/src/unitares_sdk/lease_plane/client.py
+++ b/agents/sdk/src/unitares_sdk/lease_plane/client.py
@@ -444,7 +444,11 @@ class LeasePlaneClient:
         try:
             payload_sha = canonical_payload_sha256(payload)
         except CanonicalizationError as e:
-            logger.debug("effect-grant mint skipped: payload not canonical (%s)", e)
+            # WARNING, not debug: a payload that cannot canonicalize can never
+            # bind, so under enforcement every propose from this producer is
+            # vetoed (binding_absent) and falls back — a standing condition the
+            # operator needs to see, not a transient mint hiccup.
+            logger.warning("effect-grant mint skipped: payload not canonical (%s)", e)
             return None
 
         gov_base = (

--- a/agents/sdk/tests/test_effect_grant_mint.py
+++ b/agents/sdk/tests/test_effect_grant_mint.py
@@ -119,3 +119,27 @@ def test_mint_hits_governance_url_not_lease_plane():
     _propose(_client(transport))
     (mint,) = transport.mint_requests()
     assert mint.url == "http://gov.test:8767/v1/effect-grant"
+
+def test_auto_mints_for_multiline_text_content():
+    """Regression (#1075 activation attempt, 2026-07-02): real file content is
+    multi-line text — the floor writer proposes pretty-printed JSON — and the
+    canonical form must admit the short-escape controls, or the sole standing
+    producer can never mint and every enforced propose vetoes binding_absent."""
+    transport = RecordingTransport({"ok": True, "grant": "gnt.v1.abc.def"})
+    content = '{\n  "a": 1,\n\t"b": "x"\r\n}\n'
+    result = _client(transport).propose_file_write(
+        path="/tmp/floor.json",
+        content=content,
+        proposer_uuid="00000000-0000-0000-0000-000000000001",
+        continuity_token="v1.tok",
+        session_id="s-1",
+        idempotency_key="fw-multiline",
+    )
+    assert result["ok"] is True
+
+    (mint,) = transport.mint_requests()
+    expected_sha = canonical_payload_sha256({"path": "/tmp/floor.json", "content": content})
+    assert mint.json_body["payload_sha256"] == expected_sha
+
+    (effect,) = transport.effect_requests()
+    assert effect.json_body["proposer"]["effect_grant"] == "gnt.v1.abc.def"

--- a/elixir/lease_plane/lib/unitares_lease_plane/canonical_payload.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/canonical_payload.ex
@@ -19,10 +19,14 @@ defmodule UnitaresLeasePlane.CanonicalPayload do
     object, array.
   - **Floats are rejected** (`{:error, :float_in_payload}`): float
     formatting is not stable across languages.
-  - **Control characters (U+0000–U+001F) in strings/keys are rejected**
-    (`{:error, :control_char_in_payload}`): the one region where JSON
-    escape spelling can differ between encoders; real payloads (paths,
-    base64 content) never contain them.
+  - **Control characters in strings/keys are rejected EXCEPT the five
+    short-escape characters** `\\b \\t \\n \\f \\r` (U+0008, U+0009, U+000A,
+    U+000C, U+000D) — both encoders spell those five identically (pinned
+    by the shared fixture), and real text content contains them. The
+    remaining C0 controls (U+0000–U+0007, U+000B, U+000E–U+001F) are the
+    genuinely divergent region (Jason emits uppercase hex escapes where
+    Python emits lowercase) and stay rejected
+    (`{:error, :control_char_in_payload}`).
   """
 
   @type reason ::
@@ -102,8 +106,17 @@ defmodule UnitaresLeasePlane.CanonicalPayload do
   defp check_key(_), do: {:error, :non_string_key}
 
   # UTF-8 continuation bytes are always >= 0x80, so a raw byte scan for
-  # < 0x20 exactly detects control codepoints without decoding.
-  defp has_control_char?(<<b, _rest::binary>>) when b < 0x20, do: true
+  # < 0x20 exactly detects control codepoints without decoding. The five
+  # short-escape controls \b \t \n \f \r (0x08 0x09 0x0A 0x0C 0x0D) are
+  # admitted: Jason and Python's json.dumps emit them byte-identically.
+  # Every other C0 control diverges (Jason emits uppercase hex escapes,
+  # "\\u000B", where Python emits lowercase "\\u000b") and stays rejected.
+  @short_escape_ok [0x08, 0x09, 0x0A, 0x0C, 0x0D]
+
+  defp has_control_char?(<<b, rest::binary>>) when b < 0x20 do
+    if b in @short_escape_ok, do: has_control_char?(rest), else: true
+  end
+
   defp has_control_char?(<<_b, rest::binary>>), do: has_control_char?(rest)
   defp has_control_char?(<<>>), do: false
 end

--- a/tests/vectors/effect_payload_canonical.json
+++ b/tests/vectors/effect_payload_canonical.json
@@ -91,6 +91,24 @@
       },
       "canonical": "{\"0\":6,\"A\":4,\"B\":2,\"_\":5,\"a\":3,\"b\":1,\"é\":7}",
       "sha256": "d96ed29af299d962c83aed832e1bab86e12185ce2f1c494b753c275d9f97bed0"
+    },
+    {
+      "name": "multiline_text_content",
+      "payload": {
+        "path": "/tmp/floor.json",
+        "content": "{\n  \"a\": 1,\n  \"b\": 2\n}\n"
+      },
+      "canonical": "{\"content\":\"{\\n  \\\"a\\\": 1,\\n  \\\"b\\\": 2\\n}\\n\",\"path\":\"/tmp/floor.json\"}",
+      "sha256": "bacd0405b9b13e6c76deaa371a2a08f1c2f3e48382cdf02d85d9327067478d6b"
+    },
+    {
+      "name": "all_short_escape_controls",
+      "payload": {
+        "s": "tab\there\nnewline\rcr\fff\bbs",
+        "crlf": "line1\r\nline2\r\n"
+      },
+      "canonical": "{\"crlf\":\"line1\\r\\nline2\\r\\n\",\"s\":\"tab\\there\\nnewline\\rcr\\fff\\bbs\"}",
+      "sha256": "bc1c76b722c235de5980a74d90fc62026188d50d019cc2a58f7d69e70d3daf28"
     }
   ],
   "rejects": [
@@ -119,7 +137,19 @@
     {
       "name": "control_char_in_key",
       "payload": {
-        "bad\tkey": "v"
+        "bad\u000bkey": "v"
+      }
+    },
+    {
+      "name": "divergent_control_vt",
+      "payload": {
+        "s": "a\u000bb"
+      }
+    },
+    {
+      "name": "divergent_control_esc_ansi",
+      "payload": {
+        "s": "\u001b[31mred\u001b[0m"
       }
     }
   ]


### PR DESCRIPTION
## What
Live activation of `UNITARES_GOVERNED_EFFECT_BINDING_FILE_WRITE` today exposed a structural gap in #1352's canonical payload form: **all** C0 control characters were rejected — including `\n` — so the sole standing producer (Vigil's floor writer, whose content is pretty-printed JSON) could never mint a grant. Under enforcement every propose vetoed `binding_absent` and fell back to the local atomic write; the flag had to be rolled back to inert.

## Fix
Verified byte-for-byte that Python `json.dumps` and Jason spell the five short-escape controls `\b \t \n \f \r` (U+0008–U+000A, U+000C–U+000D) **identically** — those are now admitted by both canonicalizers. The genuinely divergent region stays rejected fail-closed: Python spells `\u000b` lowercase where Jason spells `\u000B` uppercase, so U+0000–U+0007, U+000B, U+000E–U+001F still refuse.

- Python `unitares_sdk.lease_plane.canonical` + Elixir `UnitaresLeasePlane.CanonicalPayload` updated symmetrically
- Shared fixture `tests/vectors/effect_payload_canonical.json`: +2 accept vectors (multi-line file content; all five escapes incl. CRLF), +2 reject vectors (VT, ESC/ANSI); the `control_char_in_key` reject moves from `\t` (now legal) to VT
- New SDK regression test: multi-line content mints and attaches the grant
- SDK mint-skip on canonicalization failure raised debug → **warning**: a payload that can't canonicalize can never bind, so under enforcement that producer silently vetoes on every propose — that deserves one loud log line (finding it cost three diagnostic rounds today)

## Verification
- Python: 64 canonical/binding tests + 8 SDK mint tests pass; full local gate green except a pre-existing, environment-specific `test_ux_fixes` catalog failure that reproduces on clean master (editable pi plugin registers `pi`/`pi_restart_service` locally; absent in CI)
- Elixir: `mix test test/canonical_payload_test.exs` 4/4 against the updated shared fixture — the cross-language byte-identity proof
- The live floor payload (`~/.unitares/watcher/pattern_floor.json` content) canonicalizes under the new rule

## Activation retry (after merge + deploy)
1. Pull deploy checkout, restart gov-mcp + lease plane (compiles new modules at boot)
2. Vigil plist already carries `UNITARES_HTTP_API_TOKEN` (added today — required for the mint call; reload via bootout/bootstrap, not kickstart)
3. Re-set `UNITARES_GOVERNED_EFFECT_BINDING_FILE_WRITE=1` on gov-mcp
4. Kick Vigil with a backdated floor `updated_at` → expect first bound effect: grant minted, `binding_ok: true`, nonce row in `effects.consumed_nonces`

Closes the producer half of #1252's item 1 correctness gap; part of the #1075 Phase-1 chain (#1237/#1240/#1249/#1352).

https://claude.ai/code/session_01XheHCotFixY5YYtThQ82Mz