### PR TITLE
ops(lease-plane): restart the plane at shared-worktree disturbance time (#1277 fix 1)

### DIFF
--- a/scripts/ops/deploy-gateway.sh
+++ b/scripts/ops/deploy-gateway.sh
@@ -56,13 +56,27 @@ fi
 echo "[deploy] fetching origin/master"
 git -C "$REPO" fetch origin master --quiet
 
+LEASE_FRESH=0
 if ! git -C "$REPO" worktree list --porcelain | grep -qx "worktree $DEPLOY"; then
   echo "[deploy] creating dedicated deploy worktree at $DEPLOY (on master)"
   git -C "$REPO" worktree add "$DEPLOY" master
+  # A fresh `worktree add` checks out TRACKED files only — the lease plane's
+  # gitignored deps/ + _build/ are GONE, while the running BEAM keeps serving
+  # in-RAM modules until an unloaded module needs disk (the 06-27 ~5.4h
+  # fail-open, #1277). Nudge the plane after the ff below.
+  LEASE_FRESH=1
 fi
 
+LEASE_PREV="$(git -C "$DEPLOY" rev-parse HEAD)"
 echo "[deploy] fast-forwarding $DEPLOY to origin/master (ff-only; refuses if it would lose work)"
 git -C "$DEPLOY" merge --ff-only origin/master
+# The shared worktree just moved under every co-resident service (#1277 fix 1).
+if [[ "$LEASE_FRESH" == 1 ]]; then
+  "$(dirname "$0")/nudge-lease-plane.sh" --reason "deploy-gateway.sh: deploy worktree re-created (deps/_build gone)" || true
+else
+  "$(dirname "$0")/nudge-lease-plane.sh" --reason "deploy-gateway.sh: shared-worktree ff" \
+    --if-changed "$LEASE_PREV" "$(git -C "$DEPLOY" rev-parse HEAD)" || true
+fi
 mkdir -p "$DEPLOY/data/logs"
 
 echo "[deploy] restarting $LABEL"

--- a/scripts/ops/deploy-mcp.sh
+++ b/scripts/ops/deploy-mcp.sh
@@ -170,6 +170,13 @@ done
 
 if [[ "$ok" == yes ]]; then
   echo "[deploy-mcp] OK — governance MCP healthy on deploy-worktree code @ $(git -C "$DEPLOY" rev-parse --short HEAD)"
+  # The ff above moved the SHARED worktree; if it touched elixir/lease_plane,
+  # the running BEAM's disk just shifted under it — the RAM-vs-disk drift class
+  # behind the 06-27 fail-open (#1277 fix 1). Restart the plane at disturbance
+  # time, not at first failure. The rollback paths above need no nudge: they
+  # return the worktree to $PREV, net-zero for the plane's on-disk sources.
+  "$(dirname "$0")/nudge-lease-plane.sh" --reason "deploy-mcp ff moved the shared worktree" \
+    --if-changed "$PREV" "$(git -C "$DEPLOY" rev-parse HEAD)" || true
 else
   echo "[deploy-mcp] FAILED — new code did not come up healthy. Rolling the worktree back to ${PREV:0:8} and restarting." >&2
   git -C "$DEPLOY" reset --hard "$PREV"

--- a/scripts/ops/deploy-sentinel.sh
+++ b/scripts/ops/deploy-sentinel.sh
@@ -72,13 +72,27 @@ fi
 echo "[deploy] fetching origin/master"
 git -C "$REPO" fetch origin master --quiet
 
+LEASE_FRESH=0
 if ! git -C "$REPO" worktree list --porcelain | grep -qx "worktree $DEPLOY"; then
   echo "[deploy] creating dedicated deploy worktree at $DEPLOY (on master)"
   git -C "$REPO" worktree add "$DEPLOY" master
+  # A fresh `worktree add` checks out TRACKED files only — the lease plane's
+  # gitignored deps/ + _build/ are GONE, while the running BEAM keeps serving
+  # in-RAM modules until an unloaded module needs disk (the 06-27 ~5.4h
+  # fail-open, #1277). Nudge the plane after the ff below.
+  LEASE_FRESH=1
 fi
 
+LEASE_PREV="$(git -C "$DEPLOY" rev-parse HEAD)"
 echo "[deploy] fast-forwarding $DEPLOY to origin/master (ff-only; refuses if it would lose work)"
 git -C "$DEPLOY" merge --ff-only origin/master
+# The shared worktree just moved under every co-resident service (#1277 fix 1).
+if [[ "$LEASE_FRESH" == 1 ]]; then
+  "$(dirname "$0")/nudge-lease-plane.sh" --reason "deploy-sentinel.sh: deploy worktree re-created (deps/_build gone)" || true
+else
+  "$(dirname "$0")/nudge-lease-plane.sh" --reason "deploy-sentinel.sh: shared-worktree ff" \
+    --if-changed "$LEASE_PREV" "$(git -C "$DEPLOY" rev-parse HEAD)" || true
+fi
 
 echo "[deploy] compiling sentinel (surfaces compile errors before the restart)"
 ( cd "$DEPLOY/elixir/sentinel" && mix deps.get && mix compile )

--- a/scripts/ops/deploy-wave3a.sh
+++ b/scripts/ops/deploy-wave3a.sh
@@ -59,13 +59,27 @@ fi
 echo "[deploy] fetching origin/master"
 git -C "$REPO" fetch origin master --quiet
 
+LEASE_FRESH=0
 if ! git -C "$REPO" worktree list --porcelain | grep -qx "worktree $DEPLOY"; then
   echo "[deploy] creating dedicated deploy worktree at $DEPLOY (on master)"
   git -C "$REPO" worktree add "$DEPLOY" master
+  # A fresh `worktree add` checks out TRACKED files only — the lease plane's
+  # gitignored deps/ + _build/ are GONE, while the running BEAM keeps serving
+  # in-RAM modules until an unloaded module needs disk (the 06-27 ~5.4h
+  # fail-open, #1277). Nudge the plane after the ff below.
+  LEASE_FRESH=1
 fi
 
+LEASE_PREV="$(git -C "$DEPLOY" rev-parse HEAD)"
 echo "[deploy] fast-forwarding $DEPLOY to origin/master (ff-only; refuses if it would lose work)"
 git -C "$DEPLOY" merge --ff-only origin/master
+# The shared worktree just moved under every co-resident service (#1277 fix 1).
+if [[ "$LEASE_FRESH" == 1 ]]; then
+  "$(dirname "$0")/nudge-lease-plane.sh" --reason "deploy-wave3a.sh: deploy worktree re-created (deps/_build gone)" || true
+else
+  "$(dirname "$0")/nudge-lease-plane.sh" --reason "deploy-wave3a.sh: shared-worktree ff" \
+    --if-changed "$LEASE_PREV" "$(git -C "$DEPLOY" rev-parse HEAD)" || true
+fi
 
 echo "[deploy] compiling wave3a_handlers (MIX_ENV=prod; surfaces compile errors before restart)"
 ( cd "$DEPLOY/elixir/wave3a_handlers" && mix deps.get && MIX_ENV=prod mix compile )

--- a/scripts/ops/migrate-deploy-plists.sh
+++ b/scripts/ops/migrate-deploy-plists.sh
@@ -52,6 +52,10 @@ if ! git -C "$REPO" worktree list --porcelain 2>/dev/null | grep -qx "worktree $
   else
     git -C "$REPO" fetch origin master --quiet
     git -C "$REPO" worktree add "$DEPLOY" master
+    # Fresh checkout = the lease plane's gitignored deps/_build are gone while
+    # its BEAM serves from RAM (#1277 fix 1) — restart it now, not at first
+    # failure. No-op when the plane isn't loaded on this machine.
+    "$(dirname "$0")/nudge-lease-plane.sh" --reason "migrate-deploy-plists: deploy worktree re-created" || true
   fi
 fi
 

--- a/scripts/ops/nudge-lease-plane.sh
+++ b/scripts/ops/nudge-lease-plane.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Restart the lease plane after a shared-worktree disturbance (#1277 fix 1).
+#
+# The lease plane runs from the SAME deploy worktree as the governance MCP,
+# gateway, sentinel, and wave3a services. Any script that re-creates that
+# worktree (`git worktree add` → fresh checkout, gitignored deps/ + _build/
+# GONE) or moves its sources (`merge --ff-only`, `reset --hard` touching
+# elixir/lease_plane) shifts the disk out from under the running BEAM. The
+# 2026-06-27 incident (#1277) was exactly this: the worktree was re-created
+# at 10:41, the 4-day-old BEAM kept serving in-RAM modules, and the first
+# error-render needed Plug.Exception from a deps/ that no longer existed —
+# file-lease coordination failed OPEN for ~5.4h. The acquire-healthcheck's
+# auto-restart (#1284, armed 2026-07-02) is the safety net; THIS is the root
+# fix: the disturbing script restarts the plane at disturbance time, not at
+# first failure. start.sh self-heals deps (mix deps.get) and compiles at
+# boot, so a kickstart is a full remediation.
+#
+# Usage:
+#   nudge-lease-plane.sh --reason "worktree re-created"
+#   nudge-lease-plane.sh --reason "mcp deploy ff" --if-changed <PREV> <NEW>
+#
+# --if-changed PREV NEW: no-op unless elixir/lease_plane differs between the
+#   two commits (use for ff/rollback moves; omit for worktree re-creation,
+#   where gitignored build state is gone regardless of source diffs).
+#
+# Exit: 0 on nudge-or-skip; 1 if the plane failed to answer after the nudge
+# (callers should treat that as a loud warning, not a deploy abort — the
+# acquire-healthcheck auto-restart remains the backstop).
+set -euo pipefail
+
+DEPLOY="${UNITARES_MCP_DEPLOY:-$HOME/projects/unitares-deploy}"
+LABEL="com.unitares.lease-plane"
+UID_NUM="$(id -u)"
+PORT="${UNITARES_LEASE_PLANE_PORT:-8788}"
+
+REASON=""
+CHECK_RANGE=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --reason) REASON="$2"; shift 2 ;;
+    --if-changed) CHECK_RANGE=("$2" "$3"); shift 3 ;;
+    *) echo "[nudge-lease-plane] unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ ${#CHECK_RANGE[@]} -eq 2 ]]; then
+  if git -C "$DEPLOY" diff --quiet "${CHECK_RANGE[0]}" "${CHECK_RANGE[1]}" -- elixir/lease_plane 2>/dev/null; then
+    echo "[nudge-lease-plane] elixir/lease_plane unchanged ${CHECK_RANGE[0]:0:8}..${CHECK_RANGE[1]:0:8} — no restart needed"
+    exit 0
+  fi
+fi
+
+if ! launchctl print "gui/$UID_NUM/$LABEL" >/dev/null 2>&1; then
+  echo "[nudge-lease-plane] $LABEL not loaded on this machine — skipping"
+  exit 0
+fi
+
+echo "[nudge-lease-plane] restarting $LABEL (${REASON:-shared-worktree disturbance}); start.sh re-runs deps.get + compiles at boot"
+launchctl kickstart -k "gui/$UID_NUM/$LABEL"
+
+# Bounded wait for the listener: any HTTP status (200/401/...) means the BEAM
+# is up and serving fresh-compiled code; 000 means not yet accepting.
+for _ in $(seq 1 30); do
+  sleep 2
+  code="$(curl -s -o /dev/null -w '%{http_code}' -m 3 "http://127.0.0.1:${PORT}/v1/health" 2>/dev/null || echo 000)"
+  if [[ "$code" != "000" ]]; then
+    echo "[nudge-lease-plane] plane answering (HTTP $code) on :$PORT"
+    exit 0
+  fi
+done
+
+echo "[nudge-lease-plane] WARNING: plane not answering on :$PORT within 60s of restart — check ~/Library/Logs/unitares-lease-plane.log (acquire-healthcheck auto-restart remains the backstop)" >&2
+exit 1


