### PR TITLE
fix(rest): renew core.sessions TTL on successful REST identity resolution

### DIFF
--- a/src/http_api.py
+++ b/src/http_api.py
@@ -10,6 +10,7 @@ Usage:
 
 from __future__ import annotations
 
+import asyncio
 import ipaddress as _ipaddress
 import json
 import os
@@ -418,6 +419,30 @@ async def _resolve_http_bound_agent(tool_name: str, arguments: dict, signals) ->
                     )
                 except Exception as e:
                     logger.debug("[STICKY-REST] cache update failed: %s", e)
+            # Transport parity with the dispatch middleware's post-resolution
+            # session-TTL update (identity_step): renew the durable
+            # core.sessions row on every successfully resolved call. REST is
+            # the only transport fleet residents use, and without this touch
+            # their PG binding never advances after provisioning — expires_at
+            # lapses after SESSION_TTL_HOURS and the Redis-loss self-heal path
+            # (PATH2, which reads the PG row) silently dies with it, while
+            # check-ins keep landing via the Redis binding. Row-scoped UPDATE:
+            # a session_key with no core.sessions row (e.g. transport-injected
+            # CSIDs) is a no-op, so this never creates or extends bindings
+            # that were not provisioned.
+            for attempt in range(2):
+                try:
+                    from src.db import get_db
+                    await get_db().update_session_activity(session_key)
+                    break
+                except Exception as e:
+                    if attempt == 0:
+                        await asyncio.sleep(0.05)
+                    else:
+                        logger.warning(
+                            "[REST-SESSION] TTL update failed for %s...: %s",
+                            str(session_key)[:20], e,
+                        )
             return agent_uuid
     return None
 

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -440,8 +440,8 @@ async def _resolve_http_bound_agent(tool_name: str, arguments: dict, signals) ->
                         await asyncio.sleep(0.05)
                     else:
                         logger.warning(
-                            "[REST-SESSION] TTL update failed for %s...: %s",
-                            str(session_key)[:20], e,
+                            "[REST-SESSION] TTL update failed for agent %s...: %s",
+                            agent_uuid[:8], e,
                         )
             return agent_uuid
     return None

