### PR TITLE
fix(dashboard): lease-anchored residents are alive, not 'Never checked in'

### DIFF
--- a/dashboard/redesign/data.js
+++ b/dashboard/redesign/data.js
@@ -384,6 +384,25 @@
       return r.json();
     },
 
+    // Light freshness map for the residents (label -> {silence, status}).
+    // The Agents pane uses it to keep lease-anchored in-process residents
+    // (e.g. Steward — zero agent_state rows BY DESIGN, liveness lives in
+    // lease_plane heartbeats) out of the "Never checked in" bucket.
+    async residentFreshness() {
+      return withFallback(
+        async () => {
+          const j = await authFetch("/v1/residents");
+          if (!j || !Array.isArray(j.residents)) return null;
+          const map = {};
+          j.residents.forEach((r) => {
+            if (r.label) map[r.label] = { silence: r.silence_seconds, status: r.status };
+          });
+          return map;
+        },
+        () => S().residentFreshness || {},
+      );
+    },
+
     async residentPanels() {
       return withFallback(async () => {
         const [w, sn, vg, h, res] = await Promise.all([

--- a/dashboard/redesign/sections/agents.js
+++ b/dashboard/redesign/sections/agents.js
@@ -181,7 +181,8 @@
 
   function rowBadges(a, st) {
     const out = [];
-    if (a.event_driven) out.push(`<span class="tag" title="event-driven resident — silence is not a liveness signal">event</span>`);
+    if (a.leaseAnchored) out.push(`<span class="tag" title="in-process resident — liveness from its lease-plane heartbeat, not check-in rows">lease heartbeat</span>`);
+    else if (a.event_driven) out.push(`<span class="tag" title="event-driven resident — silence is not a liveness signal">event</span>`);
     else if (st.level === "stale" || st.level === "dead") out.push(`<span class="tag warn">inactive</span>`);
     if (a.superseded) out.push(`<span class="tag warn" title="${a.lifecycleReason || "superseded"}">superseded</span>`);
     if (a.parent) out.push(`<span class="tag" title="lineage parent ${a.parent}">↑ lineage</span>`);
@@ -244,8 +245,8 @@
     }[sortF] || cmp_recent;
     rows.sort(cmp);
 
-    const participated = rows.filter((a) => (a.updates || 0) >= 1);
-    const never = rows.filter((a) => (a.updates || 0) === 0);
+    const participated = rows.filter((a) => (a.updates || 0) >= 1 || a.leaseAnchored);
+    const never = rows.filter((a) => (a.updates || 0) === 0 && !a.leaseAnchored);
     const shown = participated.slice(0, pageSize);
 
     const tr = (a) => {
@@ -318,6 +319,20 @@
       list: r.data.list || [], summary: r.data.summary || {}, source: r.source,
       nowMs: r.source === "live" ? Date.now() : Date.parse((window.SNAPSHOT && window.SNAPSHOT.capturedAt) || 0) || Date.now(),
     };
+    // Lease-anchored residents (in-process, e.g. Steward) have zero check-in
+    // rows BY DESIGN — their liveness is the lease-plane heartbeat. Without
+    // this they sit in "Never checked in" forever and read as dead.
+    try {
+      const fresh = (await DATA.residentFreshness()).data || {};
+      MODEL.list.forEach((a) => {
+        const f = a.label && fresh[a.label];
+        if (f && (a.updates || 0) === 0 && typeof f.silence === "number") {
+          a.leaseAnchored = true;
+          a.last = new Date(MODEL.nowMs - f.silence * 1000).toISOString();
+          a.leaseStatus = f.status;
+        }
+      });
+    } catch { /* freshness is an enhancement — the pane renders without it */ }
     render();
   }
 

--- a/dashboard/redesign/snapshot.js
+++ b/dashboard/redesign/snapshot.js
@@ -139,6 +139,11 @@ window.SNAPSHOT = {
     ],
   },
   // Real resident-panel data from /v1/{watcher,sentinel,vigil}/summary + /health/deep 2026-06-19T20:41Z.
+  residentFreshness: {
+    Steward: { silence: 120, status: "healthy" },
+    Lumen: { silence: 95, status: "healthy" },
+  },
+
   residentPanels: {
     watcher: { total:76, byStatus:{ dismissed:54, confirmed:17, surfaced:5 }, openSev:{ high:3, medium:2 },
       patterns:[ {p:"P011",confirmed:6,dismissed:16,surfaced:1,ratio:0.73}, {p:"P001",confirmed:7,dismissed:7,surfaced:0,ratio:0.50}, {p:"P016",confirmed:0,dismissed:7,surfaced:2,ratio:1.0}, {p:"P009",confirmed:0,dismissed:0,surfaced:2,ratio:null} ] },


### PR DESCRIPTION
Operator saw Steward as not checking in on the dashboard while every backend surface said healthy (46 syncs since last boot, 259s silence). Root cause: Steward is an **in-process** resident with zero `agent_state` rows by design — its liveness is the lease-plane heartbeat — and the Agents pane partitions on `updates === 0`, so it sat in 'Never checked in' permanently.

Fix (display seam only, no server change): the pane folds `/v1/residents` freshness in via a new light `DATA.residentFreshness()` accessor — a zero-update agent whose label matches a fresh resident joins the active rows, recency = its lease silence, badged **lease heartbeat** with an explanatory tooltip. Snapshot mock included; degradation is graceful (freshness fetch failure just leaves prior behavior).

https://claude.ai/code/session_0161HZuyx8XREX5AMZtrk71C