### PR TITLE
feat(identity): ephemeral-write gate + token-invalid warning on successful calls (#1351)

### DIFF
--- a/src/mcp_handlers/context.py
+++ b/src/mcp_handlers/context.py
@@ -229,6 +229,33 @@ def get_session_proof_origin() -> Optional[str]:
     return _session_proof_origin.get()
 
 
+# Set True when the caller PRESENTED a continuity_token that failed
+# verification, regardless of whether the call later succeeded via another
+# proof (client_session_id, fingerprint pin, ...). session_resolution_source
+# can't carry this: it records the proof that WON, so a valid fallback
+# overwrites the invalid-token fact and the caller never learns their token
+# is bad until the fallback rotates (the #1319 incident). A dedicated sticky
+# flag lets the post-execution warning step (#1351) surface it on every
+# successful response. Cleared at resolve_identity entry for per-request
+# hygiene (same lifecycle as session_resolution_source).
+_continuity_token_invalid: ContextVar[bool] = ContextVar('continuity_token_invalid', default=False)
+
+
+def mark_continuity_token_invalid() -> object:
+    """Record that this request presented a continuity_token that failed verification."""
+    return _continuity_token_invalid.set(True)
+
+
+def clear_continuity_token_invalid() -> object:
+    """Clear the invalid-token flag (call at request entry)."""
+    return _continuity_token_invalid.set(False)
+
+
+def get_continuity_token_invalid() -> bool:
+    """Did this request present a continuity_token that failed verification?"""
+    return _continuity_token_invalid.get()
+
+
 # Set True at every point the transport INJECTS a synthetic client_session_id
 # into the arguments (REST: http_api; typed MCP wrapper: wrapper_generator).
 # An injected CSID is indistinguishable from a caller-sent one once in

--- a/src/mcp_handlers/identity/session.py
+++ b/src/mcp_handlers/identity/session.py
@@ -687,6 +687,16 @@ async def _derive_session_key_impl(
             _mark("continuity_token")
             return resolved
         _mark("continuity_token_invalid")
+        # Sticky per-request flag (#1351): _mark records only the proof that
+        # WINS, so when a fallback proof succeeds below the invalid-token fact
+        # is overwritten and the caller never learns their token is bad until
+        # the fallback rotates (the #1319 incident). The post-execution
+        # warning step reads this flag and surfaces it on the response.
+        try:
+            from ..context import mark_continuity_token_invalid
+            mark_continuity_token_invalid()
+        except Exception:
+            pass
 
     # 2. Explicit from arguments
     if arguments.get("client_session_id"):

--- a/src/mcp_handlers/middleware/__init__.py
+++ b/src/mcp_handlers/middleware/__init__.py
@@ -17,6 +17,7 @@ from .params_step import unwrap_kwargs, resolve_alias, inject_identity, validate
 from .rate_limit_step import check_rate_limit, _tool_call_history
 from .pattern_step import track_patterns
 from .envelope_step import apply_experience_envelope
+from .identity_warning_step import apply_identity_warnings
 
 # Type alias for middleware return
 MiddlewareResult = Union[
@@ -62,4 +63,7 @@ POST_VALIDATION_STEPS = [
 # guards each step; a failing step never breaks the response.
 POST_EXECUTION_STEPS = [
     apply_experience_envelope,
+    # After the envelope so the warning lands at the top level of whichever
+    # shape (raw or envelope) the caller actually receives (#1351).
+    apply_identity_warnings,
 ]

--- a/src/mcp_handlers/middleware/identity_step.py
+++ b/src/mcp_handlers/middleware/identity_step.py
@@ -454,6 +454,12 @@ async def resolve_identity(name: str, arguments: Dict[str, Any], ctx) -> Any:
     """Extract session identity, resolve onboard pin, bind agent."""
     _clear_middleware_identity(arguments)
 
+    # Per-request hygiene for the sticky invalid-token flag (#1351): the
+    # contextvar default only covers a fresh context; a long-lived dispatch
+    # task must not leak one request's invalid-token fact into the next.
+    from ..context import clear_continuity_token_invalid
+    clear_continuity_token_invalid()
+
     # Unified session key derivation via SessionSignals + derive_session_key()
     from ..context import get_session_signals
     from ..identity.handlers import derive_session_key

--- a/src/mcp_handlers/middleware/identity_warning_step.py
+++ b/src/mcp_handlers/middleware/identity_warning_step.py
@@ -1,0 +1,99 @@
+"""Post-execution step: surface identity warnings on successful responses.
+
+#1351 item 2 (hardening follow-up to the #1319 incident). When a caller
+presents a ``continuity_token`` that fails verification but the call still
+succeeds via another proof (valid ``client_session_id``, fingerprint pin,
+...), nothing tells them their token is bad — they discover it only when the
+fallback proof rotates, at which point their resume is refused with no prior
+signal. ``session.py`` has always tracked the invalid-token fact internally
+(``_mark("continuity_token_invalid")``), but that record is overwritten by
+whichever proof wins; ``_identity_notifications`` reaches callers on
+check-ins only.
+
+This step reads the sticky per-request flag set by ``derive_session_key``
+(``context.mark_continuity_token_invalid``) and appends a structured warning
+to the successful response of ANY tool:
+
+    "identity_warnings": [
+      {
+        "code": "continuity_token_invalid",
+        "resolved_via": "<the proof that won>",
+        "message": "..."
+      }
+    ]
+
+Runs AFTER apply_experience_envelope so the warning lands at the top level
+of whichever shape (raw or envelope) the caller actually receives. Error
+responses pass through untouched — the failure contract carries its own
+context, and a refusal for a bad token already explains itself (#1319 fix).
+
+Like every post-execution step: any failure returns the result unmodified
+(the runner also guards).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+from mcp.types import TextContent
+
+from src.logging_utils import get_logger
+
+logger = get_logger(__name__)
+
+
+async def apply_identity_warnings(name: str, arguments: Dict[str, Any], ctx, result):
+    """POST_EXECUTION step. Append identity_warnings to a successful response
+    when this request presented a continuity_token that failed verification."""
+    try:
+        from ..context import (
+            get_continuity_token_invalid,
+            get_session_resolution_source,
+        )
+
+        if not get_continuity_token_invalid():
+            return result
+
+        if not (isinstance(result, (list, tuple)) and result and hasattr(result[0], "text")):
+            return result
+        payload = json.loads(result[0].text)
+        if not isinstance(payload, dict):
+            return result
+        if payload.get("success") is False or "error" in payload:
+            return result  # failure/refusal responses explain themselves
+
+        resolved_via = get_session_resolution_source() or "unknown"
+        warning = {
+            "code": "continuity_token_invalid",
+            "resolved_via": resolved_via,
+            "message": (
+                "The continuity_token presented with this call failed "
+                "verification (malformed, expired, or signed with a rotated "
+                f"secret); the call succeeded via '{resolved_via}' instead. "
+                "That fallback proof can rotate without notice — refresh your "
+                "token via identity() or re-onboard before relying on it."
+            ),
+        }
+        existing = payload.get("identity_warnings")
+        if isinstance(existing, list):
+            if any(
+                isinstance(w, dict) and w.get("code") == "continuity_token_invalid"
+                for w in existing
+            ):
+                return result
+            existing.append(warning)
+        else:
+            payload["identity_warnings"] = [warning]
+
+        return [
+            TextContent(type="text", text=json.dumps(payload, ensure_ascii=False)),
+            *result[1:],
+        ]
+    except Exception:
+        logger.warning(
+            "identity warning step failed for %r - returning raw response",
+            name,
+            exc_info=True,
+        )
+        return result

--- a/src/mcp_handlers/observability/outcome_events.py
+++ b/src/mcp_handlers/observability/outcome_events.py
@@ -534,10 +534,63 @@ async def handle_outcome_event(arguments: Dict[str, Any]) -> Sequence[TextConten
             error_category="identity_error",
         )]
 
+    # Ephemeral-write gate (#1351 item 1, defense-in-depth for #1319). The
+    # middleware stamps dispatch-minted identities `ephemeral: true /
+    # persisted: false`; until now no write path consulted it. Under strict
+    # identity an ephemeral writer should be impossible (#1325 closed the
+    # known route) — so if one appears, refuse fail-closed: it IS a future
+    # leak route. Under non-strict, auto-minted ephemeral identities are the
+    # designed flow — stamp the row and warn instead of breaking it.
+    ephemeral_stamp = False
+    try:
+        from ..context import get_session_context
+        _ident = get_session_context().get("identity_result") or {}
+        if _ident.get("ephemeral") and not _ident.get("persisted"):
+            from ..identity_bootstrap import is_strict_identity_required
+            if is_strict_identity_required():
+                logger.warning(
+                    "[EPHEMERAL-GATE] refusing outcome_event write from "
+                    "ephemeral-unpersisted identity %s... under strict "
+                    "identity — this route should not exist (#1351)",
+                    str(agent_id)[:8],
+                )
+                return [error_response(
+                    "Durable write refused: this session is bound to an "
+                    "ephemeral, unpersisted identity, which cannot own an "
+                    "outcome row under strict identity. Onboard first "
+                    "(start_session(force_new=true)) and retry.",
+                    error_code="EPHEMERAL_IDENTITY_WRITE_REFUSED",
+                    error_category="identity_error",
+                )]
+            ephemeral_stamp = True
+            logger.warning(
+                "[EPHEMERAL-GATE] outcome_event write from ephemeral-"
+                "unpersisted identity %s... — stamping row (#1351)",
+                str(agent_id)[:8],
+            )
+    except Exception:
+        # The gate is defense-in-depth; a gate error must not block a
+        # legitimate write. (Strict-mode refusal above returns before this.)
+        logger.debug("ephemeral-write gate check failed", exc_info=True)
+
     # Delegate to the non-decorated helper to avoid the @mcp_tool decorator's
     # asyncio.wait_for wrapping (anyio-asyncio deadlock risk — see CLAUDE.md).
     # agent_id resolved above is injected so the helper can skip context lookup.
-    payload = await _record_outcome_event_inline({**arguments, "agent_id": agent_id})
+    _gate_args = {**arguments, "agent_id": agent_id}
+    if ephemeral_stamp:
+        _detail = dict(_gate_args.get("detail") or {})
+        _detail["ephemeral_writer"] = True
+        _gate_args["detail"] = _detail
+    payload = await _record_outcome_event_inline(_gate_args)
+    if ephemeral_stamp and isinstance(payload, dict) and "error" not in payload:
+        payload.setdefault("identity_warnings", []).append({
+            "code": "ephemeral_writer",
+            "message": (
+                "This outcome was recorded under an ephemeral, unpersisted "
+                "identity and stamped ephemeral_writer=true. Onboard "
+                "(start_session) to write under a durable identity."
+            ),
+        })
 
     if "error" in payload:
         return [error_response(

--- a/tests/test_identity_hardening_1351.py
+++ b/tests/test_identity_hardening_1351.py
@@ -1,0 +1,208 @@
+"""#1351 hardening: ephemeral-write gate + token-invalid warning on successful calls.
+
+Follow-up to #1319 (fixed by #1325). Two defenses:
+
+1. The post-execution ``apply_identity_warnings`` step surfaces a
+   ``continuity_token_invalid`` warning on ANY successful response when the
+   request presented a token that failed verification but succeeded via a
+   fallback proof — previously the caller learned nothing until the fallback
+   rotated.
+
+2. ``outcome_event`` consults the middleware's ``ephemeral/persisted`` stamp:
+   strict identity refuses the durable write fail-closed (that route should
+   not exist); non-strict stamps the row ``ephemeral_writer=true`` and warns.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from mcp.types import TextContent
+
+from src.mcp_handlers.context import (
+    clear_continuity_token_invalid,
+    get_continuity_token_invalid,
+    mark_continuity_token_invalid,
+    set_session_context,
+    set_session_resolution_source,
+)
+from src.mcp_handlers.middleware.identity_warning_step import apply_identity_warnings
+
+
+@pytest.fixture(autouse=True)
+def _clean_flag():
+    clear_continuity_token_invalid()
+    yield
+    clear_continuity_token_invalid()
+
+
+def _result(payload) -> list:
+    return [TextContent(type="text", text=json.dumps(payload))]
+
+
+def _ctx():
+    return SimpleNamespace(original_name=None)
+
+
+class TestContinuityTokenInvalidFlag:
+    def test_mark_and_clear(self):
+        assert get_continuity_token_invalid() is False
+        mark_continuity_token_invalid()
+        assert get_continuity_token_invalid() is True
+        clear_continuity_token_invalid()
+        assert get_continuity_token_invalid() is False
+
+    @pytest.mark.asyncio
+    async def test_derive_session_key_marks_flag_on_invalid_token(self):
+        """The invalid-token branch in derive_session_key sets the sticky flag
+        even when a fallback proof wins afterwards."""
+        from src.mcp_handlers.identity.session import derive_session_key
+
+        with patch(
+            "src.mcp_handlers.identity.session.resolve_continuity_token",
+            return_value=None,
+        ):
+            resolved = await derive_session_key(
+                signals=None,
+                arguments={
+                    "continuity_token": "v1.garbage",
+                    "client_session_id": "agent-00000000-feed-4bad-8888-000000000001",
+                },
+            )
+        # Fallback proof won (explicit client_session_id)...
+        assert resolved == "agent-00000000-feed-4bad-8888-000000000001"
+        # ...but the invalid-token fact survived.
+        assert get_continuity_token_invalid() is True
+
+
+class TestIdentityWarningStep:
+    @pytest.mark.asyncio
+    async def test_appends_warning_on_success_when_flag_set(self):
+        mark_continuity_token_invalid()
+        set_session_resolution_source("explicit_client_session_id")
+        result = await apply_identity_warnings(
+            "get_state", {}, _ctx(), _result({"success": True, "data": 1})
+        )
+        payload = json.loads(result[0].text)
+        (warning,) = payload["identity_warnings"]
+        assert warning["code"] == "continuity_token_invalid"
+        assert warning["resolved_via"] == "explicit_client_session_id"
+        assert payload["data"] == 1  # payload otherwise untouched
+
+    @pytest.mark.asyncio
+    async def test_no_warning_when_flag_clear(self):
+        result = await apply_identity_warnings(
+            "get_state", {}, _ctx(), _result({"success": True})
+        )
+        assert "identity_warnings" not in json.loads(result[0].text)
+
+    @pytest.mark.asyncio
+    async def test_error_responses_pass_through_untouched(self):
+        mark_continuity_token_invalid()
+        original = _result({"success": False, "error": "nope"})
+        result = await apply_identity_warnings("get_state", {}, _ctx(), original)
+        assert result is original
+
+    @pytest.mark.asyncio
+    async def test_non_json_result_passes_through(self):
+        mark_continuity_token_invalid()
+        original = [TextContent(type="text", text="not json {")]
+        result = await apply_identity_warnings("get_state", {}, _ctx(), original)
+        assert result is original
+
+    @pytest.mark.asyncio
+    async def test_does_not_duplicate_existing_warning(self):
+        mark_continuity_token_invalid()
+        payload = {
+            "success": True,
+            "identity_warnings": [{"code": "continuity_token_invalid"}],
+        }
+        result = await apply_identity_warnings("get_state", {}, _ctx(), _result(payload))
+        assert len(json.loads(result[0].text)["identity_warnings"]) == 1
+
+    def test_registered_after_envelope_step(self):
+        from src.mcp_handlers.middleware import POST_EXECUTION_STEPS
+        from src.mcp_handlers.middleware.envelope_step import apply_experience_envelope
+
+        names = [s.__name__ for s in POST_EXECUTION_STEPS]
+        assert names.index("apply_identity_warnings") > names.index(
+            apply_experience_envelope.__name__
+        )
+
+
+class TestEphemeralWriteGate:
+    """outcome_event consults the middleware ephemeral/persisted stamp."""
+
+    def _set_ephemeral_context(self):
+        return set_session_context(
+            session_key="sk-test",
+            agent_id="00000000-dead-4bee-8888-000000000002",
+            identity_result={"ephemeral": True, "persisted": False, "created": True},
+        )
+
+    @pytest.mark.asyncio
+    async def test_strict_refuses_ephemeral_write(self):
+        from src.mcp_handlers.observability.outcome_events import handle_outcome_event
+
+        self._set_ephemeral_context()
+        with patch(
+            "src.mcp_handlers.identity_bootstrap.is_strict_identity_required",
+            return_value=True,
+        ):
+            result = await handle_outcome_event({"outcome_type": "test_passed"})
+        payload = json.loads(result[0].text)
+        assert payload.get("success") is False or "error" in payload
+        assert payload.get("error_code") == "EPHEMERAL_IDENTITY_WRITE_REFUSED"
+
+    @pytest.mark.asyncio
+    async def test_non_strict_stamps_and_warns(self):
+        from src.mcp_handlers.observability import outcome_events
+
+        self._set_ephemeral_context()
+        captured = {}
+
+        async def _fake_inline(args):
+            captured.update(args)
+            return {"recorded": True}
+
+        with patch(
+            "src.mcp_handlers.identity_bootstrap.is_strict_identity_required",
+            return_value=False,
+        ), patch.object(
+            outcome_events, "_record_outcome_event_inline", _fake_inline
+        ):
+            result = await outcome_events.handle_outcome_event(
+                {"outcome_type": "test_passed"}
+            )
+        assert captured["detail"]["ephemeral_writer"] is True
+        payload = json.loads(result[0].text)
+        codes = [w["code"] for w in payload.get("identity_warnings", [])]
+        assert "ephemeral_writer" in codes
+
+    @pytest.mark.asyncio
+    async def test_persisted_identity_writes_unaffected(self):
+        from src.mcp_handlers.observability import outcome_events
+
+        set_session_context(
+            session_key="sk-test",
+            agent_id="00000000-dead-4bee-8888-000000000003",
+            identity_result={"persisted": True},
+        )
+        captured = {}
+
+        async def _fake_inline(args):
+            captured.update(args)
+            return {"recorded": True}
+
+        with patch.object(
+            outcome_events, "_record_outcome_event_inline", _fake_inline
+        ):
+            result = await outcome_events.handle_outcome_event(
+                {"outcome_type": "test_passed"}
+            )
+        assert "ephemeral_writer" not in (captured.get("detail") or {})
+        payload = json.loads(result[0].text)
+        assert "identity_warnings" not in payload


### PR DESCRIPTION
Implements both hardening items from #1351 (the follow-ups that survived #1319's close via #1325).

## Item 2 — token-invalid warning on successful calls
`derive_session_key`'s `_mark` records only the proof that **wins** — so a presented `continuity_token` that fails verification is silently forgotten when a fallback proof (valid `client_session_id`, fingerprint pin) succeeds. The caller discovers their token is bad only when the fallback rotates: exactly how #1319 presented.

- New sticky per-request contextvar `continuity_token_invalid` — cleared at `resolve_identity` entry, set in the invalid-token branch of `derive_session_key`
- New `POST_EXECUTION` step `apply_identity_warnings`: appends `identity_warnings: [{code: continuity_token_invalid, resolved_via, message}]` to the successful response of **any** tool. Ordered after the experience envelope so the warning lands at the top level of whichever shape the caller receives. Error responses pass through untouched; the step never breaks a response (own guard + runner guard).

## Item 1 — ephemeral-write gate (defense-in-depth)
The middleware stamps dispatch-minted identities `ephemeral: true / persisted: false`; until now no write path consulted it. `outcome_event` (alias `record_result`) now does:
- **Strict identity** (the live posture): an ephemeral writer should be impossible post-#1325, so one appearing is refused fail-closed with `EPHEMERAL_IDENTITY_WRITE_REFUSED` — any future route gets caught, not recorded
- **Non-strict**: auto-minted ephemeral identities are the designed flow — the row is stamped `detail.ephemeral_writer=true` and the response carries an `ephemeral_writer` warning
- Gate errors never block a legitimate write

Other durable writes (KG store, leave_note) can adopt the same context check; `outcome_event` is the one the issue names and the one #1319 actually hit.

## Tests
11 new (`tests/test_identity_hardening_1351.py`): flag lifecycle; `derive_session_key` marks the flag through a winning fallback; warning step success/error/non-JSON/dedup/pipeline-ordering; strict refusal; non-strict stamp+warn; persisted identity untouched. Neighbors green: `test_identity_session.py` + `test_ux_fixes.py` (149) and outcome/envelope/middleware selection (148).

Closes #1351.

https://claude.ai/code/session_01XheHCotFixY5YYtThQ82Mz