--- a/tests/test_rest_session_renewal.py
+++ b/tests/test_rest_session_renewal.py
@@ -1,0 +1,146 @@
+"""REST session-TTL renewal parity (F1, Phase-2 cutover evidence 2026-07-04).
+
+The dispatch middleware renews the durable core.sessions row after every
+successful identity resolution (identity_step's post-resolution TTL update).
+The REST surface (/v1/tools/call -> _resolve_http_bound_agent) never did:
+a REST-only client checking in every 180s left last_active frozen at
+provisioning time, so expires_at lapsed after SESSION_TTL_HOURS and the
+Redis-loss self-heal path (PATH2, which reads the PG row) silently died
+while check-ins kept landing via the Redis binding. Observed live: 440
+successful REST check-ins with the PG row untouched.
+
+These tests pin the parity touch: renewal fires exactly on the
+successful-resolution branch — not on sticky-cache hits (server-inferred,
+no per-call proof), not on skip_tools, not for freshly created identities —
+and a renewal failure never fails the call.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.http_api import _resolve_http_bound_agent
+
+AGENT_UUID = "a00e9d21-0000-4000-8000-000000000000"
+SESSION_KEY = "agent-a00e9d21-cd9"
+
+
+def _no_consult():
+    return SimpleNamespace(binding=None, cacheable=False, transport_key=None)
+
+
+class _Env:
+    """Patch stack for the function-local imports in _resolve_http_bound_agent."""
+
+    def __init__(self):
+        self.db = MagicMock()
+        self.db.update_session_activity = AsyncMock(return_value=True)
+        self.resolve = AsyncMock(
+            return_value={"agent_uuid": AGENT_UUID, "created": False, "source": "session_binding"}
+        )
+        self.consult = AsyncMock(return_value=_no_consult())
+
+    def patches(self):
+        return [
+            patch(
+                "src.mcp_handlers.identity.operator.resolve_operator_identity",
+                AsyncMock(return_value=None),
+            ),
+            patch(
+                "src.mcp_handlers.middleware.identity_step.consult_sticky_binding",
+                self.consult,
+            ),
+            patch(
+                "src.mcp_handlers.identity.handlers.derive_session_key",
+                AsyncMock(return_value=SESSION_KEY),
+            ),
+            patch(
+                "src.mcp_handlers.identity.handlers.resolve_session_identity",
+                self.resolve,
+            ),
+            patch(
+                "src.mcp_handlers.decorators.get_call_identity_requirement",
+                MagicMock(return_value="post_onboard"),
+            ),
+            patch("src.db.get_db", MagicMock(return_value=self.db)),
+        ]
+
+
+@pytest.fixture
+def env():
+    e = _Env()
+    for p in e.patches():
+        p.start()
+    try:
+        yield e
+    finally:
+        patch.stopall()
+
+
+@pytest.mark.asyncio
+async def test_successful_resolution_renews_session_ttl(env):
+    agent = await _resolve_http_bound_agent(
+        "process_agent_update", {"client_session_id": SESSION_KEY}, MagicMock()
+    )
+    assert agent == AGENT_UUID
+    env.db.update_session_activity.assert_awaited_once_with(SESSION_KEY)
+
+
+@pytest.mark.asyncio
+async def test_created_identity_does_not_renew(env):
+    env.resolve.return_value = {"agent_uuid": AGENT_UUID, "created": True}
+    agent = await _resolve_http_bound_agent(
+        "process_agent_update", {"client_session_id": SESSION_KEY}, MagicMock()
+    )
+    assert agent is None
+    env.db.update_session_activity.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_renewal_failure_is_nonfatal(env):
+    env.db.update_session_activity = AsyncMock(side_effect=RuntimeError("pool down"))
+    agent = await _resolve_http_bound_agent(
+        "process_agent_update", {"client_session_id": SESSION_KEY}, MagicMock()
+    )
+    assert agent == AGENT_UUID
+    assert env.db.update_session_activity.await_count == 2  # both attempts consumed
+
+
+@pytest.mark.asyncio
+async def test_renewal_retries_once_then_succeeds(env):
+    env.db.update_session_activity = AsyncMock(side_effect=[RuntimeError("blip"), True])
+    agent = await _resolve_http_bound_agent(
+        "process_agent_update", {"client_session_id": SESSION_KEY}, MagicMock()
+    )
+    assert agent == AGENT_UUID
+    assert env.db.update_session_activity.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_sticky_cache_hit_does_not_renew(env):
+    cached = SimpleNamespace(agent_uuid=AGENT_UUID)
+    env.consult.return_value = SimpleNamespace(
+        binding=cached, cacheable=False, transport_key=None
+    )
+    with patch(
+        "src.mcp_handlers.middleware.identity_step.sticky_resolution_source",
+        MagicMock(return_value="sticky_cache:unknown"),
+    ):
+        agent = await _resolve_http_bound_agent(
+            "process_agent_update", {}, MagicMock()
+        )
+    assert agent == AGENT_UUID
+    env.db.update_session_activity.assert_not_awaited()
+    env.resolve.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_skip_tools_do_not_renew(env):
+    agent = await _resolve_http_bound_agent(
+        "identity", {"client_session_id": SESSION_KEY}, MagicMock()
+    )
+    assert agent is None
+    env.db.update_session_activity.assert_not_awaited()


### PR DESCRIPTION
## Problem

The dispatch middleware renews the durable session row (`update_session_activity`) after every successful identity resolution; the REST surface (`/v1/tools/call` → `_resolve_http_bound_agent`) never did.

Observed live (2026-07-04): a REST-only resident client checking in every 180s accumulated **440 successful check-ins while its `core.sessions` row stayed frozen at provisioning time** — `last_active` never advanced, `expires_at` lapsed after SESSION_TTL_HOURS (24h). From that point the Redis-loss self-heal path (PATH2, which reads the PG row) is silently dead: check-ins keep landing via the Redis binding, and a later Redis wipe presents as both-store loss requiring the operator rebind runbook. This re-ships, on the REST transport, exactly the incident class the Phase-2 governance seam addendum amendment (anima-mcp #97) exists to close.

## Fix

Transport parity: after a successful (non-created) resolution, renew the row with the same two-attempt touch the middleware uses (`identity_step`'s post-resolution TTL update). Scope guarantees:

- **Sticky-cache hits never renew** — server-inferred bindings with no per-call proof early-return before the touch.
- **Created identities never renew.**
- **Row-scoped no-op for unprovisioned keys** — `UPDATE … WHERE session_id = $1 AND is_active` means a transport-injected CSID with no `core.sessions` row touches nothing; the fix never creates or extends bindings that were not provisioned.
- **Renewal failure is non-fatal** to the call (retry once, then warn).

## Tests

`tests/test_rest_session_renewal.py` — six tests pinning the branch scope (renew on success; no renew on sticky-hit / created / skip-tools; retry-once; non-fatal failure). Full suite green locally: 11,471 passed, coverage 82.05%.

## Post-deploy verification

Re-run the Redis-only-wipe acceptance against an **aged** binding: confirm `expires_at` advances on the next REST check-in, then `DEL` the Redis session key and confirm the following check-in lands unaided (PATH2). The prior acceptance pass used a minutes-old row and could not observe this decay.

https://claude.ai/code/session_017BTTkAiL2pbfBF7dUbtWKb