### PR TITLE
docs: refresh public production snapshot (3.7M→4.2M, frozen 2026-07-02)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Most controls inspect one action against one rule. UNITARES keeps history for ea
 [![License](https://img.shields.io/badge/license-Apache_2.0-2f7d72?style=flat-square&labelColor=0f171f)](LICENSE)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19647159.svg)](https://doi.org/10.5281/zenodo.19647159)
 
-*Status: live since November 2025 — 3.7M+ governance events (public snapshot frozen 2026-06-16).*
+*Status: live since November 2025 — 4.2M+ governance events (public snapshot frozen 2026-07-02).*
 
 [![Quickstart](https://img.shields.io/badge/▶-quickstart-5eead4?style=for-the-badge&labelColor=0f171f)](#try-the-demo-locally)
 [![Docs](https://img.shields.io/badge/docs-read-7d8f97?style=for-the-badge&labelColor=0f171f)](docs/README.md)
@@ -64,7 +64,7 @@ docker compose up -d --wait && make demo
 
 For a human operator view, open the optional dashboard at `http://localhost:8767/dashboard`. Dashboard implementation details live in [`dashboard/README.md`](dashboard/README.md); public deployment screenshots live in [`docs/PRODUCTION_SNAPSHOT.md`](docs/PRODUCTION_SNAPSHOT.md).
 
-> **Running continuously since November 2025 · 3.7M+ governance events** — the agents building UNITARES run under it. ([Production snapshot →](docs/PRODUCTION_SNAPSHOT.md) · [verify the numbers →](docs/REVIEWER_GUIDE.md))
+> **Running continuously since November 2025 · 4.2M+ governance events** — the agents building UNITARES run under it. ([Production snapshot →](docs/PRODUCTION_SNAPSHOT.md) · [verify the numbers →](docs/REVIEWER_GUIDE.md))
 
 ## Where it fits
 

--- a/docs/PRODUCTION_SNAPSHOT.md
+++ b/docs/PRODUCTION_SNAPSHOT.md
@@ -1,8 +1,10 @@
 # Production snapshot
 
-Frozen public snapshot from June 16, 2026 (single-operator — the author's own
-traffic). Headline: **3.7M+ governance events processed · ≈714K in the last 7
-days**. Running continuously since November 2025 and dogfooded — the agents
+Frozen public snapshot from July 2, 2026 (single-operator — the author's own
+traffic; previous snapshot: June 16, 2026). Headline: **4.2M+ governance events
+processed · ≈72K in the last 7 days**. Weekly volume varies with the operator's
+workload — the June snapshot coincided with a high-throughput period, and
+identity-consolidation work since then removed phantom per-session traffic. Running continuously since November 2025 and dogfooded — the agents
 building UNITARES run under it. The falsifiability checks run on a fresh clone;
 the live deployment metrics below need governance-DB access to reproduce — see
 the [Reviewer Guide](REVIEWER_GUIDE.md#falsifiability-grade-eisv-yourself-dont-trust-this-doc).
@@ -11,13 +13,13 @@ the [Reviewer Guide](REVIEWER_GUIDE.md#falsifiability-grade-eisv-yourself-dont-t
 
 | Metric | Value |
 |--------|-------|
-| Agents onboarded | 3,777 total process-instances — overwhelmingly ephemeral CLI sessions from one operator's workstation plus a handful of long-running resident agents (launchd crons) |
-| Distinct event-emitting identities (last 21 days) | 510; mostly ephemeral local CLI sessions (lower than earlier snapshots as identity-consolidation work cut phantom per-session identities) |
-| Unique agents active (last 7 days) | 369 distinct event emitters |
-| Governance events processed | 3,748,000+ (≈714K in the last 7 days) |
-| Knowledge graph discoveries | 1,054 |
+| Agents onboarded | 5,162 total process-instances — overwhelmingly ephemeral CLI sessions from one operator's workstation plus a handful of long-running resident agents (launchd crons) |
+| Distinct event-emitting identities (last 21 days) | 1,336; mostly ephemeral local CLI sessions |
+| Unique agents active (last 7 days) | 448 distinct event emitters |
+| Governance events processed | 4,244,000+ (≈72K in the last 7 days) |
+| Knowledge graph discoveries | 1,339 |
 | V operating range | Active agents often within [-0.1, 0.1] |
-| Tests | 8,500+ collected · smoke/pre-push subset plus 75% min coverage gate |
+| Tests | 10,300+ collected · smoke/pre-push subset plus 75% min coverage gate |
 
 *What these numbers show:* the pipeline holds up under sustained volume. *What
 they don't show:* product-market traction. External adoption is the open question.


### PR DESCRIPTION
The June 16 freeze had drifted ~14% under the live site (cirwel.org auto-refreshes daily against the same meter, so the two public surfaces visibly disagreed — operator noticed today). This re-freezes the README headline + PRODUCTION_SNAPSHOT.md from the live governance DB.

All table rows re-derived with the snapshot's own meters. The one unflattering change is disclosed rather than smoothed: weekly event volume dropped ~10× since June (~714K→~72K/7d) — the June snapshot coincided with a high-throughput period and identity-consolidation removed phantom per-session traffic since.

Suggestion for the standing gap: the freeze will drift again by design. Options are (a) periodic re-freeze (this PR = the pattern, quarterly is probably enough), or (b) have CI inject the figure the way tool-counts are machine-checked. (a) keeps the 'frozen snapshot, dated' honesty property; recorded in the portfolio oversight cadence either way.

Docs-only.