### PR TITLE
Operator-attested genesis re-baseline + drift alerts emit on change only (#1370)

### DIFF
--- a/scripts/ops/rebaseline-genesis.sh
+++ b/scripts/ops/rebaseline-genesis.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# rebaseline-genesis.sh <agent_uuid> <reason> — operator-attested trajectory
+# genesis (Σ₀) re-baseline for a sanctioned client migration / embodiment change.
+#
+# Why this exists (2026-07-24, #1370): genesis is immutable at trust tier 2+ —
+# correct anti-hijack posture — but a sanctioned client cutover (e.g. the
+# Python bridge → Elixir broker migration) changes the trajectory fingerprint
+# of the SAME creature, pinning lineage_similarity below threshold forever and
+# firing identity_drift on every check-in. No client call may reseed genesis
+# BY DESIGN (same fail-closed philosophy as rebind-resident-session.sh); the
+# sanctioned recreation path is the operator, i.e. this script.
+#
+# What it does, atomically per statement:
+#   1. archives the current trajectory_genesis into trajectory_genesis_history[]
+#      (nothing is destroyed — the old Σ₀ stays inspectable)
+#   2. seeds trajectory_genesis from trajectory_current, which must be fresh
+#      (<24h) so the new baseline reflects the live client, not a stale ghost
+#   3. emits an explicit genesis_rebaselined audit event carrying the reason
+#
+# The next check-in recomputes lineage_similarity against the new Σ₀.
+set -euo pipefail
+UUID="${1:?usage: rebaseline-genesis.sh <agent_uuid> <reason>}"
+REASON="${2:?usage: rebaseline-genesis.sh <agent_uuid> <reason>}"
+DB="${UNITARES_DB:-governance}"
+
+CHECK=$(psql -d "$DB" -tA -c "
+select (metadata ? 'trajectory_genesis')::int
+       + ((metadata ? 'trajectory_current')::int * 2)
+       + (coalesce((metadata->>'trajectory_updated_at')::timestamptz
+                    >= now() - interval '24 hours', false))::int * 4
+from core.identities where agent_id = '$UUID' and disabled_at is null;")
+if [ -z "$CHECK" ]; then
+  echo "no active identity row for agent_id=$UUID — refusing (verify the UUID first)" >&2
+  exit 1
+fi
+if [ "$CHECK" -ne 7 ]; then
+  echo "preconditions not met (flags=$CHECK; need genesis=1 + current=2 + fresh<24h=4 = 7)." >&2
+  echo "The agent must have a genesis, a current signature, and a check-in in the last 24h." >&2
+  exit 1
+fi
+
+psql -d "$DB" -c "
+update core.identities set metadata =
+  jsonb_set(
+    jsonb_set(
+      jsonb_set(
+        metadata,
+        '{trajectory_genesis_history}',
+        coalesce(metadata->'trajectory_genesis_history', '[]'::jsonb)
+          || jsonb_build_array(jsonb_build_object(
+               'genesis', metadata->'trajectory_genesis',
+               'archived_at', now()::text,
+               'reason', '$REASON',
+               'attested_via', 'operator_rebaseline_script')),
+        true),
+      '{trajectory_genesis}', metadata->'trajectory_current', true),
+    '{trajectory_genesis_at}', to_jsonb(now()::text), true),
+  updated_at = now()
+where agent_id = '$UUID' and disabled_at is null
+returning identity_id;"
+
+psql -d "$DB" -c "
+insert into audit.events (ts, agent_id, event_type, payload)
+values (now(), '$UUID', 'genesis_rebaselined',
+        jsonb_build_object(
+          'reason', '$REASON',
+          'attested_via', 'operator_rebaseline_script',
+          'genesis_history_depth',
+            (select jsonb_array_length(metadata->'trajectory_genesis_history')
+             from core.identities where agent_id = '$UUID')))
+returning event_id, event_type;"
+
+echo "rebaselined. The next check-in scores lineage_similarity against the new Σ₀."

--- a/src/trajectory_identity.py
+++ b/src/trajectory_identity.py
@@ -31,6 +31,12 @@ _TRUST_TIER_NAMES = {
     3: "verified",
 }
 
+# Drift alerts re-emit only when lineage_similarity moves more than this since
+# the last emitted alert (plus one trajectory_drift_resolved when it clears).
+# Static drift conditions otherwise flood audit.events and the event feed
+# with an identical row per check-in (#1370).
+_DRIFT_EMIT_DELTA = 0.05
+
 # Paper Definition 2.2: Viability Envelope (EISV bounds)
 VIABILITY_BOUNDS = {
     "E": (0.1, 0.9),
@@ -636,28 +642,72 @@ async def update_current_signature(
                     if prev_trust_tier is not None:
                         metadata["trust_tier"] = prev_trust_tier
 
-            # Drift alert: emit audit event + broadcast if anomaly persists after reseed
+            # Drift alert: emit audit event + broadcast on state CHANGE, not on
+            # every check-in. A static condition (e.g. a client cutover pinning
+            # lineage_similarity — #1370) used to re-emit identical events every
+            # check-in: ~480 audit rows/day per agent and a flooded events feed.
+            # Emit when drift starts, when the metric moves > _DRIFT_EMIT_DELTA,
+            # and once more when it resolves; stay silent in between.
+            drift_emit = metadata.get("trajectory_drift_emit")
+            prev_emit_sim = None
+            if isinstance(drift_emit, dict):
+                try:
+                    prev_emit_sim = float(drift_emit.get("lineage_similarity"))
+                except (TypeError, ValueError):
+                    prev_emit_sim = None
             if result.get("is_anomaly"):
+                changed = (
+                    prev_emit_sim is None
+                    or abs(lineage_sim - prev_emit_sim) > _DRIFT_EMIT_DELTA
+                )
+                if changed:
+                    try:
+                        from src.audit_db import append_audit_event_async
+                        from src.broadcaster import broadcaster_instance
+                        await append_audit_event_async({
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
+                            "event_type": "trajectory_drift",
+                            "agent_id": agent_id,
+                            "details": {
+                                "lineage_similarity": lineage_sim,
+                                "threshold": 0.6,
+                                "trust_tier": tier,
+                            },
+                        })
+                        await broadcaster_instance.broadcast_event(
+                            "identity_drift",
+                            agent_id=agent_id,
+                            payload={"lineage_similarity": lineage_sim, "threshold": 0.6},
+                        )
+                        metadata["trajectory_drift_emit"] = {
+                            "lineage_similarity": lineage_sim,
+                            "emitted_at": datetime.now(timezone.utc).isoformat(),
+                        }
+                    except Exception as e:
+                        logger.debug(f"Drift alert emission failed: {e}")
+            elif prev_emit_sim is not None:
+                # Previously-alerted drift has cleared (reseed, operator
+                # re-baseline, or genuine reconvergence) — say so once.
+                metadata.pop("trajectory_drift_emit", None)
                 try:
                     from src.audit_db import append_audit_event_async
                     from src.broadcaster import broadcaster_instance
                     await append_audit_event_async({
                         "timestamp": datetime.now(timezone.utc).isoformat(),
-                        "event_type": "trajectory_drift",
+                        "event_type": "trajectory_drift_resolved",
                         "agent_id": agent_id,
                         "details": {
                             "lineage_similarity": lineage_sim,
                             "threshold": 0.6,
-                            "trust_tier": tier,
                         },
                     })
                     await broadcaster_instance.broadcast_event(
-                        "identity_drift",
+                        "identity_drift_resolved",
                         agent_id=agent_id,
                         payload={"lineage_similarity": lineage_sim, "threshold": 0.6},
                     )
                 except Exception as e:
-                    logger.debug(f"Drift alert emission failed: {e}")
+                    logger.debug(f"Drift-resolved emission failed: {e}")
         else:
             # No genesis - store this as genesis
             await store_genesis_signature(agent_id, signature)

--- a/tests/test_trajectory_integration.py
+++ b/tests/test_trajectory_integration.py
@@ -520,6 +520,114 @@ class TestUpdateCurrentSignature:
                     assert payload.get("old_tier") != payload.get("new_tier"), \
                         f"Spurious broadcast: old_tier={payload.get('old_tier')} == new_tier={payload.get('new_tier')}"
 
+    @staticmethod
+    def _drifted_fixture():
+        """Tier-2 identity whose current signature is far from genesis."""
+        from src.trajectory_identity import TrajectorySignature
+
+        current_sig = TrajectorySignature(
+            attractor={"center": [0.9, 0.9, 0.9, 0.9]},
+            beliefs={"values": [0.9, 0.9, 0.9]},
+            recovery={"tau_estimate": 100.0},
+            stability_score=0.95,
+            observation_count=100,
+        )
+        metadata = {
+            "trajectory_genesis": {
+                "attractor": {"center": [0.1, 0.1, 0.1, 0.1]},
+                "beliefs": {"values": [0.1, 0.1, 0.1]},
+                "recovery": {"tau_estimate": 5.0},
+                "stability_score": 0.2,
+                "observation_count": 10,
+            },
+            "trust_tier": {"tier": 2, "name": "established"},
+        }
+        return current_sig, metadata
+
+    @pytest.mark.asyncio
+    async def test_static_drift_emits_once_not_per_checkin(self):
+        """A static drift condition alerts on entry, then stays silent (#1370)."""
+        from src.trajectory_identity import update_current_signature
+
+        current_sig, metadata = self._drifted_fixture()
+
+        with patch('src.db.get_db') as mock_db, \
+             patch('src.trajectory_identity.store_genesis_signature',
+                   new_callable=AsyncMock, return_value=False), \
+             patch('src.audit_db.append_audit_event_async',
+                   new_callable=AsyncMock) as mock_audit, \
+             patch('src.broadcaster.broadcaster_instance') as mock_bc:
+            mock_bc.broadcast_event = AsyncMock()
+            mock_identity = MagicMock()
+            mock_identity.metadata = metadata  # shared dict = persisted metadata
+            mock_db_instance = AsyncMock()
+            mock_db_instance.get_identity = AsyncMock(return_value=mock_identity)
+            mock_db_instance.update_identity_metadata = AsyncMock()
+            mock_db.return_value = mock_db_instance
+
+            first = await update_current_signature("test-uuid", current_sig)
+            second = await update_current_signature("test-uuid", current_sig)
+
+            assert first["is_anomaly"] is True
+            assert second["is_anomaly"] is True
+            drift_broadcasts = [
+                c for c in mock_bc.broadcast_event.call_args_list
+                if c.args and c.args[0] == "identity_drift"
+            ]
+            drift_audits = [
+                c for c in mock_audit.call_args_list
+                if c.args and c.args[0].get("event_type") == "trajectory_drift"
+            ]
+            assert len(drift_broadcasts) == 1
+            assert len(drift_audits) == 1
+            assert "trajectory_drift_emit" in metadata
+
+    @pytest.mark.asyncio
+    async def test_drift_resolution_emits_resolved_once(self):
+        """When previously-alerted drift clears, emit trajectory_drift_resolved once."""
+        from src.trajectory_identity import update_current_signature, TrajectorySignature
+
+        # Current ≈ genesis → high similarity, no anomaly.
+        current_sig = TrajectorySignature(
+            attractor={"center": [0.5, 0.5, 0.5, 0.5]},
+            observation_count=50,
+        )
+        metadata = {
+            "trajectory_genesis": {
+                "attractor": {"center": [0.5, 0.5, 0.5, 0.5]},
+                "observation_count": 50,
+            },
+            "trust_tier": {"tier": 2, "name": "established"},
+            # A drift alert was emitted earlier; condition has now cleared.
+            "trajectory_drift_emit": {
+                "lineage_similarity": 0.12,
+                "emitted_at": "2026-07-24T00:00:00+00:00",
+            },
+        }
+
+        with patch('src.db.get_db') as mock_db, \
+             patch('src.audit_db.append_audit_event_async',
+                   new_callable=AsyncMock) as mock_audit, \
+             patch('src.broadcaster.broadcaster_instance') as mock_bc:
+            mock_bc.broadcast_event = AsyncMock()
+            mock_identity = MagicMock()
+            mock_identity.metadata = metadata
+            mock_db_instance = AsyncMock()
+            mock_db_instance.get_identity = AsyncMock(return_value=mock_identity)
+            mock_db_instance.update_identity_metadata = AsyncMock()
+            mock_db.return_value = mock_db_instance
+
+            first = await update_current_signature("test-uuid", current_sig)
+            second = await update_current_signature("test-uuid", current_sig)
+
+            assert first.get("is_anomaly") is False
+            resolved_broadcasts = [
+                c for c in mock_bc.broadcast_event.call_args_list
+                if c.args and c.args[0] == "identity_drift_resolved"
+            ]
+            assert len(resolved_broadcasts) == 1
+            assert "trajectory_drift_emit" not in metadata
+
 
 class TestGetTrajectoryStatus:
     """Tests for get_trajectory_status function."""


### PR DESCRIPTION
Closes #1370.

## What
1. **`scripts/ops/rebaseline-genesis.sh`** — the sanctioned operator path for a client migration / embodiment change. Genesis (Σ₀) stays immutable to clients — the tier-2+ anti-hijack guard is untouched. The script: archives old Σ₀ → `trajectory_genesis_history[]`, seeds Σ₀ from a **fresh (<24h)** `trajectory_current`, emits an explicit `genesis_rebaselined` audit event with the operator's reason. Same fail-closed philosophy as `rebind-resident-session.sh` — no client call can do this.
2. **Emit-on-change drift alerts** — `update_current_signature` now emits `trajectory_drift`/`identity_drift` when drift *starts* or the similarity *moves* >0.05, plus one `trajectory_drift_resolved` when it clears. Previously a static condition re-emitted an identical event on every check-in.

## Why now
The Jul-9 Elixir broker cutover pinned Lumen's `lineage_similarity` at 0.123 (genesis was built from ~88k Python-bridge check-ins): identity_drift every 3 minutes, ~480 audit rows/day, flooded #signals. Full diagnosis in #1370.

## Already run
The script was operator-run for Lumen (2026-07-24, reason=`client_migration`, audit event `f053a70b`) — it's standalone psql, deployable independent of this merge. The server-code half (emit-on-change) takes effect on next deploy.

## Notes for review
- Identity single-writer surface — no other open PRs touch it (checked).
- Emit-state lives in `metadata.trajectory_drift_emit`; popped on resolution so the resolved event fires exactly once.
- Bridge-side complement already live: unitares-discord-bridge#31 suppresses repeat drift embeds.
- Tests: 2 new in `test_trajectory_integration.py` (41 pass); full test-cache gate run before push.