### PR DESCRIPTION
Closes the remaining half of #1277 (fix 2, healthcheck auto-restart, was armed 2026-07-02).

## Confirmed deletion vector
The deploy worktree's gitdir (`.git/worktrees/unitares-deploy`) was created **2026-06-27 10:41:17** — the whole worktree was removed and re-created, matching the incident's "all source mtime 10:41, 3 min before first failure." `git worktree add` checks out tracked files only, so the plane's gitignored `deps/` + `_build/` vanished while its 4-day-old BEAM kept serving in-RAM modules. `reset --hard` was never the vector (it does not touch gitignored dirs) — the KG discovery's original blame was wrong, as the issue suspected.

## Fix
New `scripts/ops/nudge-lease-plane.sh` — kickstart + bounded listener wait (`start.sh` self-heals deps and compiles at boot, so a restart is full remediation). Unconditional mode for worktree re-creation; `--if-changed PREV NEW` mode that no-ops unless `elixir/lease_plane` actually moved.

Wired into every disturbance site: gateway/sentinel/wave3a deploys (fresh-worktree + ff), migrate-deploy-plists (fresh-worktree), deploy-mcp (success-path ff; its rollbacks are net-zero for the plane — documented inline). deploy-lease-plane.sh unchanged (already rebuilds + restarts).

## Verification
- `bash -n` clean on all five scripts
- Live on this machine: no-op mode correctly skips an unchanged range; full mode restarted the running plane and confirmed the listener answering (HTTP 401 = auth plug serving) within the wait budget
- Scripts-only diff — no pytest surface; CI full gate is the check

https://claude.ai/code/session_01XheHCotFixY5YYtThQ82Mz