### PR TITLE
fix(kg): default null details pagination

### DIFF
--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -200,6 +200,18 @@ def _invalid_enum_response(field: str, value: Any, valid_values: set[str], *, ti
     )
 
 
+def _coerce_pagination_int(value: Any, *, default: int, minimum: int) -> int:
+    if value is None:
+        return default
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError):
+        return default
+    if coerced < minimum:
+        return default
+    return coerced
+
+
 async def _clamp_confidence_to_coherence(discovery, agent_id: str) -> bool:
     """Cross-check discovery confidence against agent's EISV coherence.
 
@@ -2416,8 +2428,8 @@ async def handle_get_discovery_details(arguments: Dict[str, Any]) -> Sequence[Te
             return [await _discovery_not_found(discovery_id, graph)]
 
         # UX FIX: Pagination support for long details
-        offset = arguments.get("offset", 0)
-        length = arguments.get("length", 2000)
+        offset = _coerce_pagination_int(arguments.get("offset"), default=0, minimum=0)
+        length = _coerce_pagination_int(arguments.get("length"), default=2000, minimum=1)
 
         details = discovery.details or ""
         total_length = len(details)

--- a/src/mcp_handlers/schemas/knowledge.py
+++ b/src/mcp_handlers/schemas/knowledge.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Literal, List, get_args
+from typing import Optional, Union, Literal, List, Any, get_args
 from pydantic import Field, model_validator
 from .mixins import AgentIdentityMixin
 
@@ -17,6 +17,19 @@ _DISCOVERY_TYPE_DESC = (
 )
 
 Severity = Literal["low", "medium", "high", "critical"]
+
+
+def _coerce_int_default(value: Any, default: int, *, minimum: int | None = None) -> int:
+    if value is None:
+        return default
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError):
+        return default
+    if minimum is not None and coerced < minimum:
+        return default
+    return coerced
+
 
 class StoreKnowledgeGraphParams(AgentIdentityMixin):
     """
@@ -241,6 +254,10 @@ class GetDiscoveryDetailsParams(AgentIdentityMixin):
         default=0,
         description="Character offset for details pagination"
     )
+    length: Union[int, str, None] = Field(
+        default=2000,
+        description="Max characters to return for details pagination"
+    )
     fetch_chain: Union[bool, str, None] = Field(
         default=False,
         description="If true, fetches the full discussion chain linked to this item"
@@ -252,11 +269,8 @@ class GetDiscoveryDetailsParams(AgentIdentityMixin):
     
     @model_validator(mode='after')
     def coerce_types(self):
-        if isinstance(self.offset, str):
-            try:
-                self.offset = int(self.offset)
-            except ValueError:
-                self.offset = 0
+        self.offset = _coerce_int_default(self.offset, 0, minimum=0)
+        self.length = _coerce_int_default(self.length, 2000, minimum=1)
         if isinstance(self.fetch_chain, str):
             self.fetch_chain = self.fetch_chain.lower() in ('true', '1', 'yes')
         if isinstance(self.include_provenance, str):
@@ -412,4 +426,7 @@ class KnowledgeParams(AgentIdentityMixin):
             self.include_response_chain = self.include_response_chain.lower() in ('true', '1', 'yes')
         if isinstance(self.including_cold, str):
             self.including_cold = self.including_cold.lower() in ('true', '1', 'yes')
+        if self.action == "details":
+            self.offset = _coerce_int_default(self.offset, 0, minimum=0)
+            self.length = _coerce_int_default(self.length, 2000, minimum=1)
         return self

--- a/tests/test_kg_lifecycle.py
+++ b/tests/test_kg_lifecycle.py
@@ -405,6 +405,29 @@ class TestGetDiscoveryDetails:
         assert data["pagination"]["has_more"] is True
 
     @pytest.mark.asyncio
+    async def test_get_details_null_pagination_values_use_defaults(self, patch_common):
+        """Explicit null pagination from validated KG calls behaves like omission."""
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_get_discovery_details
+
+        long_details = "A" * 2500
+        disc = make_discovery(id="2026-01-01T00:00:00.000000", details=long_details)
+        mock_graph.get_discovery = AsyncMock(return_value=disc)
+
+        result = await handle_get_discovery_details({
+            "discovery_id": "2026-01-01T00:00:00.000000",
+            "offset": None,
+            "length": None,
+        })
+
+        data = parse_result(result)
+        assert data["success"] is True
+        assert data["details"] == long_details[:2000]
+        assert data["pagination"]["offset"] == 0
+        assert data["pagination"]["length"] == 2000
+        assert data["pagination"]["next_offset"] == 2000
+
+    @pytest.mark.asyncio
     async def test_get_details_short_content_no_pagination(self, patch_common):
         """Short details don't trigger pagination."""
         mock_mcp_server, mock_graph = patch_common

--- a/tests/test_pydantic_schemas.py
+++ b/tests/test_pydantic_schemas.py
@@ -272,6 +272,31 @@ class TestPydanticSchemas:
         assert dumped["top_n"] == 5
         assert dumped["agent_id"] == "agent-1"
 
+    def test_knowledge_details_null_pagination_uses_defaults(self):
+        """Explicit null offset/length must not reach the details handler."""
+        from src.mcp_handlers.schemas.knowledge import GetDiscoveryDetailsParams, KnowledgeParams
+
+        unified = KnowledgeParams(
+            action="details",
+            discovery_id="disc-1",
+            offset=None,
+            length=None,
+        )
+        legacy = GetDiscoveryDetailsParams(
+            discovery_id="disc-1",
+            offset=None,
+            length=None,
+        )
+
+        assert unified.offset == 0
+        assert unified.length == 2000
+        assert legacy.offset == 0
+        assert legacy.length == 2000
+
+        unrelated = KnowledgeParams(action="search", query="pagination")
+        assert unrelated.offset is None
+        assert unrelated.length is None
+
     def test_leave_note_accepts_s22_h5_agent_knowable_fields(self):
         """Quick notes must preserve the same S22 diagnostic fields as store."""
         from src.mcp_handlers.schemas.knowledge import LeaveNoteParams


### PR DESCRIPTION
## Summary
- Default explicit null details pagination values before comparison/slicing in the KG details handler.
- Expose and coerce legacy get_discovery_details length plus unified knowledge(action=details) offset/length defaults.
- Add regression coverage for offset=null/length=null while keeping unrelated knowledge actions from materializing pagination defaults.

## Tests
- python3 -m pytest tests/test_kg_lifecycle.py::TestGetDiscoveryDetails tests/test_pydantic_schemas.py tests/test_knowledge_param_coverage.py
- ./scripts/dev/test-cache.sh (11452 passed, 22 skipped, 4 warnings; coverage 81.93%)
- pre-push smoke via git push (138 passed, 10640 deselected, 1 warning)

## Pre-PR Gate
- git prepr --scope "kg details null offset dogfood friction" passed branch/git/PR visibility checks but failed the process gate on ambient deploy services from a separate deploy checkout: mcp_server.py --port 8767, gateway_server.py --port 8768, ipv6_loopback_proxy.py. Those were not from this working checkout and were not stopped.