### PR TITLE
feat(eisv): individuality test v2 — pre-registered, fresh-data-only, with kill criterion

### DIFF
--- a/docs/proposals/eisv-individuality-v2-preregistration.md
+++ b/docs/proposals/eisv-individuality-v2-preregistration.md
@@ -1,0 +1,211 @@
+# EISV individuality test v2 — pre-registration
+
+**Status:** PRE-REGISTERED 2026-07-02. Design frozen at the merge commit of the
+PR introducing this file, after an adversarial design review
+(independent statistical, implementation-correctness, and live-data
+feasibility passes) whose material findings are incorporated and disclosed
+below. **The verdict counts only on
+raw observations recorded after `2026-07-02T18:00:00Z`** — an instant later
+than every piece of data consulted during design, including the review's.
+Companion to `docs/proposals/eisv-grounding-next-move-v0.md` (step 4);
+successor to the v1 operationalization in
+`scripts/analysis/eisv_self_predictability.py`.
+
+## Why a v2 exists (and why it is suspect by construction)
+
+The v1 gate — per-agent EMA must beat fleet-mean AND persistence AND fitted
+AR(1) on 1-step MAE over the raw series — **failed 0/4 at native cadence**
+(2026-07-01 early read; confirmed 2026-07-02 with cadence stratification,
+PR #1355). Two structural problems were then discovered in the
+operationalization itself:
+
+1. **Sticky measurement.** Sentinel's raw series is 53% exact consecutive
+   repeats. Against a piecewise-constant series, last-value is 1-step-MAE
+   optimal at any cadence *whether or not a stable per-agent normal exists*.
+2. **The AR(1) leg tests estimator choice, not individuality.**
+   AR(1)-with-intercept nests the stationary per-agent normal (φ→0 reduces it
+   to the per-agent mean), so on the axiom's own best case the expanding
+   AR(1) fit converges to the optimal predictor and the fixed-α EMA loses
+   asymptotically (pinned by regression test in
+   `tests/test_eisv_self_predictability.py`).
+
+Because v2 was designed AFTER seeing v1 fail, it gets stricter treatment:
+fresh data only, thresholds frozen here, machinery validated on synthetic
+organisms, an adversarial design review run BEFORE freeze, and a kill criterion.
+
+The v1 result stands as reported: FAILED. v2 does not reopen v1.
+
+## The claim under test (scoped by review findings R2/R4)
+
+**Each eligible agent's raw behavioral EISV series has an agent-specific,
+temporally stable operating level** — a level the series is anchored to
+(excursions revert; the level does not wander) and that is distinct and
+rank-stable across agents.
+
+Two scope concessions, made explicit rather than discovered later:
+
+- **Stable environmental coupling is admitted** (review finding R2). A fleet-shared
+  driver with agent-specific stable gains (x_i = μ + β_i·Z_t + ε) is
+  indistinguishable from an intrinsic home in this data and — for the
+  residual paradigm's purpose, a per-agent reference against which deviation
+  is meaningful — does not need to be distinguished. A PASS earns "stable
+  agent-specific operating level," not "intrinsic essence."
+- **The eligible population is ~4 role-distinct resident daemons**
+  (review finding R4 + live-data feasibility check). A PASS must be read as "these residents show
+  anchored, distinct, rank-stable operating levels," NOT as the universal
+  individuality axiom over arbitrary agents. Two instances of the same role
+  sharing a home is untested here.
+
+This says NOTHING about outcome validity (label-blocked); it is the
+precondition for a residual to mean anything.
+
+## Structure: two gating legs + one estimator leg
+
+| Leg | Question | Null it must beat |
+|---|---|---|
+| A(i) — reversion | Does reversion structure exist (vs pure random walk)? | Increment permutation: same increments, shuffled order |
+| A(ii) — drift veto | Does the level wander more than a stationary process would? | Small-block permutation: short-range correlation kept, long-range wandering scrambled |
+| B — individuality | Is the anchor level agent-specific and rank-stable over time? | Agent-label permutation on split-half means |
+| C — reference quality at jumps (estimator; NOT part of the axiom verdict) | When the state moves, does the runtime-form EMA beat last-value? | Persistence at moved observations |
+
+**Why leg A has two parts (review finding R1, the design's hardest finding):** the
+raw observations are ~10-event rolling-window features
+(`src/behavioral_sensor.py`, `history[-10:]`). Window-filtered measurement
+noise reverts at short horizons *by construction*, so an affirmative
+variance-ratio rejection alone cannot distinguish "stable level" from
+"slowly drifting level under window noise" — the adversarial organism (a
+random-walking behavior rate seen through the window) defeats any single VR
+statistic at feasible horizons; this was confirmed empirically during test
+construction, not just argued. Part (i) therefore proves reversion exists
+(kills pure walks), and part (ii) — sensitive exactly where (i) is blind —
+vetoes level-wandering. A dim passes leg A only if (i) rejects AND (ii) does
+not fire. Consequence, disclosed: an agent with a *constant* underlying
+behavior rate passes leg A — correctly, because a constant rate IS a home;
+the `windowed-stable-rate` organism pins this as intended behavior. Leg A is
+the anti-drift precondition; **leg B carries the individuality burden.**
+
+### Leg A — anchoredness (per agent, per dim, E/I/S)
+
+- **(i)** `VR(h) = Var(x_{t+h} − x_t) / (h · Var(x_{t+1} − x_t))`,
+  overlapping differences, primary **h = 24** (chosen > 2× the 10-event
+  feature window; h ∈ {8, 16, 48} reported descriptively, no inference).
+  Null: permute the 1-step increment sequence (1000 permutations, per-dim
+  seeds), rebuild cumulatively, recompute. One-sided
+  `p = (1 + #{perm VR ≤ obs}) / (1 + N)`. Rejects at p < 0.05.
+- **(ii)** Dispersion (variance) of non-overlapping big-block means
+  (block = 32 obs) vs a null that permutes small blocks (16 obs ≥ window)
+  and recomputes; veto fires when observed dispersion exceeds the null at
+  one-sided p < 0.05. Weak on short series (few blocks) — which is why (i)
+  must also pass affirmatively; veto power grows toward the final read.
+- **Dim passes** = (i) rejects AND (ii) does not fire. **Agent passes leg A**
+  on ≥ 2 of 3 dims.
+
+### Leg B — split-half stability of the per-agent home
+
+Across eligible agents, per dim: split each series at its midpoint (row
+count); Spearman rho between first-half and second-half mean vectors across
+agents; null = agent-label permutation of the second-half vector (exact for
+≤ 7 agents, else 1000 sampled). One-sided; dim passes at p < 0.05; **leg B
+passes on ≥ 2 of 3 dims.** At the n=4 verdict floor the exact null has 24
+orderings, so only a perfect rank agreement (rho = 1) clears α = 0.05 —
+brittle by design and disclosed: with 4 agents, leg B passes only if the
+home ordering is exactly preserved out-of-sample in time.
+
+### Leg C — jump-conditional reference quality (estimator leg)
+
+At moved observations (consecutive values not byte-identical, |Δ| > 1e-12),
+after a 15-observation burn-in: compare `|ema_ref − x_t|` vs `|x_{t−1} − x_t|`
+where the reference is the live EMA's **form** (runtime alphas E 0.12 /
+I 0.08 / S 0.15, folding every observation) **cold-started at the first
+post-registration observation** — an approximation of, not a replay of, the
+true runtime EMA, whose earlier history the fresh-data rule excludes.
+Win rate > 0.5 with one-sided binomial p < 0.05, trials pooled across dims.
+Disclosed caveats: the pooled binomial treats cross-dim trials at one
+timestep as independent (they are not; the p-value is anti-conservative),
+and the per-row persisted `alphas` are cross-checked — a mismatch against
+the hardcoded runtime mirror invalidates leg C for that agent (legs A/B are
+alpha-free). Leg C **does not gate the axiom**: axiom-pass + C-fail = retune
+the reference; it can neither rescue nor kill the axiom.
+
+## Eligibility, verdict rule, schedule
+
+- **Agent eligibility:** ≥ 100 post-registration raw states AND ≥ 30 moved
+  observations.
+- **Verdict floor:** ≥ **4** eligible agents. Live-verified arithmetic
+  (2026-07-02): exactly four agents have unambiguous accrual support —
+  Sentinel (~287 rows/day), Watcher (~133), Vigil (~54), lumen-broker-ex-
+  shadow (~480/day measured cadence; eligible within hours if the P2 soak
+  survives past the cutoff). Claude-session identities fragment by design
+  (fresh agent_id per session under strict identity) and have never
+  sustained 100 states; Lumen and Steward emit zero raw_obs rows. A floor of
+  5 would make the verdict hostage to an atypical long-lived session — the
+  arithmetically-unwinnable-gate failure mode the label-power analysis
+  already killed once. At n=4: leg A majority = ≥ 3 of 4; leg B as above.
+- **AXIOM EARNED** iff leg A passes for a majority of eligible agents AND
+  leg B passes.
+- **Reads:** interim (trend-only) **2026-07-16**; final **2026-07-30**.
+  If < 4 eligible agents at the final read: **NOT EVALUABLE — treated as
+  not-earned for all shipping and public-framing purposes** (identical
+  consequences to FAIL; distinct wording because it indicts fleet activity).
+
+## Provenance disclosure (review finding R5)
+
+Chosen before any post-registration data existed, with the following
+design-time knowledge: the v1 FAIL and its diagnostics (stickiness fractions,
+φ decay, decimation curves) on pre-registration data; the feature window
+length (10 events) read from source during the review; measured accrual
+rates. h was initially drafted as 8 *before* the window length was inspected;
+the review flagged h < window as mechanically confounded and h moved to 24
+(> 2w) plus the drift veto was added — both changes made in direct response
+to an adversarial organism, before freeze, with the organism now in the test
+suite. α = 0.05, dim-majority 2-of-3, and the eligibility floors were set by
+convention and accrual arithmetic respectively, not tuned against any VR
+curve. The residents' processes are stationary across the freeze line, so
+garden-of-forking-paths risk cannot be fully eliminated by the timestamp —
+it is mitigated by the organism-validated nulls, the adversarial review,
+and the kill criterion below.
+
+## Kill criterion
+
+If v2 **fails** at the final read (2026-07-30) on the frozen thresholds: the
+individuality axiom is **retired for raw behavioral EISV as currently
+measured**. No v3 against this measurement process — a further attempt
+requires *changing the measurement* (different raw features, event-triggered
+sampling), pre-registered before any of its data exists. The
+grounding-program reconsideration escalates per the preserved dissent in
+`eisv-grounding-next-move-v0.md`.
+
+Standing prohibitions (unchanged, restated for self-containment): no public
+"EISV self-model" framing, no Stage B, nothing new wired to the live verdict
+path — regardless of v2's outcome. A v2 PASS earns the scoped claim above,
+for this population, only.
+
+## Known limitations (documented, not fixed)
+
+- **Cadence heterogeneity** (review finding R3): h and blocks are step-counts, so
+  h=24 spans ~2 hours for Sentinel and ~11 hours for Vigil. The per-agent
+  verdicts therefore probe anchoredness at different wall-clock scales; the
+  report includes each agent's median gap so reads are interpreted per-agent.
+- **Leg B common-driver admissibility** (F2) and **population scope** (F4):
+  see the claim section — conceded and scoped, not controlled away.
+- **Per-dim tests share the agent's underlying events**, so the 2-of-3
+  majorities are over correlated tests (conservative direction for type-I;
+  permutation seeds are decorrelated per dim, review finding R7).
+
+## Implementation
+
+`scripts/analysis/eisv_individuality_v2.py` — frozen in the same PR. The
+fetch applies the registration cutoff in SQL (with a deterministic
+`state_id` tie-break); there is deliberately no flag to include earlier
+rows. Machinery validated by deterministic model-organism tests
+(`tests/test_eisv_individuality_v2.py`):
+
+| Organism | A(i) | A(ii) veto | A | B | Why it matters |
+|---|---|---|---|---|---|
+| Random walk | no reject | — | fail | — | the dressed-up-autocorrelation null |
+| iid noise, distinct means | reject | no | pass | pass | the textbook case |
+| Sticky-anchored (pins + reverting jumps) | reject | no | pass | pass | the v1 blind spot — v2 sees through stickiness |
+| Sticky-drift (pins + same-sign jumps) | — | fires | fail | — | anti-laundering: drift must not pass |
+| Windowed stable rate (review finding R1) | reject | no | pass | — | window mechanics + constant rate = a real home, passes by design (disclosed) |
+| Windowed drifting rate (review finding R1) | reject (falsely) | **fires** | fail | — | the organism that defeats any single-statistic leg A — caught by the veto |
+| Shared home (identical means) | reject | no | pass | fail | anchored ≠ individual |

--- a/scripts/analysis/eisv_individuality_v2.py
+++ b/scripts/analysis/eisv_individuality_v2.py
@@ -1,0 +1,571 @@
+#!/usr/bin/env python3
+"""EISV individuality test v2 — pre-registered, fresh-data-only.
+
+Spec: docs/proposals/eisv-individuality-v2-preregistration.md. Read it before
+touching thresholds — they are FROZEN as of 2026-07-02; edits after
+post-registration data exists invalidate the pre-registration.
+
+Three legs on the raw pre-EMA series (`behavioral_eisv.raw_obs`):
+
+  A — anchoredness: variance-ratio VR(8) vs an increment-permutation null.
+      Permutation preserves the marginal increment distribution (stickiness,
+      drift) and destroys only serial ordering — which is where reversion
+      lives. Survives both v1 artifacts.
+  B — individuality of the home: split-half per-agent means, Spearman rho
+      across agents vs an agent-label permutation null.
+  C — jump-conditional reference quality (estimator leg, NOT part of the
+      axiom verdict): at moved observations, does the runtime EMA reference
+      beat last-value?
+
+The verdict counts ONLY rows recorded after REGISTRATION_TS. The fetch
+excludes earlier rows; there is deliberately no flag to include them.
+
+Usage:
+    PYTHONPATH=. python3 scripts/analysis/eisv_individuality_v2.py
+    PYTHONPATH=. python3 scripts/analysis/eisv_individuality_v2.py --output data/analysis/eisv_individuality_v2.md
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import math
+import os
+import random
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+DEFAULT_DB_URL = os.environ.get(
+    "GOVERNANCE_DATABASE_URL",
+    "postgresql://postgres:postgres@localhost:5432/governance",
+)
+
+# --- Pre-registered constants (FROZEN 2026-07-02 — see the proposal doc) ----
+
+REGISTRATION_TS = dt.datetime(2026, 7, 2, 18, 0, 0, tzinfo=dt.timezone.utc)
+
+RAW_DIMS = ("E", "I", "S")
+# Runtime EMA alphas — must mirror state_json.behavioral_eisv.alphas. The
+# fetch cross-checks every row's persisted alphas against these and the
+# report flags any mismatch (leg C is invalid for a mismatched agent).
+EMA_ALPHA = {"E": 0.12, "I": 0.08, "S": 0.15}
+
+# raw_obs components are ~10-event rolling-window features
+# (src/behavioral_sensor.py: history[-10:]). The primary VR horizon sits
+# PAST that window (h >= 2w) so leg A measures behavior-rate stability, not
+# mechanical window overlap — see the spec's leg-A reframe + provenance note.
+FEATURE_WINDOW = 10
+VR_HORIZON = 24                     # primary horizon for leg A (> 2*window)
+VR_HORIZONS_DESCRIPTIVE = (8, 16, 48)
+N_PERMUTATIONS = 1000
+PERM_SEED = 20260702                # registration date — fixed, not wall-clock
+ALPHA_LEVEL = 0.05
+
+MIN_STATES = 100                    # per-agent eligibility floor
+MIN_MOVED = 30                      # moved-observation floor (leg C power)
+MIN_ELIGIBLE_AGENTS = 4             # verdict floor — see spec (n=4: leg B
+                                    # passes only at perfect rho, p=1/24)
+MOVED_EPS = 1e-12                   # "moved" = consecutive values differ
+LEG_C_BURNIN = 15                   # obs skipped before leg C scores (the
+                                    # cold-started reference needs ~2/alpha
+                                    # folds to shed its init transient)
+
+DIM_MAJORITY = 2                    # leg passes on >= 2 of 3 dims
+
+# Leg A part (ii) — the drift veto. The VR test (part i) proves reversion
+# structure exists but is blind to a slowly drifting level hidden under
+# window-filtered measurement noise (the adversarial-review F1 organism:
+# a random-walking behavior rate seen through the window still shows
+# short-horizon noise reversion). The veto compares the dispersion of
+# big-block means against a small-block permutation null: small blocks
+# (>= window length) preserve the feature's short-range correlation while
+# permutation scrambles long-range level wandering, so observed dispersion
+# above the null's 95th percentile = the level drifts = veto.
+DRIFT_BLOCK_SMALL = 16              # permutation unit (> feature window 10)
+DRIFT_BLOCK_BIG = 32                # dispersion unit (2 small blocks)
+
+
+# --- data ---------------------------------------------------------------
+
+
+def _extract_raw(state_json: dict) -> dict | None:
+    if not isinstance(state_json, dict):
+        return None
+    beh = state_json.get("behavioral_eisv")
+    if not isinstance(beh, dict):
+        return None
+    raw = beh.get("raw_obs")
+    if not isinstance(raw, (list, tuple)) or len(raw) != len(RAW_DIMS):
+        return None
+    out = {}
+    for d, v in zip(RAW_DIMS, raw):
+        if not isinstance(v, (int, float)):
+            return None
+        out[d] = float(v)
+    return out
+
+
+async def fetch_post_registration(db_url: str) -> tuple[dict[str, list[dict]],
+                                                         dict[str, str],
+                                                         set[str]]:
+    """Raw trajectories restricted to rows recorded AFTER REGISTRATION_TS.
+
+    The cutoff is applied in SQL — pre-registration rows never enter the
+    process. This is the fresh-data-only rule; it is not configurable.
+    """
+    try:
+        import asyncpg
+    except ImportError:
+        print("error: asyncpg not installed (pip install asyncpg)", file=sys.stderr)
+        raise SystemExit(1)
+
+    conn = await asyncpg.connect(db_url)
+    try:
+        records = await conn.fetch(
+            """
+            SELECT i.agent_id, a.label, s.recorded_at, s.state_json
+            FROM core.identities i
+            JOIN core.agent_state s ON s.identity_id = i.identity_id
+            LEFT JOIN core.agents a ON a.id = i.agent_id
+            WHERE s.synthetic IS NOT TRUE
+              AND s.recorded_at > $1
+            ORDER BY i.agent_id, s.recorded_at ASC, s.state_id ASC
+            """,
+            REGISTRATION_TS,
+        )
+    finally:
+        await conn.close()
+
+    import json
+
+    traj: dict[str, list[dict]] = {}
+    labels: dict[str, str] = {}
+    alpha_mismatch: set[str] = set()
+    for r in records:
+        sj = r["state_json"]
+        if isinstance(sj, str):
+            try:
+                sj = json.loads(sj)
+            except Exception:
+                continue
+        if r["label"]:
+            labels[r["agent_id"]] = r["label"]
+        raw = _extract_raw(sj)
+        if raw is not None:
+            traj.setdefault(r["agent_id"], []).append(raw)
+            # Leg C validity guard: the persisted per-row alphas must match
+            # the hardcoded runtime mirror, else leg C scores the wrong EMA.
+            alphas = sj.get("behavioral_eisv", {}).get("alphas")
+            if isinstance(alphas, dict) and any(
+                abs(float(alphas.get(d, EMA_ALPHA[d])) - EMA_ALPHA[d]) > 1e-9
+                for d in RAW_DIMS
+            ):
+                alpha_mismatch.add(r["agent_id"])
+    return traj, labels, alpha_mismatch
+
+
+# --- shared helpers -------------------------------------------------------
+
+
+def _moved_count(seq: list[dict]) -> int:
+    n = 0
+    for a, b in zip(seq, seq[1:]):
+        if any(abs(b[d] - a[d]) > MOVED_EPS for d in RAW_DIMS):
+            n += 1
+    return n
+
+
+def _variance(xs: list[float]) -> float:
+    n = len(xs)
+    if n < 2:
+        return float("nan")
+    mu = sum(xs) / n
+    return sum((x - mu) ** 2 for x in xs) / (n - 1)
+
+
+def variance_ratio(series: list[float], h: int) -> float:
+    """VR(h) with overlapping h-differences. nan when undefined."""
+    if len(series) < h + 2:
+        return float("nan")
+    d1 = [b - a for a, b in zip(series, series[1:])]
+    dh = [series[i + h] - series[i] for i in range(len(series) - h)]
+    v1 = _variance(d1)
+    vh = _variance(dh)
+    if not (v1 > 0):
+        return float("nan")
+    return vh / (h * v1)
+
+
+# --- Leg A: anchoredness --------------------------------------------------
+
+
+def _block_mean_dispersion(series: list[float], big: int) -> float:
+    """Variance of non-overlapping big-block means. nan below 3 blocks."""
+    k = len(series) // big
+    if k < 3:
+        return float("nan")
+    means = [sum(series[i * big:(i + 1) * big]) / big for i in range(k)]
+    return _variance(means)
+
+
+def drift_veto(series: list[float], *,
+               small: int = DRIFT_BLOCK_SMALL,
+               big: int = DRIFT_BLOCK_BIG,
+               n_perm: int = N_PERMUTATIONS,
+               seed: int = PERM_SEED) -> dict:
+    """Leg A part (ii): is big-block-mean dispersion consistent with a
+    stationary level, judged against a small-block permutation null?
+
+    Small blocks preserve within-window correlation; permuting their order
+    destroys long-range level wandering. Observed dispersion above the null
+    = drift = veto. One-sided; veto fires at p < ALPHA_LEVEL. Weak on short
+    series (few big blocks) — a non-veto at the eligibility floor is low
+    power, which is why part (i) must ALSO pass affirmatively.
+    """
+    obs = _block_mean_dispersion(series, big)
+    if obs != obs:
+        return {"dispersion": obs, "p": None, "veto": False}
+    blocks = [series[i:i + small] for i in range(0, len(series), small)]
+    rng = random.Random(seed)
+    at_or_above = 0
+    for _ in range(n_perm):
+        order = list(range(len(blocks)))
+        rng.shuffle(order)
+        x = [v for bi in order for v in blocks[bi]]
+        pd = _block_mean_dispersion(x, big)
+        if pd == pd and pd >= obs:
+            at_or_above += 1
+    p = (1 + at_or_above) / (1 + n_perm)
+    return {"dispersion": obs, "p": p, "veto": p < ALPHA_LEVEL}
+
+
+def leg_a_agent(seq_by_dim: dict[str, list[float]], *,
+                h: int = VR_HORIZON,
+                n_perm: int = N_PERMUTATIONS,
+                seed: int = PERM_SEED) -> dict:
+    """Leg A per dim = (i) increment-permutation VR test passes AND (ii) the
+    drift veto does not fire. Agent passes on dim majority."""
+    dims = {}
+    for di, d in enumerate(RAW_DIMS):
+        series = seq_by_dim[d]
+        obs = variance_ratio(series, h)
+        if obs != obs:  # nan — constant series or too short
+            dims[d] = {"vr": obs, "p": None, "passes": False,
+                       "vr_descriptive": {}, "drift": None}
+            continue
+        increments = [b - a for a, b in zip(series, series[1:])]
+        # Per-dim seed offset: a shared seed would apply the IDENTICAL
+        # permutation-index sequence to all three dims (shuffle depends only
+        # on list length), artificially coupling the 2-of-3 majority vote.
+        rng = random.Random(seed * 31 + di)
+        at_or_below = 0
+        for _ in range(n_perm):
+            perm = increments[:]
+            rng.shuffle(perm)
+            x = [series[0]]
+            for inc in perm:
+                x.append(x[-1] + inc)
+            pvr = variance_ratio(x, h)
+            if pvr == pvr and pvr <= obs:
+                at_or_below += 1
+        p = (1 + at_or_below) / (1 + n_perm)
+        drift = drift_veto(series, n_perm=n_perm, seed=seed * 31 + di + 200)
+        dims[d] = {"vr": obs, "p": p,
+                   "passes": p < ALPHA_LEVEL and not drift["veto"],
+                   "vr_descriptive": {hh: variance_ratio(series, hh)
+                                      for hh in VR_HORIZONS_DESCRIPTIVE},
+                   "drift": drift}
+    n_pass = sum(1 for v in dims.values() if v["passes"])
+    return {"dims": dims, "n_dims_pass": n_pass,
+            "passes": n_pass >= DIM_MAJORITY}
+
+
+# --- Leg B: individuality of the home --------------------------------------
+
+
+def _spearman(xs: list[float], ys: list[float]) -> float:
+    def ranks(v: list[float]) -> list[float]:
+        order = sorted(range(len(v)), key=lambda i: v[i])
+        r = [0.0] * len(v)
+        i = 0
+        while i < len(order):
+            j = i
+            while j + 1 < len(order) and v[order[j + 1]] == v[order[i]]:
+                j += 1
+            avg = (i + j) / 2 + 1
+            for k in range(i, j + 1):
+                r[order[k]] = avg
+            i = j + 1
+        return r
+    rx, ry = ranks(xs), ranks(ys)
+    n = len(xs)
+    mx = sum(rx) / n
+    my = sum(ry) / n
+    cov = sum((a - mx) * (b - my) for a, b in zip(rx, ry))
+    vx = sum((a - mx) ** 2 for a in rx)
+    vy = sum((b - my) ** 2 for b in ry)
+    if vx <= 0 or vy <= 0:
+        return float("nan")
+    return cov / math.sqrt(vx * vy)
+
+
+def leg_b(traj_by_agent: dict[str, dict[str, list[float]]], *,
+          n_perm: int = N_PERMUTATIONS, seed: int = PERM_SEED) -> dict:
+    """Split-half home stability across agents, per dim, label-permutation null."""
+    import itertools
+
+    agents = sorted(traj_by_agent)
+    dims = {}
+    for d in RAW_DIMS:
+        first, second = [], []
+        for a in agents:
+            s = traj_by_agent[a][d]
+            mid = len(s) // 2
+            first.append(sum(s[:mid]) / mid)
+            second.append(sum(s[mid:]) / (len(s) - mid))
+        obs = _spearman(first, second)
+        if obs != obs:
+            dims[d] = {"rho": obs, "p": None, "passes": False}
+            continue
+        n = len(agents)
+        rng = random.Random(seed * 31 + RAW_DIMS.index(d) + 100)
+        if n <= 7:  # exact permutation (7! = 5040 orderings)
+            perms = list(itertools.permutations(range(n)))
+            stats = [_spearman(first, [second[i] for i in pm]) for pm in perms]
+            # exact null includes identity; standard exact p
+            p = sum(1 for s_ in stats if s_ == s_ and s_ >= obs) / len(stats)
+        else:
+            at_or_above = 0
+            idx = list(range(n))
+            for _ in range(n_perm):
+                rng.shuffle(idx)
+                s_ = _spearman(first, [second[i] for i in idx])
+                if s_ == s_ and s_ >= obs:
+                    at_or_above += 1
+            p = (1 + at_or_above) / (1 + n_perm)
+        dims[d] = {"rho": obs, "p": p, "passes": p < ALPHA_LEVEL}
+    n_pass = sum(1 for v in dims.values() if v["passes"])
+    return {"dims": dims, "n_dims_pass": n_pass,
+            "passes": n_pass >= DIM_MAJORITY, "n_agents": len(agents)}
+
+
+# --- Leg C: jump-conditional reference quality ------------------------------
+
+
+def _binom_p_greater_half(wins: int, n: int) -> float:
+    """One-sided binomial P(X >= wins) under p=0.5.
+
+    Exact for n <= 100 (covers the MIN_MOVED floor where precision matters);
+    normal approximation with continuity correction above — the exact sum
+    overflows float conversion for large n and the approximation error there
+    is far below the 0.05 decision threshold.
+    """
+    if n == 0:
+        return 1.0
+    if n <= 100:
+        total = sum(math.comb(n, k) for k in range(wins, n + 1))
+        return total / (2 ** n)
+    mu = n / 2
+    sd = math.sqrt(n) / 2
+    z = (wins - 0.5 - mu) / sd
+    return 0.5 * math.erfc(z / math.sqrt(2))
+
+
+def leg_c_agent(seq_by_dim: dict[str, list[float]]) -> dict:
+    """At moved observations, reference-vs-persistence; pooled dims.
+
+    The reference is the live EMA's FORM (runtime alphas, folding every
+    observation) cold-started at the first post-registration observation —
+    NOT a replay of the true runtime EMA, whose pre-registration history is
+    excluded by the fresh-data rule. The first LEG_C_BURNIN observations are
+    fold-only (never scored) so the init transient doesn't contaminate the
+    comparison. Ties go to the null (persistence). NB the pooled binomial
+    treats cross-dim trials at the same timestep as independent — they are
+    not; the p-value is anti-conservative and leg C is non-gating partly for
+    this reason (see spec).
+    """
+    wins = 0
+    n = 0
+    for d in RAW_DIMS:
+        series = seq_by_dim[d]
+        if not series:
+            continue
+        ema = series[0]
+        for i in range(1, len(series)):
+            cur = series[i]
+            prev = series[i - 1]
+            if i > LEG_C_BURNIN and abs(cur - prev) > MOVED_EPS:
+                n += 1
+                if abs(ema - cur) < abs(prev - cur):
+                    wins += 1
+            ema = EMA_ALPHA[d] * cur + (1 - EMA_ALPHA[d]) * ema
+    p = _binom_p_greater_half(wins, n)
+    win_rate = (wins / n) if n else float("nan")
+    return {"wins": wins, "n_moved": n, "win_rate": win_rate, "p": p,
+            "passes": (n > 0 and win_rate > 0.5 and p < ALPHA_LEVEL)}
+
+
+# --- verdict ---------------------------------------------------------------
+
+
+def evaluate_v2(traj: dict[str, list[dict]], *,
+                alpha_mismatch: set[str] | None = None) -> dict:
+    """Run all legs on post-registration trajectories; apply the frozen rule."""
+    alpha_mismatch = alpha_mismatch or set()
+    per_agent = []
+    eligible_by_dim: dict[str, dict[str, list[float]]] = {}
+    for agent, seq in sorted(traj.items(), key=lambda kv: -len(kv[1])):
+        moved = _moved_count(seq)
+        eligible = len(seq) >= MIN_STATES and moved >= MIN_MOVED
+        seq_by_dim = {d: [m[d] for m in seq] for d in RAW_DIMS}
+        row = {"agent": agent, "n_states": len(seq), "n_moved": moved,
+               "eligible": eligible, "leg_a": None, "leg_c": None,
+               "leg_c_alpha_mismatch": agent in alpha_mismatch}
+        if eligible:
+            row["leg_a"] = leg_a_agent(seq_by_dim)
+            # Leg C scores against the hardcoded runtime alphas; a persisted
+            # per-row alpha mismatch invalidates that comparison (leg A/B are
+            # alpha-free and unaffected).
+            row["leg_c"] = (leg_c_agent(seq_by_dim)
+                            if agent not in alpha_mismatch else None)
+            eligible_by_dim[agent] = seq_by_dim
+        per_agent.append(row)
+
+    n_eligible = len(eligible_by_dim)
+    a_winners = sum(1 for r in per_agent
+                    if r["eligible"] and r["leg_a"]["passes"])
+    leg_a_majority = (a_winners * 2 > n_eligible) if n_eligible else None
+    leg_b_res = leg_b(eligible_by_dim) if n_eligible >= 2 else None
+
+    if n_eligible < MIN_ELIGIBLE_AGENTS:
+        verdict = "NOT EVALUABLE"
+    elif leg_a_majority and leg_b_res and leg_b_res["passes"]:
+        verdict = "AXIOM EARNED"
+    else:
+        verdict = "FAIL"
+    return {
+        "registration_ts": REGISTRATION_TS.isoformat(),
+        "per_agent": per_agent,
+        "n_eligible": n_eligible,
+        "leg_a_winners": a_winners,
+        "leg_a_majority": leg_a_majority,
+        "leg_b": leg_b_res,
+        "verdict": verdict,
+    }
+
+
+# --- report ----------------------------------------------------------------
+
+
+def build_report(res: dict, labels: dict[str, str]) -> str:
+    a: list[str] = []
+    a.append("# EISV individuality v2 — pre-registered read\n")
+    a.append(f"Registration: `{res['registration_ts']}` — only rows recorded "
+             "after this instant are counted. Spec: "
+             "`docs/proposals/eisv-individuality-v2-preregistration.md` "
+             "(thresholds frozen; do not reinterpret).\n")
+    a.append("## Per-agent")
+    a.append(f"| Agent | states | moved | eligible | leg A (VR{VR_HORIZON} "
+             "dims E/I/S, p) | A | leg C win-rate (p) | C |")
+    a.append("|---|---:|---:|---|---|---|---|---|")
+    for r in res["per_agent"]:
+        name = labels.get(r["agent"], r["agent"][:8])
+        if r["eligible"]:
+            la = r["leg_a"]
+            dims = " / ".join(
+                f"{la['dims'][d]['vr']:.2f}({la['dims'][d]['p']:.3f})"
+                if la["dims"][d]["p"] is not None else "—"
+                for d in RAW_DIMS)
+            a_flag = "**pass**" if la["passes"] else "fail"
+            lc = r["leg_c"]
+            if lc is None:
+                c_txt, c_flag = "ALPHA MISMATCH — invalid", "—"
+            elif lc["n_moved"]:
+                c_txt = f"{lc['win_rate']:.2f} ({lc['p']:.3f}, n={lc['n_moved']})"
+                c_flag = "pass" if lc["passes"] else "fail"
+            else:
+                c_txt, c_flag = "—", "—"
+        else:
+            dims, a_flag, c_txt, c_flag = "—", "—", "—", "—"
+        a.append(f"| {name} | {r['n_states']} | {r['n_moved']} | "
+                 f"{'yes' if r['eligible'] else 'no'} | {dims} | {a_flag} | "
+                 f"{c_txt} | {c_flag} |")
+
+    eligible_rows = [r for r in res["per_agent"] if r["eligible"]]
+    if eligible_rows:
+        a.append(f"\n### Descriptive VR curve (h ∈ {VR_HORIZONS_DESCRIPTIVE}, "
+                 "no inference — trend context for the primary h)")
+        a.append("| Agent | dim | " + " | ".join(
+            f"VR{hh}" for hh in VR_HORIZONS_DESCRIPTIVE) + f" | VR{VR_HORIZON} |")
+        a.append("|---|---|" + "---:|" * (len(VR_HORIZONS_DESCRIPTIVE) + 1))
+        for r in eligible_rows:
+            name = labels.get(r["agent"], r["agent"][:8])
+            for d in RAW_DIMS:
+                dd = r["leg_a"]["dims"][d]
+                cells = " | ".join(
+                    (f"{dd['vr_descriptive'].get(hh, float('nan')):.2f}"
+                     if dd["vr_descriptive"].get(hh, float("nan"))
+                     == dd["vr_descriptive"].get(hh, float("nan")) else "—")
+                    for hh in VR_HORIZONS_DESCRIPTIVE)
+                vr_p = f"{dd['vr']:.2f}" if dd["vr"] == dd["vr"] else "—"
+                a.append(f"| {name} | {d} | {cells} | {vr_p} |")
+
+    a.append(f"\nEligible agents: **{res['n_eligible']}** (verdict floor "
+             f"{MIN_ELIGIBLE_AGENTS}); leg A winners: "
+             f"**{res['leg_a_winners']} / {res['n_eligible']}**")
+    if res["leg_b"]:
+        b = res["leg_b"]
+        dims = " / ".join(
+            f"{d}: rho={b['dims'][d]['rho']:.2f} (p={b['dims'][d]['p']:.3f})"
+            if b["dims"][d]["p"] is not None else f"{d}: —"
+            for d in RAW_DIMS)
+        a.append(f"\nLeg B (split-half home stability, {b['n_agents']} agents): "
+                 f"{dims} → **{'pass' if b['passes'] else 'fail'}**")
+    a.append(f"\n## Verdict: **{res['verdict']}**")
+    a.append(
+        "\n- AXIOM EARNED = leg A majority AND leg B pass, at >= "
+        f"{MIN_ELIGIBLE_AGENTS} eligible agents. Earns the individuality "
+        "axiom's estimator half ONLY — outcome validity remains "
+        "label-blocked; no public 'self-model' framing, no Stage B, nothing "
+        "new wired to the live verdict path, regardless of outcome."
+        "\n- Leg C is an estimator finding (is the runtime EMA reference fit "
+        "to size residuals at informative moments) — it neither rescues nor "
+        "kills the axiom."
+        "\n- FAIL at the final read (2026-07-30) triggers the kill criterion: "
+        "the axiom is retired for raw behavioral EISV as currently measured; "
+        "no v3 without changing the measurement process."
+    )
+    return "\n".join(a) + "\n"
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    traj, labels, alpha_mismatch = await fetch_post_registration(args.db_url)
+    res = evaluate_v2(traj, alpha_mismatch=alpha_mismatch)
+    report = build_report(res, labels)
+    if args.output:
+        path = Path(args.output)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(report)
+        print(f"wrote {path}")
+    else:
+        print(report)
+    return 0
+
+
+def parse_args(argv=None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--db-url", default=DEFAULT_DB_URL)
+    p.add_argument("--output", help="optional markdown output path")
+    return p.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    import asyncio
+
+    return asyncio.run(main_async(parse_args(argv)))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_eisv_individuality_v2.py
+++ b/tests/test_eisv_individuality_v2.py
@@ -1,0 +1,364 @@
+"""Model-organism checks for the pre-registered individuality v2 machinery.
+
+No DB. Each organism pins a row of the discrimination table in
+docs/proposals/eisv-individuality-v2-preregistration.md — the spec's promise
+that the legs separate anchoredness, individuality, drift, and stickiness.
+Seeds are fixed; permutation nulls are seeded inside the module.
+"""
+import math
+import random
+
+from scripts.analysis.eisv_individuality_v2 import (
+    RAW_DIMS,
+    VR_HORIZON,
+    evaluate_v2,
+    leg_a_agent,
+    leg_b,
+    leg_c_agent,
+    variance_ratio,
+    _binom_p_greater_half,
+    _moved_count,
+    _spearman,
+)
+
+
+# --- organisms --------------------------------------------------------------
+
+
+def _iid(mean: float, n: int, sigma: float, seed: int) -> list[dict]:
+    rng = random.Random(seed)
+    return [{d: mean + rng.gauss(0, sigma) for d in RAW_DIMS} for _ in range(n)]
+
+
+def _walk(start: float, n: int, step: float, seed: int) -> list[dict]:
+    rng = random.Random(seed)
+    seq, level = [], {d: start for d in RAW_DIMS}
+    for _ in range(n):
+        level = {d: level[d] + rng.gauss(0, step) for d in RAW_DIMS}
+        seq.append(dict(level))
+    return seq
+
+
+def _sticky_anchored(home: float, n: int, seed: int, *,
+                     p_jump: float = 0.25, delta: float = 0.1) -> list[dict]:
+    """Pins at a home level; occasional excursions that revert next jump.
+    The v1 blind spot: 1-step persistence is near-optimal, yet the series is
+    strongly anchored."""
+    rng = random.Random(seed)
+    seq = []
+    level = {d: home for d in RAW_DIMS}
+    excursion = {d: False for d in RAW_DIMS}
+    for _ in range(n):
+        for d in RAW_DIMS:
+            if rng.random() < p_jump:
+                if excursion[d]:
+                    level[d] = home          # revert
+                    excursion[d] = False
+                else:
+                    level[d] = home + rng.choice((-delta, delta))
+                    excursion[d] = True
+        seq.append(dict(level))
+    return seq
+
+
+def _sticky_drift(start: float, n: int, seed: int, *,
+                  p_jump: float = 0.25, delta: float = 0.02) -> list[dict]:
+    """Pins punctuated by same-sign jumps — a drifting staircase. Anti-
+    laundering organism: must NOT pass anchoredness."""
+    rng = random.Random(seed)
+    seq = []
+    level = {d: start for d in RAW_DIMS}
+    for _ in range(n):
+        for d in RAW_DIMS:
+            if rng.random() < p_jump:
+                level[d] = level[d] + delta
+        seq.append(dict(level))
+    return seq
+
+
+def _by_dim(seq: list[dict]) -> dict:
+    return {d: [m[d] for m in seq] for d in RAW_DIMS}
+
+
+# --- variance ratio basics ---------------------------------------------------
+
+
+def test_vr_random_walk_near_one():
+    s = [m["E"] for m in _walk(0.5, 600, step=0.02, seed=1)]
+    vr = variance_ratio(s, 8)
+    assert 0.6 < vr < 1.6
+
+
+def test_vr_iid_well_below_one():
+    s = [m["E"] for m in _iid(0.5, 600, sigma=0.05, seed=2)]
+    assert variance_ratio(s, 8) < 0.5
+
+
+def test_vr_undefined_on_constant_or_short():
+    assert variance_ratio([0.5] * 50, 8) != variance_ratio([0.5] * 50, 8)  # nan
+    assert variance_ratio([0.1, 0.2], 8) != variance_ratio([0.1, 0.2], 8)  # nan
+
+
+# --- leg A organisms ---------------------------------------------------------
+
+
+def test_leg_a_random_walk_fails():
+    res = leg_a_agent(_by_dim(_walk(0.5, 300, step=0.02, seed=3)), n_perm=300)
+    assert res["passes"] is False
+
+
+def test_leg_a_iid_passes():
+    res = leg_a_agent(_by_dim(_iid(0.5, 300, sigma=0.05, seed=4)), n_perm=300)
+    assert res["passes"] is True
+
+
+def test_leg_a_sticky_anchored_passes():
+    """The v1 blind spot organism: persistence near-optimal 1-step, yet
+    anchored — leg A must see through the stickiness."""
+    res = leg_a_agent(_by_dim(_sticky_anchored(0.5, 300, seed=5)), n_perm=300)
+    assert res["passes"] is True
+
+
+def test_leg_a_sticky_drift_fails():
+    """Anti-laundering: same-sign staircase drift is permutation-invariant —
+    observed VR sits inside the permuted distribution, no rejection."""
+    res = leg_a_agent(_by_dim(_sticky_drift(0.3, 300, seed=6)), n_perm=300)
+    assert res["passes"] is False
+
+
+def test_leg_a_constant_series_fails_not_crashes():
+    res = leg_a_agent({d: [0.5] * 200 for d in RAW_DIMS}, n_perm=50)
+    assert res["passes"] is False
+
+
+# --- leg B organisms ---------------------------------------------------------
+
+
+def _fleet(means: list[float], n: int, sigma: float, seed0: int) -> dict:
+    return {f"a{i}": _by_dim(_iid(mu, n, sigma=sigma, seed=seed0 + i))
+            for i, mu in enumerate(means)}
+
+
+def test_leg_b_distinct_homes_pass():
+    fleet = _fleet([0.2, 0.35, 0.5, 0.65, 0.8], 200, sigma=0.03, seed0=10)
+    res = leg_b(fleet)
+    assert res["passes"] is True
+
+
+def test_leg_b_shared_home_fails():
+    """Anchored but identical: rank order of split-half means is noise."""
+    fleet = _fleet([0.5, 0.5, 0.5, 0.5, 0.5], 200, sigma=0.03, seed0=20)
+    res = leg_b(fleet)
+    assert res["passes"] is False
+
+
+# --- leg C ------------------------------------------------------------------
+
+
+def test_leg_c_iid_reference_beats_persistence():
+    """iid noise: the EMA hugs the mean; last-value carries full noise."""
+    res = leg_c_agent(_by_dim(_iid(0.5, 400, sigma=0.05, seed=30)))
+    assert res["passes"] is True
+    assert res["n_moved"] > 300
+
+
+def test_leg_c_random_walk_persistence_wins():
+    res = leg_c_agent(_by_dim(_walk(0.5, 400, step=0.02, seed=31)))
+    assert res["passes"] is False
+
+
+def test_moved_count_ignores_exact_repeats():
+    seq = [{d: 0.5 for d in RAW_DIMS}] * 10
+    assert _moved_count(seq) == 0
+    seq = seq + [{d: 0.6 for d in RAW_DIMS}]
+    assert _moved_count(seq) == 1
+
+
+# --- verdict rule -------------------------------------------------------------
+
+
+def test_verdict_not_evaluable_below_agent_floor():
+    """Floor is 4 eligible agents: 3 must be NOT EVALUABLE, 4 evaluable."""
+    means = [0.2, 0.5, 0.8]
+    traj = {f"a{i}": _iid(mu, 200, sigma=0.03, seed=40 + i)
+            for i, mu in enumerate(means)}
+    res = evaluate_v2(traj)
+    assert res["n_eligible"] == 3
+    assert res["verdict"] == "NOT EVALUABLE"
+    traj["a3"] = _iid(0.35, 200, sigma=0.03, seed=44)
+    res4 = evaluate_v2(traj)
+    assert res4["n_eligible"] == 4
+    assert res4["verdict"] != "NOT EVALUABLE"
+
+
+def test_verdict_earned_on_textbook_fleet():
+    means = [0.2, 0.35, 0.5, 0.65, 0.8]
+    traj = {f"a{i}": _iid(mu, 150, sigma=0.03, seed=50 + i)
+            for i, mu in enumerate(means)}
+    res = evaluate_v2(traj)
+    assert res["n_eligible"] == 5
+    assert res["leg_a_majority"] is True
+    assert res["leg_b"]["passes"] is True
+    assert res["verdict"] == "AXIOM EARNED"
+
+
+def test_verdict_fail_on_random_walk_fleet():
+    traj = {f"a{i}": _walk(0.5, 150, step=0.02, seed=60 + i)
+            for i in range(5)}
+    res = evaluate_v2(traj)
+    assert res["n_eligible"] == 5
+    assert res["verdict"] == "FAIL"
+
+
+def test_ineligible_agents_excluded_not_scored():
+    traj = {"big": _iid(0.5, 150, sigma=0.03, seed=70),
+            "small": _iid(0.5, 20, sigma=0.03, seed=71)}
+    res = evaluate_v2(traj)
+    rows = {r["agent"]: r for r in res["per_agent"]}
+    assert rows["small"]["eligible"] is False
+    assert rows["small"]["leg_a"] is None
+
+
+def test_eligibility_floors_are_independent():
+    """MIN_STATES and MIN_MOVED must AND: an agent can fail either alone."""
+    frozen = [{d: 0.5 for d in RAW_DIMS}] * 150            # 150 states, 0 moved
+    frozen[10] = {d: 0.6 for d in RAW_DIMS}                # 2 moved transitions
+    short_busy = _iid(0.5, 60, sigma=0.05, seed=72)        # 59 moved, 60 states
+    res = evaluate_v2({"frozen": frozen, "short_busy": short_busy})
+    rows = {r["agent"]: r for r in res["per_agent"]}
+    assert rows["frozen"]["n_states"] >= 100
+    assert rows["frozen"]["eligible"] is False             # fails MIN_MOVED
+    assert rows["short_busy"]["n_moved"] >= 30
+    assert rows["short_busy"]["eligible"] is False         # fails MIN_STATES
+
+
+def test_agent_majority_is_strict():
+    """Exactly half of eligible agents passing leg A is NOT a majority."""
+    traj = {
+        "i1": _iid(0.2, 150, sigma=0.03, seed=80),
+        "i2": _iid(0.8, 150, sigma=0.03, seed=81),
+        "w1": _walk(0.5, 150, step=0.02, seed=82),
+        "w2": _walk(0.5, 150, step=0.02, seed=83),
+    }
+    res = evaluate_v2(traj)
+    assert res["n_eligible"] == 4
+    assert res["leg_a_winners"] == 2
+    assert res["leg_a_majority"] is False
+    assert res["verdict"] == "FAIL"
+
+
+def test_dim_majority_two_of_three():
+    """2 anchored dims + 1 random-walk dim must still pass leg A (>= 2 of 3)."""
+    anchored = _iid(0.5, 250, sigma=0.05, seed=90)
+    walk = _walk(0.5, 250, step=0.02, seed=91)
+    seq_by_dim = {
+        "E": [m["E"] for m in anchored],
+        "I": [m["I"] for m in anchored],
+        "S": [m["S"] for m in walk],
+    }
+    res = leg_a_agent(seq_by_dim, n_perm=300)
+    assert res["dims"]["E"]["passes"] and res["dims"]["I"]["passes"]
+    assert not res["dims"]["S"]["passes"]
+    assert res["n_dims_pass"] == 2
+    assert res["passes"] is True
+
+
+# --- windowed-feature organisms (adversarial review F1) ---------------------
+
+
+def _windowed_feature(events: list[float], w: int = 10) -> list[float]:
+    """Rolling-window mean — the shape of the live raw_obs features."""
+    out = []
+    for i in range(len(events)):
+        win = events[max(0, i - w + 1):i + 1]
+        out.append(sum(win) / len(win))
+    return out
+
+
+def _windowed_stable_rate(p: float, n: int, seed: int) -> dict:
+    """Constant underlying behavior rate seen through the 10-event window.
+    Under the reframed leg A this HAS a home (the rate itself) and passes —
+    disclosed as correct-by-design in the spec, not laundering."""
+    rng = random.Random(seed)
+    series = {}
+    for d in RAW_DIMS:
+        events = [1.0 if rng.random() < p else 0.0 for _ in range(n)]
+        series[d] = _windowed_feature(events)
+    return series
+
+
+def _windowed_drifting_rate(n: int, seed: int, *, step: float = 0.03) -> dict:
+    """Random-walking underlying rate through the same window — no stable
+    home at the behavior level. MUST fail leg A (the anti-laundering pin
+    demanded by the adversarial review). One shared walk drives all dims,
+    as a real behavior change would: the drift is agent-level, so the veto
+    must fire on the dim majority, not on one lucky realization."""
+    rng = random.Random(seed)
+    p = 0.5
+    rates = []
+    for _ in range(n):
+        p = min(0.95, max(0.05, p + rng.gauss(0, step)))
+        rates.append(p)
+    series = {}
+    for d in RAW_DIMS:
+        events = [1.0 if rng.random() < r else 0.0 for r in rates]
+        series[d] = _windowed_feature(events)
+    return series
+
+
+def test_leg_a_windowed_stable_rate_passes():
+    res = leg_a_agent(_windowed_stable_rate(0.7, 400, seed=95), n_perm=300)
+    assert res["passes"] is True
+
+
+def test_leg_a_windowed_drifting_rate_fails():
+    res = leg_a_agent(_windowed_drifting_rate(400, seed=96), n_perm=300)
+    assert res["passes"] is False
+
+
+# --- helper-level pins (implementation review) -------------------------------
+
+
+def test_vr_length_boundary():
+    rng = random.Random(97)
+    xs = [rng.random() for _ in range(VR_HORIZON + 1)]   # one short of floor
+    assert variance_ratio(xs, VR_HORIZON) != variance_ratio(xs, VR_HORIZON)
+    xs.append(rng.random())                              # exactly h + 2
+    assert variance_ratio(xs, VR_HORIZON) == variance_ratio(xs, VR_HORIZON)
+
+
+def test_spearman_tie_handling():
+    # ties in xs: ranks (1.5, 1.5, 3); ys strictly increasing (1, 2, 3)
+    rho = _spearman([0.5, 0.5, 0.9], [0.1, 0.2, 0.3])
+    expected = _spearman([1.5, 1.5, 3.0], [1.0, 2.0, 3.0])
+    assert math.isclose(rho, expected)
+    assert 0 < rho < 1  # ties dilute but don't destroy the correlation
+    assert _spearman([0.5, 0.5], [0.1, 0.2]) != _spearman([0.5, 0.5], [0.1, 0.2])  # nan
+
+
+def test_binom_exact_branch():
+    assert math.isclose(_binom_p_greater_half(0, 10), 1.0)
+    # P(X >= 8 | n=10, p=.5) = (45 + 10 + 1)/1024
+    assert math.isclose(_binom_p_greater_half(8, 10), 56 / 1024)
+    # boundary continuity: exact at n=100 vs approx at n=101, similar tails
+    exact = _binom_p_greater_half(60, 100)
+    approx = _binom_p_greater_half(61, 101)
+    assert abs(exact - approx) < 0.02
+
+
+def test_leg_b_sampled_branch_eight_agents():
+    fleet = _fleet([0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.85],
+                   150, sigma=0.03, seed0=100)
+    res = leg_b(fleet, n_perm=400)
+    assert res["n_agents"] == 8
+    assert res["passes"] is True
+
+
+def test_leg_c_alpha_mismatch_invalidates_c_only():
+    traj = {"a": _iid(0.5, 150, sigma=0.03, seed=110)}
+    res = evaluate_v2(traj, alpha_mismatch={"a"})
+    row = res["per_agent"][0]
+    assert row["eligible"] is True
+    assert row["leg_a"] is not None      # A unaffected (alpha-free)
+    assert row["leg_c"] is None          # C invalidated
+    assert row["leg_c_alpha_mismatch"] is True


### PR DESCRIPTION
## What

The v2 operationalization of the individuality axiom, replacing the failed v1 AR(1) gate (0/4, #1355). **Merging this PR freezes the pre-registration** — the verdict counts only on raw observations recorded after `2026-07-02T18:00:00Z` (applied in SQL, no override flag), with reads on **2026-07-16** (trend) and **2026-07-30** (final).

## Design

**Claim (scoped):** each eligible agent's raw behavioral EISV series has an agent-specific, temporally stable operating level — anchored (excursions revert, level doesn't wander) and rank-stable across agents. Stable environmental coupling is explicitly admitted; the population is ~4 role-distinct residents, so a PASS is about *them*, not the universal axiom.

| Leg | Tests | Null |
|---|---|---|
| A(i) reversion | VR(24) | increment permutation |
| A(ii) drift veto | big-block-mean dispersion | small-block permutation |
| B individuality | split-half home rank-stability | agent-label permutation |
| C estimator (non-gating) | EMA vs persistence at jumps | binomial vs 0.5 |

**Verdict:** AXIOM EARNED iff A-majority AND B, at ≥4 eligible agents (floor sized against measured accrual — exactly 4 agents have unambiguous support; at n=4 leg B passes only on perfect rho=1, p=1/24, disclosed).

**Kill criterion:** FAIL at the final read retires the axiom for raw behavioral EISV as currently measured — no v3 without changing the measurement process, pre-registered before its data exists.

## Adversarial review (pre-freeze)

Three independent passes (statistical, implementation-correctness, live-data feasibility) ran *before* the freeze; every material finding is incorporated and disclosed in the spec:

- **R1 (the hard one):** raw_obs are ~10-event rolling-window features; window-filtered noise reverts by construction, so any single VR statistic is defeated by a *drifting level under window noise* — confirmed empirically by an organism, not just argued. Fix: h moved past the window (24 > 2w) **and** the drift veto added; the defeating organism is now a permanent test.
- **R2:** shared-driver-with-stable-gains is indistinguishable from an intrinsic home → scoped into the claim rather than papered over with a control that doesn't work (fleet-demeaning preserves rank order).
- **R4 + feasibility:** verdict floor 5→4 — session identities fragment by design (strict identity mints fresh agent_id per session), so a floor of 5 would make the verdict hostage to an atypical long-lived session; Lumen/Steward emit zero raw_obs.
- **R5:** full provenance disclosure — what was known at design time, what changed in response to the review, and why the timestamp alone can't eliminate forking-paths risk (mitigations: organism-validated nulls, adversarial review, kill criterion).
- **R7 + implementation review:** per-dim permutation seeds (decorrelates the 2-of-3 majority), SQL determinism tie-break, leg C burn-in + cold-start honesty + persisted-alphas mismatch guard, binomial overflow fix.

## Validation

27 deterministic organism tests pin the discrimination table: random walk fails, iid-distinct-means earns, sticky-anchored passes (the v1 blind spot), sticky-drift vetoed, windowed-stable-rate passes by design (disclosed), **windowed-drifting-rate defeats the naive design and is caught by the veto**, shared-home fails leg B. Live smoke run produces NOT EVALUABLE (0 post-registration rows), as required.

Known pre-existing flake: `test_ux_fixes` catalog-category, order-dependent in the full serial suite, passes standalone — unrelated.

## Operator notes

- Merging = freezing. Threshold edits after post-registration data accrues would invalidate the pre-registration.
- Suggest a calendar hold for the two reads; the script is a one-liner: `PYTHONPATH=. python3 scripts/analysis/eisv_individuality_v2.py`
- The broker-shadow agent's eligibility assumes the P2 soak keeps running past the cutover decision (~Jul 8) — if it's retired early, we're at exactly 4 eligible with no margin.